### PR TITLE
fix: allow Codex input while a session is running

### DIFF
--- a/src/components/chat/hooks/useChatProviderState.ts
+++ b/src/components/chat/hooks/useChatProviderState.ts
@@ -8,11 +8,29 @@ interface UseChatProviderStateArgs {
   selectedSession: ProjectSession | null;
 }
 
+const VALID_PROVIDERS: SessionProvider[] = ['claude', 'cursor', 'codex'];
+
+function normalizeStoredProvider(rawProvider: string | null): SessionProvider {
+  // Backward compatibility with older provider naming.
+  if (rawProvider === 'openai') {
+    return 'codex';
+  }
+
+  if (rawProvider && VALID_PROVIDERS.includes(rawProvider as SessionProvider)) {
+    return rawProvider as SessionProvider;
+  }
+
+  return 'claude';
+}
+
 export function useChatProviderState({ selectedSession }: UseChatProviderStateArgs) {
   const [permissionMode, setPermissionMode] = useState<PermissionMode>('default');
   const [pendingPermissionRequests, setPendingPermissionRequests] = useState<PendingPermissionRequest[]>([]);
   const [provider, setProvider] = useState<SessionProvider>(() => {
-    return (localStorage.getItem('selected-provider') as SessionProvider) || 'claude';
+    if (typeof window === 'undefined') {
+      return 'claude';
+    }
+    return normalizeStoredProvider(localStorage.getItem('selected-provider'));
   });
   const [cursorModel, setCursorModel] = useState<string>(() => {
     return localStorage.getItem('cursor-model') || CURSOR_MODELS.DEFAULT;

--- a/src/components/chat/view/ChatInterface.tsx
+++ b/src/components/chat/view/ChatInterface.tsx
@@ -164,6 +164,7 @@ function ChatInterface({
     handleGrantToolPermission,
     handleInputFocusChange,
     isInputFocused,
+    isCodexConversation,
   } = useChatComposerState({
     selectedProject,
     selectedSession,
@@ -322,6 +323,7 @@ function ChatInterface({
           isLoading={isLoading}
           onAbortSession={handleAbortSession}
           provider={provider}
+          isCodexConversation={isCodexConversation}
           permissionMode={permissionMode}
           onModeSwitch={cyclePermissionMode}
           thinkingMode={thinkingMode}

--- a/src/components/chat/view/subcomponents/ChatComposer.tsx
+++ b/src/components/chat/view/subcomponents/ChatComposer.tsx
@@ -45,6 +45,7 @@ interface ChatComposerProps {
   isLoading: boolean;
   onAbortSession: () => void;
   provider: Provider | string;
+  isCodexConversation: boolean;
   permissionMode: PermissionMode | string;
   onModeSwitch: () => void;
   thinkingMode: string;
@@ -102,6 +103,7 @@ export default function ChatComposer({
   isLoading,
   onAbortSession,
   provider,
+  isCodexConversation,
   permissionMode,
   onModeSwitch,
   thinkingMode,
@@ -151,6 +153,7 @@ export default function ChatComposer({
   onTranscript,
 }: ChatComposerProps) {
   const { t } = useTranslation('chat');
+  const isInputLocked = isLoading && !isCodexConversation;
   const textareaRect = textareaRef.current?.getBoundingClientRect();
   const commandMenuPosition = {
     top: textareaRect ? Math.max(16, textareaRect.top - 316) : 0,
@@ -301,7 +304,7 @@ export default function ChatComposer({
               onBlur={() => onInputFocusChange?.(false)}
               onInput={onTextareaInput}
               placeholder={placeholder}
-              disabled={isLoading}
+              disabled={isInputLocked}
               className="chat-input-placeholder block w-full pl-12 pr-20 sm:pr-40 py-1.5 sm:py-4 bg-transparent rounded-2xl focus:outline-none text-foreground placeholder-muted-foreground/50 disabled:opacity-50 resize-none min-h-[50px] sm:min-h-[80px] max-h-[40vh] sm:max-h-[300px] overflow-y-auto text-base leading-6 transition-all duration-200"
               style={{ height: '50px' }}
             />
@@ -328,7 +331,7 @@ export default function ChatComposer({
 
             <button
               type="submit"
-              disabled={!input.trim() || isLoading}
+              disabled={!input.trim() || isInputLocked}
               onMouseDown={(event) => {
                 event.preventDefault();
                 onSubmit(event);


### PR DESCRIPTION
## Summary
- allow chat input/send while Codex session is running
- avoid blocking submit when current/selected session is Codex
- reuse pending Codex session id while the first turn is still running
- normalize legacy provider value (`openai` -> `codex`) for compatibility

## Verification
- npm run typecheck

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Chat now recognizes a "Codex" conversation type and keeps input active for those interactions.

* **Bug Fixes**
  * Improved submission and session handling for more reliable message delivery and fewer stale sessions.
  * Normalized provider detection so the correct model/flow is selected consistently.
  * Optimized input field disabling behavior during loading across providers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->