### PR TITLE
fix(sidebar): display project name instead of full path

### DIFF
--- a/server/projects.js
+++ b/server/projects.js
@@ -53,13 +53,8 @@ async function generateDisplayName(projectName, actualProjectDir = null) {
   // If it starts with /, it's an absolute path
   if (projectPath.startsWith('/')) {
     const parts = projectPath.split('/').filter(Boolean);
-    if (parts.length > 3) {
-      // Show last 2 folders with ellipsis: "...projects/myapp"
-      return `.../${parts.slice(-2).join('/')}`;
-    } else {
-      // Show full path if short: "/home/user"
-      return projectPath;
-    }
+    // Return only the last folder name
+    return parts[parts.length - 1] || projectPath;
   }
   
   return projectPath;


### PR DESCRIPTION
## Summary
  Fix project name display in Sidebar to show only folder name instead of full path for better UI clarity.

  ## Changes Made
  - **Modified**: `server/projects.js` lines 54-58
  - **Function**: `generateDisplayName()`
  - **Before**: Projects displayed as `...projects/myapp` or full paths
  - **After**: Projects display as `myapp` (folder name only)

  ## Technical Details
  - Preserves existing package.json name detection as primary method
  - Simplified path parsing to extract only the last folder segment
  - Maintains backward compatibility and error handling

  ## Screenshots
  *Before:*
  - Projects shown as `...documents/projects/myapp`

  *After:*
  - Projects shown as `myapp`

  ## Test Plan
  - [x] Verify project names show only folder names in Sidebar
  - [x] Confirm package.json names still take precedence when available
  - [x] Test with various project path lengths and structures
  - [x] Check both desktop and mobile responsive views
  - [x] Ensure all project functionality remains intact (sessions, navigation, etc.)
