### PR TITLE
fix: hide session badge and icon on hover to show action buttons

### DIFF
--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -1166,11 +1166,11 @@ function Sidebar({
                                         {formatTimeAgo(sessionTime, currentTime)}
                                       </span>
                                       {messageCount > 0 && (
-                                        <Badge variant="secondary" className="text-xs px-1 py-0 ml-auto">
+                                        <Badge variant="secondary" className="text-xs px-1 py-0 ml-auto group-hover:opacity-0 transition-opacity">
                                           {messageCount}
                                         </Badge>
                                       )}
-                                      <span className="ml-1 opacity-70">
+                                      <span className="ml-1 opacity-70 group-hover:opacity-0 transition-opacity">
                                         {isCursorSession ? (
                                           <CursorLogo className="w-3 h-3" />
                                         ) : isCodexSession ? (


### PR DESCRIPTION
## Summary
- Hide the message count badge and provider icon when hovering over a session
- Prevents overlap with the edit/delete action buttons for better readability

before
<img width="232" height="78" alt="image" src="https://github.com/user-attachments/assets/64c2cde4-b3ea-48fd-86b2-5427b23f002d" />
after
<img width="153" height="79" alt="image" src="https://github.com/user-attachments/assets/fac05989-11e0-445a-94c6-5355d5add01e" />
