### PR TITLE
Fix version matching regex to handle uppercase 'V'

### DIFF
--- a/src/hooks/useVersionCheck.js
+++ b/src/hooks/useVersionCheck.js
@@ -14,7 +14,7 @@ export const useVersionCheck = (owner, repo) => {
         
         // Handle the case where there might not be any releases
         if (data.tag_name) {
-          const latest = data.tag_name.replace(/^v/, '');
+          const latest = data.tag_name.replace(/^[v|V]/, '');
           setLatestVersion(latest);
           setUpdateAvailable(version !== latest);
         } else {


### PR DESCRIPTION
## Summary
- Updated version tag regex to handle both lowercase 'v' and uppercase 'V' prefixes

## Changes
- Modified the regex pattern in `useVersionCheck.js` from `/^v/` to `/^[v|V]/` to properly handle version tags that start with uppercase 'V'

## Test plan
- [ ] Test with version tags starting with 'v' (e.g., v1.0.0)
- [ ] Test with version tags starting with 'V' (e.g., V1.0.0)
- [ ] Verify version comparison works correctly in both cases

🤖 Generated with [Claude Code](https://claude.ai/code)