### PR TITLE
Add optional HTTPS support for backend and Vite dev server

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,6 +21,17 @@ PORT=3001
 #Frontend port
 VITE_PORT=5173
 
+# Optional HTTPS/SSL support (backend + Vite dev server)
+# Set SSL_ENABLED=true to run backend over HTTPS.
+# Set VITE_HTTPS=true to run Vite dev server over HTTPS.
+# Provide paths to PEM files. You can use the same files for both.
+#SSL_ENABLED=false
+#VITE_HTTPS=false
+#SSL_CERT_PATH=./certs/localhost.crt
+#SSL_KEY_PATH=./certs/localhost.key
+#VITE_SSL_CERT_PATH=./certs/localhost.crt
+#VITE_SSL_KEY_PATH=./certs/localhost.key
+
 # Uncomment the following line if you have a custom claude cli path other than the default "claude"
 # CLAUDE_CLI_PATH=claude
 

--- a/README.md
+++ b/README.md
@@ -173,6 +173,25 @@ cp .env.example .env
 # Edit .env with your preferred settings
 ```
 
+Optional: **Enable HTTPS with a self-signed certificate** (for local SSL testing)
+```bash
+mkdir -p certs
+openssl req -x509 -newkey rsa:2048 -nodes \
+  -keyout certs/localhost.key \
+  -out certs/localhost.crt \
+  -days 365 \
+  -subj "/CN=localhost"
+```
+Then set the following in `.env`:
+```bash
+SSL_ENABLED=true
+VITE_HTTPS=true
+SSL_CERT_PATH=./certs/localhost.crt
+SSL_KEY_PATH=./certs/localhost.key
+VITE_SSL_CERT_PATH=./certs/localhost.crt
+VITE_SSL_KEY_PATH=./certs/localhost.key
+```
+
 4. **Start the application:**
 ```bash
 # Development mode (with hot reload)

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,23 +1,51 @@
 import { defineConfig, loadEnv } from 'vite'
 import react from '@vitejs/plugin-react'
+import fs from 'fs'
+import path from 'path'
+
+const isTruthyEnv = (value) =>
+  typeof value === 'string' && ['1', 'true', 'yes', 'on'].includes(value.toLowerCase())
 
 export default defineConfig(({ command, mode }) => {
   // Load env file based on `mode` in the current working directory.
   const env = loadEnv(mode, process.cwd(), '')
-  
-  
+
+  const httpsEnabled = isTruthyEnv(env.VITE_HTTPS) || isTruthyEnv(env.SSL_ENABLED)
+  const certPath = env.VITE_SSL_CERT_PATH || env.SSL_CERT_PATH
+  const keyPath = env.VITE_SSL_KEY_PATH || env.SSL_KEY_PATH
+
+  let httpsConfig
+  if (httpsEnabled) {
+    if (certPath && keyPath) {
+      try {
+        httpsConfig = {
+          cert: fs.readFileSync(path.resolve(certPath)),
+          key: fs.readFileSync(path.resolve(keyPath))
+        }
+      } catch (error) {
+        console.warn('[vite] HTTPS enabled but SSL cert files could not be read. Falling back to HTTP.', error?.message || error)
+      }
+    } else {
+      console.warn('[vite] HTTPS enabled but VITE_SSL_CERT_PATH/VITE_SSL_KEY_PATH (or SSL_CERT_PATH/SSL_KEY_PATH) are missing. Falling back to HTTP.')
+    }
+  }
+
+  const apiProtocol = httpsConfig ? 'https' : 'http'
+  const wsProtocol = httpsConfig ? 'wss' : 'ws'
+
   return {
     plugins: [react()],
     server: {
       port: parseInt(env.VITE_PORT) || 5173,
+      https: httpsConfig,
       proxy: {
-        '/api': `http://localhost:${env.PORT || 3001}`,
+        '/api': `${apiProtocol}://localhost:${env.PORT || 3001}`,
         '/ws': {
-          target: `ws://localhost:${env.PORT || 3001}`,
+          target: `${wsProtocol}://localhost:${env.PORT || 3001}`,
           ws: true
         },
         '/shell': {
-          target: `ws://localhost:${env.PORT || 3001}`,
+          target: `${wsProtocol}://localhost:${env.PORT || 3001}`,
           ws: true
         }
       }


### PR DESCRIPTION
## Summary
- add optional HTTPS server creation for backend via env + cert paths
- add optional HTTPS support for Vite dev server and protocol-aware proxy targets
- document HTTPS env/config in .env.example and README

## Relationship to #362
This is **not intended to compete with #362**. It is a complementary follow-up that can be folded into #362 if preferred.

PR #362 adds backend SSL fallback behavior. This PR adds related improvements for consistency:
- Vite HTTPS support using env-driven cert/key paths
- protocol-aware proxy targets (`http/ws` -> `https/wss` when enabled)
- matching docs/env guidance for local setup

If maintainers prefer, I can close this PR and provide these commits/changes to be cherry-picked directly into #362.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added HTTPS/SSL support for local development with automatic fallback to HTTP if certificates are unavailable.

* **Documentation**
  * Added setup guide for configuring HTTPS with self-signed certificates for testing.
  * Documented new environment variables for SSL configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->