### PR TITLE
fix(codex): improve session discovery and diagnostics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -95,6 +95,10 @@ temp/
 # Vite
 .vite/
 
+# Local toolchains / installers
+.node/
+node-v*-win-*.zip
+
 # Local Netlify folder
 .netlify
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,7 +47,6 @@
         "mime-types": "^3.0.1",
         "multer": "^2.0.1",
         "node-fetch": "^2.7.0",
-        "node-pty": "^1.1.0-beta34",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-dropzone": "^14.2.3",
@@ -80,6 +79,9 @@
         "sharp": "^0.34.2",
         "tailwindcss": "^3.4.0",
         "vite": "^7.0.4"
+      },
+      "optionalDependencies": {
+        "node-pty": "^1.1.0-beta34"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -2753,20 +2755,6 @@
       "integrity": "sha512-lxV2Pako3ujjuUe9jiU3/s7KSrDfH6IgTSQOnDWr9aJ92YsFd7EurmClK0ly/t8dzMkDtd04g60WX6yl0sGfdw==",
       "cpu": [
         "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
-    },
-    "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.45.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.45.1.tgz",
-      "integrity": "sha512-M/fKi4sasCdM8i0aWJjCSFm2qEnYRR8AMLG2kxp6wD13+tMGA4Z1tVAuHkNRjud5SW2EM3naLuK35w9twvf6aA==",
-      "cpu": [
-        "x64"
       ],
       "dev": true,
       "license": "MIT",
@@ -8209,6 +8197,7 @@
       "integrity": "sha512-20JqtutY6JPXTUnL0ij1uad7Qe1baT46lyolh2sSENDd4sTzKZ4nmAFkeAARDKwmlLjPx6XKRlwRUxwjOy+lUg==",
       "hasInstallScript": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "node-addon-api": "^7.1.0"
       }
@@ -8217,7 +8206,8 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
       "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/node-releases": {
       "version": "2.0.19",
@@ -9885,6 +9875,20 @@
         "@rollup/rollup-win32-x64-msvc": "4.45.1",
         "fsevents": "~2.3.2"
       }
