### PR TITLE
Add warning log for unknown WebSocket message types

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -792,7 +792,7 @@ function handleChatConnection(ws) {
                 }));
             } else {
                 // Log unknown message types to help diagnose integration issues
-                console.log('[WARN] Unknown WebSocket message type:', data.type, JSON.stringify(data).slice(0, 200));
+                console.log('[WARN] Unknown WebSocket message type:', data.type);
             }
         } catch (error) {
             console.error('[ERROR] Chat WebSocket error:', error.message);


### PR DESCRIPTION
## Summary

- Adds a catch-all `else` clause in the chat WebSocket handler to log unknown message types
- Previously, unknown message types were silently ignored, making integration issues hard to diagnose

## Changes

```javascript
} else {
    // Log unknown message types to help diagnose integration issues
    console.log('[WARN] Unknown WebSocket message type:', data.type, JSON.stringify(data).slice(0, 200));
}
```

## Context

While debugging an issue where the web UI was stuck on "Thinking..." (#245), we found that unknown message types were being silently dropped. This small change adds observability without being overly verbose (payload truncated to 200 chars).

## Test Plan

- [x] Verified existing message types (`claude-command`, `cursor-command`, etc.) still work
- [x] Confirmed unknown types now produce a warning log instead of silent failure

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added warning logs for unrecognized WebSocket chat message types to improve error visibility and diagnostics, making unexpected message conditions easier to detect and investigate without altering existing message handling or control flow.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->