### PR TITLE
fix(claude): move model usage log to result message only

### DIFF
--- a/server/claude-sdk.js
+++ b/server/claude-sdk.js
@@ -593,9 +593,6 @@ async function queryClaudeSDK(command, options = {}, ws) {
         console.log('No session_id in message or already captured. message.session_id:', message.session_id, 'capturedSessionId:', capturedSessionId);
       }
 
-      // logs which model was used in the message
-      console.log("---> Model was sent using:", Object.keys(message.modelUsage || {}));
-
       // Transform and send message to WebSocket
       const transformedMessage = transformMessage(message);
       ws.send({
@@ -606,6 +603,10 @@ async function queryClaudeSDK(command, options = {}, ws) {
 
       // Extract and send token budget updates from result messages
       if (message.type === 'result') {
+        const models = Object.keys(message.modelUsage || {});
+        if (models.length > 0) {
+          console.log("---> Model was sent using:", models);
+        }
         const tokenBudget = extractTokenBudget(message);
         if (tokenBudget) {
           console.log('Token budget from modelUsage:', tokenBudget);


### PR DESCRIPTION
## Summary
- The 'modelUsage' debug log on line 597 of 'server/claude-sdk.js' ran on every streamed SDK message, but 'modelUsage' is only populated on 'result' messages per the SDK type definitions. This produced repeated '---> Model was sent using: []' console output for every non-result message during streaming.
- Moved the log inside the existing 'if (message.type === 'result')' block so it fires once with the actual model data.

## Summary by CodeRabbit

* **Refactor**
  * Optimized debug logging by moving it to be more targeted and conditional, improving performance efficiency during result processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->