### PR TITLE
fix: parse serialized JSON content in subagent Task results

### DIFF
--- a/src/components/chat/tools/configs/toolConfigs.ts
+++ b/src/components/chat/tools/configs/toolConfigs.ts
@@ -436,16 +436,28 @@ export const TOOL_CONFIGS: Record<string, ToolDisplayConfig> = {
       getContentProps: (result) => {
         // Handle agent results which may have complex structure
         if (result && result.content) {
+          let content = result.content;
+          // If content is a JSON string, try to parse it (agent results may arrive serialized)
+          if (typeof content === 'string') {
+            try {
+              const parsed = JSON.parse(content);
+              if (Array.isArray(parsed)) {
+                content = parsed;
+              }
+            } catch {
+              // Not JSON — use as-is
+              return { content };
+            }
+          }
           // If content is an array (typical for agent responses with multiple text blocks)
-          if (Array.isArray(result.content)) {
-            const textContent = result.content
+          if (Array.isArray(content)) {
+            const textContent = content
               .filter((item: any) => item.type === 'text')
               .map((item: any) => item.text)
               .join('\n\n');
             return { content: textContent || 'No response text' };
           }
-          // If content is already a string
-          return { content: String(result.content) };
+          return { content: String(content) };
         }
         // Fallback to string representation
         return { content: String(result || 'No response') };


### PR DESCRIPTION
## Problem

Subagent (Task/Explore) results were rendered as raw JSON in the UI:

```
[{"type":"text","text":"Perfect! Now I have a complete understanding..."}]
```

Instead of formatted markdown, users saw the raw JSON string with literal `\n` characters — making subagent output completely unreadable.

## Root Cause

The Task tool result handler in `toolConfigs.ts` checked `Array.isArray(result.content)` to detect content blocks. However, the API sometimes returns content blocks as a **serialized JSON string** rather than a parsed array. In that case the check failed and the code fell through to `String(result.content)`, rendering raw JSON as-is.

## Fix

Added `JSON.parse()` for string content before the array check — if the string parses as an array, extract text blocks from it. If it's not valid JSON, use it as a plain string. This matches the pattern already used by the `exit_plan_mode` tool handler.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced the Task tool to better handle different content input formats with improved error recovery and fallback handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->