### PR TITLE
feat: add an environment variable to configure `allowedHosts` in `vite.config.js` to access service from alternative hostnames

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,3 +10,6 @@
 PORT=3001
 #Frontend port
 VITE_PORT=5173
+
+# Allowed hosts (if additional hosts are needed). Comma-separated string
+ALLOWED_HOSTS=

--- a/vite.config.js
+++ b/vite.config.js
@@ -3,13 +3,20 @@ import react from '@vitejs/plugin-react'
 
 export default defineConfig(({ command, mode }) => {
   // Load env file based on `mode` in the current working directory.
-  const env = loadEnv(mode, process.cwd(), '')
-  
-  
+  const env = loadEnv(mode, process.cwd(), '');
+
+  // Parse allowed hosts from env (comma-separated)
+  const allowedHosts = (env.ALLOWED_HOSTS || '')
+    .split(',')
+    .map((h) => h.trim())
+    .filter(Boolean);
+
   return {
     plugins: [react()],
     server: {
       port: parseInt(env.VITE_PORT) || 5173,
+      // Allow restricting which Host headers are accepted by Vite dev server
+      ...(allowedHosts.length ? { allowedHosts } : {}),
       proxy: {
         '/api': `http://localhost:${env.PORT || 3001}`,
         '/ws': {


### PR DESCRIPTION
Didn't open up a separate issue for this as I thought this was rather straight-forward, but this addresses issues like #140 which will allow users to access the service from alternative hostnames without having to maintain a separate fork and manually edit `vite.config.js`.

This was tested locally and it eliminates the following error message.
```
Blocked request. This host ("[REDACTED]") is not allowed.
To allow this host, add "[REDACTED]" to `server.allowedHosts` in vite.config.js.
```
