### PR TITLE
fix: pretty-print raw params and handle escaped newlines

### DIFF
--- a/src/components/chat/tools/components/CollapsibleDisplay.tsx
+++ b/src/components/chat/tools/components/CollapsibleDisplay.tsx
@@ -67,7 +67,13 @@ export const CollapsibleDisplay: React.FC<CollapsibleDisplayProps> = ({
               raw params
             </summary>
             <pre className="mt-1 text-[11px] bg-gray-50 dark:bg-gray-900/50 border border-gray-200/40 dark:border-gray-700/40 p-2 rounded whitespace-pre-wrap break-words overflow-hidden text-gray-600 dark:text-gray-400 font-mono">
-              {rawContent}
+              {(() => {
+                try {
+                  return JSON.stringify(JSON.parse(rawContent), null, 2).replace(/\\n/g, '\n');
+                } catch {
+                  return rawContent;
+                }
+              })()}
             </pre>
           </details>
         )}

--- a/src/components/chat/tools/configs/toolConfigs.ts
+++ b/src/components/chat/tools/configs/toolConfigs.ts
@@ -425,9 +425,17 @@ export const TOOL_CONFIGS: Record<string, ToolDisplayConfig> = {
     result: {
       type: 'collapsible',
       title: (result) => {
-        // Check if result has content with type array (agent results often have this structure)
-        if (result && result.content && Array.isArray(result.content)) {
-          return 'Subagent Response';
+        if (result && result.content) {
+          let content = result.content;
+          if (typeof content === 'string') {
+            try {
+              const parsed = JSON.parse(content);
+              if (Array.isArray(parsed)) content = parsed;
+            } catch { /* not JSON */ }
+          }
+          if (Array.isArray(content)) {
+            return 'Subagent Response';
+          }
         }
         return 'Subagent Result';
       },


### PR DESCRIPTION
## Summary
- Pretty-print JSON in raw params section with proper indentation and replace escaped `\n` with actual newlines for readability
- Fix Task result `title` function to handle serialized JSON arrays consistently (applies same parse-if-string logic as `getContentProps`)

Addresses feedback from #391 review by @blackmammoth (raw params showing literal `\n` characters) and CodeRabbit suggestion for title consistency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* JSON content displayed in chat parameters is now automatically formatted with proper indentation and escaped newlines converted to readable line breaks, improving clarity
* Results from agent tasks with array-based content are now handled more robustly, with improved detection and consistent rendering of multi-part responses in markdown format

<!-- end of auto-generated comment: release notes by coderabbit.ai -->