### PR TITLE
feat: add full-text search across conversations

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -44,7 +44,7 @@ import pty from 'node-pty';
 import fetch from 'node-fetch';
 import mime from 'mime-types';
 
-import { getProjects, getSessions, getSessionMessages, renameProject, deleteSession, deleteProject, addProjectManually, extractProjectDirectory, clearProjectDirectoryCache } from './projects.js';
+import { getProjects, getSessions, getSessionMessages, renameProject, deleteSession, deleteProject, addProjectManually, extractProjectDirectory, clearProjectDirectoryCache, searchConversations } from './projects.js';
 import { queryClaudeSDK, abortClaudeSDKSession, isClaudeSDKSessionActive, getActiveClaudeSDKSessions, resolveToolApproval, getPendingApprovalsForSession, reconnectSessionWriter } from './claude-sdk.js';
 import { spawnCursor, abortCursorSession, isCursorSessionActive, getActiveCursorSessions } from './cursor-cli.js';
 import { queryCodex, abortCodexSession, isCodexSessionActive, getActiveCodexSessions } from './openai-codex.js';
@@ -604,6 +604,24 @@ app.post('/api/projects/create', authenticateToken, async (req, res) => {
         res.json({ success: true, project });
     } catch (error) {
         console.error('Error creating project:', error);
+        res.status(500).json({ error: error.message });
+    }
+});
+
+// Search conversations content
+app.get('/api/search/conversations', authenticateToken, async (req, res) => {
+    try {
+        const query = req.query.q;
+        const limit = parseInt(req.query.limit) || 50;
+
+        if (!query || query.length < 2) {
+            return res.status(400).json({ error: 'Query must be at least 2 characters' });
+        }
+
+        const results = await searchConversations(query, limit);
+        res.json(results);
+    } catch (error) {
+        console.error('Error searching conversations:', error);
         res.status(500).json({ error: error.message });
     }
 });

--- a/server/projects.js
+++ b/server/projects.js
@@ -1834,6 +1834,168 @@ async function deleteCodexSession(sessionId) {
   }
 }
 
