### PR TITLE
Make authentication database path configurable via DATABASE_PATH environment variable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,3 +13,13 @@ VITE_PORT=5173
 
 # Uncomment the following line if you have a custom claude cli path other than the default "claude"
 # CLAUDE_CLI_PATH=claude
+
+# =============================================================================
+# DATABASE CONFIGURATION
+# =============================================================================
+
+# Path to the authentication database file
+# This should be set to a persistent volume path when running in containers
+# Default: server/database/auth.db (relative to project root)
+# Example for Docker: /data/auth.db
+# DATABASE_PATH=/data/auth.db

--- a/server/database/db.js
+++ b/server/database/db.js
@@ -7,12 +7,22 @@ import { dirname } from 'path';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
-const DB_PATH = path.join(__dirname, 'auth.db');
+// Use DATABASE_PATH environment variable if set, otherwise use default location
+const DB_PATH = process.env.DATABASE_PATH || path.join(__dirname, 'auth.db');
 const INIT_SQL_PATH = path.join(__dirname, 'init.sql');
+
+// Ensure database directory exists if custom path is provided
+if (process.env.DATABASE_PATH) {
+  const dbDir = path.dirname(DB_PATH);
+  if (!fs.existsSync(dbDir)) {
+    fs.mkdirSync(dbDir, { recursive: true });
+    console.log(`Created database directory: ${dbDir}`);
+  }
+}
 
 // Create database connection
 const db = new Database(DB_PATH);
-console.log('Connected to SQLite database');
+console.log(`Connected to SQLite database at: ${DB_PATH}`);
 
 // Initialize database with schema
 const initializeDatabase = async () => {


### PR DESCRIPTION
## Summary

The authentication database path is now configurable via the `DATABASE_PATH` environment variable, enabling persistent data storage across container restarts and flexible deployment scenarios.

## Problem

Previously, the authentication database path was hardcoded to `server/database/auth.db`. This created issues for containerized deployments where:
- Database data was lost on container restarts
- Volume mounts couldn't be used for persistence
- No flexibility for custom storage locations

## Solution

Added support for the `DATABASE_PATH` environment variable with the following features:

### ✅ Configurable Path
The database location can now be set via environment variable:
```bash
DATABASE_PATH=/data/auth.db npm start
```

### ✅ Automatic Directory Creation
If a custom path is provided, the database directory is automatically created:
```javascript
// Automatically creates /data directory if it doesn't exist
DATABASE_PATH=/data/auth.db
```

### ✅ Backward Compatible
No changes required for existing deployments - defaults to `server/database/auth.db` when `DATABASE_PATH` is not set.

### ✅ Enhanced Logging
The actual database path is now logged on startup for easier debugging:
```
Connected to SQLite database at: /data/auth.db
```

## Usage

### Docker Deployment
```bash
docker run -d \
  -e DATABASE_PATH=/data/auth.db \
  -v claude-data:/data \
  -p 3001:3001 \
  your-image
```

### Docker Compose
```yaml
services:
  claude-code-ui:
    environment:
      - DATABASE_PATH=/data/auth.db
    volumes:
      - claude-data:/data
```

### Local Development
Add to `.env` file:
```bash
DATABASE_PATH=/var/lib/claude-ui/auth.db
```

## Testing

All functionality has been thoroughly tested:
- ✅ Default path behavior (backward compatibility)
- ✅ Custom path configuration
- ✅ Directory auto-creation
- ✅ Authentication flow (user creation, login, password verification)
- ✅ Database persistence

## Files Changed

- `server/database/db.js` - Added environment variable support and directory creation logic
- `.env.example` - Documented the new `DATABASE_PATH` variable with examples

## Migration Guide

For existing deployments: No changes needed.

For container deployments wanting persistence:
1. Set `DATABASE_PATH` environment variable
2. Mount a volume at the database directory
3. Restart the container

The database will be created at the new location on first startup.

<!-- START COPILOT CODING AGENT SUFFIX -->



<details>

<summary>Original prompt</summary>

> Make the authentication database (and any other databases that should be persisted across container restarts) path configurable with an environment variable instead of hardcoding to live in the database directory.


</details>
