### PR TITLE
Fix duplicate project when adding existing workspace

### DIFF
--- a/server/projects.js
+++ b/server/projects.js
@@ -1095,7 +1095,7 @@ async function addProjectManually(projectPath, displayName = null) {
   }
 
   // Generate project name (encode path for use as directory name)
-  const projectName = absolutePath.replace(/\//g, '-');
+  const projectName = absolutePath.replace(/[\\/:\s~_]/g, '-');
 
   // Check if project already exists in config
   const config = await loadProjectConfig();


### PR DESCRIPTION
## Summary
- Replace `_` with `-` in project name generation to match Claude's naming convention
- Add check to prevent adding a project if its directory already exists in `.claude/projects/`

Fixes issue where adding an existing workspace via the wizard would create a duplicate project entry.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Manual project additions now validate that the target project directory does not already exist to prevent accidental conflicts.

* **Refactor**
  * Standardized how manual project directory names are derived by normalizing additional path separators to ensure consistent naming and directory construction.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->