### PR TITLE
fix: remove duplicate 'Loading projects...' in sidebar

### DIFF
--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -793,10 +793,6 @@ function Sidebar({
                 <div className="w-6 h-6 animate-spin rounded-full border-2 border-muted-foreground border-t-transparent" />
               </div>
               <h3 className="text-base font-medium text-foreground mb-2 md:mb-1">{t('projects.loadingProjects')}</h3>
-              <p className="text-sm text-muted-foreground">
-                {t('projects.fetchingProjects')}
-              </p>
-              <h3 className="text-base font-medium text-foreground mb-2 md:mb-1">{t('projects.loadingProjects')}</h3>
               {loadingProgress && loadingProgress.total > 0 ? (
                 <div className="space-y-2">
                   <div className="w-full bg-muted rounded-full h-2 overflow-hidden">


### PR DESCRIPTION
## Summary
- Removed a duplicate `<h3>Loading projects...</h3>` heading that appeared twice in the sidebar during project loading
- The duplicate was accidentally introduced in commit fea8e30 (i18n translation) which re-added a heading that had been replaced by the progress bar in commit 9e03acb

<img width="547" height="487" alt="image" src="https://github.com/user-attachments/assets/fcf99ba3-0d4f-4c21-b130-e3269401a55a" />
<img width="557" height="367" alt="image" src="https://github.com/user-attachments/assets/8692e084-2eba-49e8-9c5b-a675e6d93128" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Removed a duplicated heading and extra descriptive line from the Projects loading state, leaving a single loading header alongside the existing spinner and progress UI to reduce visual clutter and improve clarity during load.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->