### PR TITLE
fix: filter VCS directories (.git, .svn, .hg) from file autocomplete

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -1637,10 +1637,13 @@ async function getFileTree(dirPath, maxDepth = 3, currentDepth = 0, showHidden =
             // Debug: log all entries including hidden files
 
 
-            // Skip only heavy build directories
+            // Skip heavy build directories and VCS directories
             if (entry.name === 'node_modules' ||
                 entry.name === 'dist' ||
-                entry.name === 'build') continue;
+                entry.name === 'build' ||
+                entry.name === '.git' ||
+                entry.name === '.svn' ||
+                entry.name === '.hg') continue;
 
             const itemPath = path.join(dirPath, entry.name);
             const item = {


### PR DESCRIPTION
## Summary

Filters out version control system directories from the file tree, preventing VCS internal files from appearing in the `@` file autocomplete dropdown.

## Changes

Updated `getFileTree()` in `server/index.js` to skip:
- `.git/` - Git repository internals
- `.svn/` - Subversion repository internals  
- `.hg/` - Mercurial repository internals

These are added alongside the existing filters for `node_modules`, `dist`, and `build`.

## Why server-side?

The fix is applied server-side rather than client-side because:
1. Reduces data transferred over the network
2. Benefits all features using `getFileTree()`, not just autocomplete
3. Single point of change for consistent filtering

## Before/After

**Before**: Typing `@` shows files like `.git/config`, `.git/HEAD`, `.git/objects/...`

**After**: VCS internals are filtered out, showing only project source files

Fixes #290

🤖 Generated with [Claude Code](https://claude.ai/code)