### PR TITLE
feat: support custom Anthropic API endpoint configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,5 @@ dev-debug.log
 # Task files
 tasks.json
 tasks/ 
+pnpm-lock.yaml
+pnpm-workspace.yaml

--- a/README.md
+++ b/README.md
@@ -178,6 +178,8 @@ cp .env.example .env
 # Development mode (with hot reload)
 npm run dev
 
+# Or with custom API endpoint (e.g., for using OpenRouter, Zhipu AI, etc.)
+cross-env ANTHROPIC_BASE_URL=https://open.bigmodel.cn/api/anthropic ANTHROPIC_API_KEY=your_api_key npm run dev
 ```
 The application will start at the port you specified in your .env
 

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "@codemirror/lang-python": "^6.2.1",
     "@codemirror/merge": "^6.11.1",
     "@codemirror/theme-one-dark": "^6.1.2",
+    "@codemirror/view": "^6.39.0",
     "@iarna/toml": "^2.2.5",
     "@octokit/rest": "^22.0.0",
     "@openai/codex-sdk": "^0.75.0",

--- a/server/claude-sdk.js
+++ b/server/claude-sdk.js
@@ -152,6 +152,28 @@ function mapCliOptionsToSDK(options = {}) {
 
   const sdkOptions = {};
 
+  // Build env object for SDK with custom API configuration
+  // This allows using custom API endpoints (e.g., OpenRouter, Zhipu AI, etc.)
+  sdkOptions.env = {
+    ...process.env,
+  };
+
+  // Add custom API key if specified
+  if (process.env.ANTHROPIC_API_KEY) {
+    sdkOptions.env.ANTHROPIC_API_KEY = process.env.ANTHROPIC_API_KEY;
+  }
+
+  // Add custom base URL if specified
+  if (process.env.ANTHROPIC_BASE_URL) {
+    sdkOptions.env.ANTHROPIC_BASE_URL = process.env.ANTHROPIC_BASE_URL;
+    console.log(`Using custom ANTHROPIC_BASE_URL: ${process.env.ANTHROPIC_BASE_URL}`);
+  }
+
+  // Add other Anthropic-related environment variables
+  if (process.env.ANTHROPIC_MODEL) {
+    sdkOptions.env.ANTHROPIC_MODEL = process.env.ANTHROPIC_MODEL;
+  }
+
   // Map working directory
   if (cwd) {
     sdkOptions.cwd = cwd;


### PR DESCRIPTION
- Add support for ANTHROPIC_BASE_URL and ANTHROPIC_API_KEY env vars
- Enable using custom API endpoints like OpenRouter, Zhipu AI, etc.
- Add dev mode example in README for custom endpoint usage
- Add @codemirror/view dependency
- Add pnpm lock files to gitignore

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated development setup guide with instructions for configuring custom Anthropic API endpoint and authentication.

* **New Features**
  * Added support for custom API endpoint and authentication configuration in development environment.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->