### PR TITLE
fix: correct spelling of "claude code" and update license to GPL-3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,14 +33,14 @@
     "release": "./release.sh"
   },
   "keywords": [
-    "claude coode",
+    "claude code",
     "ai",
     "anthropic",
     "ui",
     "mobile"
   ],
   "author": "Claude Code UI Contributors",
-  "license": "MIT",
+  "license": "GPL-3.0",
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.1.29",
     "@codemirror/lang-css": "^6.3.1",


### PR DESCRIPTION
This pull request updates project metadata in the `package.json` file. The most significant changes are a correction to the keywords and a change in the project's license.

Project metadata updates:

* Fixed a typo in the `keywords` field, changing `"claude coode"` to `"claude code"` to improve searchability.
* Changed the project `license` from `MIT` to `GPL-3.0`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project license from MIT to GPL-3.0
  * Corrected project metadata with keyword fix

<!-- end of auto-generated comment: release notes by coderabbit.ai -->