### PR TITLE
Enable dual-stack IPv4/IPv6 listening for backend and Vite

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "scripts": {
     "dev": "concurrently --kill-others \"npm run server\" \"npm run client\"",
     "server": "node server/index.js",
-    "client": "vite --host",
+    "client": "vite",
     "build": "vite build",
     "preview": "vite preview",
     "typecheck": "tsc --noEmit -p tsconfig.json",

--- a/vite.config.js
+++ b/vite.config.js
@@ -9,6 +9,7 @@ export default defineConfig(({ command, mode }) => {
   return {
     plugins: [react()],
     server: {
+      host: env.VITE_HOST || '::',
       port: parseInt(env.VITE_PORT) || 5173,
       proxy: {
         '/api': `http://localhost:${env.PORT || 3001}`,


### PR DESCRIPTION
## Summary
- enable dual-stack backend listening by preferring host :: with ipv6Only: false, and fallback to 0.0.0.0 when IPv6 is unavailable
- set Vite dev server host to :: for IPv4 + IPv6 reachability
- remove the package script host override so Vite config host is respected

## Validation
- backend responds on both loopbacks:
  - http://127.0.0.1:3001 -> 302
  - http://[::1]:3001 -> 302
- Vite responds on both loopbacks:
  - http://127.0.0.1:5173 -> 200
  - http://[::1]:5173 -> 200

Related issue: #399


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved development server network binding with IPv6 support and automatic IPv4 fallback
  * Enhanced server startup logging to display actual listening host and port information
  * Updated development server configuration for better network interface handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->