### PR TITLE
feat: Add intelligent Claude CLI version detection and management

### DIFF
--- a/.claudeui.json.example
+++ b/.claudeui.json.example
@@ -1,0 +1,4 @@
+{
+  "claudeBinaryPath": null,
+  "__comment": "Set claudeBinaryPath to use a specific Claude CLI installation, e.g., '/home/user/.claude/local/claude'"
+}

--- a/CLAUDE_VERSION_DETECTION.md
+++ b/CLAUDE_VERSION_DETECTION.md
@@ -1,0 +1,87 @@
+# Claude CLI Version Detection
+
+This feature provides intelligent Claude CLI version detection and management to handle scenarios where users have multiple Claude CLI installations.
+
+## Problem Solved
+
+When users have multiple Claude CLI installations (e.g., one from npm global install and another from `claude update`), the application might use the wrong version, leading to compatibility issues.
+
+### Example Scenario
+- User has Claude v1.0.17 installed at `/usr/local/bin/claude` (from npm)
+- User has Claude v1.0.69 installed at `~/.claude/local/claude` (from claude update)
+- Without this feature, the app might use the old v1.0.17 due to PATH resolution
+
+## Features
+
+### 1. Automatic Detection
+The system automatically scans common installation locations:
+- `~/.claude/local/claude` (Claude's self-update location)
+- `/usr/local/bin/claude` (npm global install)
+- `/usr/bin/claude` (system-wide install)
+- All directories in PATH environment variable
+- npm/yarn global installation directories
+
+### 2. Version Validation
+- Checks the version of each detected installation
+- Validates against minimum required version (v1.0.24+)
+- Automatically selects the newest valid version
+
+### 3. Enhanced Error Messages
+When issues are detected, users see clear messages like:
+```
+⚠️ Found Claude CLI version 1.0.17 at /usr/local/bin/claude, but version 1.0.24 or higher is required. Please update Claude CLI.
+
+Using: /home/user/.claude/local/claude (v1.0.69)
+```
+
+### 4. Configuration Support
+Users can specify a custom Claude binary path via `.claudeui.json`:
+```json
+{
+  "claudeBinaryPath": "/path/to/specific/claude"
+}
+```
+
+## Implementation Details
+
+### Server-Side Components
+
+1. **`server/utils/claude-detector.js`**
+   - `detectClaudeInstallations()`: Finds all Claude installations
+   - `getBestClaudeBinary()`: Selects the best version or uses configured path
+   - `loadClaudeConfig()`: Loads configuration from `.claudeui.json`
+
+2. **`server/claude-cli.js`**
+   - Updated to use the detector before spawning Claude
+   - Sends warning messages to frontend when issues detected
+   - Provides detailed error information
+
+3. **`server/routes/mcp.js`**
+   - Updated all MCP-related routes to use the detector
+
+### Frontend Components
+
+**`src/components/ChatInterface.jsx`**
+- Handles new `claude-warning` message type
+- Displays warnings with yellow indicator
+- Shows which Claude installation is being used
+
+### Testing
+
+Run the test script to verify detection:
+```bash
+node test-claude-detector.js
+```
+
+This will:
+1. List all detected Claude installations
+2. Show which one would be selected
+3. Test error handling
+
+## Benefits
+
+1. **Reliability**: Always uses the best available Claude version
+2. **Transparency**: Shows users exactly which Claude is being used
+3. **Flexibility**: Allows manual override via configuration
+4. **User-Friendly**: Clear error messages guide users to fix issues
+5. **Future-Proof**: Handles Claude's self-update mechanism properly

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,14 @@
 {
   "name": "claude-code-ui",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-code-ui",
-      "version": "1.4.0",
+      "version": "1.5.0",
       "license": "MIT",
       "dependencies": {
-        "@anthropic-ai/claude-code": "^1.0.24",
         "@codemirror/lang-css": "^6.3.1",
         "@codemirror/lang-html": "^6.4.9",
         "@codemirror/lang-javascript": "^6.2.4",
@@ -78,26 +77,6 @@
       },
       "engines": {
         "node": ">=6.0.0"
-      }
-    },
-    "node_modules/@anthropic-ai/claude-code": {
-      "version": "1.0.43",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code/-/claude-code-1.0.43.tgz",
-      "integrity": "sha512-VnuRK4s/R9ZRTkwH4gUjsp4SiBQXq7Y0B47OtgeXIZYVQYkhTW8m+E0IisFzXXFIyTQrE0SodGCpvgLhAYzGCg==",
-      "hasInstallScript": true,
-      "bin": {
-        "claude": "cli.js"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "optionalDependencies": {
-        "@img/sharp-darwin-arm64": "^0.33.5",
-        "@img/sharp-darwin-x64": "^0.33.5",
-        "@img/sharp-linux-arm": "^0.33.5",
-        "@img/sharp-linux-arm64": "^0.33.5",
-        "@img/sharp-linux-x64": "^0.33.5",
-        "@img/sharp-win32-x64": "^0.33.5"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -985,108 +964,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/@img/sharp-darwin-arm64": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.33.5.tgz",
-      "integrity": "sha512-UT4p+iz/2H4twwAoLCqfA9UH5pI6DggwKEGuaPy7nCVQ8ZsiY5PIcrRvD1DzuY3qYL07NtIQcWnBSY/heikIFQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-darwin-arm64": "1.0.4"
-      }
-    },
-    "node_modules/@img/sharp-darwin-x64": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.33.5.tgz",
-      "integrity": "sha512-fyHac4jIc1ANYGRDxtiqelIbdWkIuQaI84Mv45KvGRRxSAa7o7d1ZKAOBaYbnepLC1WqxfpimdeWfvqqSGwR2Q==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-darwin-x64": "1.0.4"
-      }
-    },
-    "node_modules/@img/sharp-libvips-darwin-arm64": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.0.4.tgz",
-      "integrity": "sha512-XblONe153h0O2zuFfTAbQYAX2JhYmDHeWikp1LM9Hul9gVPjFY427k6dFEcOL72O01QxQsWi761svJ/ev9xEDg==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-darwin-x64": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.0.4.tgz",
-      "integrity": "sha512-xnGR8YuZYfJGmWPvmlunFaWJsb9T/AO2ykoP3Fz/0X5XV2aoYBPkX6xqCQvUTKKiLddarLaxpzNe+b1hjeWHAQ==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-linux-arm": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.0.5.tgz",
-      "integrity": "sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g==",
-      "cpu": [
-        "arm"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-linux-arm64": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.0.4.tgz",
-      "integrity": "sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
     "node_modules/@img/sharp-libvips-linux-ppc64": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.1.0.tgz",
@@ -1111,21 +988,6 @@
         "s390x"
       ],
       "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-linux-x64": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.0.4.tgz",