+async function searchConversations(query, limit = 50) {
+  const claudeDir = path.join(os.homedir(), '.claude', 'projects');
+  const config = await loadProjectConfig();
+  const results = [];
+  let totalMatches = 0;
+  const queryLower = query.toLowerCase();
+
+  const isSystemMessage = (textContent) => {
+    return typeof textContent === 'string' && (
+      textContent.startsWith('<command-name>') ||
+      textContent.startsWith('<command-message>') ||
+      textContent.startsWith('<command-args>') ||
+      textContent.startsWith('<local-command-stdout>') ||
+      textContent.startsWith('<system-reminder>') ||
+      textContent.startsWith('Caveat:') ||
+      textContent.startsWith('This session is being continued from a previous') ||
+      textContent.startsWith('Invalid API key') ||
+      textContent.includes('{"subtasks":') ||
+      textContent.includes('CRITICAL: You MUST respond with ONLY a JSON') ||
+      textContent === 'Warmup'
+    );
+  };
+
+  const extractText = (content) => {
+    if (typeof content === 'string') return content;
+    if (Array.isArray(content)) {
+      return content
+        .filter(part => part.type === 'text' && part.text)
+        .map(part => part.text)
+        .join(' ');
+    }
+    return '';
+  };
+
+  const buildSnippet = (text, matchIndex, snippetLen = 150) => {
+    const halfLen = Math.floor(snippetLen / 2);
+    let start = Math.max(0, matchIndex - halfLen);
+    let end = Math.min(text.length, matchIndex + query.length + halfLen);
+    let snippet = text.slice(start, end).replace(/\n/g, ' ');
+    if (start > 0) snippet = '...' + snippet;
+    if (end < text.length) snippet = snippet + '...';
+    const matchStart = matchIndex - start + (start > 0 ? 3 : 0);
+    const matchEnd = matchStart + query.length;
+    return { snippet, matchStart, matchEnd };
+  };
+
+  try {
+    await fs.access(claudeDir);
+    const entries = await fs.readdir(claudeDir, { withFileTypes: true });
+    const projectDirs = entries.filter(e => e.isDirectory());
+
+    for (const projectEntry of projectDirs) {
+      if (totalMatches >= limit) break;
+
+      const projectName = projectEntry.name;
+      const projectDir = path.join(claudeDir, projectName);
+      const displayName = config[projectName]?.displayName
+        || await generateDisplayName(projectName);
+
+      let files;
+      try {
+        files = await fs.readdir(projectDir);
+      } catch {
+        continue;
+      }
+
+      const jsonlFiles = files.filter(
+        file => file.endsWith('.jsonl') && !file.startsWith('agent-')
+      );
+
+      const projectResult = {
+        projectName,
+        projectDisplayName: displayName,
+        sessions: []
+      };
+
+      for (const file of jsonlFiles) {
+        if (totalMatches >= limit) break;
+
+        const filePath = path.join(projectDir, file);
+        const sessionMatches = new Map();
+        let sessionSummary = 'New Session';
+        let currentSessionId = null;
+
+        try {
+          const fileStream = fsSync.createReadStream(filePath);
+          const rl = readline.createInterface({
+            input: fileStream,
+            crlfDelay: Infinity
+          });
+
+          for await (const line of rl) {
+            if (totalMatches >= limit) break;
+            if (!line.trim()) continue;
+
+            let entry;
+            try {
+              entry = JSON.parse(line);
+            } catch {
+              continue;
+            }
+
+            if (entry.sessionId && !currentSessionId) {
+              currentSessionId = entry.sessionId;
+            }
+            if (entry.type === 'summary' && entry.summary) {
+              sessionSummary = entry.summary;
+            }
+
+            if (!entry.message?.content) continue;
+            if (entry.message.role !== 'user' && entry.message.role !== 'assistant') continue;
+            if (entry.isApiErrorMessage) continue;
+
+            const text = extractText(entry.message.content);
+            if (!text || isSystemMessage(text)) continue;
+
+            const textLower = text.toLowerCase();
+            const matchIndex = textLower.indexOf(queryLower);
+            if (matchIndex === -1) continue;
+
+            const sessionId = entry.sessionId || currentSessionId || file.replace('.jsonl', '');
+            if (!sessionMatches.has(sessionId)) {
+              sessionMatches.set(sessionId, []);
+            }
+
+            const matches = sessionMatches.get(sessionId);
+            if (matches.length < 2) {
+              const { snippet, matchStart, matchEnd } = buildSnippet(text, matchIndex);
+              matches.push({
+                role: entry.message.role,
+                snippet,
+                matchStart,
+                matchEnd,
+                timestamp: entry.timestamp || null
+              });
+              totalMatches++;
+            }
+          }
+        } catch {
+          continue;
+        }
+
+        for (const [sessionId, matches] of sessionMatches) {
+          projectResult.sessions.push({
+            sessionId,
+            sessionSummary,
+            matches
+          });
+        }
+      }
+
+      if (projectResult.sessions.length > 0) {
+        results.push(projectResult);
+      }
+    }
+  } catch {
+    // claudeDir doesn't exist
+  }
+
+  return { results, totalMatches, query };
+}
+
 export {
   getProjects,
   getSessions,
@@ -1850,5 +2012,6 @@ export {
   clearProjectDirectoryCache,
   getCodexSessions,
   getCodexSessionMessages,
-  deleteCodexSession
+  deleteCodexSession,
+  searchConversations
 };

--- a/src/components/sidebar/hooks/useSidebarController.ts
+++ b/src/components/sidebar/hooks/useSidebarController.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type React from 'react';
 import type { TFunction } from 'i18next';
 import { api } from '../../../utils/api';
@@ -72,6 +72,10 @@ export function useSidebarController({
   const [sessionDeleteConfirmation, setSessionDeleteConfirmation] = useState<SessionDeleteConfirmation | null>(null);
   const [showVersionModal, setShowVersionModal] = useState(false);
   const [starredProjects, setStarredProjects] = useState<Set<string>>(() => loadStarredProjects());
+  const [searchMode, setSearchMode] = useState<'projects' | 'conversations'>('projects');
+  const [conversationResults, setConversationResults] = useState<any>(null);
+  const [isSearching, setIsSearching] = useState(false);
+  const searchTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const isSidebarCollapsed = !isMobile && !sidebarVisible;
 
@@ -140,6 +144,42 @@ export function useSidebarController({
       clearInterval(interval);
     };
   }, []);
+
+  // Debounced conversation search
+  useEffect(() => {
+    if (searchTimeoutRef.current) {
+      clearTimeout(searchTimeoutRef.current);
+    }
+
+    if (searchMode !== 'conversations' || searchFilter.trim().length < 2) {
+      setConversationResults(null);
+      setIsSearching(false);
+      return;
+    }
+
+    setIsSearching(true);
+    searchTimeoutRef.current = setTimeout(async () => {
+      try {
+        const response = await api.searchConversations(searchFilter.trim());
+        if (response.ok) {
+          const data = await response.json();
+          setConversationResults(data);
+        } else {
+          setConversationResults({ results: [], totalMatches: 0, query: searchFilter });
+        }
+      } catch {
+        setConversationResults({ results: [], totalMatches: 0, query: searchFilter });
+      } finally {
+        setIsSearching(false);
+      }
+    }, 400);
+
+    return () => {
+      if (searchTimeoutRef.current) {
+        clearTimeout(searchTimeoutRef.current);
+      }
+    };
+  }, [searchFilter, searchMode]);
 
   const handleTouchClick = useCallback(
     (callback: () => void) =>
@@ -483,6 +523,10 @@ export function useSidebarController({
     setEditingName,
     setEditingSession,
     setEditingSessionName,
+    searchMode,
+    setSearchMode,
+    conversationResults,
+    isSearching,
     setSearchFilter,
     setDeleteConfirmation,
     setSessionDeleteConfirmation,

--- a/src/components/sidebar/view/Sidebar.tsx
+++ b/src/components/sidebar/view/Sidebar.tsx
@@ -60,6 +60,10 @@ function Sidebar({
     editingSession,
     editingSessionName,
     searchFilter,
+    searchMode,
+    setSearchMode,
+    conversationResults,
+    isSearching,
     deletingProjects,
     deleteConfirmation,
     sessionDeleteConfirmation,
@@ -222,6 +226,20 @@ function Sidebar({
             searchFilter={searchFilter}
             onSearchFilterChange={setSearchFilter}
             onClearSearchFilter={() => setSearchFilter('')}
+            searchMode={searchMode}
+            onSearchModeChange={(mode: 'projects' | 'conversations') => {
+              setSearchMode(mode);
+              if (mode === 'projects') setConversationResults(null);
+            }}
+            conversationResults={conversationResults}
+            isSearching={isSearching}
+            onConversationResultClick={(projectName: string, sessionId: string) => {
+              const project = projects.find(p => p.name === projectName);
+              if (project) {
+                onProjectSelect(project);
+                onSessionSelect({ id: sessionId } as any);
+              }
+            }}
             onRefresh={() => {
               void refreshProjects();
             }}

--- a/src/components/sidebar/view/subcomponents/SidebarContent.tsx
+++ b/src/components/sidebar/view/subcomponents/SidebarContent.tsx
@@ -1,10 +1,52 @@
 import { ScrollArea } from '../../../ui/scroll-area';
+import { Folder, MessageSquare, Search } from 'lucide-react';
 import type { TFunction } from 'i18next';
 import type { Project } from '../../../../types/app';
 import type { ReleaseInfo } from '../../../../types/sharedTypes';
 import SidebarFooter from './SidebarFooter';
 import SidebarHeader from './SidebarHeader';
 import SidebarProjectList, { type SidebarProjectListProps } from './SidebarProjectList';
+
+type ConversationMatch = {
+  role: string;
+  snippet: string;
+  matchStart: number;
+  matchEnd: number;
+  timestamp: string | null;
+};
+
+type ConversationSession = {
+  sessionId: string;
+  sessionSummary: string;
+  matches: ConversationMatch[];
+};
+
+type ConversationProjectResult = {
+  projectName: string;
+  projectDisplayName: string;
+  sessions: ConversationSession[];
+};
+
+type ConversationSearchResults = {
+  results: ConversationProjectResult[];
+  totalMatches: number;
+  query: string;
+} | null;
+
+type SearchMode = 'projects' | 'conversations';
+
+function HighlightedSnippet({ snippet, matchStart, matchEnd }: { snippet: string; matchStart: number; matchEnd: number }) {
+  const before = snippet.slice(0, matchStart);
+  const match = snippet.slice(matchStart, matchEnd);
+  const after = snippet.slice(matchEnd);
+  return (
+    <span className="text-xs text-muted-foreground leading-relaxed">
+      {before}
+      <mark className="bg-yellow-200 dark:bg-yellow-800 text-foreground rounded-sm px-0.5">{match}</mark>
+      {after}
+    </span>
+  );
+}
 
 type SidebarContentProps = {
   isPWA: boolean;
@@ -14,6 +56,11 @@ type SidebarContentProps = {
   searchFilter: string;
   onSearchFilterChange: (value: string) => void;
   onClearSearchFilter: () => void;
+  searchMode: SearchMode;
+  onSearchModeChange: (mode: SearchMode) => void;
+  conversationResults: ConversationSearchResults;
+  isSearching: boolean;
+  onConversationResultClick: (projectName: string, sessionId: string) => void;
   onRefresh: () => void;
   isRefreshing: boolean;
   onCreateProject: () => void;
@@ -35,6 +82,11 @@ export default function SidebarContent({
   searchFilter,
   onSearchFilterChange,
   onClearSearchFilter,
+  searchMode,
+  onSearchModeChange,
+  conversationResults,
+  isSearching,
+  onConversationResultClick,
   onRefresh,
   isRefreshing,
   onCreateProject,
@@ -47,6 +99,8 @@ export default function SidebarContent({
   projectListProps,
   t,
 }: SidebarContentProps) {
+  const showConversationSearch = searchMode === 'conversations' && searchFilter.trim().length >= 2;
+
   return (
     <div
       className="h-full flex flex-col bg-background/80 backdrop-blur-sm md:select-none md:w-72"
@@ -60,6 +114,8 @@ export default function SidebarContent({
         searchFilter={searchFilter}
         onSearchFilterChange={onSearchFilterChange}
         onClearSearchFilter={onClearSearchFilter}
+        searchMode={searchMode}
+        onSearchModeChange={onSearchModeChange}
         onRefresh={onRefresh}
         isRefreshing={isRefreshing}
         onCreateProject={onCreateProject}
@@ -68,7 +124,70 @@ export default function SidebarContent({
       />
 
       <ScrollArea className="flex-1 md:px-1.5 md:py-2 overflow-y-auto overscroll-contain">
-        <SidebarProjectList {...projectListProps} />
+        {showConversationSearch ? (
+          isSearching ? (
+            <div className="text-center py-12 md:py-8 px-4">
+              <div className="w-12 h-12 bg-muted rounded-lg flex items-center justify-center mx-auto mb-4 md:mb-3">
+                <div className="w-6 h-6 animate-spin rounded-full border-2 border-muted-foreground border-t-transparent" />
+              </div>
+              <p className="text-sm text-muted-foreground">{t('search.searching')}</p>
+            </div>
+          ) : conversationResults && conversationResults.results.length === 0 ? (
+            <div className="text-center py-12 md:py-8 px-4">
+              <div className="w-12 h-12 bg-muted rounded-lg flex items-center justify-center mx-auto mb-4 md:mb-3">
+                <Search className="w-6 h-6 text-muted-foreground" />
+              </div>
+              <h3 className="text-base font-medium text-foreground mb-2 md:mb-1">{t('search.noResults')}</h3>
+              <p className="text-sm text-muted-foreground">{t('search.tryDifferentQuery')}</p>
+            </div>
+          ) : conversationResults ? (
+            <div className="space-y-3 px-2">
+              <p className="text-xs text-muted-foreground px-1">
+                {conversationResults.totalMatches} {t('search.matches')}
+              </p>
+              {conversationResults.results.map((projectResult: ConversationProjectResult) => (
+                <div key={projectResult.projectName} className="space-y-1">
+                  <div className="flex items-center gap-1.5 px-1 py-1">
+                    <Folder className="w-3 h-3 text-muted-foreground flex-shrink-0" />
+                    <span className="text-xs font-medium text-foreground truncate">
+                      {projectResult.projectDisplayName}
+                    </span>
+                  </div>
+                  {projectResult.sessions.map((session: ConversationSession) => (
+                    <button
+                      key={`${projectResult.projectName}-${session.sessionId}`}
+                      className="w-full text-left rounded-md px-2 py-2 hover:bg-accent/50 transition-colors"
+                      onClick={() => onConversationResultClick(projectResult.projectName, session.sessionId)}
+                    >
+                      <div className="flex items-center gap-1.5 mb-1">
+                        <MessageSquare className="w-3 h-3 text-primary flex-shrink-0" />
+                        <span className="text-xs font-medium text-foreground truncate">
+                          {session.sessionSummary}
+                        </span>
+                      </div>
+                      <div className="space-y-1 pl-4">
+                        {session.matches.map((match: ConversationMatch, idx: number) => (
+                          <div key={idx} className="flex items-start gap-1">
+                            <span className="text-[10px] text-muted-foreground/60 font-medium uppercase flex-shrink-0 mt-0.5">
+                              {match.role === 'user' ? 'U' : 'A'}
+                            </span>
+                            <HighlightedSnippet
+                              snippet={match.snippet}
+                              matchStart={match.matchStart}
+                              matchEnd={match.matchEnd}
+                            />
+                          </div>
+                        ))}
+                      </div>
+                    </button>
+                  ))}
+                </div>
+              ))}
+            </div>
+          ) : null
+        ) : (
+          <SidebarProjectList {...projectListProps} />
+        )}
       </ScrollArea>
 
       <SidebarFooter

--- a/src/components/sidebar/view/subcomponents/SidebarHeader.tsx
+++ b/src/components/sidebar/view/subcomponents/SidebarHeader.tsx
@@ -1,8 +1,11 @@
-import { FolderPlus, Plus, RefreshCw, Search, X, PanelLeftClose } from 'lucide-react';
+import { Folder, FolderPlus, MessageSquare, Plus, RefreshCw, Search, X, PanelLeftClose } from 'lucide-react';
 import type { TFunction } from 'i18next';
 import { Button } from '../../../ui/button';
 import { Input } from '../../../ui/input';
 import { IS_PLATFORM } from '../../../../constants/config';
+import { cn } from '../../../../lib/utils';
+
+type SearchMode = 'projects' | 'conversations';
 
 type SidebarHeaderProps = {
   isPWA: boolean;
@@ -12,6 +15,8 @@ type SidebarHeaderProps = {
   searchFilter: string;
   onSearchFilterChange: (value: string) => void;
   onClearSearchFilter: () => void;
+  searchMode: SearchMode;
+  onSearchModeChange: (mode: SearchMode) => void;
   onRefresh: () => void;
   isRefreshing: boolean;
   onCreateProject: () => void;
@@ -27,6 +32,8 @@ export default function SidebarHeader({
   searchFilter,
   onSearchFilterChange,
   onClearSearchFilter,
+  searchMode,
+  onSearchModeChange,
   onRefresh,
   isRefreshing,
   onCreateProject,
@@ -102,23 +109,52 @@ export default function SidebarHeader({
 
         {/* Search bar */}
         {projectsCount > 0 && !isLoading && (
-          <div className="relative mt-2.5">
-            <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-muted-foreground/50 pointer-events-none" />
-            <Input
-              type="text"
-              placeholder={t('projects.searchPlaceholder')}
-              value={searchFilter}
-              onChange={(event) => onSearchFilterChange(event.target.value)}
-              className="nav-search-input pl-9 pr-8 h-9 text-sm rounded-xl border-0 placeholder:text-muted-foreground/40 focus-visible:ring-0 focus-visible:ring-offset-0 transition-all duration-200"
-            />
-            {searchFilter && (
+          <div className="mt-2.5 space-y-2">
+            {/* Search mode toggle */}
+            <div className="flex rounded-lg bg-muted/50 p-0.5">
               <button
-                onClick={onClearSearchFilter}
-                className="absolute right-2.5 top-1/2 -translate-y-1/2 p-0.5 hover:bg-accent rounded-md"
+                onClick={() => onSearchModeChange('projects')}
+                className={cn(
+                  "flex-1 flex items-center justify-center gap-1.5 rounded-md px-2 py-1.5 text-xs font-medium transition-all",
+                  searchMode === 'projects'
+                    ? "bg-background shadow-sm text-foreground"
+                    : "text-muted-foreground hover:text-foreground"
+                )}
               >
-                <X className="w-3 h-3 text-muted-foreground" />
+                <Folder className="w-3 h-3" />
+                {t('search.modeProjects')}
               </button>
-            )}
+              <button
+                onClick={() => onSearchModeChange('conversations')}
+                className={cn(
+                  "flex-1 flex items-center justify-center gap-1.5 rounded-md px-2 py-1.5 text-xs font-medium transition-all",
+                  searchMode === 'conversations'
+                    ? "bg-background shadow-sm text-foreground"
+                    : "text-muted-foreground hover:text-foreground"
+                )}
+              >
+                <MessageSquare className="w-3 h-3" />
+                {t('search.modeConversations')}
+              </button>
+            </div>
+            <div className="relative">
+              <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-muted-foreground/50 pointer-events-none" />
+              <Input
+                type="text"
+                placeholder={searchMode === 'conversations' ? t('search.conversationsPlaceholder') : t('projects.searchPlaceholder')}
+                value={searchFilter}
+                onChange={(event) => onSearchFilterChange(event.target.value)}
+                className="nav-search-input pl-9 pr-8 h-9 text-sm rounded-xl border-0 placeholder:text-muted-foreground/40 focus-visible:ring-0 focus-visible:ring-offset-0 transition-all duration-200"
+              />
+              {searchFilter && (
+                <button
+                  onClick={onClearSearchFilter}
+                  className="absolute right-2.5 top-1/2 -translate-y-1/2 p-0.5 hover:bg-accent rounded-md"
+                >
+                  <X className="w-3 h-3 text-muted-foreground" />
+                </button>
+              )}
+            </div>
           </div>
         )}
       </div>
@@ -163,23 +199,51 @@ export default function SidebarHeader({
 
         {/* Mobile search */}
         {projectsCount > 0 && !isLoading && (
-          <div className="relative mt-2.5">
-            <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground/50 pointer-events-none" />
-            <Input
-              type="text"
-              placeholder={t('projects.searchPlaceholder')}
-              value={searchFilter}
-              onChange={(event) => onSearchFilterChange(event.target.value)}
-              className="nav-search-input pl-10 pr-9 h-10 text-sm rounded-xl border-0 placeholder:text-muted-foreground/40 focus-visible:ring-0 focus-visible:ring-offset-0 transition-all duration-200"
-            />
-            {searchFilter && (
+          <div className="mt-2.5 space-y-2">
+            <div className="flex rounded-lg bg-muted/50 p-0.5">
               <button
-                onClick={onClearSearchFilter}
-                className="absolute right-2.5 top-1/2 -translate-y-1/2 p-1 hover:bg-accent rounded-md"
+                onClick={() => onSearchModeChange('projects')}
+                className={cn(
+                  "flex-1 flex items-center justify-center gap-1.5 rounded-md px-2 py-1.5 text-xs font-medium transition-all",
+                  searchMode === 'projects'
+                    ? "bg-background shadow-sm text-foreground"
+                    : "text-muted-foreground hover:text-foreground"
+                )}
               >
-                <X className="w-3.5 h-3.5 text-muted-foreground" />
+                <Folder className="w-3 h-3" />
+                {t('search.modeProjects')}
               </button>
-            )}
+              <button
+                onClick={() => onSearchModeChange('conversations')}
+                className={cn(
+                  "flex-1 flex items-center justify-center gap-1.5 rounded-md px-2 py-1.5 text-xs font-medium transition-all",
+                  searchMode === 'conversations'
+                    ? "bg-background shadow-sm text-foreground"
+                    : "text-muted-foreground hover:text-foreground"
+                )}
+              >
+                <MessageSquare className="w-3 h-3" />
+                {t('search.modeConversations')}
+              </button>
+            </div>
+            <div className="relative">
+              <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground/50 pointer-events-none" />
+              <Input
+                type="text"
+                placeholder={searchMode === 'conversations' ? t('search.conversationsPlaceholder') : t('projects.searchPlaceholder')}
+                value={searchFilter}
+                onChange={(event) => onSearchFilterChange(event.target.value)}
+                className="nav-search-input pl-10 pr-9 h-10 text-sm rounded-xl border-0 placeholder:text-muted-foreground/40 focus-visible:ring-0 focus-visible:ring-offset-0 transition-all duration-200"
+              />
+              {searchFilter && (
+                <button
+                  onClick={onClearSearchFilter}
+                  className="absolute right-2.5 top-1/2 -translate-y-1/2 p-1 hover:bg-accent rounded-md"
+                >
+                  <X className="w-3.5 h-3.5 text-muted-foreground" />
+                </button>
+              )}
+            </div>
           </div>
         )}
       </div>

--- a/src/i18n/locales/en/sidebar.json
+++ b/src/i18n/locales/en/sidebar.json
@@ -103,6 +103,15 @@
   "version": {
     "updateAvailable": "Update available"
   },
+  "search": {
+    "modeProjects": "Projects",
+    "modeConversations": "Conversations",
+    "conversationsPlaceholder": "Search in conversations...",
+    "searching": "Searching...",
+    "noResults": "No results found",
+    "tryDifferentQuery": "Try a different search query",
+    "matches": "matches"
+  },
   "deleteConfirmation": {
     "deleteProject": "Delete Project",
     "deleteSession": "Delete Session",

--- a/src/i18n/locales/zh-CN/sidebar.json
+++ b/src/i18n/locales/zh-CN/sidebar.json
@@ -103,6 +103,15 @@
   "version": {
     "updateAvailable": "有可用更新"
   },
+  "search": {
+    "modeProjects": "项目",
+    "modeConversations": "对话",
+    "conversationsPlaceholder": "搜索对话内容...",
+    "searching": "搜索中...",
+    "noResults": "未找到结果",
+    "tryDifferentQuery": "尝试不同的搜索词",
+    "matches": "匹配"
+  },
   "deleteConfirmation": {
     "deleteProject": "删除项目",
     "deleteSession": "删除会话",

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -94,6 +94,8 @@ export const api = {
     authenticatedFetch(`/api/projects/${projectName}${force ? '?force=true' : ''}`, {
       method: 'DELETE',
     }),
+  searchConversations: (query, limit = 50) =>
+    authenticatedFetch(`/api/search/conversations?q=${encodeURIComponent(query)}&limit=${limit}`),
   createProject: (path) =>
     authenticatedFetch('/api/projects/create', {
       method: 'POST',


### PR DESCRIPTION
## Summary
- Add a Projects/Conversations toggle to the sidebar search bar
- In Conversations mode, search text content across all JSONL session files with debounced API calls (400ms)
- Display results grouped by project/session with highlighted snippets and click-to-navigate
- Backend: new `searchConversations()` function in `server/projects.js` + `GET /api/search/conversations` endpoint
- Frontend: search mode state + debounce in `useSidebarController`, toggle UI in `SidebarHeader`, results display in `SidebarContent`
- i18n keys added for EN and ZH-CN

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added conversation search functionality to find and navigate conversations across your projects.
  * Added search mode toggle to switch between searching projects and searching conversations.
  * Search results display matching conversations with context snippets and session details.
  * Integrated localization support for English and Simplified Chinese for the new search feature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->