### PR TITLE
feat: add filter to show only currently running sessions

### DIFF
--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -44,7 +44,12 @@ export const api = {
 
   // Protected endpoints
   // config endpoint removed - no longer needed (frontend uses window.location)
-  projects: () => authenticatedFetch('/api/projects'),
+  projects: (options = {}) => {
+    const params = new URLSearchParams();
+    if (options.running) params.append('running', 'true');
+    const queryString = params.toString();
+    return authenticatedFetch(`/api/projects${queryString ? `?${queryString}` : ''}`);
+  },
   sessions: (projectName, limit = 5, offset = 0) => 
     authenticatedFetch(`/api/projects/${projectName}/sessions?limit=${limit}&offset=${offset}`),
   sessionMessages: (projectName, sessionId, limit = null, offset = 0, provider = 'claude') => {


### PR DESCRIPTION
## Summary
- Add a toggle button (lightning/Zap icon) next to the search filter that filters the project list to show only projects with actively running Claude, Cursor, or Codex sessions
- Backend supports `?running=true` query param on `/api/projects` endpoint
- Shows loading spinner and specific empty states when filter is active

## Changes
- `server/index.js`: Add `running` query param support to `/api/projects`, filters projects using existing `getActive*Sessions()` functions
- `src/components/Sidebar.jsx`: Add `showRunningOnly` state, toggle button with Zap icon, loading states, and empty state messaging
- `src/utils/api.js`: Update `projects()` to accept options object with `running` filter

## Test plan
- [x] Toggle the running filter button (should turn green when active)
- [x] Verify only projects with running sessions appear when filter is on
- [x] Verify empty state shows "No running sessions" message when no sessions are active
- [x] Verify loading spinner shows while fetching running sessions
- [x] Verify search filter still works in combination with running filter

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a "running only" filter in the sidebar to display projects with active sessions. Toggle the filter to switch between all projects and running projects, with loading indicators and empty-state messaging.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->