### PR TITLE
feat(chat): display system-injected messages as collapsible cards

### DIFF
--- a/src/components/chat/types/types.ts
+++ b/src/components/chat/types/types.ts
@@ -50,6 +50,7 @@ export interface ChatMessage {
   injectedType?: string;
   injectedSummary?: string;
   isTaskNotification?: boolean;
+  taskStatus?: string;
   skillName?: string;
   skillDescription?: string;
   [key: string]: unknown;

--- a/src/components/chat/types/types.ts
+++ b/src/components/chat/types/types.ts
@@ -46,6 +46,12 @@ export interface ChatMessage {
     currentToolIndex: number;
     isComplete: boolean;
   };
+  isSystemInjected?: boolean;
+  injectedType?: string;
+  injectedSummary?: string;
+  isTaskNotification?: boolean;
+  skillName?: string;
+  skillDescription?: string;
   [key: string]: unknown;
 }
 

--- a/src/components/chat/utils/messageTransforms.ts
+++ b/src/components/chat/utils/messageTransforms.ts
@@ -42,8 +42,8 @@ const toAbsolutePath = (projectPath: string, filePath?: string) => {
 };
 
 export const calculateDiff = (oldStr: string, newStr: string): DiffLine[] => {
-  const oldLines = oldStr.split('\n');
-  const newLines = newStr.split('\n');
+  const oldLines = (oldStr ?? '').split('\n');
+  const newLines = (newStr ?? '').split('\n');
 
   // Use LCS alignment so insertions/deletions don't cascade into a full-file "changed" diff.
   const lcsTable: number[][] = Array.from({ length: oldLines.length + 1 }, () =>
@@ -350,6 +350,116 @@ export const convertCursorSessionMessages = (blobs: CursorBlob[], projectPath: s
   return converted;
 };
 
+interface ClassifiedMessage {
+  injectedType: ChatMessage['injectedType'];
+  injectedSummary: string;
+  taskStatus?: string;
+}
+
+const classifyUserMessage = (content: string): ClassifiedMessage | null => {
+  // 1. <task-notification> — parse status/summary
+  const taskNotifRegex = /<task-notification>\s*<task-id>[^<]*<\/task-id>\s*(?:<tool-use-id>[^<]*<\/tool-use-id>\s*)?<output-file>[^<]*<\/output-file>\s*<status>([^<]*)<\/status>\s*<summary>([^<]*)<\/summary>\s*<\/task-notification>/;
+  const taskMatch = taskNotifRegex.exec(content);
+  if (taskMatch) {
+    return {
+      injectedType: 'task-notification',
+      injectedSummary: taskMatch[2]?.trim() || 'Background task finished',
+      taskStatus: taskMatch[1]?.trim() || 'completed',
+    };
+  }
+
+  // 2. <system-reminder> — extract first meaningful line as summary
+  if (content.startsWith('<system-reminder>')) {
+    const innerMatch = content.match(/<system-reminder>\s*\n?(.*)/s);
+    const firstLine = innerMatch?.[1]?.split('\n').find(l => l.trim())?.trim() || 'System reminder';
+    return {
+      injectedType: 'system-reminder',
+      injectedSummary: firstLine.length > 80 ? firstLine.slice(0, 77) + '...' : firstLine,
+    };
+  }
+
+  // 3. Command-related tags
+  if (content.startsWith('<command-name>')) {
+    const nameMatch = content.match(/<command-name>([^<]*)<\/command-name>/);
+    return {
+      injectedType: 'command',
+      injectedSummary: nameMatch?.[1]?.trim() || 'Command',
+    };
+  }
+  if (content.startsWith('<command-message>') || content.startsWith('<command-args>')) {
+    return {
+      injectedType: 'command',
+      injectedSummary: 'Command arguments',
+    };
+  }
+  if (content.startsWith('<local-command-stdout>') || content.startsWith('<local-command-caveat>')) {
+    return {
+      injectedType: 'command',
+      injectedSummary: 'Command output',
+    };
+  }
+
+  // 4. Hook output
+  if (content.startsWith('<user-prompt-submit-hook>') || content.includes('<user-prompt-submit-hook>')) {
+    return {
+      injectedType: 'hook',
+      injectedSummary: 'Hook output',
+    };
+  }
+
+  // 5. Background task completion results (injected by server after subagent finishes)
+  if (content.startsWith('[Background task completed]')) {
+    const agentMatch = content.match(/Agent\s+(\S+)\s+finished/);
+    const agentId = agentMatch?.[1] || '';
+    const summary = agentId ? `Agent ${agentId} completed` : 'Background task completed';
+    return {
+      injectedType: 'background-task-result',
+      injectedSummary: summary,
+    };
+  }
+
+  // 6. Session continuation / interruption / errors
+  if (content.startsWith('Caveat:')) {
+    return {
+      injectedType: 'continuation',
+      injectedSummary: content.length > 80 ? content.slice(0, 77) + '...' : content,
+    };
+  }
+  if (content.startsWith('This session is being continued from a previous') || content.startsWith('This session is a continuation')) {
+    return {
+      injectedType: 'continuation',
+      injectedSummary: 'Session continuation',
+    };
+  }
+  if (content.startsWith('[Request interrupted')) {
+    return {
+      injectedType: 'continuation',
+      injectedSummary: 'Request interrupted',
+    };
+  }
+  if (content.startsWith('Invalid API key')) {
+    return {
+      injectedType: 'other',
+      injectedSummary: 'Invalid API key',
+    };
+  }
+  if (content === 'Warmup') {
+    return {
+      injectedType: 'other',
+      injectedSummary: 'Warmup',
+    };
+  }
+  // TaskMaster system prompts (should be hidden)
+  if (content.includes('{"subtasks":') || content.includes('CRITICAL: You MUST respond with ONLY a JSON')) {
+    return {
+      injectedType: 'other',
+      injectedSummary: 'TaskMaster system prompt',
+    };
+  }
+
+  return null;
+};
+
 export const convertSessionMessages = (rawMessages: any[]): ChatMessage[] => {
   const converted: ChatMessage[] = [];
   const toolResults = new Map<
@@ -391,38 +501,53 @@ export const convertSessionMessages = (rawMessages: any[]): ChatMessage[] => {
         content = decodeHtmlEntities(String(message.message.content));
       }
 
-      const shouldSkip =
-        !content ||
-        content.startsWith('<command-name>') ||
-        content.startsWith('<command-message>') ||
-        content.startsWith('<command-args>') ||
-        content.startsWith('<local-command-stdout>') ||
-        content.startsWith('<system-reminder>') ||
-        content.startsWith('Caveat:') ||
-        content.startsWith('This session is being continued from a previous') ||
-        content.startsWith('[Request interrupted');
+      if (!content) {
+        return;
+      }
 
-      if (!shouldSkip) {
-        // Parse <task-notification> blocks into compact system messages
-        const taskNotifRegex = /<task-notification>\s*<task-id>[^<]*<\/task-id>\s*<output-file>[^<]*<\/output-file>\s*<status>([^<]*)<\/status>\s*<summary>([^<]*)<\/summary>\s*<\/task-notification>/g;
-        const taskNotifMatch = taskNotifRegex.exec(content);
-        if (taskNotifMatch) {
-          const status = taskNotifMatch[1]?.trim() || 'completed';
-          const summary = taskNotifMatch[2]?.trim() || 'Background task finished';
+      const classified = classifyUserMessage(content);
+      if (classified) {
+        // Task notifications keep existing compact pill rendering (backward compat)
+        if (classified.injectedType === 'task-notification') {
           converted.push({
             type: 'assistant',
-            content: summary,
+            content: classified.injectedSummary || content,
             timestamp: message.timestamp || new Date().toISOString(),
             isTaskNotification: true,
-            taskStatus: status,
+            taskStatus: classified.taskStatus || 'completed',
+            isSystemInjected: true,
+            injectedType: 'task-notification',
+            injectedSummary: classified.injectedSummary,
+          });
+        } else if (classified.injectedType === 'background-task-result') {
+          // Background task result: collapsible card, collapsed by default
+          const resultIdx = content.indexOf('\n\nResult:\n');
+          const resultBody = resultIdx >= 0 ? content.slice(resultIdx + '\n\nResult:\n'.length) : content;
+          converted.push({
+            type: 'assistant',
+            content: resultBody,
+            timestamp: message.timestamp || new Date().toISOString(),
+            isSystemInjected: true,
+            injectedType: 'background-task-result',
+            injectedSummary: classified.injectedSummary,
           });
         } else {
+          // All other system-injected messages: show with muted styling
           converted.push({
             type: 'user',
-            content: unescapeWithMathProtection(content),
+            content,
             timestamp: message.timestamp || new Date().toISOString(),
+            isSystemInjected: true,
+            injectedType: classified.injectedType,
+            injectedSummary: classified.injectedSummary,
           });
         }
+      } else {
+        converted.push({
+          type: 'user',
+          content: unescapeWithMathProtection(content),
+          timestamp: message.timestamp || new Date().toISOString(),
+        });
       }
       return;
     }

--- a/src/components/chat/utils/messageTransforms.ts
+++ b/src/components/chat/utils/messageTransforms.ts
@@ -400,7 +400,7 @@ const classifyUserMessage = (content: string): ClassifiedMessage | null => {
   }
 
   // 4. Hook output
-  if (content.startsWith('<user-prompt-submit-hook>') || content.includes('<user-prompt-submit-hook>')) {
+  if (content.includes('<user-prompt-submit-hook>')) {
     return {
       injectedType: 'hook',
       injectedSummary: 'Hook output',

--- a/src/components/chat/utils/messageTransforms.ts
+++ b/src/components/chat/utils/messageTransforms.ts
@@ -356,7 +356,10 @@ interface ClassifiedMessage {
   taskStatus?: string;
 }
 
-const classifyUserMessage = (content: string): ClassifiedMessage | null => {
+const classifyUserMessage = (rawContent: string): ClassifiedMessage | null => {
+  // Normalize: trim leading/trailing whitespace so startsWith checks aren't bypassed
+  const content = rawContent.trim();
+
   // 1. <task-notification> — parse status/summary
   const taskNotifRegex = /<task-notification>\s*<task-id>[^<]*<\/task-id>\s*(?:<tool-use-id>[^<]*<\/tool-use-id>\s*)?<output-file>[^<]*<\/output-file>\s*<status>([^<]*)<\/status>\s*<summary>([^<]*)<\/summary>\s*<\/task-notification>/;
   const taskMatch = taskNotifRegex.exec(content);
@@ -451,7 +454,7 @@ const classifyUserMessage = (content: string): ClassifiedMessage | null => {
   }
   // TaskMaster system prompts (should be hidden)
   // Require the JSON to appear at the start of content to avoid false positives on normal messages
-  if (content.trimStart().startsWith('{"subtasks":') || content.includes('CRITICAL: You MUST respond with ONLY a JSON')) {
+  if (content.startsWith('{"subtasks":') || content.includes('CRITICAL: You MUST respond with ONLY a JSON')) {
     return {
       injectedType: 'other',
       injectedSummary: 'TaskMaster system prompt',

--- a/src/components/chat/utils/messageTransforms.ts
+++ b/src/components/chat/utils/messageTransforms.ts
@@ -450,7 +450,8 @@ const classifyUserMessage = (content: string): ClassifiedMessage | null => {
     };
   }
   // TaskMaster system prompts (should be hidden)
-  if (content.includes('{"subtasks":') || content.includes('CRITICAL: You MUST respond with ONLY a JSON')) {
+  // Require the JSON to appear at the start of content to avoid false positives on normal messages
+  if (content.trimStart().startsWith('{"subtasks":') || content.includes('CRITICAL: You MUST respond with ONLY a JSON')) {
     return {
       injectedType: 'other',
       injectedSummary: 'TaskMaster system prompt',

--- a/src/components/chat/view/subcomponents/MessageComponent.tsx
+++ b/src/components/chat/view/subcomponents/MessageComponent.tsx
@@ -97,9 +97,31 @@ const MessageComponent = memo(({ message, index, prevMessage, createDiff, onFile
   return (
     <div
       ref={messageRef}
-      className={`chat-message ${message.type} ${isGrouped ? 'grouped' : ''} ${message.type === 'user' ? 'flex justify-end px-3 sm:px-0' : 'px-3 sm:px-0'}`}
+      className={`chat-message ${message.type} ${isGrouped ? 'grouped' : ''} ${message.type === 'user' && !message.isSystemInjected ? 'flex justify-end px-3 sm:px-0' : 'px-3 sm:px-0'}`}
     >
-      {message.type === 'user' ? (
+      {message.isSystemInjected && !message.isTaskNotification && message.injectedType !== 'background-task-result' ? (
+        /* System-injected message — muted, collapsed by default */
+        <div className="w-full">
+          <details className="group">
+            <summary className="cursor-pointer flex items-center gap-2 py-1 px-2 rounded hover:bg-gray-100 dark:hover:bg-gray-800/60 transition-colors select-none">
+              <svg className="w-3 h-3 text-gray-400 dark:text-gray-500 transition-transform group-open:rotate-90 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+              </svg>
+              <span className="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium bg-gray-200 dark:bg-gray-700 text-gray-600 dark:text-gray-300">
+                {t(`systemInjected.${message.injectedType || 'other'}`)}
+              </span>
+              <span className="text-xs text-gray-500 dark:text-gray-400 truncate">
+                {String(message.injectedSummary || '')}
+              </span>
+            </summary>
+            <div className="mt-1 ml-5 border-l-2 border-gray-300 dark:border-gray-600 pl-3">
+              <pre className="text-xs text-gray-600 dark:text-gray-400 whitespace-pre-wrap break-words font-mono bg-gray-50 dark:bg-gray-800/40 rounded p-2 max-h-64 overflow-y-auto">
+                {message.content}
+              </pre>
+            </div>
+          </details>
+        </div>
+      ) : message.type === 'user' ? (
         /* User message bubble on the right */
         <div className="flex items-end space-x-0 sm:space-x-3 w-full sm:w-auto sm:max-w-[85%] md:max-w-md lg:max-w-lg xl:max-w-xl">
           <div className="bg-blue-600 text-white rounded-2xl rounded-br-md px-3 sm:px-4 py-2 shadow-sm flex-1 sm:flex-initial group">
@@ -165,6 +187,35 @@ const MessageComponent = memo(({ message, index, prevMessage, createDiff, onFile
               U
             </div>
           )}
+        </div>
+      ) : message.injectedType === 'background-task-result' ? (
+        /* Background task result — collapsible card, collapsed by default */
+        <div className="w-full">
+          <details className="group border border-emerald-200 dark:border-emerald-800/60 rounded-lg overflow-hidden bg-emerald-50/50 dark:bg-emerald-900/10">
+            <summary className="cursor-pointer flex items-center gap-3 py-2.5 px-3 hover:bg-emerald-100/60 dark:hover:bg-emerald-900/20 transition-colors select-none">
+              <div className="flex items-center justify-center w-6 h-6 bg-emerald-500 dark:bg-emerald-600 rounded-full flex-shrink-0">
+                <svg className="w-3.5 h-3.5 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+                </svg>
+              </div>
+              <div className="flex-1 min-w-0">
+                <span className="text-sm font-medium text-emerald-900 dark:text-emerald-100">
+                  {String(message.injectedSummary || '') || t('systemInjected.background-task-result')}
+                </span>
+              </div>
+              <span className="text-[10px] text-emerald-600/70 dark:text-emerald-400/60 flex-shrink-0">
+                {formattedTime}
+              </span>
+              <svg className="w-4 h-4 text-emerald-500 dark:text-emerald-400 transition-transform group-open:rotate-90 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+              </svg>
+            </summary>
+            <div className="border-t border-emerald-200 dark:border-emerald-800/60 bg-white dark:bg-gray-900 p-3">
+              <pre className="text-xs text-gray-700 dark:text-gray-300 whitespace-pre-wrap break-words font-mono max-h-96 overflow-y-auto">
+                {message.content}
+              </pre>
+            </div>
+          </details>
         </div>
       ) : message.isTaskNotification ? (
         /* Compact task notification on the left */

--- a/src/i18n/locales/en/chat.json
+++ b/src/i18n/locales/en/chat.json
@@ -245,7 +245,6 @@
     "background-task-result": "Background Task Result",
     "hook": "Hook Output",
     "command": "Command",
-    "skill": "Skill",
     "continuation": "Session Info",
     "other": "System"
   }

--- a/src/i18n/locales/en/chat.json
+++ b/src/i18n/locales/en/chat.json
@@ -238,5 +238,15 @@
   },
   "tasks": {
     "nextTaskPrompt": "Start the next task"
+  },
+  "systemInjected": {
+    "system-reminder": "System Reminder",
+    "task-notification": "Task Notification",
+    "background-task-result": "Background Task Result",
+    "hook": "Hook Output",
+    "command": "Command",
+    "skill": "Skill",
+    "continuation": "Session Info",
+    "other": "System"
   }
 }

--- a/src/i18n/locales/ja/chat.json
+++ b/src/i18n/locales/ja/chat.json
@@ -205,5 +205,15 @@
     "runCommand": "{{projectName}}で{{command}}を実行",
     "startCli": "{{projectName}}でClaude CLIを起動しています",
     "defaultCommand": "コマンド"
+  },
+  "systemInjected": {
+    "system-reminder": "システムリマインダー",
+    "task-notification": "タスク通知",
+    "background-task-result": "バックグラウンドタスク結果",
+    "hook": "フック出力",
+    "command": "コマンド",
+    "skill": "スキル",
+    "continuation": "セッション情報",
+    "other": "システム"
   }
 }

--- a/src/i18n/locales/ja/chat.json
+++ b/src/i18n/locales/ja/chat.json
@@ -212,7 +212,6 @@
     "background-task-result": "バックグラウンドタスク結果",
     "hook": "フック出力",
     "command": "コマンド",
-    "skill": "スキル",
     "continuation": "セッション情報",
     "other": "システム"
   }

--- a/src/i18n/locales/ko/chat.json
+++ b/src/i18n/locales/ko/chat.json
@@ -227,7 +227,6 @@
     "background-task-result": "백그라운드 작업 결과",
     "hook": "Hook 출력",
     "command": "명령어",
-    "skill": "스킬",
     "continuation": "세션 정보",
     "other": "시스템"
   }

--- a/src/i18n/locales/ko/chat.json
+++ b/src/i18n/locales/ko/chat.json
@@ -220,5 +220,15 @@
   },
   "tasks": {
     "nextTaskPrompt": "다음 작업 시작"
+  },
+  "systemInjected": {
+    "system-reminder": "시스템 알림",
+    "task-notification": "작업 알림",
+    "background-task-result": "백그라운드 작업 결과",
+    "hook": "Hook 출력",
+    "command": "명령어",
+    "skill": "스킬",
+    "continuation": "세션 정보",
+    "other": "시스템"
   }
 }

--- a/src/i18n/locales/zh-CN/chat.json
+++ b/src/i18n/locales/zh-CN/chat.json
@@ -227,7 +227,6 @@
     "background-task-result": "后台任务结果",
     "hook": "Hook 输出",
     "command": "命令",
-    "skill": "技能",
     "continuation": "会话信息",
     "other": "系统"
   }

--- a/src/i18n/locales/zh-CN/chat.json
+++ b/src/i18n/locales/zh-CN/chat.json
@@ -220,5 +220,15 @@
   },
   "tasks": {
     "nextTaskPrompt": "开始下一个任务"
+  },
+  "systemInjected": {
+    "system-reminder": "系统提醒",
+    "task-notification": "任务通知",
+    "background-task-result": "后台任务结果",
+    "hook": "Hook 输出",
+    "command": "命令",
+    "skill": "技能",
+    "continuation": "会话信息",
+    "other": "系统"
   }
 }


### PR DESCRIPTION
## Summary

- **Classify system-injected messages** instead of silently hiding them. A new `classifyUserMessage()` function detects system-reminders, command outputs, hook outputs, task notifications, session continuations, and other injected content.
- **Render as collapsible cards** with type badges (e.g. "System Reminder", "Command", "Hook Output") and auto-generated summaries. Collapsed by default to keep the chat clean.
- **Background task results** get a distinct emerald-styled collapsible card.
- **i18n support** with translations for all categories in en, ja, ko, zh-CN.

### Before
System-injected messages were completely hidden from the chat view, making it impossible to see what Claude was responding to when system-reminders, hooks, or command outputs were injected.

### After
System-injected messages appear as muted, collapsible inline cards. Users can expand them to see the full content when needed, providing context without cluttering the conversation.

## Files Changed

| File | Change |
|------|--------|
| `messageTransforms.ts` | Add `classifyUserMessage()`, replace binary skip logic with classification |
| `MessageComponent.tsx` | Add collapsible card rendering for system-injected + background-task-result |
| `chat.json` (en/ja/ko/zh-CN) | Add `systemInjected` translation keys |

## Test plan

- [ ] Open an existing Claude session that contains system-reminder or hook-injected messages
- [ ] Verify system-injected messages appear as collapsed cards with correct type badges
- [ ] Verify expanding a card shows the full raw content
- [ ] Verify regular user messages still render as blue bubbles on the right
- [ ] Verify task notification pills still render correctly (backward compat)
- [ ] Verify `npm run build` passes
- [ ] Verify `npm run typecheck` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * System-injected messages now display as distinct, collapsible blocks with category badges and specialized layouts for background-task results and task notifications.
  * Supports multiple injected types: task-notification, background-task-result, system-reminder, hook, command, continuation, other.

* **Improvements**
  * Safer message processing to avoid runtime errors when message content is missing.
  * Added localized labels for system-injected messages (en, ja, ko, zh-CN).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->