### PR TITLE
fix: prevent triple message submission on iOS touch events

### DIFF
--- a/src/components/chat/hooks/useChatComposerState.ts
+++ b/src/components/chat/hooks/useChatComposerState.ts
@@ -131,6 +131,8 @@ export function useChatComposerState({
     ((event: FormEvent<HTMLFormElement> | MouseEvent | TouchEvent | KeyboardEvent<HTMLTextAreaElement>) => Promise<void>) | null
   >(null);
   const inputValueRef = useRef(input);
+  // Submission lock — prevents triple-fire on iOS (onTouchStart + onMouseDown + form onSubmit all firing together)
+  const isSubmittingRef = useRef(false);
 
   const handleBuiltInCommand = useCallback(
     (result: CommandExecutionResult) => {
@@ -473,8 +475,12 @@ export function useChatComposerState({
       event: FormEvent<HTMLFormElement> | MouseEvent | TouchEvent | KeyboardEvent<HTMLTextAreaElement>,
     ) => {
       event.preventDefault();
+      // Guard against triple-fire on iOS: onTouchStart + onMouseDown + form onSubmit all fire simultaneously
+      if (isSubmittingRef.current) return;
+      isSubmittingRef.current = true;
       const currentInput = inputValueRef.current;
       if (!currentInput.trim() || isLoading || !selectedProject) {
+        isSubmittingRef.current = false;
         return;
       }
 
@@ -679,6 +685,8 @@ export function useChatComposerState({
       }
 
       safeLocalStorage.removeItem(`draft_input_${selectedProject.name}`);
+      // Release submission lock after a short delay to absorb any remaining duplicate events
+      setTimeout(() => { isSubmittingRef.current = false; }, 800);
     },
     [
       attachedImages,


### PR DESCRIPTION
## Problem

On iOS, tapping the send button fires three submission events simultaneously:
1. `onTouchStart` → calls `onSubmit()` directly
2. `onMouseDown` → calls `onSubmit()` (iOS generates synthetic mouse events after touch)
3. `<form onSubmit>` → fires from the resulting synthetic click

This causes every message — especially image uploads — to be sent **3× to the backend**, resulting in the same message being processed three times and images being uploaded and processed three times.

## Fix

Add an `isSubmittingRef` guard at the top of `handleSubmit` in `useChatComposerState.ts`:

- First caller sets the flag and proceeds normally
- Subsequent duplicate calls within 800ms return early
- Lock releases via `setTimeout` after state cleanup, so normal sequential sends are unaffected

```ts
const isSubmittingRef = useRef(false);

// In handleSubmit:
if (isSubmittingRef.current) return;
isSubmittingRef.current = true;
// ...existing logic...
setTimeout(() => { isSubmittingRef.current = false; }, 800);
```

## Testing

Tested on iPhone (iOS Chrome/WebKit). Before fix: every send with an image triggered 3 backend requests. After fix: exactly 1 backend request per tap.

The 800ms window safely absorbs all three iOS touch event phases without blocking legitimate rapid re-sends.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue on iOS devices where chat messages could be submitted multiple times unintentionally due to simultaneous input interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->