### PR TITLE
Update DEFAULT model version to gpt-5.3-codex

### DIFF
--- a/shared/modelConstants.js
+++ b/shared/modelConstants.js
@@ -63,5 +63,5 @@ export const CODEX_MODELS = {
     { value: 'o4-mini', label: 'O4-mini' }
   ],
 
-  DEFAULT: 'gpt-5.2'
+  DEFAULT: 'gpt-5.3-codex'
 };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the default Codex model version from 5.2 to 5.3-codex, affecting the initial model selection when using the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->