### PR TITLE
fix: pass maxThinkingTokens to SDK for extended thinking support

### DIFF
--- a/server/claude-sdk.js
+++ b/server/claude-sdk.js
@@ -201,6 +201,12 @@ function mapCliOptionsToSDK(options = {}) {
   sdkOptions.model = options.model || CLAUDE_MODELS.DEFAULT;
   console.log(`Using model: ${sdkOptions.model}`);
 
+  // Map maxThinkingTokens for extended thinking
+  if (options.maxThinkingTokens && typeof options.maxThinkingTokens === 'number') {
+    sdkOptions.maxThinkingTokens = options.maxThinkingTokens;
+    console.log(`Using maxThinkingTokens: ${sdkOptions.maxThinkingTokens}`);
+  }
+
   // Map system prompt configuration
   sdkOptions.systemPrompt = {
     type: 'preset',

--- a/src/components/ChatInterface.jsx
+++ b/src/components/ChatInterface.jsx
@@ -4266,12 +4266,9 @@ function ChatInterface({ selectedProject, selectedSession, ws, sendMessage, mess
     e.preventDefault();
     if (!input.trim() || isLoading || !selectedProject) return;
 
-    // Apply thinking mode prefix if selected
-    let messageContent = input;
+    // Get thinking mode budget tokens for extended thinking
     const selectedThinkingMode = thinkingModes.find(mode => mode.id === thinkingMode);
-    if (selectedThinkingMode && selectedThinkingMode.prefix) {
-      messageContent = `${selectedThinkingMode.prefix}: ${input}`;
-    }
+    const maxThinkingTokens = selectedThinkingMode?.budgetTokens || null;
 
     // Upload images first if any
     let uploadedImages = [];
@@ -4402,7 +4399,8 @@ function ChatInterface({ selectedProject, selectedSession, ws, sendMessage, mess
           toolsSettings: toolsSettings,
           permissionMode: permissionMode,
           model: claudeModel,
-          images: uploadedImages // Pass images to backend
+          images: uploadedImages,
+          maxThinkingTokens: maxThinkingTokens
         }
       });
     }

--- a/src/components/ThinkingModeSelector.jsx
+++ b/src/components/ThinkingModeSelector.jsx
@@ -9,6 +9,7 @@ const thinkingModes = [
     description: 'Regular Claude response',
     icon: null,
     prefix: '',
+    budgetTokens: null,
     color: 'text-gray-600'
   },
   {
@@ -17,6 +18,7 @@ const thinkingModes = [
     description: 'Basic extended thinking',
     icon: Brain,
     prefix: 'think',
+    budgetTokens: 10000,
     color: 'text-blue-600'
   },
   {
@@ -25,6 +27,7 @@ const thinkingModes = [
     description: 'More thorough evaluation',
     icon: Zap,
     prefix: 'think hard',
+    budgetTokens: 31999,
     color: 'text-purple-600'
   },
   {
@@ -33,6 +36,7 @@ const thinkingModes = [
     description: 'Deep analysis with alternatives',
     icon: Sparkles,
     prefix: 'think harder',
+    budgetTokens: 64000,
     color: 'text-indigo-600'
   },
   {
@@ -41,6 +45,7 @@ const thinkingModes = [
     description: 'Maximum thinking budget',
     icon: Atom,
     prefix: 'ultrathink',
+    budgetTokens: 128000,
     color: 'text-red-600'
   }
 ];


### PR DESCRIPTION
## Summary
- Fix Thinking Mode selector not working - extended thinking was never enabled
- Add `budgetTokens` property to each thinking mode
- Pass `maxThinkingTokens` in WebSocket options from frontend
- Map `maxThinkingTokens` in `mapCliOptionsToSDK` function on backend

## Token Budgets
| Mode | Budget Tokens |
|------|---------------|
| Standard | null (disabled) |
| Think | 10,000 |
| Think Hard | 31,999 |
| Think Harder | 64,000 |
| Ultrathink | 128,000 |

## Test plan
- [ ] Select each thinking mode and verify `maxThinkingTokens` appears in server logs
- [ ] Verify Claude's response includes thinking content with extended thinking modes

Fixes #329

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable thinking token budgets for AI reasoning with multiple tier options: 10K, 32K, 64K, and 128K tokens.

* **Refactor**
  * Streamlined thinking mode handling with improved token budget management and cleaner message processing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->