### PR TITLE
feat: add support for ANTHROPIC_AUTH_TOKEN authentication detection

### DIFF
--- a/server/routes/cli-auth.js
+++ b/server/routes/cli-auth.js
@@ -100,7 +100,8 @@ router.get('/gemini/status', async (req, res) => {
  * Checks Claude authentication credentials using two methods with priority order:
  *
  * Priority 1: ANTHROPIC_API_KEY environment variable
- * Priority 2: ~/.claude/.credentials.json OAuth tokens
+ * Priority 2: ANTHROPIC_AUTH_TOKEN environment variable
+ * Priority 3: ~/.claude/.credentials.json OAuth tokens
  *
  * The Claude Agent SDK prioritizes environment variables over authenticated subscriptions.
  * This matching behavior ensures consistency with how the SDK authenticates.
@@ -128,7 +129,17 @@ async function checkClaudeCredentials() {
     };
   }
 
-  // Priority 2: Check ~/.claude/.credentials.json for OAuth tokens
+  // Priority 2: Check for ANTHROPIC_AUTH_TOKEN environment variable.
+  // The SDK accepts this token-based auth path when API key is not configured.
+  if (process.env.ANTHROPIC_AUTH_TOKEN && process.env.ANTHROPIC_AUTH_TOKEN.trim()) {
+    return {
+      authenticated: true,
+      email: 'API Key Auth',
+      method: 'api_key'
+    };
+  }
+
+  // Priority 3: Check ~/.claude/.credentials.json for OAuth tokens
   // This is the standard authentication method used by Claude CLI after running
   // 'claude /login' or 'claude setup-token' commands.
   try {

--- a/tests/cli-auth.test.js
+++ b/tests/cli-auth.test.js
@@ -1,0 +1,55 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import express from 'express';
+import fs from 'fs/promises';
+import os from 'os';
+import path from 'path';
+
+import cliAuthRouter from '../server/routes/cli-auth.js';
+
+function restoreEnv(snapshot) {
+  for (const key of Object.keys(process.env)) {
+    if (!(key in snapshot)) {
+      delete process.env[key];
+    }
+  }
+
+  for (const [key, value] of Object.entries(snapshot)) {
+    process.env[key] = value;
+  }
+}
+
+test('claude status authenticates when ANTHROPIC_AUTH_TOKEN is set', async () => {
+  const envSnapshot = { ...process.env };
+  const originalHome = process.env.HOME;
+  const tempHome = await fs.mkdtemp(path.join(os.tmpdir(), 'ccui-auth-test-'));
+
+  const app = express();
+  app.use('/api/cli-auth', cliAuthRouter);
+  const server = app.listen(0);
+
+  try {
+    delete process.env.ANTHROPIC_API_KEY;
+    process.env.ANTHROPIC_AUTH_TOKEN = 'test-auth-token';
+    process.env.HOME = tempHome;
+
+    const address = server.address();
+    assert.ok(address && typeof address === 'object' && 'port' in address);
+
+    const response = await fetch(`http://127.0.0.1:${address.port}/api/cli-auth/claude/status`);
+    assert.equal(response.status, 200);
+
+    const payload = await response.json();
+    assert.equal(payload.authenticated, true);
+    assert.equal(payload.method, 'api_key');
+  } finally {
+    server.close();
+    restoreEnv(envSnapshot);
+    if (originalHome === undefined) {
+      delete process.env.HOME;
+    } else {
+      process.env.HOME = originalHome;
+    }
+    await fs.rm(tempHome, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary

This PR extends Claude authentication detection to support the `ANTHROPIC_AUTH_TOKEN` environment variable while preserving SDK-aligned priority behavior.

## Changes

### Modified Files
- `server/routes/cli-auth.js`
- `tests/cli-auth.test.js`

### Key Updates
1. **Extended `checkClaudeCredentials()`** to detect `ANTHROPIC_AUTH_TOKEN` as env-based authentication.
2. **Updated auth priority order** to:
   - `ANTHROPIC_API_KEY` (highest priority)
   - `ANTHROPIC_AUTH_TOKEN`
   - `~/.claude/.credentials.json` OAuth tokens
3. **Kept API response compatibility** by returning `method: 'api_key'` for env-based auth paths.
4. **Added regression test** for `/api/cli-auth/claude/status` when only `ANTHROPIC_AUTH_TOKEN` is set.

## Authentication Priority Order

1. **`ANTHROPIC_API_KEY` environment variable**
2. **`ANTHROPIC_AUTH_TOKEN` environment variable**
3. **`~/.claude/.credentials.json` OAuth tokens**

This maintains consistency with SDK-style env-first behavior and avoids frontend behavior changes.

## Backward Compatibility

✅ Fully backward compatible:
- Existing consumers that rely on `authenticated` continue to work.
- Existing UI logic that checks `method === 'api_key'` continues to work for env auth.

## Testing

Verified with:
- `node --test tests/cli-auth.test.js`

Result:
- ✅ `claude status authenticates when ANTHROPIC_AUTH_TOKEN is set`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for the ANTHROPIC_AUTH_TOKEN environment variable for Claude authentication; API-key auth now takes precedence over stored OAuth credentials.

* **Tests**
  * New test coverage validating Claude authentication status via environment-configured API key, with robust setup and cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->