### PR TITLE
fix: apply originalPath config to auto-detected projects

### DIFF
--- a/server/projects.js
+++ b/server/projects.js
@@ -266,8 +266,16 @@ async function extractProjectDirectory(projectName) {
   if (projectDirectoryCache.has(projectName)) {
     return projectDirectoryCache.get(projectName);
   }
-  
-  
+
+  // Check if originalPath is configured in project-config.json
+  // This allows users to override the auto-detected path
+  const config = await loadProjectConfig();
+  if (config[projectName]?.originalPath) {
+    const customPath = config[projectName].originalPath;
+    projectDirectoryCache.set(projectName, customPath);
+    return customPath;
+  }
+
   const projectDir = path.join(process.env.HOME, '.claude', 'projects', projectName);
   const cwdCounts = new Map();
   let latestTimestamp = 0;


### PR DESCRIPTION
## Summary

- Fix `originalPath` setting in `project-config.json` being ignored for auto-detected projects

## Problem

The `originalPath` setting was only being used for manually added projects (those with `manuallyAdded` flag). Auto-detected projects in `~/.claude/projects/` were ignoring this setting entirely.

This caused issues when users worked in subdirectories. For example:
- User has a project at `/Users/name/Projects/myproject`
- User runs Claude Code in `/Users/name/Projects/myproject/subdir`
- The UI incorrectly shows `/Projects/myproject/subdir` as the project path
- Even after setting `originalPath` in config, the subdirectory path is still displayed

## Solution

Modified `extractProjectDirectory()` to check for `originalPath` in the config before falling back to session-based detection.

Users can now override the auto-detected path by setting `originalPath` in `~/.claude/project-config.json`:

```json
{
  "-Users-name-Projects-myproject": {
    "displayName": "My Project",
    "originalPath": "/Users/name/Projects/myproject"
  }
}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Project paths can now be customized in project-config.json, allowing users to override automatic path detection with a configured originalPath.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->