### PR TITLE
Skip <INSTRUCTIONS> blocks (e.g. AGENTS.md) when rendering Codex sessions

### DIFF
--- a/server/projects.js
+++ b/server/projects.js
@@ -1617,6 +1617,11 @@ async function getCodexSessionMessages(sessionId, limit = null, offset = 0) {
               continue;
             }
 
+            // Skip AGENTS.md and other instruction blocks
+            if (textContent?.includes('<INSTRUCTIONS>')) {
+              continue;
+            }
+
             // Only add if there's actual content
             if (textContent?.trim()) {
               messages.push({


### PR DESCRIPTION
Fixes: https://github.com/siteboon/claudecodeui/issues/428

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed an issue where instruction-related content was being incorrectly included in session message timelines. Previously, instruction blocks were appearing alongside actual conversation messages in session histories. With this update, message timelines now properly filter out system instructions and contain only relevant conversation content, improving the clarity and accuracy of session records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->