### PR TITLE
windows powershell 优化：

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -1785,7 +1785,7 @@ function handleShellConnection(ws) {
 
                     // Use appropriate shell based on platform
                     const shell = os.platform() === 'win32' ? 'powershell.exe' : 'bash';
-                    const shellArgs = os.platform() === 'win32' ? ['-Command', shellCommand] : ['-c', shellCommand];
+                    const shellArgs = os.platform() === 'win32'  ? ['-ExecutionPolicy', 'RemoteSigned', '-Command', shellCommand] : ['-c', shellCommand];
 
                     // Use terminal dimensions from client if provided, otherwise use defaults
                     const termCols = data.cols || 80;


### PR DESCRIPTION
http://localhost:3001/中连接claude code时，提示无法加载文件 ~\nodejs\node_global\claude.ps1，因为在此系统上禁止运行脚本。
sever/index.js: line 1788, 添加参数 ： '-ExecutionPolicy', 'RemoteSigned' 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced Windows shell invocation configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->