### PR TITLE
Fix: surface image upload error details

### DIFF
--- a/src/components/ChatInterface.jsx
+++ b/src/components/ChatInterface.jsx
@@ -3956,7 +3956,15 @@ function ChatInterface({ selectedProject, selectedSession, ws, sendMessage, mess
         });
         
         if (!response.ok) {
-          throw new Error('Failed to upload images');
+          let errorDetails = `HTTP ${response.status}${response.statusText ? ` ${response.statusText}` : ''}`;
+          try {
+            const errorBody = await response.json();
+            if (errorBody?.error) errorDetails = errorBody.error;
+            else if (errorBody?.message) errorDetails = errorBody.message;
+          } catch (_) {
+            // Ignore JSON parse errors and keep the HTTP fallback
+          }
+          throw new Error(errorDetails);
         }
         
         const result = await response.json();


### PR DESCRIPTION
### Problem
When the image upload endpoint returns a non-2xx response, the UI currently throws a generic error (`Failed to upload images`) and then displays `Failed to upload images: Failed to upload images`, which hides the actual server-side error and HTTP status.

### Fix
- When `response.ok` is false, attempt to parse `{ error }` / `{ message }` from the JSON response and surface it in the thrown Error.
- Fallback to `HTTP <status> <statusText>` when JSON parsing fails.

This makes troubleshooting (401/403 auth, multer validation, etc.) much easier.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messages for image upload failures, now providing more detailed feedback including HTTP status information and server-provided error details to help users understand what went wrong.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->