### PR TITLE
style: remove revert rule causing unexpected transparency in modal

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -559,16 +559,6 @@
       transform: inherit !important;
     }
     
-    /* Preserve backgrounds for containers and modals */
-    .fixed:hover,
-    .modal:hover,
-    .bg-white:hover,
-    .bg-gray-800:hover,
-    .bg-gray-900:hover,
-    [class*="bg-"]:hover {
-      background-color: revert !important;
-    }
-    
     /* Force buttons to be immediately clickable */
     button, [role="button"], .cursor-pointer {
       cursor: pointer !important;


### PR DESCRIPTION
resolve #56 
 
 ### Summary
  This PR removes a CSS rule that was causing unexpected transparency issues in modal overlays on touch
  devices. The `background-color: revert` rule intended to preserve modal backgrounds was actually causing
   the opposite effect.

  ### Problem
  - The `background-color: revert !important` rule for modals and containers on touch devices was causing
  transparency issues
  - This affected modal overlays, making them appear transparent instead of maintaining their intended
  background colors
  - The rule was originally added to preserve backgrounds when disabling hover states, but had unintended
  side effects

  ### Solution
  - Removed the problematic CSS rule block (lines 562-570 in `src/index.css`)
  - Simplified the touch device hover state handling
  - Other UI elements remain unaffected as the rule was redundant

  ### Testing
  - [v] Tested on iOS Safari - modal overlays display correctly
  - [v] Tested on Android Chrome - backgrounds remain as expected
  - [v] Verified desktop browsers are unaffected
  - [v] Confirmed no regression in other touch device interactions

  ### Screenshots
<img width="400" height="847" alt="Claude-Code-UI-08-10-2025_03_45_PM" src="https://github.com/user-attachments/assets/b2b59b28-827b-45e0-b32f-3510e1e85ba1" />
<img width="400" height="847" alt="Claude-Code-UI-08-10-2025_03_45_PM (1)" src="https://github.com/user-attachments/assets/3c8e4995-8ae8-4f7e-9024-acc8fa357111" />

