### PR TITLE
Fix command escaping in claude-cli.js

### DIFF
--- a/server/claude-cli.js
+++ b/server/claude-cli.js
@@ -23,7 +23,7 @@ async function spawnClaude(command, options = {}, ws) {
     
     // Add print flag with command if we have a command
     if (command && command.trim()) {
-      args.push('--print', command);
+      args.push('--print', "${command.replace(/"/g, '\\"')}");
     }
     
     // Use cwd (actual project directory) instead of projectPath (Claude's metadata directory)

--- a/server/claude-cli.js
+++ b/server/claude-cli.js
@@ -23,7 +23,7 @@ async function spawnClaude(command, options = {}, ws) {
     
     // Add print flag with command if we have a command
     if (command && command.trim()) {
-      args.push('--print', "${command.replace(/"/g, '\\"')}");
+      args.push('--print', `"${command.replace(/"/g, '\\"')}"`);
     }
     
     // Use cwd (actual project directory) instead of projectPath (Claude's metadata directory)


### PR DESCRIPTION
## Bug Fix

Fixed an issue where commands with special characters were not properly escaped when passed to the Claude CLI.

### Changes
- Added proper quote escaping for commands in `server/claude-cli.js`
- Commands are now wrapped in quotes and internal quotes are escaped with backslashes

### Before
```javascript
args.push('--print', command);
```
### After
```javascript
args.push('--print', `"${command.replace(/"/g, '\\"')}"`);
```