### PR TITLE
fix: enforce WORKSPACES_ROOT in folder browser and folder creation

### DIFF
--- a/server/routes/projects.js
+++ b/server/routes/projects.js
@@ -13,7 +13,7 @@ function sanitizeGitError(message, token) {
 }
 
 // Configure allowed workspace root (defaults to user's home directory)
-const WORKSPACES_ROOT = process.env.WORKSPACES_ROOT || os.homedir();
+export const WORKSPACES_ROOT = process.env.WORKSPACES_ROOT || os.homedir();
 
 // System-critical paths that should never be used as workspace directories
 export const FORBIDDEN_PATHS = [
@@ -48,7 +48,7 @@ export const FORBIDDEN_PATHS = [
  * @param {string} requestedPath - The path to validate
  * @returns {Promise<{valid: boolean, resolvedPath?: string, error?: string}>}
  */
-async function validateWorkspacePath(requestedPath) {
+export async function validateWorkspacePath(requestedPath) {
   try {
     // Resolve to absolute path
     let absolutePath = path.resolve(requestedPath);

--- a/src/components/ProjectCreationWizard.jsx
+++ b/src/components/ProjectCreationWizard.jsx
@@ -183,7 +183,7 @@ const ProjectCreationWizard = ({ onClose, onProjectCreated }) => {
       const data = await response.json();
 
       if (!response.ok) {
-        throw new Error(data.error || t('projectWizard.errors.failedToCreate'));
+        throw new Error(data.details || data.error || t('projectWizard.errors.failedToCreate'));
       }
 
       if (onProjectCreated) {


### PR DESCRIPTION
# Summary
Align folder browsing and folder creation with the same WORKSPACES_ROOT validation used by create‑workspace.
Surface backend validation details in the wizard so users see the allowed root.
# Changes
Export WORKSPACES_ROOT and validateWorkspacePath for reuse. 
Validate /api/create-folder against WORKSPACES_ROOT.
Show backend details for create‑workspace errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced workspace path handling with improved validation to ensure file operations work correctly within designated workspace directories.
  * Improved error messages when creating workspaces, now providing more detailed information about what went wrong.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->