### PR TITLE
feat: persist active tab across reloads via localStorage

### DIFF
--- a/src/hooks/useProjectsState.ts
+++ b/src/hooks/useProjectsState.ts
@@ -101,6 +101,20 @@ const isUpdateAdditive = (
   );
 };
 
+const VALID_TABS: Set<string> = new Set(['chat', 'files', 'shell', 'git', 'tasks', 'preview']);
+
+const readPersistedTab = (): AppTab => {
+  try {
+    const stored = localStorage.getItem('activeTab');
+    if (stored && VALID_TABS.has(stored)) {
+      return stored as AppTab;
+    }
+  } catch {
+    // localStorage unavailable
+  }
+  return 'chat';
+};
+
 export function useProjectsState({
   sessionId,
   navigate,
@@ -111,12 +125,14 @@ export function useProjectsState({
   const [projects, setProjects] = useState<Project[]>([]);
   const [selectedProject, setSelectedProject] = useState<Project | null>(null);
   const [selectedSession, setSelectedSession] = useState<ProjectSession | null>(null);
-  const [activeTab, setActiveTab] = useState<AppTab>(
-    () => (localStorage.getItem('activeTab') as AppTab) || 'chat'
-  );
+  const [activeTab, setActiveTab] = useState<AppTab>(readPersistedTab);
 
   useEffect(() => {
-    localStorage.setItem('activeTab', activeTab);
+    try {
+      localStorage.setItem('activeTab', activeTab);
+    } catch {
+      // Silently ignore storage errors
+    }
   }, [activeTab]);
 
   const [sidebarOpen, setSidebarOpen] = useState(false);


### PR DESCRIPTION
## Summary
- Persist the active tab in `localStorage` so it survives page reloads — users no longer land on Chat every time
- Remove forced tab switch to Chat on session change, so users stay on their preferred tab (Shell, Git, etc.)

Closes #387

## Changes
- `useProjectsState.ts`: Initialize `activeTab` from `localStorage` with fallback to `'chat'`
- `useProjectsState.ts`: Save `activeTab` to `localStorage` on every change via `useEffect`
- `useProjectsState.ts`: Remove `setActiveTab('chat')` calls from `selectSession` that forced tab switch on session change
- `useProjectsState.ts`: Adjust `handleSessionClick` logic — only switch to Chat from `tasks` or `preview` tabs, not from `shell`/`git`/etc.

## Test plan
- [ ] Open app, switch to Shell tab, reload page — should reopen on Shell
- [ ] Switch sessions while on Git tab — should stay on Git tab
- [ ] Click a session while on Tasks tab — should switch to Chat
- [ ] Clear localStorage, reload — should default to Chat

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tab selection is now persisted between sessions and restored on return, with safe handling if browser storage is unavailable or errors occur.

* **Bug Fixes**
  * Prevented unintended automatic tab switches during provider session updates; active tab is no longer force-reset broadly and will only revert to chat in specific flows (now only when switching from tasks or preview as appropriate).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->