### PR TITLE
fix: replace getDatabase with better-sqlite3 db in getGithubTokenById

### DIFF
--- a/server/routes/projects.js
+++ b/server/routes/projects.js
@@ -311,13 +311,11 @@ router.post('/create-workspace', async (req, res) => {
  * Helper function to get GitHub token from database
  */
 async function getGithubTokenById(tokenId, userId) {
-  const { getDatabase } = await import('../database/db.js');
-  const db = await getDatabase();
+  const { db } = await import('../database/db.js');
 
-  const credential = await db.get(
-    'SELECT * FROM user_credentials WHERE id = ? AND user_id = ? AND credential_type = ? AND is_active = 1',
-    [tokenId, userId, 'github_token']
-  );
+  const credential = db.prepare(
+    'SELECT * FROM user_credentials WHERE id = ? AND user_id = ? AND credential_type = ? AND is_active = 1'
+  ).get(tokenId, userId, 'github_token');
 
   // Return in the expected format (github_token field for compatibility)
   if (credential) {


### PR DESCRIPTION
## Bug

When creating a project using a stored GitHub token, the following error is thrown:

```
getDatabase is not a function
```

## Root Cause

`getGithubTokenById` in `server/routes/projects.js` imports `getDatabase` from `database/db.js`:

```js
const { getDatabase } = await import('../database/db.js');
const db = await getDatabase();
const credential = await db.get(sql, [params]);
```

However, `db.js` uses `better-sqlite3` and does **not** export a `getDatabase` function — it exports the `db` instance directly. The code also uses the async `sqlite` package API (`db.get(sql, array)`) which is incompatible with `better-sqlite3`'s synchronous API.

## Fix

Import `db` directly and use the correct `better-sqlite3` API:

```js
const { db } = await import('../database/db.js');
const credential = db.prepare(sql).get(...params);
```

## How to Reproduce

1. Set up a self-hosted instance
2. Add a GitHub token via the UI
3. Create a new project using that stored token
4. Observe `getDatabase is not a function` error on the confirm step

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal code structure for enhanced maintainability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->