### PR TITLE
feat: add Docker deployment support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -41,6 +41,6 @@ Thumbs.db
 .travis.yml
 
 # Docker
-Dockerfile*
-docker-compose*
-.dockerignore
+#Dockerfile*
+#docker-compose*
+#.dockerignore

--- a/Dockerfile
+++ b/Dockerfile
@@ -64,9 +64,5 @@ ENV NODE_ENV=production \
 # Expose port
 EXPOSE 3001
 
-# Health check
-HEALTHCHECK --interval=30s --timeout=10s --start-period=40s --retries=3 \
-    CMD node -e "require('http').get('http://localhost:3001/api/health', (r) => {process.exit(r.statusCode === 200 ? 0 : 1)})"
-
 # Start server
 CMD ["node", "server/index.js"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,11 +6,10 @@ networks:
 
 services:
   claudecodeui:
-    container_name: claudecodeui
     build:
       context: .
       dockerfile: Dockerfile
-    image: claudecodeui:latest
+        # image: claudecodeui:latest
     restart: unless-stopped
     ports:
       - "${EXTERNAL_PORT:-3002}:3001"
@@ -24,14 +23,14 @@ services:
       - CLAUDE_CLI_PATH=${CLAUDE_CLI_PATH:-claude}
       - NODE_ENV=production
     volumes:
-      # Data persistence
+      # sadly these paths must be hardcoded (no we cannot use $HOME) because claude code uses
+      # hardcoded absolute paths in the ../node/.claude file and Docker must have identical full ones
+      #- /home/faris/Projects/:/home/faris/Projects/
+      - ${HOME}/Projects/:${HOME}/Projects/
+#      - /mnt/d2/Projects/:/mnt/d2/Projects/
+      - ${HOME}/.claude:/home/node/.claude:rw
       - claudecodeui-data:/data
       - claudecodeui-config:/config
-      # Mount user's .claude directory for project access (read-only)
-      - ${HOME}/.claude:/home/node/.claude:ro
-      # Mount user's home for project access (optional, configure as needed)
-      # Uncomment and adjust if you need access to specific project directories
-      # - ${HOME}/projects:/projects:rw
     networks:
       - claudecodeui
       - public
@@ -41,19 +40,10 @@ services:
       timeout: 10s
       retries: 3
       start_period: 40s
-    labels:
-      - "traefik.enable=true"
-      - "traefik.http.routers.claudecodeui.rule=Host(`claudecodeui.fhijazi.com`)"
-      - "traefik.http.routers.claudecodeui.entrypoints=web"
-      - "traefik.http.services.claudecodeui.loadbalancer.server.port=3001"
-      - "traefik.http.routers.claudecodeui.middlewares=common-headers@file"
-      # WebSocket support
-      - "traefik.http.routers.claudecodeui-ws.rule=Host(`claudecodeui.fhijazi.com`) && PathPrefix(`/ws`)"
-      - "traefik.http.routers.claudecodeui-ws.entrypoints=web"
-      - "traefik.http.services.claudecodeui-ws.loadbalancer.server.port=3001"
 
 volumes:
   claudecodeui-data:
     name: claudecodeui_data
   claudecodeui-config:
     name: claudecodeui_config
+


### PR DESCRIPTION
Add production-ready Docker deployment with the following features:

- **Multi-stage Dockerfile**: Optimized build with separate builder and production stages
- **Docker Compose**: Full orchestration with Traefik integration for automatic routing
- **Security**: Runs as non-root user (node:node) with minimal runtime dependencies
- **Health Checks**: Built-in health monitoring every 30 seconds
- **Volume Persistence**: Separate volumes for data and configuration
- **Network Isolation**: Dedicated network with Traefik integration via public network
- **LinuxServer.io Standards**: Follows container best practices for production deployment

Configuration:
- Internal port: 3001
- External port: 3002 (configurable via EXTERNAL_PORT env var)
- Traefik labels for automatic routing to claudecodeui.fhijazi.com
- WebSocket support for real-time communication
- Read-only mount of ~/.claude for project discovery

Build and deployment tested successfully with health checks passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added containerization with optimized multi-stage image builds for smaller, production-ready artifacts.
  * Added orchestration configuration for easy local and production deployment with networks, persistent volumes, environment-driven settings, and health checks.
  * Added build-context ignore rules to reduce image size and exclude development artifacts.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->