### PR TITLE
fix: detect router basename for path-prefixed deployments

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,9 @@ import { PluginsProvider } from './contexts/PluginsContext';
 import AppContent from './components/app/AppContent';
 import i18n from './i18n/config.js';
 
+/**
+ * Detect the router basename from explicit runtime config or deployment hints.
+ */
 function detectRouterBasename() {
   const explicitBasename = typeof window !== 'undefined' ? window.__ROUTER_BASENAME__ || '' : '';
   if (explicitBasename) {
@@ -20,21 +23,45 @@ function detectRouterBasename() {
   }
 
   const candidatePaths = [
-    document.querySelector('link[rel="manifest"]')?.getAttribute('href'),
-    document.querySelector('script[type="module"][src]')?.getAttribute('src'),
-    document.querySelector('link[rel="icon"][href]')?.getAttribute('href'),
-  ].filter((value): value is string => Boolean(value));
+    { kind: 'manifest' as const, value: document.querySelector('link[rel="manifest"]')?.getAttribute('href') },
+    { kind: 'script' as const, value: document.querySelector('script[type="module"][src]')?.getAttribute('src') },
+    ...Array.from(
+      document.querySelectorAll(
+        'link[rel~="icon"][href], link[rel="apple-touch-icon"][href], link[rel="apple-touch-icon-precomposed"][href], link[rel="mask-icon"][href]'
+      )
+    ).map((node) => ({
+      kind: 'icon' as const,
+      value: node.getAttribute('href'),
+    })),
+  ].filter((candidate): candidate is { kind: 'manifest' | 'script' | 'icon'; value: string } => Boolean(candidate.value));
 
   let detectedBasename = '';
   for (const candidate of candidatePaths) {
     try {
-      const pathname = new URL(candidate, document.baseURI || window.location.href).pathname;
-      const match = pathname.match(/^(.*)\/(?:assets\/|manifest\.json$|favicon\.(?:svg|png)$)/);
-      if (match) {
-        const normalized = match[1] ? match[1].replace(/\/+$/, '') : '';
-        if (normalized.length > detectedBasename.length) {
-          detectedBasename = normalized;
+      const pathname = new URL(candidate.value, document.baseURI || window.location.href).pathname;
+      const normalizedPathname = pathname.replace(/\/+$/, '');
+
+      let normalized = '';
+      if (candidate.kind === 'script') {
+        const match = normalizedPathname.match(/^(.*)\/assets\//);
+        normalized = match?.[1] ? match[1].replace(/\/+$/, '') : '';
+      } else {
+        const manifestMatch = normalizedPathname.match(/^(.*)\/(?:manifest\.json|site\.webmanifest)$/);
+        const iconMatch = normalizedPathname.match(
+          /^(.*)\/(?:favicon(?:\.[^/]+)?|apple-touch-icon(?:-[^/]+)?(?:\.[^/]+)?|mask-icon(?:\.[^/]+)?|[^/]*icon[^/]*)$/
+        );
+        const match = candidate.kind === 'manifest' ? manifestMatch : iconMatch;
+        if (match?.[1]) {
+          const segments = match[1].split('/').filter(Boolean);
+          while (segments.length > 0 && ['assets', 'static', 'icons', 'images'].includes(segments[segments.length - 1])) {
+            segments.pop();
+          }
+          normalized = segments.length > 0 ? `/${segments.join('/')}` : '';
         }
+      }
+
+      if (normalized.length > detectedBasename.length) {
+        detectedBasename = normalized;
       }
     } catch {
       // Ignore invalid candidate URLs and continue checking other hints.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -38,7 +38,12 @@ function detectRouterBasename() {
   let detectedBasename = '';
   for (const candidate of candidatePaths) {
     try {
-      const pathname = new URL(candidate.value, document.baseURI || window.location.href).pathname;
+      const candidateUrl = new URL(candidate.value, document.baseURI || window.location.href);
+      if (candidateUrl.origin !== window.location.origin) {
+        continue;
+      }
+
+      const pathname = candidateUrl.pathname;
       const normalizedPathname = pathname.replace(/\/+$/, '');
 
       let normalized = '';
@@ -53,7 +58,7 @@ function detectRouterBasename() {
         const match = candidate.kind === 'manifest' ? manifestMatch : iconMatch;
         if (match?.[1]) {
           const segments = match[1].split('/').filter(Boolean);
-          while (segments.length > 0 && ['assets', 'static', 'icons', 'images'].includes(segments[segments.length - 1])) {
+          while (segments.length > 1 && ['assets', 'static', 'icons', 'images'].includes(segments[segments.length - 1])) {
             segments.pop();
           }
           normalized = segments.length > 0 ? `/${segments.join('/')}` : '';

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,7 +9,44 @@ import { PluginsProvider } from './contexts/PluginsContext';
 import AppContent from './components/app/AppContent';
 import i18n from './i18n/config.js';
 
+function detectRouterBasename() {
+  const explicitBasename = typeof window !== 'undefined' ? window.__ROUTER_BASENAME__ || '' : '';
+  if (explicitBasename) {
+    return explicitBasename.replace(/\/+$/, '');
+  }
+
+  if (typeof window === 'undefined' || typeof document === 'undefined') {
+    return '';
+  }
+
+  const candidatePaths = [
+    document.querySelector('link[rel="manifest"]')?.getAttribute('href'),
+    document.querySelector('script[type="module"][src]')?.getAttribute('src'),
+    document.querySelector('link[rel="icon"][href]')?.getAttribute('href'),
+  ].filter((value): value is string => Boolean(value));
+
+  let detectedBasename = '';
+  for (const candidate of candidatePaths) {
+    try {
+      const pathname = new URL(candidate, document.baseURI || window.location.href).pathname;
+      const match = pathname.match(/^(.*)\/(?:assets\/|manifest\.json$|favicon\.(?:svg|png)$)/);
+      if (match) {
+        const normalized = match[1] ? match[1].replace(/\/+$/, '') : '';
+        if (normalized.length > detectedBasename.length) {
+          detectedBasename = normalized;
+        }
+      }
+    } catch {
+      // Ignore invalid candidate URLs and continue checking other hints.
+    }
+  }
+
+  return detectedBasename;
+}
+
 export default function App() {
+  const routerBasename = detectRouterBasename();
+
   return (
     <I18nextProvider i18n={i18n}>
       <ThemeProvider>
@@ -19,7 +56,7 @@ export default function App() {
               <TasksSettingsProvider>
                 <TaskMasterProvider>
                 <ProtectedRoute>
-                  <Router basename={window.__ROUTER_BASENAME__ || ''}>
+                  <Router basename={routerBasename}>
                     <Routes>
                       <Route path="/" element={<AppContent />} />
                       <Route path="/session/:sessionId" element={<AppContent />} />


### PR DESCRIPTION
## Summary
Fix blank-page routing failures when CloudCLI UI is deployed behind a reverse proxy under a path prefix such as `/ai`.

Closes #464.

## Problem
`src/App.tsx` currently uses `window.__ROUTER_BASENAME__ || ''`, but that global is not initialized by the app.

As a result, path-prefixed deployments can successfully rewrite HTML, assets, and API calls, while React Router still assumes it is mounted at `/`.

That breaks routed views after login and direct links like:
- `/ai/session/:sessionId`

## Solution
Keep the explicit `window.__ROUTER_BASENAME__` override when present, but otherwise derive the basename from runtime URLs that already reflect the deployed prefix:
- manifest href
- module script src
- icon href

This makes prefixed deployments work without requiring an additional server-side bootstrap script.

## Validation
Built locally with Vite after the change and verified that the generated app bundle was updated.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Routing now dynamically determines the app base path: it honors an explicit override when present, otherwise inspects page-provided hints (manifest, script and icon links) and ignores invalid values. If nothing reliable is found, an empty base is used. This improves routing reliability across varied hosting setups and prevents incorrect base-path resolution at runtime.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->