### PR TITLE
style: Improve PWA experience on iOS devices

### DIFF
--- a/src/components/CodeEditor.jsx
+++ b/src/components/CodeEditor.jsx
@@ -258,7 +258,7 @@ function CodeEditor({ file, onClose, projectPath }) {
   }
 
   return (
-    <div className={`ios-top-safe fixed inset-0 z-50 ${
+    <div className={`ios-top-safe ios-bottom-safe fixed inset-0 z-50 ${
       // Mobile: native fullscreen, Desktop: modal with backdrop
       'md:bg-black/50 md:flex md:items-center md:justify-center md:p-4'
     } ${isFullscreen ? 'md:p-0' : ''}`}>

--- a/src/components/CodeEditor.jsx
+++ b/src/components/CodeEditor.jsx
@@ -258,7 +258,7 @@ function CodeEditor({ file, onClose, projectPath }) {
   }
 
   return (
-    <div className={`fixed inset-0 z-50 ${
+    <div className={`ios-top-safe fixed inset-0 z-50 ${
       // Mobile: native fullscreen, Desktop: modal with backdrop
       'md:bg-black/50 md:flex md:items-center md:justify-center md:p-4'
     } ${isFullscreen ? 'md:p-0' : ''}`}>

--- a/src/components/FileTree.jsx
+++ b/src/components/FileTree.jsx
@@ -307,7 +307,7 @@ function FileTree({ selectedProject }) {
   }
 
   return (
-    <div className="h-full flex flex-col bg-card">
+    <div className="ios-bottom-safe h-full flex flex-col bg-card">
       {/* View Mode Toggle */}
       <div className="p-4 border-b border-border flex items-center justify-between">
         <h3 className="text-sm font-medium text-foreground">Files</h3>
@@ -372,6 +372,7 @@ function FileTree({ selectedProject }) {
             {viewMode === 'detailed' && renderDetailedView(files)}
           </div>
         )}
+				<div className='h-12 py-6'></div>
       </ScrollArea>
       
       {/* Code Editor Modal */}

--- a/src/components/MainContent.jsx
+++ b/src/components/MainContent.jsx
@@ -66,7 +66,7 @@ function MainContent({
       <div className="h-full flex flex-col">
         {/* Header with menu button for mobile */}
         {isMobile && (
-          <div className="bg-white dark:bg-gray-800 border-b border-gray-200 dark:border-gray-700 p-3 sm:p-4 flex-shrink-0">
+          <div className="ios-top-safe bg-white dark:bg-gray-800 border-b border-gray-200 dark:border-gray-700 pb-3 px-3 flex-shrink-0">
             <button
               onClick={onMenuClick}
               className="p-1.5 text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white rounded-md hover:bg-gray-100 dark:hover:bg-gray-700"
@@ -102,7 +102,7 @@ function MainContent({
       <div className="h-full flex flex-col">
         {/* Header with menu button for mobile */}
         {isMobile && (
-          <div className="bg-white dark:bg-gray-800 border-b border-gray-200 dark:border-gray-700 p-3 sm:p-4 flex-shrink-0">
+          <div className="ios-top-safe bg-white dark:bg-gray-800 border-b border-gray-200 dark:border-gray-700 pb-3 px-3 flex-shrink-0">
             <button
               onClick={onMenuClick}
               className="p-1.5 text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white rounded-md hover:bg-gray-100 dark:hover:bg-gray-700"
@@ -138,7 +138,7 @@ function MainContent({
   return (
     <div className="h-full flex flex-col">
       {/* Header with tabs */}
-      <div className="bg-white dark:bg-gray-800 border-b border-gray-200 dark:border-gray-700 p-3 sm:p-4 flex-shrink-0">
+      <div className="ios-top-safe bg-white dark:bg-gray-800 border-b border-gray-200 dark:border-gray-700 pb-3 flex-shrink-0">
         <div className="flex items-center justify-between">
           <div className="flex items-center space-x-2 sm:space-x-3">
             {isMobile && (

--- a/src/components/QuickSettingsPanel.jsx
+++ b/src/components/QuickSettingsPanel.jsx
@@ -69,7 +69,7 @@ const QuickSettingsPanel = ({
 
       {/* Panel */}
       <div
-        className={`fixed top-0 right-0 h-full w-64 bg-white dark:bg-gray-900 border-l border-gray-200 dark:border-gray-700 shadow-xl transform transition-transform duration-150 ease-out z-40 ${
+        className={`fixed top-0 right-0 ios-top-safe h-full w-64 bg-white dark:bg-gray-900 border-l border-gray-200 dark:border-gray-700 shadow-xl transform transition-transform duration-150 ease-out z-40 ${
           localIsOpen ? 'translate-x-0' : 'translate-x-full'
         } ${isMobile ? 'h-screen' : ''}`}
       >

--- a/src/components/QuickSettingsPanel.jsx
+++ b/src/components/QuickSettingsPanel.jsx
@@ -52,7 +52,7 @@ const QuickSettingsPanel = ({
       <div
         className={`fixed ${isMobile ? 'bottom-44' : 'top-1/2 -translate-y-1/2'} ${
           localIsOpen ? 'right-64' : 'right-0'
-        } z-50 transition-all duration-150 ease-out`}
+        } z-40 transition-all duration-150 ease-out`}
       >
         <button
           onClick={handleToggle}

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -543,7 +543,7 @@ function Sidebar({
           
           {/* Mobile Form - Simple Overlay */}
           <div className="md:hidden fixed inset-0 z-50 bg-black/50 backdrop-blur-sm">
-            <div className="absolute bottom-0 left-0 right-0 bg-card rounded-t-lg border-t border-border p-4 space-y-4 animate-in slide-in-from-bottom duration-300">
+            <div className="absolute ios-bottom-safe-position pb-8 left-0 right-0 bg-card rounded-t-lg border-t border-border p-4 space-y-4 animate-in slide-in-from-bottom duration-300">
               <div className="flex items-center justify-between">
                 <div className="flex items-center gap-2">
                   <div className="w-6 h-6 bg-primary/10 rounded-md flex items-center justify-center">

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -418,7 +418,7 @@ function Sidebar({
   });
 
   return (
-    <div className="h-full flex flex-col bg-card md:select-none">
+    <div className="ios-top-safe ios-bottom-safe h-full flex flex-col bg-card md:select-none">
       {/* Header */}
       <div className="md:p-4 md:border-b md:border-border">
         {/* Desktop Header */}

--- a/src/index.css
+++ b/src/index.css
@@ -583,6 +583,10 @@
   .ios-bottom-safe {
     padding-bottom: max(env(safe-area-inset-bottom), 12px);
   }
+
+	.ios-bottom-safe-position {
+		bottom: env(safe-area-inset-bottom);
+	}
   
   @media screen and (max-width: 768px) {
     .chat-input-mobile {

--- a/src/index.css
+++ b/src/index.css
@@ -80,9 +80,11 @@
     font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
     margin: 0;
     padding: 0;
+		height: 100vh;
+		overflow: hidden;
   }
 
-  html, body, #root {
+  #root {
     height: 100%;
     margin: 0;
     padding: 0;

--- a/src/index.css
+++ b/src/index.css
@@ -80,6 +80,7 @@
     font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
     margin: 0;
     padding: 0;
+		/* fix app height in screen height */
 		height: 100vh;
 		overflow: hidden;
   }
@@ -574,6 +575,10 @@
     }
   }
   
+	.ios-top-safe {
+    padding-top: max(env(safe-area-inset-top), 0.75rem);
+	}
+
   /* Safe area support for iOS devices */
   .ios-bottom-safe {
     padding-bottom: max(env(safe-area-inset-bottom), 12px);


### PR DESCRIPTION
## Summary
- Enhanced PWA experience for iOS devices by adding proper safe area handling
- Fixed layout issues where content was hidden behind iOS home indicator and status bar

## Problem
There was an issue where the update available button kept showing because version matching failed due to the remaining 'V' prefix. Additionally, on iOS devices running as PWA, content was being obscured by system UI elements.

## Changes
- Fixed app height to prevent overflow issues in PWA mode
- Added `ios-top-safe` and `ios-bottom-safe` classes for proper safe area padding
<img width="300" height="650" alt="pwa_before" src="https://github.com/user-attachments/assets/126bcb8c-4ae7-470b-aa74-a89091bab41a" />
<img width="300" height="650" alt="pwa_after" src="https://github.com/user-attachments/assets/00bf4983-273d-4b19-8b98-876252ff2c08" />


- Added padding adjustments for:
  - Sidebar component (top/bottom safe areas)
<img width="300" height="650" alt="sidebar_before" src="https://github.com/user-attachments/assets/17c55b0b-4102-4172-93c8-363e76f994de" />
<img width="300" height="650" alt="sidebar_after" src="https://github.com/user-attachments/assets/22071784-81c3-4122-9b08-01e37dc9175b" />

  - MainContent header (top safe area)
<img width="300" height="650" alt="main_before" src="https://github.com/user-attachments/assets/63c00f8e-ba2b-4c0d-9858-edcc52a97474" />
<img width="300" height="650" alt="main_after" src="https://github.com/user-attachments/assets/644ee0a7-fc88-4216-9379-70821c2cfde1" />

  - FileTree component (bottom safe area with extra spacing)
**Forget to take screenshots**

  - CodeEditor modal (top/bottom safe areas)
<img width="300" height="650" alt="code_before" src="https://github.com/user-attachments/assets/3d2fe5fb-b81f-474f-87d6-86e32eecd348" />
<img width="300" height="650" alt="code_after" src="https://github.com/user-attachments/assets/2246e73a-dbc7-4718-8274-72d869916207" />
 
  - QuickSettingsPanel (top safe area)
<img width="300" height="650" alt="quick_before" src="https://github.com/user-attachments/assets/cb5ebf8b-cbab-4599-9a97-fa49d284f7d9" />
 <img width="300" height="650" alt="quick_after" src="https://github.com/user-attachments/assets/5aeb8351-7625-4baa-930e-29546fe02a29" />

  - New Project mobile form (bottom safe area positioning)
<img width="300" height="650" alt="new_project_before" src="https://github.com/user-attachments/assets/ba8bc5c3-45cf-4c69-8e2b-173f2c2ed05d" />
<img width="300" height="650" alt="new_project_after" src="https://github.com/user-attachments/assets/bd8a02b0-64fc-4df7-b514-933a48c6182e" />

- Adjusted z-index for QuickSettingsPanel pull tab to prevent overlap issues

**Before**
<video src="https://github.com/user-attachments/assets/5d7ba93a-f118-4078-b380-c059d891f125"></video>

**After**
<video src="https://github.com/user-attachments/assets/b8e11bd9-3871-47af-8b1f-e174a84db61d"></video>

## Test plan
- [x] Test on iOS devices in PWA mode
- [x] Test on regular desktop/mobile browsers for regression
- [x] Verify all modals and overlays display correctly