### PR TITLE
Fix message flash/disappear on send

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -209,7 +209,10 @@ function AppContent() {
 
             // Check if this is the currently-selected session
             if (changedSessionId === selectedSession.id) {
-              const isSessionActive = activeSessions.has(selectedSession.id);
+              // Check for active session: either the exact session ID or any temporary new-session-* ID
+              // This prevents race conditions where activeSessions hasn't been updated yet
+              const isSessionActive = activeSessions.has(selectedSession.id) ||
+                Array.from(activeSessions).some(id => id.startsWith('new-session-'));
 
               if (!isSessionActive) {
                 // Session is not active - safe to reload messages

--- a/src/components/ChatInterface.jsx
+++ b/src/components/ChatInterface.jsx
@@ -3181,11 +3181,12 @@ function ChatInterface({ selectedProject, selectedSession, ws, sendMessage, mess
   }, [selectedSession?.id]);
 
   // Update chatMessages when convertedMessages changes
+  // Skip during active sessions to preserve optimistic UI updates
   useEffect(() => {
-    if (sessionMessages.length > 0) {
+    if (sessionMessages.length > 0 && !isLoading) {
       setChatMessages(convertedMessages);
     }
-  }, [convertedMessages, sessionMessages]);
+  }, [convertedMessages, sessionMessages, isLoading]);
 
   // Notify parent when input focus changes
   useEffect(() => {


### PR DESCRIPTION
## Description
Fixes a race condition where user messages would briefly disappear then reappear when sending new messages.

## Root Cause
The issue was caused by two independent code paths that could overwrite optimistic UI updates:

1. **App.jsx (line 189)**: The file watcher checked `activeSessions.has(selectedSession.id)` but didn't account for temporary `new-session-*` IDs. This caused `externalMessageUpdate` to be incremented prematurely, triggering a message reload.

2. **ChatInterface.jsx (line 3139)**: The useEffect syncing `chatMessages` with `convertedMessages` ran even during `isLoading`, overwriting optimistic UI updates before the server responded.

## Changes

### App.jsx
- Added check for temporary session IDs in active session detection
- Prevents race condition where `activeSessions` hasn't been updated yet with the real session ID

### ChatInterface.jsx  
- Added `!isLoading` condition to the chatMessages sync useEffect
- Preserves optimistic UI updates during active message sending

## Testing
✅ Tested: Messages now stay visible during the entire send/response cycle without flashing

## Why Both Fixes Are Needed
- The App.jsx fix prevents `externalMessageUpdate` from triggering the useEffect at line 3102, which calls `setChatMessages(converted)` directly (bypassing `isLoading` protection)
- The ChatInterface.jsx fix protects the useEffect at line 3138 that syncs via `convertedMessages`

Without both fixes, messages can still flash via the unprotected code path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Treats newly created/in-flight sessions as active to avoid race-condition updates that could trigger unnecessary reloads.
  * Prevents converted messages from overwriting the optimistic chat UI while data is loading, preserving in-progress message state.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->