### PR TITLE
fix(chat): clear stuck Processing/Thinking indicators on terminal and error lifecycle paths

### DIFF
--- a/src/components/chat/hooks/useChatComposerState.ts
+++ b/src/components/chat/hooks/useChatComposerState.ts
@@ -551,7 +551,7 @@ export function useChatComposerState({
       };
 
       setChatMessages((previous) => [...previous, userMessage]);
-      setIsLoading(true);
+      setIsLoading(true); // Processing banner starts
       setCanAbortSession(true);
       setClaudeStatus({
         text: 'Processing',

--- a/src/components/chat/hooks/useChatRealtimeHandlers.ts
+++ b/src/components/chat/hooks/useChatRealtimeHandlers.ts
@@ -134,9 +134,10 @@ export function useChatRealtimeHandlers({
       latestMessage.data && typeof latestMessage.data === 'object'
         ? (latestMessage.data as Record<string, any>)
         : null;
+    const messageType = String(latestMessage.type);
 
     const globalMessageTypes = ['projects_updated', 'taskmaster-project-updated', 'session-created'];
-    const isGlobalMessage = globalMessageTypes.includes(String(latestMessage.type));
+    const isGlobalMessage = globalMessageTypes.includes(messageType);
     const lifecycleMessageTypes = new Set([
       'claude-complete',
       'codex-complete',
@@ -146,6 +147,7 @@ export function useChatRealtimeHandlers({
       'cursor-error',
       'codex-error',
       'gemini-error',
+      'error',
     ]);
 
     const isClaudeSystemInit =
@@ -168,9 +170,12 @@ export function useChatRealtimeHandlers({
 
     const activeViewSessionId =
       selectedSession?.id || currentSessionId || pendingViewSessionRef.current?.sessionId || null;
+    const hasPendingUnboundSession =
+      Boolean(pendingViewSessionRef.current) && !pendingViewSessionRef.current?.sessionId;
     const isSystemInitForView =
       systemInitSessionId && (!activeViewSessionId || systemInitSessionId === activeViewSessionId);
     const shouldBypassSessionFilter = isGlobalMessage || Boolean(isSystemInitForView);
+    const isLifecycleMessage = lifecycleMessageTypes.has(messageType);
     const isUnscopedError =
       !latestMessage.sessionId &&
       pendingViewSessionRef.current &&
@@ -201,6 +206,30 @@ export function useChatRealtimeHandlers({
       setClaudeStatus(null);
     };
 
+    const clearPendingViewSession = (resolvedSessionId?: string | null) => {
+      const pendingSession = pendingViewSessionRef.current;
+      if (!pendingSession) {
+        return;
+      }
+
+      // If the in-view request never received a concrete session ID (or this terminal event
+      // resolves the same pending session), clear it to avoid stale "in-flight" UI state.
+      if (!pendingSession.sessionId || !resolvedSessionId || pendingSession.sessionId === resolvedSessionId) {
+        pendingViewSessionRef.current = null;
+      }
+    };
+
+    const flushStreamingState = () => {
+      if (streamTimerRef.current) {
+        clearTimeout(streamTimerRef.current);
+        streamTimerRef.current = null;
+      }
+      const pendingChunk = streamBufferRef.current;
+      streamBufferRef.current = '';
+      appendStreamingChunk(setChatMessages, pendingChunk, false);
+      finalizeStreamingMessage(setChatMessages);
+    };
+
     const markSessionsAsCompleted = (...sessionIds: Array<string | null | undefined>) => {
       const normalizedSessionIds = collectSessionIds(...sessionIds);
       normalizedSessionIds.forEach((sessionId) => {
@@ -209,25 +238,46 @@ export function useChatRealtimeHandlers({
       });
     };
 
+    const finalizeLifecycleForCurrentView = (...sessionIds: Array<string | null | undefined>) => {
+      const pendingSessionId = typeof window !== 'undefined' ? sessionStorage.getItem('pendingSessionId') : null;
+      const resolvedSessionIds = collectSessionIds(...sessionIds, pendingSessionId, pendingViewSessionRef.current?.sessionId);
+      const resolvedPrimarySessionId = resolvedSessionIds[0] || null;
+
+      flushStreamingState();
+      clearLoadingIndicators();
+      markSessionsAsCompleted(...resolvedSessionIds);
+      setPendingPermissionRequests([]);
+      clearPendingViewSession(resolvedPrimarySessionId);
+    };
+
     if (!shouldBypassSessionFilter) {
       if (!activeViewSessionId) {
-        if (latestMessage.sessionId && lifecycleMessageTypes.has(String(latestMessage.type))) {
+        if (latestMessage.sessionId && isLifecycleMessage && !hasPendingUnboundSession) {
           handleBackgroundLifecycle(latestMessage.sessionId);
+          return;
         }
-        if (!isUnscopedError) {
+        if (!isUnscopedError && !hasPendingUnboundSession) {
           return;
         }
       }
 
-      if (!latestMessage.sessionId && !isUnscopedError) {
+      if (!latestMessage.sessionId && !isUnscopedError && !hasPendingUnboundSession) {
         return;
       }
 
       if (latestMessage.sessionId !== activeViewSessionId) {
-        if (latestMessage.sessionId && lifecycleMessageTypes.has(String(latestMessage.type))) {
-          handleBackgroundLifecycle(latestMessage.sessionId);
+        const shouldTreatAsPendingViewLifecycle =
+          !activeViewSessionId &&
+          hasPendingUnboundSession &&
+          latestMessage.sessionId &&
+          isLifecycleMessage;
+
+        if (!shouldTreatAsPendingViewLifecycle) {
+          if (latestMessage.sessionId && isLifecycleMessage) {
+            handleBackgroundLifecycle(latestMessage.sessionId);
+          }
+          return;
         }
-        return;
       }
     }
 
@@ -545,6 +595,7 @@ export function useChatRealtimeHandlers({
         break;
 
       case 'claude-error':
+        finalizeLifecycleForCurrentView(latestMessage.sessionId, currentSessionId, selectedSession?.id);
         setChatMessages((previous) => [
           ...previous,
           {
@@ -604,6 +655,7 @@ export function useChatRealtimeHandlers({
         break;
 
       case 'cursor-error':
+        finalizeLifecycleForCurrentView(latestMessage.sessionId, currentSessionId, selectedSession?.id);
         setChatMessages((previous) => [
           ...previous,
           {
@@ -618,8 +670,7 @@ export function useChatRealtimeHandlers({
         const cursorCompletedSessionId = latestMessage.sessionId || currentSessionId;
         const pendingCursorSessionId = sessionStorage.getItem('pendingSessionId');
 
-        clearLoadingIndicators();
-        markSessionsAsCompleted(
+        finalizeLifecycleForCurrentView(
           cursorCompletedSessionId,
           currentSessionId,
           selectedSession?.id,
@@ -701,8 +752,7 @@ export function useChatRealtimeHandlers({
         const completedSessionId =
           latestMessage.sessionId || currentSessionId || pendingSessionId;
 
-        clearLoadingIndicators();
-        markSessionsAsCompleted(
+        finalizeLifecycleForCurrentView(
           completedSessionId,
           currentSessionId,
           selectedSession?.id,
@@ -718,7 +768,6 @@ export function useChatRealtimeHandlers({
         if (selectedProject && latestMessage.exitCode === 0) {
           safeLocalStorage.removeItem(`chat_messages_${selectedProject.name}`);
         }
-        setPendingPermissionRequests([]);
         break;
       }
 
@@ -836,13 +885,11 @@ export function useChatRealtimeHandlers({
         }
 
         if (codexData.type === 'turn_complete') {
-          clearLoadingIndicators();
-          markSessionsAsCompleted(latestMessage.sessionId, currentSessionId, selectedSession?.id);
+          finalizeLifecycleForCurrentView(latestMessage.sessionId, currentSessionId, selectedSession?.id);
         }
 
         if (codexData.type === 'turn_failed') {
-          clearLoadingIndicators();
-          markSessionsAsCompleted(latestMessage.sessionId, currentSessionId, selectedSession?.id);
+          finalizeLifecycleForCurrentView(latestMessage.sessionId, currentSessionId, selectedSession?.id);
           setChatMessages((previous) => [
             ...previous,
             {
@@ -861,8 +908,7 @@ export function useChatRealtimeHandlers({
         const codexCompletedSessionId =
           latestMessage.sessionId || currentSessionId || codexPendingSessionId;
 
-        clearLoadingIndicators();
-        markSessionsAsCompleted(
+        finalizeLifecycleForCurrentView(
           codexCompletedSessionId,
           codexActualSessionId,
           currentSessionId,
@@ -886,8 +932,7 @@ export function useChatRealtimeHandlers({
       }
 
       case 'codex-error':
-        setIsLoading(false);
-        setCanAbortSession(false);
+        finalizeLifecycleForCurrentView(latestMessage.sessionId, currentSessionId, selectedSession?.id);
         setChatMessages((previous) => [
           ...previous,
           {
@@ -937,8 +982,7 @@ export function useChatRealtimeHandlers({
       }
 
       case 'gemini-error':
-        setIsLoading(false);
-        setCanAbortSession(false);
+        finalizeLifecycleForCurrentView(latestMessage.sessionId, currentSessionId, selectedSession?.id);
         setChatMessages((previous) => [
           ...previous,
           {
@@ -990,13 +1034,11 @@ export function useChatRealtimeHandlers({
         const abortSucceeded = latestMessage.success !== false;
 
         if (abortSucceeded) {
-          clearLoadingIndicators();
-          markSessionsAsCompleted(abortedSessionId, currentSessionId, selectedSession?.id, pendingSessionId);
+          finalizeLifecycleForCurrentView(abortedSessionId, currentSessionId, selectedSession?.id, pendingSessionId);
           if (pendingSessionId && (!abortedSessionId || pendingSessionId === abortedSessionId)) {
             sessionStorage.removeItem('pendingSessionId');
           }
 
-          setPendingPermissionRequests([]);
           setChatMessages((previous) => [
             ...previous,
             {
@@ -1092,6 +1134,12 @@ export function useChatRealtimeHandlers({
         setPendingPermissionRequests(serverRequests);
         break;
       }
+
+      case 'error':
+        // Generic backend failure (e.g., provider process failed before a provider-specific
+        // completion event was emitted). Treat it as terminal for current view lifecycle.
+        finalizeLifecycleForCurrentView(latestMessage.sessionId, currentSessionId, selectedSession?.id);
+        break;
 
       default:
         break;

--- a/src/contexts/WebSocketContext.tsx
+++ b/src/contexts/WebSocketContext.tsx
@@ -67,6 +67,7 @@ const useWebSocketProviderState = (): WebSocketContextType => {
         try {
           const data = JSON.parse(event.data);
           setLatestMessage(data);
+          console.log('--->Received WebSocket message:', data);
         } catch (error) {
           console.error('Error parsing WebSocket message:', error);
         }


### PR DESCRIPTION
# Summary
This PR fixes a chat lifecycle bug where the Processing... banner and inline Thinking... indicator could remain visible after operations had already terminated (especially on error or incomplete completion signaling).

# Problem
- UI loading state is started when sending a message in src/components/chat/hooks/useChatComposerState.ts:554.
- Rendering of the two stuck indicators is driven by loading state:
1. src/components/chat/view/subcomponents/ClaudeStatus.tsx:89
2. src/components/chat/view/subcomponents/ChatMessagesPane.tsx:267
- Some provider terminal/error paths did not fully clear loading + processing session lifecycle.
- Pending unbound sessions could filter out terminal lifecycle messages before teardown, leaving the view in an in-flight state.

# What Changed
- Added normalized lifecycle handling in src/components/chat/hooks/useChatRealtimeHandlers.ts:
- messageType normalization and lifecycle classification at :137.
- pending-unbound session detection at :173.
- shared finalizer finalizeLifecycleForCurrentView at :241.
- filter updates to allow terminal teardown for pending-unbound views at :255, :259, :264, :271.
- Applied shared finalizer to terminal/error events:
1. claude-error at :597
2. cursor-error at :657
- completion/result paths at :673, :755, :911, :1037
1. codex-error at :934
2. gemini-error at :984
- generic backend error at :1138
- Added inline context comments/logging from staged changes:
1. src/components/chat/hooks/useChatComposerState.ts:554
2. src/contexts/WebSocketContext.tsx:70

# Behavioral Impact
Processing... and Thinking... now reliably disappear when a request ends via:
1. explicit completion
2. provider error
3. successful abort
4. generic backend terminal error
5. Stream buffers are flushed/finalized during terminal teardown, reducing partial in-flight UI artifacts.
6. Processing session markers are cleared consistently to avoid re-triggering loading state.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved error handling and recovery for chat messaging scenarios
  * Enhanced message lifecycle management and streaming state handling
  * Refined session completion and state cleanup processes

* **Chores**
  * Added debug logging to WebSocket message handler

<!-- end of auto-generated comment: release notes by coderabbit.ai -->