### PR TITLE
Fix Codex session rehydration leaking AGENTS.md/internal context into user-visible history

### DIFF
--- a/server/projects.js
+++ b/server/projects.js
@@ -1490,6 +1490,23 @@ async function getCodexSessions(projectPath, options = {}) {
   }
 }
 
+function isVisibleCodexUserMessage(payload) {
+  if (!payload || payload.type !== 'user_message') {
+    return false;
+  }
+
+  // Codex logs internal context (environment, instructions) as non-plain user_message kinds.
+  if (payload.kind && payload.kind !== 'plain') {
+    return false;
+  }
+
+  if (typeof payload.message !== 'string' || payload.message.trim().length === 0) {
+    return false;
+  }
+  
+  return true;
+}
+
 // Parse a Codex session JSONL file to extract metadata
 async function parseCodexSessionFile(filePath) {
   try {
@@ -1525,8 +1542,8 @@ async function parseCodexSessionFile(filePath) {
             };
           }
 
-          // Count messages and extract user messages for summary
-          if (entry.type === 'event_msg' && entry.payload?.type === 'user_message') {
+          // Count visible user messages and extract summary from the latest plain user input.
+          if (entry.type === 'event_msg' && isVisibleCodexUserMessage(entry.payload)) {
             messageCount++;
             if (entry.payload.message) {
               lastUserMessage = entry.payload.message;
@@ -1633,25 +1650,36 @@ async function getCodexSessionMessages(sessionId, limit = null, offset = 0) {
               };
             }
           }
+          
+          // Use event_msg.user_message for user-visible inputs.
+          if (entry.type === 'event_msg' && isVisibleCodexUserMessage(entry.payload)) {
+            messages.push({
+              type: 'user',
+              timestamp: entry.timestamp,
+              message: {
+                role: 'user',
+                content: entry.payload.message
+              }
+            });
+          }
 
-          // Extract messages from response_item
-          if (entry.type === 'response_item' && entry.payload?.type === 'message') {
+          // response_item.message may include internal prompts for non-assistant roles.
+          // Keep only assistant output from response_item.
+          if (
+            entry.type === 'response_item' &&
+            entry.payload?.type === 'message' &&
+            entry.payload.role === 'assistant'
+          ) {
             const content = entry.payload.content;
-            const role = entry.payload.role || 'assistant';
             const textContent = extractText(content);
-
-            // Skip system context messages (environment_context)
-            if (textContent?.includes('<environment_context>')) {
-              continue;
-            }
 
             // Only add if there's actual content
             if (textContent?.trim()) {
               messages.push({
-                type: role === 'user' ? 'user' : 'assistant',
+                type: 'assistant',
                 timestamp: entry.timestamp,
                 message: {
-                  role: role,
+                  role: 'assistant',
                   content: textContent
                 }
               });


### PR DESCRIPTION
**Summary** This PR fixes a Codex history parsing bug where session reload could show hidden internal prompt context (for example AGENTS.md instructions) that never appeared in live websocket responses. The fix aligns restored history with live behavior by sourcing user-visible user messages from `event_msg.user_message (plain)` and restricting `response_item.message` to assistant role only.

**Issue**

- Repro:

1. Send `Hi`.
2. UI shows correct assistant reply from websocket.
3. Refresh and reopen session.
4. Unexpected AGENTS.md content appears as user input in history.

- Impact:
    - False user-visible history.
    - Confusing conversation timeline.
    - Potential accidental display of internal prompt scaffolding.

**Root cause analysis**

- Live rendering path:
    - `server/openai-codex.js:26-120` transforms Codex stream items.
    - `src/components/chat/hooks/useChatRealtimeHandlers.ts:774-903` renders assistant/tool/reasoning items.
- Reload path:
    - `src/components/chat/hooks/useChatSessionState.ts:100-121` calls session history endpoint.
    - `src/utils/api.js:51-67` routes codex to `/api/codex/sessions/:sessionId/messages`.
    - `server/routes/codex.js:71-83` calls `getCodexSessionMessages`.
    - `server/projects.js` previously reconstructed user messages from `response_item.message`.
- Codex JSONL nuance:
    - `response_item role=user` may include expanded internal context (AGENTS/system/developer/env payloads).
    - `event_msg user_message` with `kind=plain` is the canonical end-user text.

**Solution**

1. Introduce visibility filter:
    - `server/projects.js:1493-1513`
    - New `isVisibleCodexUserMessage(payload)` ensures only real user-facing plain messages are accepted.
2. Session summary/message count:
    - `server/projects.js:1550-1556`
    - Count/summarize from visible user messages only.
3. History reconstruction changes:
    - `server/projects.js:1659-1669` add user messages from `event_msg.user_message` only.
    - `server/projects.js:1671-1692` parse `response_item.message` only when role is assistant.

**Concrete examples**

Example (target bug):

- Input: `Hi`
- Before reload:
    - user: `# AGENTS.md instructions ...` (incorrect)
    - assistant: `Hi. What do you want to work on?`
- After reload:
    - user: `Hi`
    - assistant: `Hi. What do you want to work on?`

**Manual QA checklist**

1. Start new Codex session and send `Hi`.
2. Confirm live websocket rendering remains unchanged.
3. Refresh page and reopen same session.
4. Confirm no AGENTS/environment scaffold appears.
5. Confirm user `Hi` + assistant response are preserved.
6. Test one older Codex session for backward compatibility.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved filtering of session messages to prevent internal content and system context from appearing in user-facing displays.
  * Enhanced extraction and proper handling of assistant responses, reasoning processes, and tool interactions in session data.
  * Refined message type handling to ensure only user-visible interactions are surfaced appropriately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->