+    },
+    "node_modules/rollup/node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.45.1",
+      "resolved": "https://registry.npmmirror.com/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.45.1.tgz",
+      "integrity": "sha512-M/fKi4sasCdM8i0aWJjCSFm2qEnYRR8AMLG2kxp6wD13+tMGA4Z1tVAuHkNRjud5SW2EM3naLuK35w9twvf6aA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/run-applescript": {
       "version": "7.1.0",

--- a/package.json
+++ b/package.json
@@ -79,7 +79,6 @@
     "mime-types": "^3.0.1",
     "multer": "^2.0.1",
     "node-fetch": "^2.7.0",
-    "node-pty": "^1.1.0-beta34",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-dropzone": "^14.2.3",
@@ -94,6 +93,9 @@
     "sqlite3": "^5.1.7",
     "tailwind-merge": "^3.3.1",
     "ws": "^8.14.2"
+  },
+  "optionalDependencies": {
+    "node-pty": "^1.1.0-beta34"
   },
   "devDependencies": {
     "@types/react": "^18.2.43",

--- a/server/openai-codex.js
+++ b/server/openai-codex.js
@@ -177,9 +177,57 @@ function mapPermissionModeToCodexOptions(permissionMode) {
     default:
       return {
         sandboxMode: 'workspace-write',
-        approvalPolicy: 'untrusted'
+        // UI 暂未实现 Codex 的审批交互，默认避免进入“等待审批/卡住”的状态
+        approvalPolicy: 'never'
       };
   }
+}
+
+function codexErrorToPayload(error) {
+  const rawMessage = String(error?.message || 'Unknown error');
+  if (error?.code) {
+    return {
+      code: String(error.code),
+      message: String(error?.message || rawMessage),
+      details: String(error?.details || rawMessage)
+    };
+  }
+  const status = error?.status || error?.response?.status;
+
+  const lower = rawMessage.toLowerCase();
+  const looksLikeNotFound =
+    status === 404 ||
+    lower.includes('not found') ||
+    lower.includes('thread') && lower.includes('missing');
+
+  if (looksLikeNotFound) {
+    return {
+      code: 'CODEX_THREAD_NOT_FOUND',
+      message: 'Codex 会话不存在或已失效：请在侧边栏选择一个有效会话，或新建会话后重试。',
+      details: rawMessage
+    };
+  }
+
+  const looksLikeAuth =
+    status === 401 ||
+    status === 403 ||
+    lower.includes('api key') ||
+    lower.includes('unauthorized') ||
+    lower.includes('forbidden');
+
+  if (looksLikeAuth) {
+    return {
+      code: 'CODEX_AUTH_FAILED',
+      message: 'Codex 认证失败：请检查环境变量/配置（如 OPENAI_API_KEY），或确认本机已完成 Codex 登录。',
+      details: rawMessage
+    };
+  }
+
+  return {
+    code: 'CODEX_ERROR',
+    message: rawMessage,
+    details: rawMessage
+  };
 }
 
 /**
@@ -205,6 +253,16 @@ export async function queryCodex(command, options = {}, ws) {
   let currentSessionId = sessionId;
 
   try {
+    console.info('[Codex] query', {
+      projectPath,
+      cwd,
+      sessionId,
+      model,
+      permissionMode,
+      mapped: { sandboxMode, approvalPolicy },
+      workingDirectory
+    });
+
     // Initialize Codex SDK
     codex = new Codex();
 
@@ -219,7 +277,15 @@ export async function queryCodex(command, options = {}, ws) {
 
     // Start or resume thread
     if (sessionId) {
-      thread = codex.resumeThread(sessionId, threadOptions);
+      try {
+        thread = codex.resumeThread(sessionId, threadOptions);
+      } catch (resumeError) {
+        const payload = codexErrorToPayload(resumeError);
+        const err = new Error(payload.message);
+        err.code = payload.code;
+        err.details = payload.details;
+        throw err;
+      }
     } else {
       thread = codex.startThread(threadOptions);
     }
@@ -285,11 +351,14 @@ export async function queryCodex(command, options = {}, ws) {
     });
 
   } catch (error) {
-    console.error('[Codex] Error:', error);
+    const payload = codexErrorToPayload(error);
+    console.error('[Codex] Error:', { code: payload.code, message: payload.message, details: payload.details });
 
     sendMessage(ws, {
       type: 'codex-error',
-      error: error.message,
+      error: payload.message,
+      code: payload.code,
+      details: payload.details,
       sessionId: currentSessionId
     });
 

--- a/server/projects.js
+++ b/server/projects.js
@@ -197,6 +197,77 @@ async function detectTaskMasterFolder(projectPath) {
 // Cache for extracted project directories
 const projectDirectoryCache = new Map();
 
+// Codex sessions scan cache (避免每个 project 重复全盘扫描 ~/.codex/sessions)
+const codexSessionsScanCache = {
+  scannedAt: 0,
+  ttlMs: 15 * 1000,
+  sessions: null
+};
+
+function encodeProjectNameFromPath(absolutePath) {
+  return String(absolutePath).replace(/[:/\\]/g, '-');
+}
+
+async function scanAllCodexSessionsFiles(codexSessionsDir) {
+  const findJsonlFiles = async (dir) => {
+    const files = [];
+    try {
+      const entries = await fs.readdir(dir, { withFileTypes: true });
+      for (const entry of entries) {
+        const fullPath = path.join(dir, entry.name);
+        if (entry.isDirectory()) {
+          files.push(...await findJsonlFiles(fullPath));
+        } else if (entry.name.endsWith('.jsonl')) {
+          files.push(fullPath);
+        }
+      }
+    } catch {}
+    return files;
+  };
+
+  const jsonlFiles = await findJsonlFiles(codexSessionsDir);
+  const all = [];
+
+  for (const filePath of jsonlFiles) {
+    try {
+      const sessionData = await parseCodexSessionFile(filePath);
+      if (!sessionData) continue;
+      all.push({
+        id: sessionData.id,
+        summary: sessionData.summary || 'Codex Session',
+        messageCount: sessionData.messageCount || 0,
+        lastActivity: sessionData.timestamp ? new Date(sessionData.timestamp) : new Date(),
+        cwd: sessionData.cwd,
+        model: sessionData.model,
+        filePath: filePath,
+        provider: 'codex'
+      });
+    } catch (error) {
+      console.warn(`Could not parse Codex session file ${filePath}:`, error.message);
+    }
+  }
+
+  all.sort((a, b) => new Date(b.lastActivity) - new Date(a.lastActivity));
+  return all;
+}
+
+async function refreshCodexSessionsScanCache() {
+  const codexSessionsDir = path.join(os.homedir(), '.codex', 'sessions');
+  try {
+    await fs.access(codexSessionsDir);
+  } catch {
+    codexSessionsScanCache.sessions = [];
+    codexSessionsScanCache.scannedAt = Date.now();
+    return;
+  }
+
+  const now = Date.now();
+  if (!codexSessionsScanCache.sessions || now - codexSessionsScanCache.scannedAt > codexSessionsScanCache.ttlMs) {
+    codexSessionsScanCache.sessions = await scanAllCodexSessionsFiles(codexSessionsDir);
+    codexSessionsScanCache.scannedAt = now;
+  }
+}
+
 // Clear cache when needed (called when project files change)
 function clearProjectDirectoryCache() {
   projectDirectoryCache.clear();
@@ -381,7 +452,7 @@ async function extractProjectDirectory(projectName) {
 
 async function getProjects(progressCallback = null) {
   const claudeDir = path.join(os.homedir(), '.claude', 'projects');
-  const config = await loadProjectConfig();
+  let config = await loadProjectConfig();
   const projects = [];
   const existingProjects = new Set();
   let totalProjects = 0;
@@ -1064,7 +1135,7 @@ async function addProjectManually(projectPath, displayName = null) {
   }
   
   // Generate project name (encode path for use as directory name)
-  const projectName = absolutePath.replace(/\//g, '-');
+  const projectName = encodeProjectNameFromPath(absolutePath);
   
   // Check if project already exists in config
   const config = await loadProjectConfig();
@@ -1097,7 +1168,8 @@ async function addProjectManually(projectPath, displayName = null) {
     displayName: displayName || await generateDisplayName(projectName, absolutePath),
     isManuallyAdded: true,
     sessions: [],
-    cursorSessions: []
+    cursorSessions: [],
+    codexSessions: []
   };
 }
 
@@ -1227,60 +1299,104 @@ async function getCodexSessions(projectPath) {
       return [];
     }
 
-    // Recursively find all .jsonl files in the sessions directory
-    const findJsonlFiles = async (dir) => {
-      const files = [];
-      try {
-        const entries = await fs.readdir(dir, { withFileTypes: true });
-        for (const entry of entries) {
-          const fullPath = path.join(dir, entry.name);
-          if (entry.isDirectory()) {
-            files.push(...await findJsonlFiles(fullPath));
-          } else if (entry.name.endsWith('.jsonl')) {
-            files.push(fullPath);
-          }
-        }
-      } catch (error) {
-        // Skip directories we can't read
+    await refreshCodexSessionsScanCache();
+
+    const isWindows = process.platform === 'win32';
+
+    const stripWindowsLongPathPrefix = (value) => {
+      if (!value || typeof value !== 'string') return value;
+      if (!isWindows) return value;
+      if (!value.startsWith('\\\\?\\')) return value;
+      const rest = value.slice(4);
+      if (rest.toUpperCase().startsWith('UNC\\')) {
+        return '\\\\' + rest.slice(4);
       }
-      return files;
+      return rest;
     };
 
-    const jsonlFiles = await findJsonlFiles(codexSessionsDir);
+    const trimTrailingSeparator = (value) => {
+      if (!value || typeof value !== 'string') return value;
+      const root = path.parse(value).root;
+      let out = value;
+      while (out.length > root.length && (out.endsWith('/') || out.endsWith('\\'))) {
+        out = out.slice(0, -1);
+      }
+      return out;
+    };
 
-    // Process each file to find sessions matching the project path
-    for (const filePath of jsonlFiles) {
+    const normalizeComparablePath = (value) => {
+      if (!value || typeof value !== 'string') return null;
+      const stripped = stripWindowsLongPathPrefix(value);
+      const normalized = trimTrailingSeparator(path.normalize(stripped));
+      const absolute = path.isAbsolute(normalized) ? normalized : path.resolve(normalized);
+      const comparable = isWindows ? absolute.toLowerCase() : absolute;
+      return trimTrailingSeparator(comparable);
+    };
+
+    const getPathCandidates = async (value) => {
+      const candidates = new Set();
+      const base = normalizeComparablePath(value);
+      if (base) candidates.add(base);
+
+      // Best-effort symlink/realpath normalization when the path exists.
       try {
-        const sessionData = await parseCodexSessionFile(filePath);
-
-        // Check if this session matches the project path
-        // Handle Windows long paths with \\?\ prefix
-        const sessionCwd = sessionData?.cwd || '';
-        const cleanSessionCwd = sessionCwd.startsWith('\\\\?\\') ? sessionCwd.slice(4) : sessionCwd;
-        const cleanProjectPath = projectPath.startsWith('\\\\?\\') ? projectPath.slice(4) : projectPath;
-
-        if (sessionData && (sessionData.cwd === projectPath || cleanSessionCwd === cleanProjectPath || path.relative(cleanSessionCwd, cleanProjectPath) === '')) {
-          sessions.push({
-            id: sessionData.id,
-            summary: sessionData.summary || 'Codex Session',
-            messageCount: sessionData.messageCount || 0,
-            lastActivity: sessionData.timestamp ? new Date(sessionData.timestamp) : new Date(),
-            cwd: sessionData.cwd,
-            model: sessionData.model,
-            filePath: filePath,
-            provider: 'codex'
-          });
+        if (base) {
+          const real = await fs.realpath(base);
+          const realNorm = normalizeComparablePath(real);
+          if (realNorm) candidates.add(realNorm);
         }
-      } catch (error) {
-        console.warn(`Could not parse Codex session file ${filePath}:`, error.message);
+      } catch {
+        // ignore
+      }
+
+      return [...candidates];
+    };
+
+    const isPathWithin = (child, parent) => {
+      try {
+        const rel = path.relative(parent, child);
+        if (rel === '') return true;
+        if (rel.startsWith('..')) return false;
+        if (path.isAbsolute(rel)) return false;
+        return true;
+      } catch {
+        return false;
+      }
+    };
+
+    const projectCandidates = await getPathCandidates(projectPath);
+    const sessionCandidateCache = new Map();
+
+    const getCachedSessionCandidates = async (sessionCwd) => {
+      const key = String(sessionCwd || '');
+      if (sessionCandidateCache.has(key)) return sessionCandidateCache.get(key);
+      const candidates = await getPathCandidates(sessionCwd);
+      sessionCandidateCache.set(key, candidates);
+      return candidates;
+    };
+
+    const sessionBelongsToProject = async (sessionCwd) => {
+      const sessionCandidates = await getCachedSessionCandidates(sessionCwd);
+
+      for (const sc of sessionCandidates) {
+        for (const pc of projectCandidates) {
+          if (sc === pc) return true;
+          // Primary requirement: session created in project root OR any subdirectory.
+          if (isPathWithin(sc, pc)) return true;
+        }
+      }
+
+      return false;
+    };
+
+    // Filter cached sessions by project path
+    for (const session of codexSessionsScanCache.sessions || []) {
+      if (await sessionBelongsToProject(session.cwd || '')) {
+        sessions.push(session);
       }
     }
 
-    // Sort sessions by last activity (newest first)
-    sessions.sort((a, b) => new Date(b.lastActivity) - new Date(a.lastActivity));
-
-    // Return only the first 5 sessions for performance
-    return sessions.slice(0, 5);
+    return sessions;
 
   } catch (error) {
     console.error('Error fetching Codex sessions:', error);
@@ -1456,6 +1572,25 @@ async function getCodexSessionMessages(sessionId, limit = null, offset = 0) {
             }
           }
 
+          // Extract user messages from event_msg (Codex JSONL 常见格式)
+          if (entry.type === 'event_msg' && entry.payload?.type === 'user_message') {
+            const textContent = entry.payload?.message;
+            if (typeof textContent === 'string' && textContent.trim()) {
+              // Skip system context messages (environment_context)
+              if (textContent.includes('<environment_context>')) {
+                continue;
+              }
+              messages.push({
+                type: 'user',
+                timestamp: entry.timestamp,
+                message: {
+                  role: 'user',
+                  content: textContent
+                }
+              });
+            }
+          }
+
           if (entry.type === 'response_item' && entry.payload?.type === 'reasoning') {
             const summaryText = entry.payload.summary
               ?.map(s => s.text)
@@ -1568,13 +1703,29 @@ async function getCodexSessionMessages(sessionId, limit = null, offset = 0) {
     // Sort by timestamp
     messages.sort((a, b) => new Date(a.timestamp || 0) - new Date(b.timestamp || 0));
 
-    const total = messages.length;
+    // Best-effort de-duplication (某些日志会同时记录 event_msg 与 response_item)
+    const deduped = [];
+    const seen = new Set();
+    for (const m of messages) {
+      const role = m?.message?.role || m.type || '';
+      const content = typeof m?.message?.content === 'string' ? m.message.content : (m.output || '');
+      const toolCallId = m?.toolCallId || m?.message?.toolCallId || '';
+      const toolName = m?.toolName || m?.message?.toolName || '';
+      const toolOutputRaw = m?.output || m?.message?.output || '';
+      const toolOutput = typeof toolOutputRaw === 'string' ? toolOutputRaw.slice(0, 200) : String(toolOutputRaw || '').slice(0, 200);
+      const key = `${m.timestamp || ''}::${role}::${content}::${toolCallId}::${toolName}::${toolOutput}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      deduped.push(m);
+    }
+
+    const total = deduped.length;
 
     // Apply pagination if limit is specified
     if (limit !== null) {
       const startIndex = Math.max(0, total - offset - limit);
       const endIndex = total - offset;
-      const paginatedMessages = messages.slice(startIndex, endIndex);
+      const paginatedMessages = deduped.slice(startIndex, endIndex);
       const hasMore = startIndex > 0;
 
       return {
@@ -1587,7 +1738,7 @@ async function getCodexSessionMessages(sessionId, limit = null, offset = 0) {
       };
     }
 
-    return { messages, tokenUsage };
+    return { messages: deduped, tokenUsage };
 
   } catch (error) {
     console.error(`Error reading Codex session messages for ${sessionId}:`, error);

--- a/src/i18n/locales/en/settings.json
+++ b/src/i18n/locales/en/settings.json
@@ -354,7 +354,7 @@
       },
       "technicalDetails": "Technical details",
       "technicalInfo": {
-        "default": "sandboxMode=workspace-write, approvalPolicy=untrusted. Trusted commands: cat, cd, grep, head, ls, pwd, tail, git status/log/diff/show, find (without -exec), etc.",
+        "default": "sandboxMode=workspace-write, approvalPolicy=never. Trusted commands: cat, cd, grep, head, ls, pwd, tail, git status/log/diff/show, find (without -exec), etc.",
         "acceptEdits": "sandboxMode=workspace-write, approvalPolicy=never. All commands auto-execute within project directory.",
         "bypassPermissions": "sandboxMode=danger-full-access, approvalPolicy=never. Full system access, use only in trusted environments.",
         "overrideNote": "You can override this per-session using the mode button in the chat interface."

--- a/src/i18n/locales/zh-CN/settings.json
+++ b/src/i18n/locales/zh-CN/settings.json
@@ -354,7 +354,7 @@
       },
       "technicalDetails": "技术详情",
       "technicalInfo": {
-        "default": "sandboxMode=workspace-write, approvalPolicy=untrusted。受信任的命令：cat、cd、grep、head、ls、pwd、tail、git status/log/diff/show、find（不带 -exec）等。",
+        "default": "sandboxMode=workspace-write, approvalPolicy=never。受信任的命令：cat、cd、grep、head、ls、pwd、tail、git status/log/diff/show、find（不带 -exec）等。",
         "acceptEdits": "sandboxMode=workspace-write, approvalPolicy=never。所有命令在项目目录内自动执行。",
         "bypassPermissions": "sandboxMode=danger-full-access, approvalPolicy=never。完全系统访问权限，仅在可信环境中使用。",
         "overrideNote": "您可以使用聊天界面中的模式按钮按会话覆盖此设置。"


### PR DESCRIPTION
﻿## Summary

This PR improves Codex support by addressing session attribution, manual triggering reliability, and diagnostics.

## Changes

- Attribute Codex sessions to a project even when sessions are created from subdirectories (path normalization + realpath candidates)
- Prevent cross-provider session ID reuse (Codex no longer falls back to Cursor session IDs)
- Add `/api/codex/health` safeguards (Codex CLI probe timeout + cached session stats)
- Preserve existing `error.code`/`error.details` in Codex error mapping and strengthen JSONL message de-duplication
- Make `node-pty` optional and gracefully degrade terminal startup with a bilingual fallback message

## Testing

- `node --check` on modified server modules
- `npm run build`

## Notes

- This PR intentionally does not include any personal plans, local logs, or environment-specific secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Codex session health monitoring and status checks
  * Enhanced provider-specific session handling for improved session management

* **Bug Fixes**
  * Improved error messaging and handling for Codex operations with detailed error codes
  * Added graceful error handling when optional dependencies are unavailable

* **Chores**
  * Made node-pty an optional dependency
  * Updated .gitignore for development tools and local configuration
  * Changed default approval policy settings for Codex

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->