### PR TITLE
feat: load commands from installed Claude Code plugins

### DIFF
--- a/server/routes/commands.js
+++ b/server/routes/commands.js
@@ -673,30 +673,44 @@ router.post("/execute", async (req, res) => {
     }
 
     // Load command content
-    // Security: validate commandPath is within allowed directories
+    // Security: Prevent path traversal and symlink escapes.
+    // Canonicalize the requested path and verify it falls within an explicit
+    // allowed command root before reading.
+    let resolvedPath;
+    try {
+      resolvedPath = await fs.realpath(commandPath);
+    } catch {
+      return res.status(404).json({
+        error: "Command not found",
+        message: `Command file not found: ${commandPath}`,
+      });
+    }
+
     {
-      const resolvedPath = path.resolve(commandPath);
-      const userBase = path.resolve(
-        path.join(os.homedir(), ".claude", "commands"),
-      );
+      const allowedRoots = [path.join(os.homedir(), ".claude", "commands")];
       const pluginDirs = await getInstalledPluginCommandDirs();
-      const pluginBases = pluginDirs.map(({ commandsDir }) =>
-        path.resolve(commandsDir),
-      );
-      const projectBase = context?.projectPath
-        ? path.resolve(path.join(context.projectPath, ".claude", "commands"))
-        : null;
-      const isUnder = (base) => {
-        const rel = path.relative(base, resolvedPath);
+      for (const { commandsDir } of pluginDirs) {
+        allowedRoots.push(commandsDir);
+      }
+      if (context?.projectPath) {
+        allowedRoots.push(
+          path.join(context.projectPath, ".claude", "commands"),
+        );
+      }
+
+      const isUnderRoot = async (rootPath) => {
+        let realRoot;
+        try {
+          realRoot = await fs.realpath(rootPath);
+        } catch {
+          return false;
+        }
+        const rel = path.relative(realRoot, resolvedPath);
         return rel !== "" && !rel.startsWith("..") && !path.isAbsolute(rel);
       };
-      if (
-        !(
-          isUnder(userBase) ||
-          pluginBases.some((base) => isUnder(base)) ||
-          (projectBase && isUnder(projectBase))
-        )
-      ) {
+
+      const checks = await Promise.all(allowedRoots.map(isUnderRoot));
+      if (!checks.some(Boolean)) {
         return res.status(403).json({
           error: "Access denied",
           message:
@@ -704,7 +718,7 @@ router.post("/execute", async (req, res) => {
         });
       }
     }
-    const content = await fs.readFile(commandPath, "utf8");
+    const content = await fs.readFile(resolvedPath, "utf8");
     const { data: metadata, content: commandContent } = matter(content);
     // Basic argument replacement (will be enhanced in command parser utility)
     let processedContent = commandContent;

--- a/server/routes/commands.js
+++ b/server/routes/commands.js
@@ -76,6 +76,56 @@ async function scanCommandsDirectory(dir, baseDir, namespace) {
 }
 
 /**
+ * Read installed plugin paths from ~/.claude/plugins/installed_plugins.json
+ * @returns {Promise<Array<{pluginName: string, commandsDir: string}>>}
+ */
+async function getInstalledPluginCommandDirs() {
+  const pluginsJsonPath = path.join(os.homedir(), '.claude', 'plugins', 'installed_plugins.json');
+  const dirs = [];
+
+  try {
+    const raw = await fs.readFile(pluginsJsonPath, 'utf8');
+    const { plugins } = JSON.parse(raw);
+
+    for (const [pluginKey, installs] of Object.entries(plugins)) {
+      const pluginName = pluginKey.split('@')[0];
+      for (const install of installs) {
+        dirs.push({
+          pluginName,
+          commandsDir: path.join(install.installPath, 'commands')
+        });
+      }
+    }
+  } catch (err) {
+    if (err.code !== 'ENOENT') {
+      console.error('Error reading installed plugins:', err.message);
+    }
+  }
+
+  return dirs;
+}
+
+/**
+ * Scan all installed plugin command directories
+ * @returns {Promise<Array>} Array of command objects with namespace 'plugin:<name>'
+ */
+async function scanPluginCommands() {
+  const pluginDirs = await getInstalledPluginCommandDirs();
+  const commands = [];
+
+  for (const { pluginName, commandsDir } of pluginDirs) {
+    const pluginCommands = await scanCommandsDirectory(
+      commandsDir,
+      commandsDir,
+      `plugin:${pluginName}`
+    );
+    commands.push(...pluginCommands);
+  }
+
+  return commands;
+}
+
+/**
  * Built-in commands that are always available
  */
 const builtInCommands = [
@@ -429,6 +479,10 @@ router.post('/list', async (req, res) => {
     );
     allCommands.push(...userCommands);
 
+    // Scan installed plugin commands (~/.claude/plugins/...)
+    const pluginCommands = await scanPluginCommands();
+    allCommands.push(...pluginCommands);
+
     // Separate built-in and custom commands
     const customCommands = allCommands.filter(cmd => cmd.namespace !== 'builtin');
 
@@ -545,6 +599,7 @@ router.post('/execute', async (req, res) => {
     {
       const resolvedPath = path.resolve(commandPath);
       const userBase = path.resolve(path.join(os.homedir(), '.claude', 'commands'));
+      const pluginCacheBase = path.resolve(path.join(os.homedir(), '.claude', 'plugins', 'cache'));
       const projectBase = context?.projectPath
         ? path.resolve(path.join(context.projectPath, '.claude', 'commands'))
         : null;
@@ -552,7 +607,7 @@ router.post('/execute', async (req, res) => {
         const rel = path.relative(base, resolvedPath);
         return rel !== '' && !rel.startsWith('..') && !path.isAbsolute(rel);
       };
-      if (!(isUnder(userBase) || (projectBase && isUnder(projectBase)))) {
+      if (!(isUnder(userBase) || isUnder(pluginCacheBase) || (projectBase && isUnder(projectBase)))) {
         return res.status(403).json({
           error: 'Access denied',
           message: 'Command must be in .claude/commands directory'

--- a/server/routes/commands.js
+++ b/server/routes/commands.js
@@ -1,10 +1,14 @@
-import express from 'express';
-import { promises as fs } from 'fs';
-import path from 'path';
-import { fileURLToPath } from 'url';
-import os from 'os';
-import matter from 'gray-matter';
-import { CLAUDE_MODELS, CURSOR_MODELS, CODEX_MODELS } from '../../shared/modelConstants.js';
+import express from "express";
+import { promises as fs } from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
+import os from "os";
+import matter from "gray-matter";
+import {
+  CLAUDE_MODELS,
+  CURSOR_MODELS,
+  CODEX_MODELS,
+} from "../../shared/modelConstants.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -32,24 +36,30 @@ async function scanCommandsDirectory(dir, baseDir, namespace) {
 
       if (entry.isDirectory()) {
         // Recursively scan subdirectories
-        const subCommands = await scanCommandsDirectory(fullPath, baseDir, namespace);
+        const subCommands = await scanCommandsDirectory(
+          fullPath,
+          baseDir,
+          namespace,
+        );
         commands.push(...subCommands);
-      } else if (entry.isFile() && entry.name.endsWith('.md')) {
+      } else if (entry.isFile() && entry.name.endsWith(".md")) {
         // Parse markdown file for metadata
         try {
-          const content = await fs.readFile(fullPath, 'utf8');
-          const { data: frontmatter, content: commandContent } = matter(content);
+          const content = await fs.readFile(fullPath, "utf8");
+          const { data: frontmatter, content: commandContent } =
+            matter(content);
 
           // Calculate relative path from baseDir for command name
           const relativePath = path.relative(baseDir, fullPath);
           // Remove .md extension and convert to command name
-          const commandName = '/' + relativePath.replace(/\.md$/, '').replace(/\\/g, '/');
+          const commandName =
+            "/" + relativePath.replace(/\.md$/, "").replace(/\\/g, "/");
 
           // Extract description from frontmatter or first line of content
-          let description = frontmatter.description || '';
+          let description = frontmatter.description || "";
           if (!description) {
-            const firstLine = commandContent.trim().split('\n')[0];
-            description = firstLine.replace(/^#+\s*/, '').trim();
+            const firstLine = commandContent.trim().split("\n")[0];
+            description = firstLine.replace(/^#+\s*/, "").trim();
           }
 
           commands.push({
@@ -58,7 +68,7 @@ async function scanCommandsDirectory(dir, baseDir, namespace) {
             relativePath,
             description,
             namespace,
-            metadata: frontmatter
+            metadata: frontmatter,
           });
         } catch (err) {
           console.error(`Error parsing command file ${fullPath}:`, err.message);
@@ -67,7 +77,7 @@ async function scanCommandsDirectory(dir, baseDir, namespace) {
     }
   } catch (err) {
     // Directory doesn't exist or can't be accessed - this is okay
-    if (err.code !== 'ENOENT' && err.code !== 'EACCES') {
+    if (err.code !== "ENOENT" && err.code !== "EACCES") {
       console.error(`Error scanning directory ${dir}:`, err.message);
     }
   }
@@ -80,25 +90,30 @@ async function scanCommandsDirectory(dir, baseDir, namespace) {
  * @returns {Promise<Array<{pluginName: string, commandsDir: string}>>}
  */
 async function getInstalledPluginCommandDirs() {
-  const pluginsJsonPath = path.join(os.homedir(), '.claude', 'plugins', 'installed_plugins.json');
+  const pluginsJsonPath = path.join(
+    os.homedir(),
+    ".claude",
+    "plugins",
+    "installed_plugins.json",
+  );
   const dirs = [];
 
   try {
-    const raw = await fs.readFile(pluginsJsonPath, 'utf8');
+    const raw = await fs.readFile(pluginsJsonPath, "utf8");
     const { plugins } = JSON.parse(raw);
 
     for (const [pluginKey, installs] of Object.entries(plugins)) {
-      const pluginName = pluginKey.split('@')[0];
+      const pluginName = pluginKey.split("@")[0];
       for (const install of installs) {
         dirs.push({
           pluginName,
-          commandsDir: path.join(install.installPath, 'commands')
+          commandsDir: path.join(install.installPath, "commands"),
         });
       }
     }
   } catch (err) {
-    if (err.code !== 'ENOENT') {
-      console.error('Error reading installed plugins:', err.message);
+    if (err.code !== "ENOENT") {
+      console.error("Error reading installed plugins:", err.message);
     }
   }
 
@@ -117,7 +132,7 @@ async function scanPluginCommands() {
     const pluginCommands = await scanCommandsDirectory(
       commandsDir,
       commandsDir,
-      `plugin:${pluginName}`
+      `plugin:${pluginName}`,
     );
     commands.push(...pluginCommands);
   }
@@ -130,53 +145,53 @@ async function scanPluginCommands() {
  */
 const builtInCommands = [
   {
-    name: '/help',
-    description: 'Show help documentation for Claude Code',
-    namespace: 'builtin',
-    metadata: { type: 'builtin' }
+    name: "/help",
+    description: "Show help documentation for Claude Code",
+    namespace: "builtin",
+    metadata: { type: "builtin" },
   },
   {
-    name: '/clear',
-    description: 'Clear the conversation history',
-    namespace: 'builtin',
-    metadata: { type: 'builtin' }
+    name: "/clear",
+    description: "Clear the conversation history",
+    namespace: "builtin",
+    metadata: { type: "builtin" },
   },
   {
-    name: '/model',
-    description: 'Switch or view the current AI model',
-    namespace: 'builtin',
-    metadata: { type: 'builtin' }
+    name: "/model",
+    description: "Switch or view the current AI model",
+    namespace: "builtin",
+    metadata: { type: "builtin" },
   },
   {
-    name: '/cost',
-    description: 'Display token usage and cost information',
-    namespace: 'builtin',
-    metadata: { type: 'builtin' }
+    name: "/cost",
+    description: "Display token usage and cost information",
+    namespace: "builtin",
+    metadata: { type: "builtin" },
   },
   {
-    name: '/memory',
-    description: 'Open CLAUDE.md memory file for editing',
-    namespace: 'builtin',
-    metadata: { type: 'builtin' }
+    name: "/memory",
+    description: "Open CLAUDE.md memory file for editing",
+    namespace: "builtin",
+    metadata: { type: "builtin" },
   },
   {
-    name: '/config',
-    description: 'Open settings and configuration',
-    namespace: 'builtin',
-    metadata: { type: 'builtin' }
+    name: "/config",
+    description: "Open settings and configuration",
+    namespace: "builtin",
+    metadata: { type: "builtin" },
   },
   {
-    name: '/status',
-    description: 'Show system status and version information',
-    namespace: 'builtin',
-    metadata: { type: 'builtin' }
+    name: "/status",
+    description: "Show system status and version information",
+    namespace: "builtin",
+    metadata: { type: "builtin" },
   },
   {
-    name: '/rewind',
-    description: 'Rewind the conversation to a previous state',
-    namespace: 'builtin',
-    metadata: { type: 'builtin' }
-  }
+    name: "/rewind",
+    description: "Rewind the conversation to a previous state",
+    namespace: "builtin",
+    metadata: { type: "builtin" },
+  },
 ];
 
 /**
@@ -184,14 +199,18 @@ const builtInCommands = [
  * Each handler returns { type: 'builtin', action: string, data: any }
  */
 const builtInHandlers = {
-  '/help': async (args, context) => {
+  "/help": async (args, context) => {
     const helpText = `# Claude Code Commands
 
 ## Built-in Commands
 
-${builtInCommands.map(cmd => `### ${cmd.name}
+${builtInCommands
+  .map(
+    (cmd) => `### ${cmd.name}
 ${cmd.description}
-`).join('\n')}
+`,
+  )
+  .join("\n")}
 
 ## Custom Commands
 
@@ -213,71 +232,76 @@ Custom commands can be created in:
 `;
 
     return {
-      type: 'builtin',
-      action: 'help',
+      type: "builtin",
+      action: "help",
       data: {
         content: helpText,
-        format: 'markdown'
-      }
+        format: "markdown",
+      },
     };
   },
 
-  '/clear': async (args, context) => {
+  "/clear": async (args, context) => {
     return {
-      type: 'builtin',
-      action: 'clear',
+      type: "builtin",
+      action: "clear",
       data: {
-        message: 'Conversation history cleared'
-      }
+        message: "Conversation history cleared",
+      },
     };
   },
 
-  '/model': async (args, context) => {
+  "/model": async (args, context) => {
     // Read available models from centralized constants
     const availableModels = {
-      claude: CLAUDE_MODELS.OPTIONS.map(o => o.value),
-      cursor: CURSOR_MODELS.OPTIONS.map(o => o.value),
-      codex: CODEX_MODELS.OPTIONS.map(o => o.value)
+      claude: CLAUDE_MODELS.OPTIONS.map((o) => o.value),
+      cursor: CURSOR_MODELS.OPTIONS.map((o) => o.value),
+      codex: CODEX_MODELS.OPTIONS.map((o) => o.value),
     };
 
-    const currentProvider = context?.provider || 'claude';
+    const currentProvider = context?.provider || "claude";
     const currentModel = context?.model || CLAUDE_MODELS.DEFAULT;
 
     return {
-      type: 'builtin',
-      action: 'model',
+      type: "builtin",
+      action: "model",
       data: {
         current: {
           provider: currentProvider,
-          model: currentModel
+          model: currentModel,
         },
         available: availableModels,
-        message: args.length > 0
-          ? `Switching to model: ${args[0]}`
-          : `Current model: ${currentModel}`
-      }
+        message:
+          args.length > 0
+            ? `Switching to model: ${args[0]}`
+            : `Current model: ${currentModel}`,
+      },
     };
   },
 
-  '/cost': async (args, context) => {
+  "/cost": async (args, context) => {
     const tokenUsage = context?.tokenUsage || {};
-    const provider = context?.provider || 'claude';
+    const provider = context?.provider || "claude";
     const model =
       context?.model ||
-      (provider === 'cursor'
+      (provider === "cursor"
         ? CURSOR_MODELS.DEFAULT
-        : provider === 'codex'
+        : provider === "codex"
           ? CODEX_MODELS.DEFAULT
           : CLAUDE_MODELS.DEFAULT);
 
-    const used = Number(tokenUsage.used ?? tokenUsage.totalUsed ?? tokenUsage.total_tokens ?? 0) || 0;
+    const used =
+      Number(
+        tokenUsage.used ?? tokenUsage.totalUsed ?? tokenUsage.total_tokens ?? 0,
+      ) || 0;
     const total =
       Number(
         tokenUsage.total ??
           tokenUsage.contextWindow ??
-          parseInt(process.env.CONTEXT_WINDOW || '160000', 10),
+          parseInt(process.env.CONTEXT_WINDOW || "160000", 10),
       ) || 160000;
-    const percentage = total > 0 ? Number(((used / total) * 100).toFixed(1)) : 0;
+    const percentage =
+      total > 0 ? Number(((used / total) * 100).toFixed(1)) : 0;
 
     const inputTokensRaw =
       Number(
@@ -306,7 +330,9 @@ Custom commands can be created in:
 
     // If we only have total used tokens, treat them as input for display/estimation.
     const inputTokens =
-      inputTokensRaw > 0 || outputTokens > 0 || cacheTokens > 0 ? inputTokensRaw + cacheTokens : used;
+      inputTokensRaw > 0 || outputTokens > 0 || cacheTokens > 0
+        ? inputTokensRaw + cacheTokens
+        : used;
 
     // Rough default rates by provider (USD / 1M tokens).
     const pricingByProvider = {
@@ -321,8 +347,8 @@ Custom commands can be created in:
     const totalCost = inputCost + outputCost;
 
     return {
-      type: 'builtin',
-      action: 'cost',
+      type: "builtin",
+      action: "cost",
       data: {
         tokenUsage: {
           used,
@@ -339,58 +365,65 @@ Custom commands can be created in:
     };
   },
 
-  '/status': async (args, context) => {
+  "/status": async (args, context) => {
     // Read version from package.json
-    const packageJsonPath = path.join(path.dirname(__dirname), '..', 'package.json');
-    let version = 'unknown';
-    let packageName = 'claude-code-ui';
+    const packageJsonPath = path.join(
+      path.dirname(__dirname),
+      "..",
+      "package.json",
+    );
+    let version = "unknown";
+    let packageName = "claude-code-ui";
 
     try {
-      const packageJson = JSON.parse(await fs.readFile(packageJsonPath, 'utf8'));
+      const packageJson = JSON.parse(
+        await fs.readFile(packageJsonPath, "utf8"),
+      );
       version = packageJson.version;
       packageName = packageJson.name;
     } catch (err) {
-      console.error('Error reading package.json:', err);
+      console.error("Error reading package.json:", err);
     }
 
     const uptime = process.uptime();
     const uptimeMinutes = Math.floor(uptime / 60);
     const uptimeHours = Math.floor(uptimeMinutes / 60);
-    const uptimeFormatted = uptimeHours > 0
-      ? `${uptimeHours}h ${uptimeMinutes % 60}m`
-      : `${uptimeMinutes}m`;
+    const uptimeFormatted =
+      uptimeHours > 0
+        ? `${uptimeHours}h ${uptimeMinutes % 60}m`
+        : `${uptimeMinutes}m`;
 
     return {
-      type: 'builtin',
-      action: 'status',
+      type: "builtin",
+      action: "status",
       data: {
         version,
         packageName,
         uptime: uptimeFormatted,
         uptimeSeconds: Math.floor(uptime),
-        model: context?.model || 'claude-sonnet-4.5',
-        provider: context?.provider || 'claude',
+        model: context?.model || "claude-sonnet-4.5",
+        provider: context?.provider || "claude",
         nodeVersion: process.version,
-        platform: process.platform
-      }
+        platform: process.platform,
+      },
     };
   },
 
-  '/memory': async (args, context) => {
+  "/memory": async (args, context) => {
     const projectPath = context?.projectPath;
 
     if (!projectPath) {
       return {
-        type: 'builtin',
-        action: 'memory',
+        type: "builtin",
+        action: "memory",
         data: {
-          error: 'No project selected',
-          message: 'Please select a project to access its CLAUDE.md file'
-        }
+          error: "No project selected",
+          message: "Please select a project to access its CLAUDE.md file",
+        },
       };
     }
 
-    const claudeMdPath = path.join(projectPath, 'CLAUDE.md');
+    const claudeMdPath = path.join(projectPath, "CLAUDE.md");
 
     // Check if CLAUDE.md exists
     let exists = false;
@@ -402,80 +435,81 @@ Custom commands can be created in:
     }
 
     return {
-      type: 'builtin',
-      action: 'memory',
+      type: "builtin",
+      action: "memory",
       data: {
         path: claudeMdPath,
         exists,
         message: exists
           ? `Opening CLAUDE.md at ${claudeMdPath}`
-          : `CLAUDE.md not found at ${claudeMdPath}. Create it to store project-specific instructions.`
-      }
+          : `CLAUDE.md not found at ${claudeMdPath}. Create it to store project-specific instructions.`,
+      },
     };
   },
 
-  '/config': async (args, context) => {
+  "/config": async (args, context) => {
     return {
-      type: 'builtin',
-      action: 'config',
+      type: "builtin",
+      action: "config",
       data: {
-        message: 'Opening settings...'
-      }
+        message: "Opening settings...",
+      },
     };
   },
 
-  '/rewind': async (args, context) => {
+  "/rewind": async (args, context) => {
     const steps = args[0] ? parseInt(args[0]) : 1;
 
     if (isNaN(steps) || steps < 1) {
       return {
-        type: 'builtin',
-        action: 'rewind',
+        type: "builtin",
+        action: "rewind",
         data: {
-          error: 'Invalid steps parameter',
-          message: 'Usage: /rewind [number] - Rewind conversation by N steps (default: 1)'
-        }
+          error: "Invalid steps parameter",
+          message:
+            "Usage: /rewind [number] - Rewind conversation by N steps (default: 1)",
+        },
       };
     }
 
     return {
-      type: 'builtin',
-      action: 'rewind',
+      type: "builtin",
+      action: "rewind",
       data: {
         steps,
-        message: `Rewinding conversation by ${steps} step${steps > 1 ? 's' : ''}...`
-      }
+        message: `Rewinding conversation by ${steps} step${steps > 1 ? "s" : ""}...`,
+      },
     };
-  }
+  },
 };
 
 /**
  * POST /api/commands/list
  * List all available commands from project and user directories
  */
-router.post('/list', async (req, res) => {
+router.post("/list", async (req, res) => {
   try {
     const { projectPath } = req.body;
     const allCommands = [...builtInCommands];
 
     // Scan project-level commands (.claude/commands/)
     if (projectPath) {
-      const projectCommandsDir = path.join(projectPath, '.claude', 'commands');
+      const projectCommandsDir = path.join(projectPath, ".claude", "commands");
       const projectCommands = await scanCommandsDirectory(
         projectCommandsDir,
         projectCommandsDir,
-        'project'
+        "project",
       );
       allCommands.push(...projectCommands);
     }
 
     // Scan user-level commands (~/.claude/commands/)
     const homeDir = os.homedir();
-    const userCommandsDir = path.join(homeDir, '.claude', 'commands');
+    const userCommandsDir = path.join(homeDir, ".claude", "commands");
     const userCommands = await scanCommandsDirectory(
       userCommandsDir,
       userCommandsDir,
-      'user'
+      "user",
     );
     allCommands.push(...userCommands);
 
@@ -484,21 +518,33 @@ router.post('/list', async (req, res) => {
     allCommands.push(...pluginCommands);
 
     // Separate built-in and custom commands
-    const customCommands = allCommands.filter(cmd => cmd.namespace !== 'builtin');
+    const customCommands = allCommands.filter(
+      (cmd) => cmd.namespace !== "builtin",
+    );
+
+    // Deduplicate by name: builtin > project > user > plugin (first seen wins).
+    // allCommands is ordered builtin, project, user, plugin so iteration order
+    // already reflects the desired precedence.
+    const seenNames = new Set(builtInCommands.map((cmd) => cmd.name));
+    const uniqueCustomCommands = customCommands.filter((cmd) => {
+      if (seenNames.has(cmd.name)) return false;
+      seenNames.add(cmd.name);
+      return true;
+    });
 
     // Sort commands alphabetically by name
-    customCommands.sort((a, b) => a.name.localeCompare(b.name));
+    uniqueCustomCommands.sort((a, b) => a.name.localeCompare(b.name));
 
     res.json({
       builtIn: builtInCommands,
-      custom: customCommands,
-      count: allCommands.length
+      custom: uniqueCustomCommands,
+      count: builtInCommands.length + uniqueCustomCommands.length,
     });
   } catch (error) {
-    console.error('Error listing commands:', error);
+    console.error("Error listing commands:", error);
     res.status(500).json({
-      error: 'Failed to list commands',
-      message: error.message
+      error: "Failed to list commands",
+      message: error.message,
     });
   }
 });
@@ -507,47 +553,76 @@ router.post('/list', async (req, res) => {
  * POST /api/commands/load
  * Load a specific command file and return its content and metadata
  */
-router.post('/load', async (req, res) => {
+router.post("/load", async (req, res) => {
   try {
     const { commandPath } = req.body;
 
     if (!commandPath) {
       return res.status(400).json({
-        error: 'Command path is required'
+        error: "Command path is required",
       });
     }
 
-    // Security: Prevent path traversal
-    const resolvedPath = path.resolve(commandPath);
-    if (!resolvedPath.startsWith(path.resolve(os.homedir())) &&
-        !resolvedPath.includes('.claude/commands')) {
+    // Security: Prevent path traversal and symlink escapes.
+    // Canonicalize the requested path and verify it falls within an explicit
+    // allowed command root before reading.
+    let realPath;
+    try {
+      realPath = await fs.realpath(commandPath);
+    } catch {
+      return res.status(404).json({
+        error: "Command not found",
+        message: `Command file not found: ${commandPath}`,
+      });
+    }
+
+    const allowedRoots = [path.join(os.homedir(), ".claude", "commands")];
+    const pluginDirs = await getInstalledPluginCommandDirs();
+    for (const { commandsDir } of pluginDirs) {
+      allowedRoots.push(commandsDir);
+    }
+
+    const isUnderRoot = async (rootPath) => {
+      let realRoot;
+      try {
+        realRoot = await fs.realpath(rootPath);
+      } catch {
+        return false;
+      }
+      const rel = path.relative(realRoot, realPath);
+      return rel !== "" && !rel.startsWith("..") && !path.isAbsolute(rel);
+    };
+
+    const checks = await Promise.all(allowedRoots.map(isUnderRoot));
+    if (!checks.some(Boolean)) {
       return res.status(403).json({
-        error: 'Access denied',
-        message: 'Command must be in .claude/commands directory'
+        error: "Access denied",
+        message:
+          "Command must be inside an allowed project, user, or plugin commands directory",
       });
     }
 
     // Read and parse the command file
-    const content = await fs.readFile(commandPath, 'utf8');
+    const content = await fs.readFile(realPath, "utf8");
     const { data: metadata, content: commandContent } = matter(content);
 
     res.json({
       path: commandPath,
       metadata,
-      content: commandContent
+      content: commandContent,
     });
   } catch (error) {
-    if (error.code === 'ENOENT') {
+    if (error.code === "ENOENT") {
       return res.status(404).json({
-        error: 'Command not found',
-        message: `Command file not found: ${req.body.commandPath}`
+        error: "Command not found",
+        message: `Command file not found: ${req.body.commandPath}`,
       });
     }
 
-    console.error('Error loading command:', error);
+    console.error("Error loading command:", error);
     res.status(500).json({
-      error: 'Failed to load command',
-      message: error.message
+      error: "Failed to load command",
+      message: error.message,
     });
   }
 });
@@ -558,13 +633,13 @@ router.post('/load', async (req, res) => {
  * This endpoint prepares the command content but doesn't execute bash commands yet
  * (that will be handled in the command parser utility)
  */
-router.post('/execute', async (req, res) => {
+router.post("/execute", async (req, res) => {
   try {
     const { commandName, commandPath, args = [], context = {} } = req.body;
 
     if (!commandName) {
       return res.status(400).json({
-        error: 'Command name is required'
+        error: "Command name is required",
       });
     }
 
@@ -575,14 +650,17 @@ router.post('/execute', async (req, res) => {
         const result = await handler(args, context);
         return res.json({
           ...result,
-          command: commandName
+          command: commandName,
         });
       } catch (error) {
-        console.error(`Error executing built-in command ${commandName}:`, error);
+        console.error(
+          `Error executing built-in command ${commandName}:`,
+          error,
+        );
         return res.status(500).json({
-          error: 'Command execution failed',
+          error: "Command execution failed",
           message: error.message,
-          command: commandName
+          command: commandName,
         });
       }
     }
@@ -590,7 +668,7 @@ router.post('/execute', async (req, res) => {
     // Handle custom commands
     if (!commandPath) {
       return res.status(400).json({
-        error: 'Command path is required for custom commands'
+        error: "Command path is required for custom commands",
       });
     }
 
@@ -598,57 +676,72 @@ router.post('/execute', async (req, res) => {
     // Security: validate commandPath is within allowed directories
     {
       const resolvedPath = path.resolve(commandPath);
-      const userBase = path.resolve(path.join(os.homedir(), '.claude', 'commands'));
-      const pluginCacheBase = path.resolve(path.join(os.homedir(), '.claude', 'plugins', 'cache'));
+      const userBase = path.resolve(
+        path.join(os.homedir(), ".claude", "commands"),
+      );
+      const pluginDirs = await getInstalledPluginCommandDirs();
+      const pluginBases = pluginDirs.map(({ commandsDir }) =>
+        path.resolve(commandsDir),
+      );
       const projectBase = context?.projectPath
-        ? path.resolve(path.join(context.projectPath, '.claude', 'commands'))
+        ? path.resolve(path.join(context.projectPath, ".claude", "commands"))
         : null;
       const isUnder = (base) => {
         const rel = path.relative(base, resolvedPath);
-        return rel !== '' && !rel.startsWith('..') && !path.isAbsolute(rel);
+        return rel !== "" && !rel.startsWith("..") && !path.isAbsolute(rel);
       };
-      if (!(isUnder(userBase) || isUnder(pluginCacheBase) || (projectBase && isUnder(projectBase)))) {
+      if (
+        !(
+          isUnder(userBase) ||
+          pluginBases.some((base) => isUnder(base)) ||
+          (projectBase && isUnder(projectBase))
+        )
+      ) {
         return res.status(403).json({
-          error: 'Access denied',
-          message: 'Command must be in .claude/commands directory'
+          error: "Access denied",
+          message:
+            "Command must be inside an allowed project, user, or plugin commands directory",
         });
       }
     }
-    const content = await fs.readFile(commandPath, 'utf8');
+    const content = await fs.readFile(commandPath, "utf8");
     const { data: metadata, content: commandContent } = matter(content);
     // Basic argument replacement (will be enhanced in command parser utility)
     let processedContent = commandContent;
 
     // Replace $ARGUMENTS with all arguments joined
-    const argsString = args.join(' ');
+    const argsString = args.join(" ");
     processedContent = processedContent.replace(/\$ARGUMENTS/g, argsString);
 
     // Replace $1, $2, etc. with positional arguments
     args.forEach((arg, index) => {
       const placeholder = `$${index + 1}`;
-      processedContent = processedContent.replace(new RegExp(`\\${placeholder}\\b`, 'g'), arg);
+      processedContent = processedContent.replace(
+        new RegExp(`\\${placeholder}\\b`, "g"),
+        arg,
+      );
     });
 
     res.json({
-      type: 'custom',
+      type: "custom",
       command: commandName,
       content: processedContent,
       metadata,
-      hasFileIncludes: processedContent.includes('@'),
-      hasBashCommands: processedContent.includes('!')
+      hasFileIncludes: processedContent.includes("@"),
+      hasBashCommands: processedContent.includes("!"),
     });
   } catch (error) {
-    if (error.code === 'ENOENT') {
+    if (error.code === "ENOENT") {
       return res.status(404).json({
-        error: 'Command not found',
-        message: `Command file not found: ${req.body.commandPath}`
+        error: "Command not found",
+        message: `Command file not found: ${req.body.commandPath}`,
       });
     }
 
-    console.error('Error executing command:', error);
+    console.error("Error executing command:", error);
     res.status(500).json({
-      error: 'Failed to execute command',
-      message: error.message
+      error: "Failed to execute command",
+      message: error.message,
     });
   }
 });

--- a/src/contexts/WebSocketContext.tsx
+++ b/src/contexts/WebSocketContext.tsx
@@ -1,6 +1,14 @@
-import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
-import { useAuth } from '../components/auth/context/AuthContext';
-import { IS_PLATFORM } from '../constants/config';
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import { useAuth } from "../components/auth/context/AuthContext";
+import { IS_PLATFORM } from "../constants/config";
 
 type WebSocketContextType = {
   ws: WebSocket | null;
@@ -14,13 +22,13 @@ const WebSocketContext = createContext<WebSocketContextType | null>(null);
 export const useWebSocket = () => {
   const context = useContext(WebSocketContext);
   if (!context) {
-    throw new Error('useWebSocket must be used within a WebSocketProvider');
+    throw new Error("useWebSocket must be used within a WebSocketProvider");
   }
   return context;
 };
 
 const buildWebSocketUrl = (token: string | null) => {
-  const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
+  const protocol = window.location.protocol === "https:" ? "wss:" : "ws:";
   if (IS_PLATFORM) return `${protocol}//${window.location.host}/ws`; // Platform mode: Use same domain as the page (goes through proxy)
   if (!token) return null;
   return `${protocol}//${window.location.host}/ws?token=${encodeURIComponent(token)}`; // OSS mode: Use same host:port that served the page
@@ -35,8 +43,9 @@ const useWebSocketProviderState = (): WebSocketContextType => {
   const { token } = useAuth();
 
   useEffect(() => {
+    unmountedRef.current = false;
     connect();
-    
+
     return () => {
       unmountedRef.current = true;
       if (reconnectTimeoutRef.current) {
@@ -54,8 +63,11 @@ const useWebSocketProviderState = (): WebSocketContextType => {
       // Construct WebSocket URL
       const wsUrl = buildWebSocketUrl(token);
 
-      if (!wsUrl) return console.warn('No authentication token found for WebSocket connection');
-      
+      if (!wsUrl)
+        return console.warn(
+          "No authentication token found for WebSocket connection",
+        );
+
       const websocket = new WebSocket(wsUrl);
 
       websocket.onopen = () => {
@@ -68,14 +80,14 @@ const useWebSocketProviderState = (): WebSocketContextType => {
           const data = JSON.parse(event.data);
           setLatestMessage(data);
         } catch (error) {
-          console.error('Error parsing WebSocket message:', error);
+          console.error("Error parsing WebSocket message:", error);
         }
       };
 
       websocket.onclose = () => {
         setIsConnected(false);
         wsRef.current = null;
-        
+
         // Attempt to reconnect after 3 seconds
         reconnectTimeoutRef.current = setTimeout(() => {
           if (unmountedRef.current) return; // Prevent reconnection if unmounted
@@ -84,11 +96,10 @@ const useWebSocketProviderState = (): WebSocketContextType => {
       };
 
       websocket.onerror = (error) => {
-        console.error('WebSocket error:', error);
+        console.error("WebSocket error:", error);
       };
-
     } catch (error) {
-      console.error('Error creating WebSocket connection:', error);
+      console.error("Error creating WebSocket connection:", error);
     }
   }, [token]); // everytime token changes, we reconnect
 
@@ -97,24 +108,30 @@ const useWebSocketProviderState = (): WebSocketContextType => {
     if (socket && socket.readyState === WebSocket.OPEN) {
       socket.send(JSON.stringify(message));
     } else {
-      console.warn('WebSocket not connected');
+      console.warn("WebSocket not connected");
     }
   }, []);
 
-  const value: WebSocketContextType = useMemo(() =>
-  ({
-    ws: wsRef.current,
-    sendMessage,
-    latestMessage,
-    isConnected
-  }), [sendMessage, latestMessage, isConnected]);
+  const value: WebSocketContextType = useMemo(
+    () => ({
+      ws: wsRef.current,
+      sendMessage,
+      latestMessage,
+      isConnected,
+    }),
+    [sendMessage, latestMessage, isConnected],
+  );
 
   return value;
 };
 
-export const WebSocketProvider = ({ children }: { children: React.ReactNode }) => {
+export const WebSocketProvider = ({
+  children,
+}: {
+  children: React.ReactNode;
+}) => {
   const webSocketData = useWebSocketProviderState();
-  
+
   return (
     <WebSocketContext.Provider value={webSocketData}>
       {children}


### PR DESCRIPTION
## Problem

Users who install marketplace plugins via Claude Code (e.g. `spec-driven-workflow`, `pr-review-toolkit`, `everything-claude-code`) cannot access those plugin commands from the slash command picker in the UI.

Plugin commands are installed to `~/.claude/plugins/cache/<marketplace>/<plugin>/<version>/commands/` but the app only scans `~/.claude/commands/` and `.claude/commands/`.

## Solution

Read `~/.claude/plugins/installed_plugins.json` to discover all installed plugins, then scan each plugin's `commands/` directory using the existing `scanCommandsDirectory` function. Plugin commands are exposed with a `plugin:<name>` namespace (e.g. `plugin:spec-driven-workflow`).

Also extends the `/execute` endpoint's security check to allow `commandPath` values under `~/.claude/plugins/cache/`, so plugin commands can actually be loaded and run.

## Changes

- `server/routes/commands.js`: add `getInstalledPluginCommandDirs()` and `scanPluginCommands()` functions, call `scanPluginCommands()` in the `POST /list` route, and extend the path-traversal guard in `POST /execute` to include the plugin cache directory.

## Testing

With marketplace plugins installed, the `/api/commands/list` endpoint now returns them alongside built-in and user commands:

```
/AddressPR          [plugin:spec-driven-workflow]
/WorkOn             [plugin:spec-driven-workflow]
/review-pr          [plugin:pr-review-toolkit]
/tdd                [plugin:everything-claude-code]
...
```

These appear in the slash command picker in the UI as expected.

## Notes

- Gracefully handles missing `installed_plugins.json` (no plugins installed = no-op)
- Reuses existing `scanCommandsDirectory` — no new scanning logic
- Zero impact if the user has no plugins installed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Installed plugins' commands are now discovered and included in command listings.

* **Bug Fixes**
  * Command listing deduplicates and prioritizes built-in > project > user > plugin to avoid collisions.
  * Path resolution and permission checks strengthened (realpath-based containment, plugin dirs allowed) for safer loading/execution.
  * Error messages and logging standardized for clearer feedback.

* **Chores**
  * Missing plugin manifest is silently ignored; other read errors are logged.

* **Style**
  * Formatting and string-style consistency improvements; provider lifecycle flag initialization fixed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->