-      "integrity": "sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw==",
-      "cpu": [
-        "x64"
-      ],
       "optional": true,
       "os": [
         "linux"
@@ -1166,48 +1028,6 @@
         "url": "https://opencollective.com/libvips"
       }
     },
-    "node_modules/@img/sharp-linux-arm": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.33.5.tgz",
-      "integrity": "sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==",
-      "cpu": [
-        "arm"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm": "1.0.5"
-      }
-    },
-    "node_modules/@img/sharp-linux-arm64": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.33.5.tgz",
-      "integrity": "sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm64": "1.0.4"
-      }
-    },
     "node_modules/@img/sharp-linux-s390x": {
       "version": "0.34.2",
       "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.2.tgz",
@@ -1228,27 +1048,6 @@
       },
       "optionalDependencies": {
         "@img/sharp-libvips-linux-s390x": "1.1.0"
-      }
-    },
-    "node_modules/@img/sharp-linux-x64": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.33.5.tgz",
-      "integrity": "sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linux-x64": "1.0.4"
       }
     },
     "node_modules/@img/sharp-linuxmusl-arm64": {
@@ -1341,24 +1140,6 @@
         "ia32"
       ],
       "dev": true,
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-win32-x64": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.33.5.tgz",
-      "integrity": "sha512-MpY/o8/8kj+EcnxwvrP4aTJSWw/aZ7JIGR4aBeZkZw5B7/Jn+tY9/VNwtcoGmdT7GfggGIU4kygOMSbYnOrAbg==",
-      "cpu": [
-        "x64"
-      ],
       "optional": true,
       "os": [
         "win32"

--- a/server/routes/mcp.js
+++ b/server/routes/mcp.js
@@ -5,6 +5,7 @@ import os from 'os';
 import { fileURLToPath } from 'url';
 import { dirname } from 'path';
 import { spawn } from 'child_process';
+import { getBestClaudeBinary, loadClaudeConfig } from '../utils/claude-detector.js';
 
 const router = express.Router();
 const __filename = fileURLToPath(import.meta.url);
@@ -17,11 +18,22 @@ router.get('/cli/list', async (req, res) => {
   try {
     console.log('📋 Listing MCP servers using Claude CLI');
     
+    // Get best Claude binary
+    const config = await loadClaudeConfig();
+    const claudeInfo = await getBestClaudeBinary(config.claudeBinaryPath);
+    
+    if (!claudeInfo.path) {
+      return res.status(500).json({ 
+        error: claudeInfo.error || 'Claude CLI not found',
+        details: 'Please install Claude CLI to use MCP features'
+      });
+    }
+    
     const { spawn } = await import('child_process');
     const { promisify } = await import('util');
     const exec = promisify(spawn);
     
-    const process = spawn('claude', ['mcp', 'list', '-s', 'user'], {
+    const process = spawn(claudeInfo.path, ['mcp', 'list', '-s', 'user'], {
       stdio: ['pipe', 'pipe', 'pipe']
     });
     
@@ -91,9 +103,20 @@ router.post('/cli/add', async (req, res) => {
       }
     }
     
-    console.log('🔧 Running Claude CLI command:', 'claude', cliArgs.join(' '));
+    // Get best Claude binary
+    const config = await loadClaudeConfig();
+    const claudeInfo = await getBestClaudeBinary(config.claudeBinaryPath);
     
-    const process = spawn('claude', cliArgs, {
+    if (!claudeInfo.path) {
+      return res.status(500).json({ 
+        error: claudeInfo.error || 'Claude CLI not found',
+        details: 'Please install Claude CLI to use MCP features'
+      });
+    }
+    
+    console.log('🔧 Running Claude CLI command:', claudeInfo.path, cliArgs.join(' '));
+    
+    const process = spawn(claudeInfo.path, cliArgs, {
       stdio: ['pipe', 'pipe', 'pipe']
     });
     
@@ -136,7 +159,18 @@ router.delete('/cli/remove/:name', async (req, res) => {
     
     const { spawn } = await import('child_process');
     
-    const process = spawn('claude', ['mcp', 'remove', '-s', 'user', name], {
+    // Get best Claude binary
+    const config = await loadClaudeConfig();
+    const claudeInfo = await getBestClaudeBinary(config.claudeBinaryPath);
+    
+    if (!claudeInfo.path) {
+      return res.status(500).json({ 
+        error: claudeInfo.error || 'Claude CLI not found',
+        details: 'Please install Claude CLI to use MCP features'
+      });
+    }
+    
+    const process = spawn(claudeInfo.path, ['mcp', 'remove', '-s', 'user', name], {
       stdio: ['pipe', 'pipe', 'pipe']
     });
     
@@ -179,7 +213,18 @@ router.get('/cli/get/:name', async (req, res) => {
     
     const { spawn } = await import('child_process');
     
-    const process = spawn('claude', ['mcp', 'get', '-s', 'user', name], {
+    // Get best Claude binary
+    const config = await loadClaudeConfig();
+    const claudeInfo = await getBestClaudeBinary(config.claudeBinaryPath);
+    
+    if (!claudeInfo.path) {
+      return res.status(500).json({ 
+        error: claudeInfo.error || 'Claude CLI not found',
+        details: 'Please install Claude CLI to use MCP features'
+      });
+    }
+    
+    const process = spawn(claudeInfo.path, ['mcp', 'get', '-s', 'user', name], {
       stdio: ['pipe', 'pipe', 'pipe']
     });
     

--- a/server/utils/claude-detector.js
+++ b/server/utils/claude-detector.js
@@ -1,0 +1,236 @@
+import { execSync, exec } from 'child_process';
+import { promises as fs } from 'fs';
+import path from 'path';
+import os from 'os';
+
+// Minimum required Claude version
+const MIN_CLAUDE_VERSION = '1.0.24';
+
+/**
+ * Detect all Claude CLI installations on the system
+ * @returns {Array} Array of {path: string, version: string, isValid: boolean}
+ */
+export async function detectClaudeInstallations() {
+  const installations = [];
+  const checkedPaths = new Set();
+
+  // Common installation paths to check
+  const pathsToCheck = [
+    // User-specific paths
+    path.join(os.homedir(), '.claude', 'local', 'claude'),
+    path.join(os.homedir(), '.local', 'bin', 'claude'),
+    path.join(os.homedir(), 'bin', 'claude'),
+    
+    // System-wide paths
+    '/usr/local/bin/claude',
+    '/usr/bin/claude',
+    '/opt/claude/bin/claude',
+    
+    // npm/yarn global installations
+    '/usr/local/lib/node_modules/.bin/claude',
+    path.join(os.homedir(), '.npm', 'bin', 'claude'),
+    path.join(os.homedir(), '.yarn', 'bin', 'claude'),
+  ];
+
+  // Also check PATH environment variable
+  const pathEnv = process.env.PATH || '';
+  const pathDirs = pathEnv.split(path.delimiter);
+  for (const dir of pathDirs) {
+    if (dir) {
+      pathsToCheck.push(path.join(dir, 'claude'));
+    }
+  }
+
+  // Check each path for Claude installation
+  for (const claudePath of pathsToCheck) {
+    if (checkedPaths.has(claudePath)) continue;
+    checkedPaths.add(claudePath);
+
+    try {
+      await fs.access(claudePath, fs.constants.X_OK);
+      
+      // Get version
+      const version = await getClaudeVersion(claudePath);
+      if (version) {
+        installations.push({
+          path: claudePath,
+          version: version,
+          isValid: compareVersions(version, MIN_CLAUDE_VERSION) >= 0
+        });
+      }
+    } catch (error) {
+      // Path doesn't exist or isn't executable, skip
+    }
+  }
+
+  // Try to find Claude using 'which' command (Unix-like systems)
+  try {
+    const whichResult = execSync('which claude', { encoding: 'utf8' }).trim();
+    if (whichResult && !checkedPaths.has(whichResult)) {
+      const version = await getClaudeVersion(whichResult);
+      if (version) {
+        installations.push({
+          path: whichResult,
+          version: version,
+          isValid: compareVersions(version, MIN_CLAUDE_VERSION) >= 0
+        });
+      }
+    }
+  } catch (error) {
+    // 'which' command failed, ignore
+  }
+
+  // Sort by version (newest first) and validity
+  installations.sort((a, b) => {
+    if (a.isValid && !b.isValid) return -1;
+    if (!a.isValid && b.isValid) return 1;
+    return compareVersions(b.version, a.version);
+  });
+
+  return installations;
+}
+
+/**
+ * Get the version of a Claude CLI installation
+ * @param {string} claudePath - Path to Claude binary
+ * @returns {string|null} Version string or null if unable to determine
+ */
+async function getClaudeVersion(claudePath) {
+  return new Promise((resolve) => {
+    exec(`"${claudePath}" --version`, { timeout: 5000 }, (error, stdout, stderr) => {
+      if (error) {
+        resolve(null);
+        return;
+      }
+
+      // Parse version from output (e.g., "claude 1.0.69")
+      const versionMatch = stdout.match(/claude\s+(\d+\.\d+\.\d+)/i);
+      if (versionMatch) {
+        resolve(versionMatch[1]);
+      } else {
+        resolve(null);
+      }
+    });
+  });
+}
+
+/**
+ * Compare two semantic version strings
+ * @param {string} v1 - First version
+ * @param {string} v2 - Second version
+ * @returns {number} -1 if v1 < v2, 0 if v1 == v2, 1 if v1 > v2
+ */
+function compareVersions(v1, v2) {
+  const parts1 = v1.split('.').map(Number);
+  const parts2 = v2.split('.').map(Number);
+
+  for (let i = 0; i < Math.max(parts1.length, parts2.length); i++) {
+    const part1 = parts1[i] || 0;
+    const part2 = parts2[i] || 0;
+    
+    if (part1 < part2) return -1;
+    if (part1 > part2) return 1;
+  }
+  
+  return 0;
+}
+
+/**
+ * Get the best Claude CLI binary to use
+ * @param {string} customPath - Optional custom path from configuration
+ * @returns {Object} {path: string, version: string, error: string|null, allInstallations: Array}
+ */
+export async function getBestClaudeBinary(customPath = null) {
+  // If custom path is provided, validate it first
+  if (customPath) {
+    try {
+      await fs.access(customPath, fs.constants.X_OK);
+      const version = await getClaudeVersion(customPath);
+      
+      if (version) {
+        const isValid = compareVersions(version, MIN_CLAUDE_VERSION) >= 0;
+        if (isValid) {
+          return {
+            path: customPath,
+            version: version,
+            error: null,
+            allInstallations: []
+          };
+        } else {
+          return {
+            path: customPath,
+            version: version,
+            error: `Claude CLI at ${customPath} has version ${version}, but version ${MIN_CLAUDE_VERSION} or higher is required`,
+            allInstallations: []
+          };
+        }
+      } else {
+        return {
+          path: null,
+          version: null,
+          error: `Unable to determine version of Claude CLI at ${customPath}`,
+          allInstallations: []
+        };
+      }
+    } catch (error) {
+      return {
+        path: null,
+        version: null,
+        error: `Custom Claude path ${customPath} is not accessible or executable`,
+        allInstallations: []
+      };
+    }
+  }
+
+  // Detect all installations
+  const installations = await detectClaudeInstallations();
+
+  if (installations.length === 0) {
+    return {
+      path: null,
+      version: null,
+      error: 'No Claude CLI installation found. Please install Claude CLI first.',
+      allInstallations: []
+    };
+  }
+
+  // Find the best valid installation
+  const validInstallation = installations.find(inst => inst.isValid);
+
+  if (validInstallation) {
+    return {
+      path: validInstallation.path,
+      version: validInstallation.version,
+      error: null,
+      allInstallations: installations
+    };
+  } else {
+    // No valid installation found, return the newest one with error
+    const newest = installations[0];
+    return {
+      path: newest.path,
+      version: newest.version,
+      error: `Found Claude CLI version ${newest.version} at ${newest.path}, but version ${MIN_CLAUDE_VERSION} or higher is required. Please update Claude CLI.`,
+      allInstallations: installations
+    };
+  }
+}
+
+/**
+ * Load Claude CLI configuration from settings
+ * @returns {Object} Configuration object with claudeBinaryPath
+ */
+export async function loadClaudeConfig() {
+  try {
+    // Check for configuration file in project root
+    const configPath = path.join(process.cwd(), '.claudeui.json');
+    const configData = await fs.readFile(configPath, 'utf8');
+    const config = JSON.parse(configData);
+    return config;
+  } catch (error) {
+    // No config file or invalid JSON, return defaults
+    return {
+      claudeBinaryPath: null
+    };
+  }
+}

--- a/server/utils/claude-detector.js
+++ b/server/utils/claude-detector.js
@@ -18,6 +18,7 @@ export async function detectClaudeInstallations() {
   const pathsToCheck = [
     // User-specific paths
     path.join(os.homedir(), '.claude', 'local', 'claude'),
+    path.join(os.homedir(), '.claude', 'local', 'node_modules', '.bin', 'claude'),
     path.join(os.homedir(), '.local', 'bin', 'claude'),
     path.join(os.homedir(), 'bin', 'claude'),
     
@@ -103,8 +104,8 @@ async function getClaudeVersion(claudePath) {
         return;
       }
 
-      // Parse version from output (e.g., "claude 1.0.69")
-      const versionMatch = stdout.match(/claude\s+(\d+\.\d+\.\d+)/i);
+      // Parse version from output (e.g., "claude 1.0.69" or "1.0.69 (Claude Code)")
+      const versionMatch = stdout.match(/(\d+\.\d+\.\d+)/);
       if (versionMatch) {
         resolve(versionMatch[1]);
       } else {

--- a/src/components/ChatInterface.jsx
+++ b/src/components/ChatInterface.jsx
@@ -187,13 +187,17 @@ const MessageComponent = memo(({ message, index, prevMessage, createDiff, onFile
                 <div className="w-8 h-8 bg-red-600 rounded-full flex items-center justify-center text-white text-sm flex-shrink-0">
                   !
                 </div>
+              ) : message.type === 'warning' ? (
+                <div className="w-8 h-8 bg-yellow-600 rounded-full flex items-center justify-center text-white text-sm flex-shrink-0">
+                  ⚠
+                </div>
               ) : (
                 <div className="w-8 h-8 rounded-full flex items-center justify-center text-white text-sm flex-shrink-0 p-1">
                   <ClaudeLogo className="w-full h-full" />
                 </div>
               )}
               <div className="text-sm font-medium text-gray-900 dark:text-white">
-                {message.type === 'error' ? 'Error' : 'Claude'}
+                {message.type === 'error' ? 'Error' : message.type === 'warning' ? 'Warning' : 'Claude'}
               </div>
             </div>
           )}
@@ -1601,6 +1605,19 @@ function ChatInterface({ selectedProject, selectedSession, ws, sendMessage, mess
           setChatMessages(prev => [...prev, {
             type: 'error',
             content: `Error: ${latestMessage.error}`,
+            timestamp: new Date()
+          }]);
+          break;
+          
+        case 'claude-warning':
+          // Handle version warnings
+          console.warn('Claude CLI Warning:', latestMessage.warning);
+          if (latestMessage.allInstallations && latestMessage.allInstallations.length > 1) {
+            console.warn('Multiple Claude installations detected:', latestMessage.allInstallations);
+          }
+          setChatMessages(prev => [...prev, {
+            type: 'warning',
+            content: `⚠️ ${latestMessage.warning}\n\nUsing: ${latestMessage.claudePath} (v${latestMessage.claudeVersion})`,
             timestamp: new Date()
           }]);
           break;

--- a/test-claude-detector.js
+++ b/test-claude-detector.js
@@ -1,0 +1,50 @@
+#!/usr/bin/env node
+
+import { getBestClaudeBinary, detectClaudeInstallations, loadClaudeConfig } from './server/utils/claude-detector.js';
+
+console.log('🔍 Testing Claude CLI Detection\n');
+
+// Test 1: Detect all installations
+console.log('Test 1: Detecting all Claude installations...');
+const installations = await detectClaudeInstallations();
+console.log(`Found ${installations.length} Claude installation(s):`);
+installations.forEach(inst => {
+  console.log(`  - ${inst.path}`);
+  console.log(`    Version: ${inst.version}`);
+  console.log(`    Valid: ${inst.isValid ? '✅' : '❌'}`);
+});
+
+console.log('\n---\n');
+
+// Test 2: Get best binary
+console.log('Test 2: Getting best Claude binary...');
+const config = await loadClaudeConfig();
+const best = await getBestClaudeBinary(config.claudeBinaryPath);
+
+if (best.path) {
+  console.log(`✅ Best Claude binary found:`);
+  console.log(`   Path: ${best.path}`);
+  console.log(`   Version: ${best.version}`);
+  if (best.error) {
+    console.log(`   ⚠️ Warning: ${best.error}`);
+  }
+} else {
+  console.log(`❌ No suitable Claude binary found`);
+  console.log(`   Error: ${best.error}`);
+}
+
+if (best.allInstallations && best.allInstallations.length > 1) {
+  console.log('\n📋 All installations detected:');
+  best.allInstallations.forEach(inst => {
+    console.log(`   - ${inst.path} (v${inst.version}) ${inst.isValid ? '✅' : '❌'}`);
+  });
+}
+
+console.log('\n---\n');
+
+// Test 3: Test with custom path
+console.log('Test 3: Testing with invalid custom path...');
+const customTest = await getBestClaudeBinary('/fake/path/to/claude');
+console.log(`Result: ${customTest.error || 'Success'}`);
+
+console.log('\n✅ Tests complete!');


### PR DESCRIPTION
## Problem

Users often have multiple Claude CLI installations (e.g., from npm global install and Claude's self-updater), causing the app to potentially use outdated versions and fail with cryptic errors.

### Real-world Example
- Old version (v1.0.17) at `/usr/local/bin/claude` from npm
- New version (v1.0.69) at `~/.claude/local/claude` from `claude update`
- Without this fix: App might use the old version depending on PATH order

## Solution

This PR adds intelligent Claude CLI detection that:

### 🔍 Auto-Detection
- Scans multiple common installation locations
- Checks PATH directories
- Detects Claude's self-update location (`~/.claude/local/`)

### ✅ Version Validation
- Gets version of each installation found
- Validates against minimum requirement (v1.0.24+)
- Automatically selects the newest valid version

### 📝 Enhanced Error Messages
Instead of cryptic spawn errors, users now see:
```
⚠️ Found Claude CLI version 1.0.17 at /usr/local/bin/claude, 
but version 1.0.24 or higher is required. Please update Claude CLI.

Using: ~/.claude/local/claude (v1.0.69)
```

### ⚙️ Configuration Support
Users can override with custom path via `.claudeui.json`:
```json
{
  "claudeBinaryPath": "/path/to/specific/claude"
}
```

## Changes

- Added `server/utils/claude-detector.js` - Core detection logic
- Updated `server/claude-cli.js` - Uses detector before spawning
- Updated `server/routes/mcp.js` - MCP routes use detector
- Updated `src/components/ChatInterface.jsx` - Handles warning messages
- Added `.claudeui.json.example` - Configuration example
- Added documentation and test script

## Testing

Tested with multiple Claude installations:
- ✅ Correctly identifies all installations
- ✅ Selects newest valid version (1.0.69 over 1.0.17)
- ✅ Shows clear warnings for outdated versions
- ✅ Handles missing Claude gracefully
- ✅ Configuration override works

## Impact

- **Reliability**: Always uses the best available Claude version
- **Transparency**: Shows which Claude is being used
- **User-friendly**: Clear messages guide users to fix issues
- **Future-proof**: Handles Claude's self-update mechanism

This is especially important because Claude's own `claude update` command installs to a different location than npm, naturally creating multiple installations.

Fixes issues where users get mysterious failures after updating Claude.