### PR TITLE
feat: add resizable sidebar width

### DIFF
--- a/src/components/app/AppContent.tsx
+++ b/src/components/app/AppContent.tsx
@@ -10,6 +10,7 @@ import { useWebSocket } from '../../contexts/WebSocketContext';
 import { useDeviceSettings } from '../../hooks/useDeviceSettings';
 import { useSessionProtection } from '../../hooks/useSessionProtection';
 import { useProjectsState } from '../../hooks/useProjectsState';
+import { useSidebarResize } from '../sidebar/hooks/useSidebarResize';
 
 export default function AppContent() {
   const navigate = useNavigate();
@@ -27,6 +28,12 @@ export default function AppContent() {
     markSessionAsNotProcessing,
     replaceTemporarySession,
   } = useSessionProtection();
+
+  const {
+    sidebarWidth,
+    resizeHandleRef,
+    handleResizeStart,
+  } = useSidebarResize();
 
   const {
     selectedProject,
@@ -74,9 +81,22 @@ export default function AppContent() {
   return (
     <div className="fixed inset-0 flex bg-background">
       {!isMobile ? (
-        <div className="h-full flex-shrink-0 border-r border-border/50">
-          <Sidebar {...sidebarSharedProps} />
-        </div>
+        <>
+          <div
+            className="h-full flex-shrink-0"
+            style={{ width: `${sidebarWidth}px` }}
+          >
+            <Sidebar {...sidebarSharedProps} />
+          </div>
+          <div
+            ref={resizeHandleRef}
+            onMouseDown={handleResizeStart}
+            className="flex-shrink-0 w-1 bg-border/50 hover:bg-primary/50 cursor-col-resize transition-colors relative group"
+            title="Drag to resize"
+          >
+            <div className="absolute inset-y-0 left-1/2 -translate-x-1/2 w-1 bg-primary opacity-0 group-hover:opacity-100 transition-opacity" />
+          </div>
+        </>
       ) : (
         <div
           className={`fixed inset-0 z-50 flex transition-all duration-150 ease-out ${sidebarOpen ? 'opacity-100 visible' : 'opacity-0 invisible'

--- a/src/components/sidebar/hooks/useSidebarResize.ts
+++ b/src/components/sidebar/hooks/useSidebarResize.ts
@@ -1,0 +1,67 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import type { MouseEvent as ReactMouseEvent } from 'react';
+
+const STORAGE_KEY = 'sidebar-width';
+const MIN_WIDTH = 288; // w-72 = 18rem = 288px
+const DEFAULT_WIDTH = 288;
+const MAX_WIDTH_RATIO = 0.4; // Max 40% of viewport
+
+export const useSidebarResize = () => {
+  const [sidebarWidth, setSidebarWidth] = useState(() => {
+    if (typeof window === 'undefined') {
+      return DEFAULT_WIDTH;
+    }
+    const stored = localStorage.getItem(STORAGE_KEY);
+    return stored ? Math.max(MIN_WIDTH, parseInt(stored, 10)) : DEFAULT_WIDTH;
+  });
+  const [isResizing, setIsResizing] = useState(false);
+  const resizeHandleRef = useRef<HTMLDivElement | null>(null);
+
+  const handleResizeStart = useCallback((event: ReactMouseEvent<HTMLDivElement>) => {
+    setIsResizing(true);
+    event.preventDefault();
+  }, []);
+
+  useEffect(() => {
+    const handleMouseMove = (event: globalThis.MouseEvent) => {
+      if (!isResizing) {
+        return;
+      }
+
+      const newWidth = event.clientX;
+      const maxWidth = window.innerWidth * MAX_WIDTH_RATIO;
+
+      if (newWidth >= MIN_WIDTH && newWidth <= maxWidth) {
+        setSidebarWidth(newWidth);
+      }
+    };
+
+    const handleMouseUp = () => {
+      if (isResizing) {
+        localStorage.setItem(STORAGE_KEY, sidebarWidth.toString());
+      }
+      setIsResizing(false);
+    };
+
+    if (isResizing) {
+      document.addEventListener('mousemove', handleMouseMove);
+      document.addEventListener('mouseup', handleMouseUp);
+      document.body.style.cursor = 'col-resize';
+      document.body.style.userSelect = 'none';
+    }
+
+    return () => {
+      document.removeEventListener('mousemove', handleMouseMove);
+      document.removeEventListener('mouseup', handleMouseUp);
+      document.body.style.cursor = '';
+      document.body.style.userSelect = '';
+    };
+  }, [isResizing, sidebarWidth]);
+
+  return {
+    sidebarWidth,
+    isResizing,
+    resizeHandleRef,
+    handleResizeStart,
+  };
+};

--- a/src/components/sidebar/view/subcomponents/SidebarContent.tsx
+++ b/src/components/sidebar/view/subcomponents/SidebarContent.tsx
@@ -49,8 +49,7 @@ export default function SidebarContent({
 }: SidebarContentProps) {
   return (
     <div
-      className="h-full flex flex-col bg-background/80 backdrop-blur-sm md:select-none md:w-72"
-      style={{}}
+      className="h-full flex flex-col bg-background/80 backdrop-blur-sm md:select-none border-r border-border/50"
     >
       <SidebarHeader
         isPWA={isPWA}


### PR DESCRIPTION
- Add useSidebarResize hook for drag-to-resize functionality
- Minimum width is 288px (previous fixed width)
- Maximum width is 40% of viewport
- Width persists to localStorage across sessions
- Add resize handle with hover effect on sidebar edge


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Sidebar is now resizable on desktop layouts—drag the right edge to adjust its width to your preference
  * Sidebar width preference is automatically saved across sessions

* **Improvements**
  * Enhanced sidebar styling with improved visual separation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->