### PR TITLE
feat: full repl mode - native CLI integration for chat tab with session sync

### DIFF
--- a/server/claude-cli-query.js
+++ b/server/claude-cli-query.js
@@ -167,8 +167,15 @@ export async function queryClaudeCLI(command, options = {}, ws) {
   // Build the full command string for bash -c.
   // The claude binary is a Bun executable that requires a proper shell
   // environment (same way the Shell tab spawns it).
-  const escapedArgs = args.map(a => `'${a.replace(/'/g, "'\\''")}'`).join(' ');
-  const shellCommand = `claude ${escapedArgs}`;
+  const claudeBin = await resolveClaudeBinary();
+  const isWindows = os.platform() === 'win32';
+  const escapedArgs = args.map(a => {
+    if (isWindows) {
+      return `'${a.replace(/'/g, "''")}'`;
+    }
+    return `'${a.replace(/'/g, "'\\''")}'`;
+  }).join(' ');
+  const shellCommand = `${claudeBin} ${escapedArgs}`;
 
   console.log(`[Full REPL v2] Spawning via bash: claude ${args.slice(0, 6).join(' ')}...`);
   console.log(`[Full REPL v2] cwd: ${resolvedCwd}`);
@@ -237,25 +244,19 @@ export async function queryClaudeCLI(command, options = {}, ws) {
         const wsMessages = mapCliEventToWsMessages(event, session);
         for (const msg of wsMessages) {
           if (msg.type === 'session-created') {
-            // Send session-created immediately, then flush buffered messages
-            // after a short delay so the UI has time to update activeViewSessionId
             console.log(`[Full REPL v2] Sending WS: ${JSON.stringify(msg)}`);
             ws.send(msg);
-            sessionCreatedSent = true;
 
-            // Flush any buffered messages after a tick
-            setTimeout(() => {
-              for (const buffered of bufferedMessages) {
-                console.log(`[Full REPL v2] Flushing buffered WS: ${JSON.stringify(buffered).substring(0, 200)}`);
-                ws.send(buffered);
-              }
-              bufferedMessages = [];
-            }, 100);
+            // Flush buffered messages synchronously after session-created
+            for (const buffered of bufferedMessages) {
+              ws.send(buffered);
+            }
+            bufferedMessages = [];
+            sessionCreatedSent = true;
           } else if (!sessionCreatedSent) {
             // Buffer messages until session-created has been sent
             bufferedMessages.push(msg);
           } else {
-            console.log(`[Full REPL v2] Sending WS: ${JSON.stringify(msg).substring(0, 200)}`);
             ws.send(msg);
           }
         }
@@ -400,8 +401,8 @@ export function abortClaudeCLISession(sessionId) {
     session.process.write('\x03'); // Ctrl+C
     setTimeout(() => {
       try { session.process.kill(); } catch { /* already dead */ }
+      activeCliSessions.delete(sessionId);
     }, 1000);
-    activeCliSessions.delete(sessionId);
     return true;
   }
   return false;

--- a/server/claude-cli-query.js
+++ b/server/claude-cli-query.js
@@ -105,13 +105,11 @@ export async function queryClaudeCLI(command, options = {}, ws) {
 
   const args = ['--output-format', 'stream-json', '--verbose'];
 
-  // Skip MCP server loading for Chat queries. The CLI loads ALL configured
-  // MCP servers on startup (including failing ones that timeout for 10s+ each).
-  // Chat queries rarely need MCP servers. The Shell tab loads them natively.
-  // Users can override this with options.loadMcpServers = true if needed.
-  if (!options.loadMcpServers) {
-    args.push('--mcp-config', '{"mcpServers":{}}', '--strict-mcp-config');
-  }
+  // Skip MCP server loading for --print mode queries. The CLI waits for all
+  // MCP servers to connect/fail before processing, which adds 20-30s for servers
+  // that timeout. MCP tools are available in the Shell tab (persistent REPL).
+  // MCP_CONNECTION_NONBLOCKING only works for the interactive SDK mode, not --print.
+  args.push('--mcp-config', '{"mcpServers":{}}', '--strict-mcp-config');
 
   // Resume: explicit session ID > registry > none
   const isValidUUID = sessionId && /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(sessionId);

--- a/server/claude-cli-query.js
+++ b/server/claude-cli-query.js
@@ -125,6 +125,8 @@ export async function queryClaudeCLI(command, options = {}, ws) {
     }
   }
 
+  const isResumed = Boolean(resumeId);
+
   if (resumeId) {
     args.push('--resume', resumeId);
   }
@@ -198,6 +200,8 @@ export async function queryClaudeCLI(command, options = {}, ws) {
   let partialLine = '';
   let sessionCreatedSent = false;
   let bufferedMessages = [];
+  let lastPlaintextLine = '';
+  let structuredErrorSent = false;
 
   const session = {
     process: cliProcess,
@@ -222,7 +226,11 @@ export async function queryClaudeCLI(command, options = {}, ws) {
 
       // Strip any ANSI escape sequences that might leak through
       const cleaned = trimmed.replace(/\x1b\[[0-9;]*[a-zA-Z]/g, '').trim();
-      if (!cleaned || cleaned[0] !== '{') continue;
+      if (!cleaned) continue;
+      if (cleaned[0] !== '{') {
+        lastPlaintextLine = cleaned;
+        continue;
+      }
 
       try {
         const event = JSON.parse(cleaned);
@@ -285,11 +293,20 @@ export async function queryClaudeCLI(command, options = {}, ws) {
       }
     }
 
+    // Emit plaintext CLI error if process failed without a structured error
+    if (exitCode && exitCode !== 0 && !structuredErrorSent && lastPlaintextLine) {
+      ws.send({
+        type: 'claude-error',
+        error: lastPlaintextLine,
+        sessionId: capturedSessionId || null,
+      });
+    }
+
     ws.send({
       type: 'claude-complete',
       sessionId: capturedSessionId,
       exitCode: exitCode || 0,
-      isNewSession: !sessionId,
+      isNewSession: !isResumed,
     });
 
     activeCliSessions.delete(capturedSessionId || sessionKey);

--- a/server/claude-cli-query.js
+++ b/server/claude-cli-query.js
@@ -2,13 +2,14 @@
  * Claude CLI Query Runner (Full REPL Mode v2)
  *
  * Spawns the native `claude` CLI with `--output-format stream-json`
- * and maps the streaming JSON events to the same WebSocket message
- * format the Chat UI already expects.
+ * via node-pty (pseudo-terminal) and maps the streaming JSON events
+ * to the same WebSocket message format the Chat UI already expects.
  *
- * This replaces the SDK-based queryClaudeSDK() when Full REPL Mode is active.
+ * The claude binary requires a TTY to produce output, so we must use
+ * node-pty instead of child_process.spawn.
  */
 
-import { spawn } from 'child_process';
+import pty from 'node-pty';
 import { promises as fs } from 'fs';
 import path from 'path';
 import os from 'os';
@@ -16,31 +17,123 @@ import os from 'os';
 const activeCliSessions = new Map();
 
 /**
+ * Maps projectPath → last CLI session UUID.
+ * Used for bidirectional session sync between Chat and Shell tabs.
+ */
+const projectSessionRegistry = new Map();
+
+export function getProjectSessionId(projectPath) {
+  return projectSessionRegistry.get(projectPath) || null;
+}
+
+export function setProjectSessionId(projectPath, sessionId) {
+  if (projectPath && sessionId) {
+    projectSessionRegistry.set(projectPath, sessionId);
+    console.log(`[Full REPL v2] Registry: ${projectPath} → ${sessionId}`);
+  }
+}
+
+/**
+ * Scans ~/.claude/projects/ for the most recently modified session file
+ * for a given project path. Returns the session UUID or null.
+ */
+export async function findLatestSessionForProject(projectPath) {
+  try {
+    // Claude encodes project paths by replacing / with -
+    const encoded = projectPath.replace(/\//g, '-');
+    const projectDir = path.join(os.homedir(), '.claude', 'projects', encoded);
+
+    const entries = await fs.readdir(projectDir);
+    const jsonlFiles = entries.filter(e => e.endsWith('.jsonl'));
+
+    if (jsonlFiles.length === 0) return null;
+
+    // Find the most recently modified
+    let latest = null;
+    let latestMtime = 0;
+
+    for (const file of jsonlFiles) {
+      const filePath = path.join(projectDir, file);
+      const stat = await fs.stat(filePath);
+      if (stat.mtimeMs > latestMtime) {
+        latestMtime = stat.mtimeMs;
+        latest = file.replace('.jsonl', '');
+      }
+    }
+
+    return latest;
+  } catch {
+    return null;
+  }
+}
+
+let cachedClaudeBin = null;
+
+/**
+ * Finds the actual claude binary path, skipping shell functions/aliases.
+ */
+async function resolveClaudeBinary() {
+  if (cachedClaudeBin) return cachedClaudeBin;
+
+  const candidates = [
+    path.join(os.homedir(), '.local', 'bin', 'claude'),
+    '/usr/local/bin/claude',
+    '/opt/homebrew/bin/claude',
+  ];
+
+  for (const candidate of candidates) {
+    try {
+      await fs.access(candidate);
+      cachedClaudeBin = candidate;
+      console.log(`[Full REPL v2] Resolved claude binary: ${cachedClaudeBin}`);
+      return cachedClaudeBin;
+    } catch {
+      // Not found, try next
+    }
+  }
+
+  console.log('[Full REPL v2] Could not resolve claude binary, falling back to PATH');
+  cachedClaudeBin = 'claude';
+  return cachedClaudeBin;
+}
+
+/**
  * Spawns the native claude CLI and streams structured JSON events to the WebSocket.
  */
 export async function queryClaudeCLI(command, options = {}, ws) {
-  const { sessionId, cwd, model, permissionMode, images, sessionSummary } = options;
+  const { sessionId, cwd, model, permissionMode, images } = options;
 
   const args = ['--output-format', 'stream-json', '--verbose'];
 
-  // Resume existing session
-  if (sessionId) {
-    args.push('--resume', sessionId);
+  // Resume: explicit session ID > registry > none
+  const isValidUUID = sessionId && /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(sessionId);
+  const resolvedCwd = cwd || process.env.HOME;
+  let resumeId = isValidUUID ? sessionId : null;
+
+  if (!resumeId) {
+    // Check registry for a session created by Shell or a previous Chat query
+    const registryId = getProjectSessionId(resolvedCwd);
+    if (registryId) {
+      resumeId = registryId;
+      console.log(`[Full REPL v2] Chat resuming session from registry: ${resumeId}`);
+    }
   }
 
-  // Model selection
+  if (resumeId) {
+    args.push('--resume', resumeId);
+  }
+
   if (model) {
     args.push('--model', model);
   }
 
-  // Permission mode
   if (permissionMode === 'plan') {
     args.push('--permission-mode', 'plan');
   } else if (permissionMode && permissionMode !== 'default') {
     args.push('--permission-mode', permissionMode);
   }
 
-  // Handle images: save to temp files and prepend to prompt
+  // Handle images
   let finalCommand = command;
   let tempImagePaths = [];
   let tempDir = null;
@@ -57,31 +150,41 @@ export async function queryClaudeCLI(command, options = {}, ws) {
         tempImagePaths.push(imgPath);
       }
     }
-    // Prepend image paths to the prompt
     if (tempImagePaths.length > 0) {
       const imageRefs = tempImagePaths.map(p => `[Image: ${p}]`).join(' ');
       finalCommand = `${imageRefs}\n\n${command}`;
     }
   }
 
-  // Non-interactive mode: send prompt via --print
   args.push('--print', finalCommand);
 
-  const resolvedCwd = cwd || process.env.HOME;
+  // Build the full command string for bash -c.
+  // The claude binary is a Bun executable that requires a proper shell
+  // environment (same way the Shell tab spawns it).
+  const escapedArgs = args.map(a => `'${a.replace(/'/g, "'\\''")}'`).join(' ');
+  const shellCommand = `claude ${escapedArgs}`;
 
-  console.log(`[Full REPL v2] Spawning: claude ${args.slice(0, 4).join(' ')}... (cwd: ${resolvedCwd})`);
+  console.log(`[Full REPL v2] Spawning via bash: claude ${args.slice(0, 6).join(' ')}...`);
+  console.log(`[Full REPL v2] cwd: ${resolvedCwd}`);
 
-  const cliProcess = spawn('claude', args, {
+  const shell = os.platform() === 'win32' ? 'powershell.exe' : 'bash';
+  const shellArgs = os.platform() === 'win32' ? ['-Command', shellCommand] : ['-c', shellCommand];
+
+  const cliProcess = pty.spawn(shell, shellArgs, {
+    name: 'xterm-256color',
+    cols: 120,
+    rows: 40,
     cwd: resolvedCwd,
     env: {
       ...process.env,
       NO_COLOR: '1',
     },
-    stdio: ['pipe', 'pipe', 'pipe'],
   });
 
   let capturedSessionId = sessionId || null;
   let partialLine = '';
+  let sessionCreatedSent = false;
+  let bufferedMessages = [];
 
   const session = {
     process: cliProcess,
@@ -89,64 +192,91 @@ export async function queryClaudeCLI(command, options = {}, ws) {
     sessionId: capturedSessionId,
   };
 
-  // Track session
   const sessionKey = sessionId || `pending_${Date.now()}`;
   activeCliSessions.set(sessionKey, session);
 
-  // Parse stdout JSONL
-  cliProcess.stdout.on('data', (chunk) => {
-    partialLine += chunk.toString();
+  console.log(`[Full REPL v2] Process PID: ${cliProcess.pid}`);
+
+  // Parse PTY output as JSONL
+  cliProcess.onData((rawData) => {
+    partialLine += rawData;
     const lines = partialLine.split('\n');
-    partialLine = lines.pop(); // Keep incomplete line for next chunk
+    partialLine = lines.pop(); // Keep incomplete line
 
     for (const line of lines) {
       const trimmed = line.trim();
       if (!trimmed) continue;
 
-      try {
-        const event = JSON.parse(trimmed);
-        const wsMessages = mapCliEventToWsMessages(event, session);
-        for (const msg of wsMessages) {
-          ws.send(msg);
-        }
+      // Strip any ANSI escape sequences that might leak through
+      const cleaned = trimmed.replace(/\x1b\[[0-9;]*[a-zA-Z]/g, '').trim();
+      if (!cleaned || cleaned[0] !== '{') continue;
 
-        // Capture session ID from init event
+      try {
+        const event = JSON.parse(cleaned);
+        console.log(`[Full REPL v2] Event: ${event.type}/${event.subtype || ''}`);
+        // Capture session ID from init event BEFORE mapping messages
         if (event.type === 'system' && event.subtype === 'init' && event.session_id) {
           capturedSessionId = event.session_id;
           session.sessionId = capturedSessionId;
 
-          // Re-key the session map
+          // Store in registry for Shell tab to pick up
+          setProjectSessionId(resolvedCwd, capturedSessionId);
+
           if (sessionKey !== capturedSessionId) {
             activeCliSessions.delete(sessionKey);
             activeCliSessions.set(capturedSessionId, session);
           }
         }
+
+        const wsMessages = mapCliEventToWsMessages(event, session);
+        for (const msg of wsMessages) {
+          if (msg.type === 'session-created') {
+            // Send session-created immediately, then flush buffered messages
+            // after a short delay so the UI has time to update activeViewSessionId
+            console.log(`[Full REPL v2] Sending WS: ${JSON.stringify(msg)}`);
+            ws.send(msg);
+            sessionCreatedSent = true;
+
+            // Flush any buffered messages after a tick
+            setTimeout(() => {
+              for (const buffered of bufferedMessages) {
+                console.log(`[Full REPL v2] Flushing buffered WS: ${JSON.stringify(buffered).substring(0, 200)}`);
+                ws.send(buffered);
+              }
+              bufferedMessages = [];
+            }, 100);
+          } else if (!sessionCreatedSent) {
+            // Buffer messages until session-created has been sent
+            bufferedMessages.push(msg);
+          } else {
+            console.log(`[Full REPL v2] Sending WS: ${JSON.stringify(msg).substring(0, 200)}`);
+            ws.send(msg);
+          }
+        }
       } catch {
-        // Not valid JSON, skip (startup noise, etc.)
+        // Not valid JSON, skip
       }
     }
   });
 
-  // Forward stderr as status messages
-  cliProcess.stderr.on('data', (chunk) => {
-    const text = chunk.toString().trim();
-    if (text) {
-      console.log(`[Full REPL v2 stderr] ${text}`);
-    }
-  });
-
-  cliProcess.on('error', (err) => {
-    console.error('[Full REPL v2] Failed to spawn claude CLI:', err.message);
-    ws.send({
-      type: 'claude-error',
-      error: `Failed to spawn claude CLI: ${err.message}. Is claude installed and in PATH?`,
-      sessionId: capturedSessionId,
-    });
-    activeCliSessions.delete(capturedSessionId || sessionKey);
-  });
-
-  cliProcess.on('close', (exitCode) => {
+  cliProcess.onExit(({ exitCode }) => {
     console.log(`[Full REPL v2] CLI process exited with code ${exitCode}`);
+
+    // Process any remaining partial line
+    if (partialLine.trim()) {
+      const cleaned = partialLine.trim().replace(/\x1b\[[0-9;]*[a-zA-Z]/g, '').trim();
+      if (cleaned && cleaned[0] === '{') {
+        try {
+          const event = JSON.parse(cleaned);
+          const wsMessages = mapCliEventToWsMessages(event, session);
+          for (const msg of wsMessages) {
+            ws.send(msg);
+          }
+        } catch {
+          // ignore
+        }
+      }
+    }
 
     ws.send({
       type: 'claude-complete',
@@ -170,8 +300,7 @@ export async function queryClaudeCLI(command, options = {}, ws) {
 }
 
 /**
- * Maps a CLI stream-json event to one or more WebSocket messages
- * in the format the Chat UI expects.
+ * Maps a CLI stream-json event to WebSocket messages the Chat UI expects.
  */
 function mapCliEventToWsMessages(event, session) {
   const sid = session.sessionId;
@@ -180,7 +309,6 @@ function mapCliEventToWsMessages(event, session) {
   switch (event.type) {
     case 'system': {
       if (event.subtype === 'init') {
-        // Emit session-created
         messages.push({
           type: 'session-created',
           sessionId: event.session_id,
@@ -190,9 +318,6 @@ function mapCliEventToWsMessages(event, session) {
     }
 
     case 'assistant': {
-      // The CLI emits the full assistant message with content array.
-      // The Chat UI expects: { type: 'claude-response', data: { message: {...}, ... }, sessionId }
-      // where data.message has { role, content: [...] }
       const msg = event.message;
       if (msg) {
         messages.push({
@@ -208,9 +333,6 @@ function mapCliEventToWsMessages(event, session) {
     }
 
     case 'user': {
-      // Tool results come as user messages with role: 'user' and content array
-      // containing tool_result blocks. The Chat UI handles this via:
-      // structuredMessageData?.role === 'user' && Array.isArray(structuredMessageData.content)
       const msg = event.message;
       if (msg) {
         messages.push({
@@ -218,7 +340,6 @@ function mapCliEventToWsMessages(event, session) {
           data: {
             message: msg,
             parent_tool_use_id: event.parent_tool_use_id || null,
-            // Include tool_use_result for richer rendering
             tool_use_result: event.tool_use_result || null,
           },
           sessionId: sid,
@@ -228,8 +349,6 @@ function mapCliEventToWsMessages(event, session) {
     }
 
     case 'result': {
-      // Final result with usage/cost info
-      // Emit token budget from the result
       if (event.modelUsage) {
         const models = Object.keys(event.modelUsage);
         if (models.length > 0) {
@@ -248,14 +367,10 @@ function mapCliEventToWsMessages(event, session) {
       break;
     }
 
-    case 'rate_limit_event': {
-      // Could emit as status, but not critical for rendering
+    case 'rate_limit_event':
       break;
-    }
 
     default: {
-      // Forward any unknown event types as generic claude-response
-      // so the UI can at least try to render them
       if (event.message) {
         messages.push({
           type: 'claude-response',
@@ -271,28 +386,25 @@ function mapCliEventToWsMessages(event, session) {
 }
 
 /**
- * Aborts an active CLI session by killing the process.
+ * Aborts an active CLI session.
  */
 export function abortClaudeCLISession(sessionId) {
   const session = activeCliSessions.get(sessionId);
   if (session?.process) {
-    session.process.kill('SIGINT');
+    session.process.write('\x03'); // Ctrl+C
+    setTimeout(() => {
+      try { session.process.kill(); } catch { /* already dead */ }
+    }, 1000);
     activeCliSessions.delete(sessionId);
     return true;
   }
   return false;
 }
 
-/**
- * Checks if a CLI session is currently active.
- */
 export function isClaudeCLISessionActive(sessionId) {
   return activeCliSessions.has(sessionId);
 }
 
-/**
- * Returns all active CLI sessions.
- */
 export function getActiveClaudeCLISessions() {
   return Array.from(activeCliSessions.keys());
 }

--- a/server/claude-cli-query.js
+++ b/server/claude-cli-query.js
@@ -39,8 +39,8 @@ export function setProjectSessionId(projectPath, sessionId) {
  */
 export async function findLatestSessionForProject(projectPath) {
   try {
-    // Claude encodes project paths by replacing / with -
-    const encoded = projectPath.replace(/\//g, '-');
+    // Claude encodes project paths by replacing non-alphanumeric chars with -
+    const encoded = projectPath.replace(/[^a-zA-Z0-9-]/g, '-');
     const projectDir = path.join(os.homedir(), '.claude', 'projects', encoded);
 
     const entries = await fs.readdir(projectDir);
@@ -150,10 +150,18 @@ export async function queryClaudeCLI(command, options = {}, ws) {
     tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'claude-img-'));
     for (let i = 0; i < images.length; i++) {
       const img = images[i];
-      if (img.data && img.mediaType) {
-        const ext = img.mediaType.split('/')[1] || 'png';
+      // Support both data URL format (data:mime;base64,...) and raw base64
+      const dataUrlMatch = typeof img.data === 'string'
+        ? img.data.match(/^data:([^;]+);base64,(.+)$/)
+        : null;
+      const mimeType = img.mediaType || img.mimeType || dataUrlMatch?.[1];
+      const base64Data = dataUrlMatch?.[2] ||
+        (typeof img.data === 'string' && !img.data.startsWith('data:') ? img.data : null);
+
+      if (mimeType && base64Data) {
+        const ext = mimeType.split('/')[1] || 'png';
         const imgPath = path.join(tempDir, `image_${i}.${ext}`);
-        const buffer = Buffer.from(img.data, 'base64');
+        const buffer = Buffer.from(base64Data, 'base64');
         await fs.writeFile(imgPath, buffer);
         tempImagePaths.push(imgPath);
       }

--- a/server/claude-cli-query.js
+++ b/server/claude-cli-query.js
@@ -1,0 +1,300 @@
+/**
+ * Claude CLI Query Runner (Full REPL Mode v2)
+ *
+ * Spawns the native `claude` CLI with `--output-format stream-json`
+ * and maps the streaming JSON events to the same WebSocket message
+ * format the Chat UI already expects.
+ *
+ * This replaces the SDK-based queryClaudeSDK() when Full REPL Mode is active.
+ */
+
+import { spawn } from 'child_process';
+import { promises as fs } from 'fs';
+import path from 'path';
+import os from 'os';
+
+const activeCliSessions = new Map();
+
+/**
+ * Spawns the native claude CLI and streams structured JSON events to the WebSocket.
+ */
+export async function queryClaudeCLI(command, options = {}, ws) {
+  const { sessionId, cwd, model, permissionMode, images, sessionSummary } = options;
+
+  const args = ['--output-format', 'stream-json', '--verbose'];
+
+  // Resume existing session
+  if (sessionId) {
+    args.push('--resume', sessionId);
+  }
+
+  // Model selection
+  if (model) {
+    args.push('--model', model);
+  }
+
+  // Permission mode
+  if (permissionMode === 'plan') {
+    args.push('--permission-mode', 'plan');
+  } else if (permissionMode && permissionMode !== 'default') {
+    args.push('--permission-mode', permissionMode);
+  }
+
+  // Handle images: save to temp files and prepend to prompt
+  let finalCommand = command;
+  let tempImagePaths = [];
+  let tempDir = null;
+
+  if (images && images.length > 0) {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'claude-img-'));
+    for (let i = 0; i < images.length; i++) {
+      const img = images[i];
+      if (img.data && img.mediaType) {
+        const ext = img.mediaType.split('/')[1] || 'png';
+        const imgPath = path.join(tempDir, `image_${i}.${ext}`);
+        const buffer = Buffer.from(img.data, 'base64');
+        await fs.writeFile(imgPath, buffer);
+        tempImagePaths.push(imgPath);
+      }
+    }
+    // Prepend image paths to the prompt
+    if (tempImagePaths.length > 0) {
+      const imageRefs = tempImagePaths.map(p => `[Image: ${p}]`).join(' ');
+      finalCommand = `${imageRefs}\n\n${command}`;
+    }
+  }
+
+  // Non-interactive mode: send prompt via --print
+  args.push('--print', finalCommand);
+
+  const resolvedCwd = cwd || process.env.HOME;
+
+  console.log(`[Full REPL v2] Spawning: claude ${args.slice(0, 4).join(' ')}... (cwd: ${resolvedCwd})`);
+
+  const cliProcess = spawn('claude', args, {
+    cwd: resolvedCwd,
+    env: {
+      ...process.env,
+      NO_COLOR: '1',
+    },
+    stdio: ['pipe', 'pipe', 'pipe'],
+  });
+
+  let capturedSessionId = sessionId || null;
+  let partialLine = '';
+
+  const session = {
+    process: cliProcess,
+    startTime: Date.now(),
+    sessionId: capturedSessionId,
+  };
+
+  // Track session
+  const sessionKey = sessionId || `pending_${Date.now()}`;
+  activeCliSessions.set(sessionKey, session);
+
+  // Parse stdout JSONL
+  cliProcess.stdout.on('data', (chunk) => {
+    partialLine += chunk.toString();
+    const lines = partialLine.split('\n');
+    partialLine = lines.pop(); // Keep incomplete line for next chunk
+
+    for (const line of lines) {
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+
+      try {
+        const event = JSON.parse(trimmed);
+        const wsMessages = mapCliEventToWsMessages(event, session);
+        for (const msg of wsMessages) {
+          ws.send(msg);
+        }
+
+        // Capture session ID from init event
+        if (event.type === 'system' && event.subtype === 'init' && event.session_id) {
+          capturedSessionId = event.session_id;
+          session.sessionId = capturedSessionId;
+
+          // Re-key the session map
+          if (sessionKey !== capturedSessionId) {
+            activeCliSessions.delete(sessionKey);
+            activeCliSessions.set(capturedSessionId, session);
+          }
+        }
+      } catch {
+        // Not valid JSON, skip (startup noise, etc.)
+      }
+    }
+  });
+
+  // Forward stderr as status messages
+  cliProcess.stderr.on('data', (chunk) => {
+    const text = chunk.toString().trim();
+    if (text) {
+      console.log(`[Full REPL v2 stderr] ${text}`);
+    }
+  });
+
+  cliProcess.on('error', (err) => {
+    console.error('[Full REPL v2] Failed to spawn claude CLI:', err.message);
+    ws.send({
+      type: 'claude-error',
+      error: `Failed to spawn claude CLI: ${err.message}. Is claude installed and in PATH?`,
+      sessionId: capturedSessionId,
+    });
+    activeCliSessions.delete(capturedSessionId || sessionKey);
+  });
+
+  cliProcess.on('close', (exitCode) => {
+    console.log(`[Full REPL v2] CLI process exited with code ${exitCode}`);
+
+    ws.send({
+      type: 'claude-complete',
+      sessionId: capturedSessionId,
+      exitCode: exitCode || 0,
+      isNewSession: !sessionId,
+    });
+
+    activeCliSessions.delete(capturedSessionId || sessionKey);
+
+    // Clean up temp images
+    if (tempImagePaths.length > 0) {
+      for (const p of tempImagePaths) {
+        fs.unlink(p).catch(() => {});
+      }
+      if (tempDir) {
+        fs.rmdir(tempDir).catch(() => {});
+      }
+    }
+  });
+}
+
+/**
+ * Maps a CLI stream-json event to one or more WebSocket messages
+ * in the format the Chat UI expects.
+ */
+function mapCliEventToWsMessages(event, session) {
+  const sid = session.sessionId;
+  const messages = [];
+
+  switch (event.type) {
+    case 'system': {
+      if (event.subtype === 'init') {
+        // Emit session-created
+        messages.push({
+          type: 'session-created',
+          sessionId: event.session_id,
+        });
+      }
+      break;
+    }
+
+    case 'assistant': {
+      // The CLI emits the full assistant message with content array.
+      // The Chat UI expects: { type: 'claude-response', data: { message: {...}, ... }, sessionId }
+      // where data.message has { role, content: [...] }
+      const msg = event.message;
+      if (msg) {
+        messages.push({
+          type: 'claude-response',
+          data: {
+            message: msg,
+            parent_tool_use_id: event.parent_tool_use_id || null,
+          },
+          sessionId: sid,
+        });
+      }
+      break;
+    }
+
+    case 'user': {
+      // Tool results come as user messages with role: 'user' and content array
+      // containing tool_result blocks. The Chat UI handles this via:
+      // structuredMessageData?.role === 'user' && Array.isArray(structuredMessageData.content)
+      const msg = event.message;
+      if (msg) {
+        messages.push({
+          type: 'claude-response',
+          data: {
+            message: msg,
+            parent_tool_use_id: event.parent_tool_use_id || null,
+            // Include tool_use_result for richer rendering
+            tool_use_result: event.tool_use_result || null,
+          },
+          sessionId: sid,
+        });
+      }
+      break;
+    }
+
+    case 'result': {
+      // Final result with usage/cost info
+      // Emit token budget from the result
+      if (event.modelUsage) {
+        const models = Object.keys(event.modelUsage);
+        if (models.length > 0) {
+          const usage = event.modelUsage[models[0]];
+          messages.push({
+            type: 'token-budget',
+            data: {
+              used: (usage.inputTokens || 0) + (usage.outputTokens || 0) +
+                    (usage.cacheReadInputTokens || 0) + (usage.cacheCreationInputTokens || 0),
+              total: usage.contextWindow || 200000,
+            },
+            sessionId: sid,
+          });
+        }
+      }
+      break;
+    }
+
+    case 'rate_limit_event': {
+      // Could emit as status, but not critical for rendering
+      break;
+    }
+
+    default: {
+      // Forward any unknown event types as generic claude-response
+      // so the UI can at least try to render them
+      if (event.message) {
+        messages.push({
+          type: 'claude-response',
+          data: { message: event.message },
+          sessionId: sid,
+        });
+      }
+      break;
+    }
+  }
+
+  return messages;
+}
+
+/**
+ * Aborts an active CLI session by killing the process.
+ */
+export function abortClaudeCLISession(sessionId) {
+  const session = activeCliSessions.get(sessionId);
+  if (session?.process) {
+    session.process.kill('SIGINT');
+    activeCliSessions.delete(sessionId);
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Checks if a CLI session is currently active.
+ */
+export function isClaudeCLISessionActive(sessionId) {
+  return activeCliSessions.has(sessionId);
+}
+
+/**
+ * Returns all active CLI sessions.
+ */
+export function getActiveClaudeCLISessions() {
+  return Array.from(activeCliSessions.keys());
+}
+
+export { activeCliSessions };

--- a/server/claude-cli-query.js
+++ b/server/claude-cli-query.js
@@ -114,14 +114,14 @@ export async function queryClaudeCLI(command, options = {}, ws) {
   args.push('--mcp-config', '{"mcpServers":{}}', '--strict-mcp-config');
 
   // Resume: explicit session ID > registry > none
-  const isValidUUID = sessionId && /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(sessionId);
+  const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
   const resolvedCwd = cwd || process.env.HOME;
-  let resumeId = isValidUUID ? sessionId : null;
+  let resumeId = (sessionId && UUID_RE.test(sessionId)) ? sessionId : null;
 
   if (!resumeId) {
     // Check registry for a session created by Shell or a previous Chat query
     const registryId = getProjectSessionId(resolvedCwd);
-    if (registryId) {
+    if (registryId && UUID_RE.test(registryId)) {
       resumeId = registryId;
       console.log(`[Full REPL v2] Chat resuming session from registry: ${resumeId}`);
     }

--- a/server/claude-cli-query.js
+++ b/server/claude-cli-query.js
@@ -14,6 +14,8 @@ import { promises as fs } from 'fs';
 import path from 'path';
 import os from 'os';
 
+const ANSI_ESCAPE_RE = /\x1b\[[0-9;]*[a-zA-Z]/g;
+
 const activeCliSessions = new Map();
 
 /**
@@ -233,7 +235,7 @@ export async function queryClaudeCLI(command, options = {}, ws) {
       if (!trimmed) continue;
 
       // Strip any ANSI escape sequences that might leak through
-      const cleaned = trimmed.replace(/\x1b\[[0-9;]*[a-zA-Z]/g, '').trim();
+      const cleaned = trimmed.replace(ANSI_ESCAPE_RE, '').trim();
       if (!cleaned) continue;
       if (cleaned[0] !== '{') {
         lastPlaintextLine = cleaned;
@@ -282,12 +284,12 @@ export async function queryClaudeCLI(command, options = {}, ws) {
     }
   });
 
-  cliProcess.onExit(({ exitCode }) => {
+  cliProcess.onExit(async ({ exitCode }) => {
     console.log(`[Full REPL v2] CLI process exited with code ${exitCode}`);
 
     // Process any remaining partial line
     if (partialLine.trim()) {
-      const cleaned = partialLine.trim().replace(/\x1b\[[0-9;]*[a-zA-Z]/g, '').trim();
+      const cleaned = partialLine.trim().replace(ANSI_ESCAPE_RE, '').trim();
       if (cleaned && cleaned[0] === '{') {
         try {
           const event = JSON.parse(cleaned);
@@ -320,12 +322,12 @@ export async function queryClaudeCLI(command, options = {}, ws) {
     activeCliSessions.delete(capturedSessionId || sessionKey);
 
     // Clean up temp images
-    if (tempImagePaths.length > 0) {
-      for (const p of tempImagePaths) {
-        fs.unlink(p).catch(() => {});
-      }
-      if (tempDir) {
-        fs.rmdir(tempDir).catch(() => {});
+    if (tempDir) {
+      try {
+        await Promise.all(tempImagePaths.map(p => fs.unlink(p).catch(() => {})));
+        await fs.rmdir(tempDir).catch(() => {});
+      } catch {
+        // ignore cleanup errors
       }
     }
   });

--- a/server/claude-cli-query.js
+++ b/server/claude-cli-query.js
@@ -10,7 +10,7 @@
  */
 
 import pty from 'node-pty';
-import { promises as fs } from 'fs';
+import { promises as fs, constants as fsConstants } from 'fs';
 import path from 'path';
 import os from 'os';
 
@@ -85,7 +85,7 @@ async function resolveClaudeBinary() {
 
   for (const candidate of candidates) {
     try {
-      await fs.access(candidate);
+      await fs.access(candidate, fsConstants.X_OK);
       cachedClaudeBin = candidate;
       console.log(`[Full REPL v2] Resolved claude binary: ${cachedClaudeBin}`);
       return cachedClaudeBin;

--- a/server/claude-cli-query.js
+++ b/server/claude-cli-query.js
@@ -105,6 +105,14 @@ export async function queryClaudeCLI(command, options = {}, ws) {
 
   const args = ['--output-format', 'stream-json', '--verbose'];
 
+  // Skip MCP server loading for Chat queries. The CLI loads ALL configured
+  // MCP servers on startup (including failing ones that timeout for 10s+ each).
+  // Chat queries rarely need MCP servers. The Shell tab loads them natively.
+  // Users can override this with options.loadMcpServers = true if needed.
+  if (!options.loadMcpServers) {
+    args.push('--mcp-config', '{"mcpServers":{}}', '--strict-mcp-config');
+  }
+
   // Resume: explicit session ID > registry > none
   const isValidUUID = sessionId && /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(sessionId);
   const resolvedCwd = cwd || process.env.HOME;

--- a/server/claude-sdk.js
+++ b/server/claude-sdk.js
@@ -24,6 +24,13 @@ import {
   notifyRunStopped,
   notifyUserIfEnabled
 } from './services/notification-orchestrator.js';
+import {
+  isFullReplMode,
+  getSettings,
+  getPermissions,
+  getMcpServersFromSettings,
+  persistAllowedTool
+} from './utils/settings-reader.js';
 
 const activeSessions = new Map();
 const pendingToolApprovals = new Map();
@@ -141,7 +148,7 @@ function matchesToolPermission(entry, toolName, input) {
  * @param {Object} options - CLI options
  * @returns {Object} SDK-compatible options
  */
-function mapCliOptionsToSDK(options = {}) {
+async function mapCliOptionsToSDK(options = {}) {
   const { sessionId, cwd, toolsSettings, permissionMode, images } = options;
 
   const sdkOptions = {};
@@ -156,39 +163,65 @@ function mapCliOptionsToSDK(options = {}) {
     sdkOptions.permissionMode = permissionMode;
   }
 
-  // Map tool settings
-  const settings = toolsSettings || {
-    allowedTools: [],
-    disallowedTools: [],
-    skipPermissions: false
-  };
+  // Full REPL Mode: override permissions from ~/.claude/settings.json
+  const fullRepl = isFullReplMode(options.fullReplMode);
+  if (fullRepl) {
+    const diskPermissions = await getPermissions();
+    const diskSettings = await getSettings();
 
-  // Handle tool permissions
-  if (settings.skipPermissions && permissionMode !== 'plan') {
-    // When skipping permissions, use bypassPermissions mode
-    sdkOptions.permissionMode = 'bypassPermissions';
-  }
+    let allowedTools = [...(diskPermissions.allow || [])];
 
-  let allowedTools = [...(settings.allowedTools || [])];
-
-  // Add plan mode default tools
-  if (permissionMode === 'plan') {
-    const planModeTools = ['Read', 'Task', 'exit_plan_mode', 'TodoRead', 'TodoWrite', 'WebFetch', 'WebSearch'];
-    for (const tool of planModeTools) {
-      if (!allowedTools.includes(tool)) {
-        allowedTools.push(tool);
+    // Add plan mode default tools
+    if (permissionMode === 'plan') {
+      const planModeTools = ['Read', 'Task', 'exit_plan_mode', 'TodoRead', 'TodoWrite', 'WebFetch', 'WebSearch'];
+      for (const tool of planModeTools) {
+        if (!allowedTools.includes(tool)) {
+          allowedTools.push(tool);
+        }
       }
     }
-  }
 
-  sdkOptions.allowedTools = allowedTools;
+    sdkOptions.allowedTools = allowedTools;
+    sdkOptions.disallowedTools = diskPermissions.deny || [];
+
+    if (diskSettings?.skipDangerousModePermissionPrompt) {
+      sdkOptions.permissionMode = 'bypassPermissions';
+    }
+
+    console.log(`[Full REPL] Loaded ${allowedTools.length} allowed, ${sdkOptions.disallowedTools.length} denied tools from settings.json`);
+  } else {
+    // Default mode: use browser-provided tool settings
+    const settings = toolsSettings || {
+      allowedTools: [],
+      disallowedTools: [],
+      skipPermissions: false
+    };
+
+    // Handle tool permissions
+    if (settings.skipPermissions && permissionMode !== 'plan') {
+      sdkOptions.permissionMode = 'bypassPermissions';
+    }
+
+    let allowedTools = [...(settings.allowedTools || [])];
+
+    // Add plan mode default tools
+    if (permissionMode === 'plan') {
+      const planModeTools = ['Read', 'Task', 'exit_plan_mode', 'TodoRead', 'TodoWrite', 'WebFetch', 'WebSearch'];
+      for (const tool of planModeTools) {
+        if (!allowedTools.includes(tool)) {
+          allowedTools.push(tool);
+        }
+      }
+    }
+
+    sdkOptions.allowedTools = allowedTools;
+    sdkOptions.disallowedTools = settings.disallowedTools || [];
+  }
 
   // Use the tools preset to make all default built-in tools available (including AskUserQuestion).
   // This was introduced in SDK 0.1.57. Omitting this preserves existing behavior (all tools available),
   // but being explicit ensures forward compatibility and clarity.
   sdkOptions.tools = { type: 'preset', preset: 'claude_code' };
-
-  sdkOptions.disallowedTools = settings.disallowedTools || [];
 
   // Map model (default to sonnet)
   // Valid models: sonnet, opus, haiku, opusplan, sonnet[1m]
@@ -404,59 +437,79 @@ async function cleanupTempFiles(tempImagePaths, tempDir) {
  * @param {string} cwd - Current working directory for project-specific configs
  * @returns {Object|null} MCP servers object or null if none found
  */
-async function loadMcpConfig(cwd) {
+async function loadMcpFromClaudeJson(cwd) {
   try {
     const claudeConfigPath = path.join(os.homedir(), '.claude.json');
 
-    // Check if config file exists
     try {
       await fs.access(claudeConfigPath);
     } catch (error) {
-      // File doesn't exist, return null
-      console.log('No ~/.claude.json found, proceeding without MCP servers');
-      return null;
+      return {};
     }
 
-    // Read and parse config file
     let claudeConfig;
     try {
       const configContent = await fs.readFile(claudeConfigPath, 'utf8');
       claudeConfig = JSON.parse(configContent);
     } catch (error) {
       console.error('Failed to parse ~/.claude.json:', error.message);
-      return null;
+      return {};
     }
 
-    // Extract MCP servers (merge global and project-specific)
     let mcpServers = {};
 
-    // Add global MCP servers
     if (claudeConfig.mcpServers && typeof claudeConfig.mcpServers === 'object') {
       mcpServers = { ...claudeConfig.mcpServers };
-      console.log(`Loaded ${Object.keys(mcpServers).length} global MCP servers`);
     }
 
-    // Add/override with project-specific MCP servers
     if (claudeConfig.claudeProjects && cwd) {
       const projectConfig = claudeConfig.claudeProjects[cwd];
       if (projectConfig && projectConfig.mcpServers && typeof projectConfig.mcpServers === 'object') {
         mcpServers = { ...mcpServers, ...projectConfig.mcpServers };
-        console.log(`Loaded ${Object.keys(projectConfig.mcpServers).length} project-specific MCP servers`);
       }
     }
 
-    // Return null if no servers found
-    if (Object.keys(mcpServers).length === 0) {
-      console.log('No MCP servers configured');
+    return mcpServers;
+  } catch (error) {
+    console.error('Error loading MCP from ~/.claude.json:', error.message);
+    return {};
+  }
+}
+
+async function loadMcpConfig(cwd, fullReplOverride) {
+  const fullRepl = isFullReplMode(fullReplOverride);
+
+  if (fullRepl) {
+    // Primary: ~/.claude/settings.json
+    const settingsMcp = await getMcpServersFromSettings();
+
+    // Secondary: ~/.claude.json for project-scoped servers
+    const claudeJsonMcp = await loadMcpFromClaudeJson(cwd);
+
+    // Merge: settings.json takes precedence
+    const merged = { ...claudeJsonMcp, ...settingsMcp };
+    const count = Object.keys(merged).length;
+
+    if (count === 0) {
+      console.log('[Full REPL] No MCP servers configured');
       return null;
     }
 
-    console.log(`Total MCP servers loaded: ${Object.keys(mcpServers).length}`);
-    return mcpServers;
-  } catch (error) {
-    console.error('Error loading MCP config:', error.message);
+    console.log(`[Full REPL] Total MCP servers loaded: ${count} (${Object.keys(settingsMcp).length} from settings.json, ${Object.keys(claudeJsonMcp).length} from .claude.json)`);
+    return merged;
+  }
+
+  // Default behavior: read from ~/.claude.json only
+  const mcpServers = await loadMcpFromClaudeJson(cwd);
+  const count = Object.keys(mcpServers).length;
+
+  if (count === 0) {
+    console.log('No MCP servers configured');
     return null;
   }
+
+  console.log(`Total MCP servers loaded: ${count}`);
+  return mcpServers;
 }
 
 /**
@@ -483,10 +536,10 @@ async function queryClaudeSDK(command, options = {}, ws) {
 
   try {
     // Map CLI options to SDK format
-    const sdkOptions = mapCliOptionsToSDK(options);
+    const sdkOptions = await mapCliOptionsToSDK(options);
 
     // Load MCP configuration
-    const mcpServers = await loadMcpConfig(options.cwd);
+    const mcpServers = await loadMcpConfig(options.cwd, options.fullReplMode);
     if (mcpServers) {
       sdkOptions.mcpServers = mcpServers;
     }
@@ -592,6 +645,11 @@ async function queryClaudeSDK(command, options = {}, ws) {
           }
           if (Array.isArray(sdkOptions.disallowedTools)) {
             sdkOptions.disallowedTools = sdkOptions.disallowedTools.filter(entry => entry !== decision.rememberEntry);
+          }
+
+          // Persist to disk in Full REPL Mode
+          if (isFullReplMode(options.fullReplMode)) {
+            await persistAllowedTool(decision.rememberEntry);
           }
         }
         return { behavior: 'allow', updatedInput: decision.updatedInput ?? input };

--- a/server/claude-sdk.js
+++ b/server/claude-sdk.js
@@ -184,7 +184,7 @@ async function mapCliOptionsToSDK(options = {}) {
     sdkOptions.allowedTools = allowedTools;
     sdkOptions.disallowedTools = diskPermissions.deny || [];
 
-    if (diskSettings?.skipDangerousModePermissionPrompt) {
+    if (diskSettings?.skipDangerousModePermissionPrompt && permissionMode !== 'plan') {
       sdkOptions.permissionMode = 'bypassPermissions';
     }
 

--- a/server/claude-sdk.js
+++ b/server/claude-sdk.js
@@ -649,7 +649,11 @@ async function queryClaudeSDK(command, options = {}, ws) {
 
           // Persist to disk in Full REPL Mode
           if (isFullReplMode(options.fullReplMode)) {
-            await persistAllowedTool(decision.rememberEntry);
+            try {
+              await persistAllowedTool(decision.rememberEntry);
+            } catch (persistError) {
+              console.error('[Full REPL] Failed to persist allowed tool to disk:', persistError.message);
+            }
           }
         }
         return { behavior: 'allow', updatedInput: decision.updatedInput ?? input };

--- a/server/index.js
+++ b/server/index.js
@@ -32,6 +32,7 @@ const c = {
 };
 
 console.log('PORT from env:', process.env.PORT);
+console.log('[FULL-REPL-MODE] Server version: full-repl-mode branch loaded');
 
 import express from 'express';
 import { WebSocketServer, WebSocket } from 'ws';
@@ -46,6 +47,8 @@ import mime from 'mime-types';
 
 import { getProjects, getSessions, getSessionMessages, renameProject, deleteSession, deleteProject, addProjectManually, extractProjectDirectory, clearProjectDirectoryCache, searchConversations } from './projects.js';
 import { queryClaudeSDK, abortClaudeSDKSession, isClaudeSDKSessionActive, getActiveClaudeSDKSessions, resolveToolApproval, getPendingApprovalsForSession, reconnectSessionWriter } from './claude-sdk.js';
+import { queryClaudeCLI, abortClaudeCLISession, isClaudeCLISessionActive, getActiveClaudeCLISessions } from './claude-cli-query.js';
+import { isFullReplMode } from './utils/settings-reader.js';
 import { spawnCursor, abortCursorSession, isCursorSessionActive, getActiveCursorSessions } from './cursor-cli.js';
 import { queryCodex, abortCodexSession, isCodexSessionActive, getActiveCodexSessions } from './openai-codex.js';
 import { spawnGemini, abortGeminiSession, isGeminiSessionActive, getActiveGeminiSessions } from './gemini-cli.js';
@@ -1464,8 +1467,14 @@ function handleChatConnection(ws, request) {
                 console.log('📁 Project:', data.options?.projectPath || 'Unknown');
                 console.log('🔄 Session:', data.options?.sessionId ? 'Resume' : 'New');
 
-                // Use Claude Agents SDK
-                await queryClaudeSDK(data.command, data.options, writer);
+                if (isFullReplMode(data.options?.fullReplMode)) {
+                    // Full REPL Mode: spawn native claude CLI
+                    console.log('[Full REPL v2] Using native CLI');
+                    await queryClaudeCLI(data.command, data.options, writer);
+                } else {
+                    // Default: use Claude Agents SDK
+                    await queryClaudeSDK(data.command, data.options, writer);
+                }
             } else if (data.type === 'cursor-command') {
                 console.log('[DEBUG] Cursor message:', data.command || '[Continue/Resume]');
                 console.log('📁 Project:', data.options?.cwd || 'Unknown');
@@ -1504,8 +1513,11 @@ function handleChatConnection(ws, request) {
                 } else if (provider === 'gemini') {
                     success = abortGeminiSession(data.sessionId);
                 } else {
-                    // Use Claude Agents SDK
-                    success = await abortClaudeSDKSession(data.sessionId);
+                    // Try CLI session first, then SDK
+                    success = abortClaudeCLISession(data.sessionId);
+                    if (!success) {
+                        success = await abortClaudeSDKSession(data.sessionId);
+                    }
                 }
 
                 writer.send({
@@ -1548,12 +1560,15 @@ function handleChatConnection(ws, request) {
                 } else if (provider === 'gemini') {
                     isActive = isGeminiSessionActive(sessionId);
                 } else {
-                    // Use Claude Agents SDK
-                    isActive = isClaudeSDKSessionActive(sessionId);
-                    if (isActive) {
-                        // Reconnect the session's writer to the new WebSocket so
-                        // subsequent SDK output flows to the refreshed client.
-                        reconnectSessionWriter(sessionId, ws);
+                    // Check CLI sessions first, then SDK
+                    isActive = isClaudeCLISessionActive(sessionId);
+                    if (!isActive) {
+                        isActive = isClaudeSDKSessionActive(sessionId);
+                        if (isActive) {
+                            // Reconnect the session's writer to the new WebSocket so
+                            // subsequent SDK output flows to the refreshed client.
+                            reconnectSessionWriter(sessionId, ws);
+                        }
                     }
                 }
 
@@ -1577,7 +1592,7 @@ function handleChatConnection(ws, request) {
             } else if (data.type === 'get-active-sessions') {
                 // Get all currently active sessions
                 const activeSessions = {
-                    claude: getActiveClaudeSDKSessions(),
+                    claude: [...getActiveClaudeSDKSessions(), ...getActiveClaudeCLISessions()],
                     cursor: getActiveCursorSessions(),
                     codex: getActiveCodexSessions(),
                     gemini: getActiveGeminiSessions()

--- a/server/index.js
+++ b/server/index.js
@@ -32,7 +32,6 @@ const c = {
 };
 
 console.log('PORT from env:', process.env.PORT);
-console.log('[FULL-REPL-MODE] Server version: full-repl-mode branch loaded');
 
 import express from 'express';
 import { WebSocketServer, WebSocket } from 'ws';

--- a/server/index.js
+++ b/server/index.js
@@ -47,7 +47,7 @@ import mime from 'mime-types';
 
 import { getProjects, getSessions, getSessionMessages, renameProject, deleteSession, deleteProject, addProjectManually, extractProjectDirectory, clearProjectDirectoryCache, searchConversations } from './projects.js';
 import { queryClaudeSDK, abortClaudeSDKSession, isClaudeSDKSessionActive, getActiveClaudeSDKSessions, resolveToolApproval, getPendingApprovalsForSession, reconnectSessionWriter } from './claude-sdk.js';
-import { queryClaudeCLI, abortClaudeCLISession, isClaudeCLISessionActive, getActiveClaudeCLISessions } from './claude-cli-query.js';
+import { queryClaudeCLI, abortClaudeCLISession, isClaudeCLISessionActive, getActiveClaudeCLISessions, getProjectSessionId, setProjectSessionId, findLatestSessionForProject } from './claude-cli-query.js';
 import { isFullReplMode } from './utils/settings-reader.js';
 import { spawnCursor, abortCursorSession, isCursorSessionActive, getActiveCursorSessions } from './cursor-cli.js';
 import { queryCodex, abortCodexSession, isCodexSessionActive, getActiveCodexSessions } from './openai-codex.js';
@@ -1470,6 +1470,20 @@ function handleChatConnection(ws, request) {
                 if (isFullReplMode(data.options?.fullReplMode)) {
                     // Full REPL Mode: spawn native claude CLI
                     console.log('[Full REPL v2] Using native CLI');
+
+                    // Kill any active Shell PTY for this project to release the session lock.
+                    // The Shell will auto-resume when the user switches back.
+                    const projectPath = data.options?.cwd || data.options?.projectPath;
+                    if (projectPath) {
+                        for (const [key, session] of ptySessionsMap.entries()) {
+                            if (session.projectPath === projectPath && session.pty) {
+                                console.log(`[Full REPL v2] Killing Shell PTY for project handoff: ${key}`);
+                                try { session.pty.kill(); } catch { /* already dead */ }
+                                ptySessionsMap.delete(key);
+                            }
+                        }
+                    }
+
                     await queryClaudeCLI(data.command, data.options, writer);
                 } else {
                     // Default: use Claude Agents SDK
@@ -1787,11 +1801,28 @@ function handleShellConnection(ws) {
                     } else {
                         // Claude (default provider)
                         const command = initialCommand || 'claude';
-                        if (hasSession && sessionId) {
+
+                        // Check for session ID: explicit > registry > none
+                        let resumeSessionId = (hasSession && sessionId) ? sessionId : null;
+                        if (!resumeSessionId) {
+                            // Full REPL Mode: check if Chat created a session for this project
+                            const registrySessionId = getProjectSessionId(resolvedProjectPath);
+                            if (registrySessionId) {
+                                resumeSessionId = registrySessionId;
+                                console.log(`[Full REPL v2] Shell resuming Chat session from registry: ${registrySessionId}`);
+
+                                // Kill any active Chat CLI process for this project
+                                if (abortClaudeCLISession(registrySessionId)) {
+                                    console.log(`[Full REPL v2] Killed Chat CLI process for session handoff`);
+                                }
+                            }
+                        }
+
+                        if (resumeSessionId) {
                             if (os.platform() === 'win32') {
-                                shellCommand = `claude --resume "${sessionId}"; if ($LASTEXITCODE -ne 0) { claude }`;
+                                shellCommand = `claude --resume "${resumeSessionId}"; if ($LASTEXITCODE -ne 0) { claude }`;
                             } else {
-                                shellCommand = `claude --resume "${sessionId}" || claude`;
+                                shellCommand = `claude --resume "${resumeSessionId}" || claude`;
                             }
                         } else {
                             shellCommand = command;
@@ -1832,6 +1863,26 @@ function handleShellConnection(ws) {
                         projectPath,
                         sessionId
                     });
+
+                    // Shell → Chat sync: after Shell's claude starts, detect its session ID
+                    // by scanning the project's session files on disk after a delay.
+                    if (provider === 'claude' && !isPlainShell) {
+                        setTimeout(async () => {
+                            try {
+                                const latestSession = await findLatestSessionForProject(resolvedProjectPath);
+                                if (latestSession) {
+                                    setProjectSessionId(resolvedProjectPath, latestSession);
+                                    // Also update the PTY session record
+                                    const ptySession = ptySessionsMap.get(ptySessionKey);
+                                    if (ptySession) {
+                                        ptySession.sessionId = latestSession;
+                                    }
+                                }
+                            } catch (err) {
+                                console.error('[Full REPL v2] Failed to detect Shell session:', err.message);
+                            }
+                        }, 5000);
+                    }
 
                     // Handle data output
                     shellProcess.onData((data) => {

--- a/server/index.js
+++ b/server/index.js
@@ -1484,6 +1484,11 @@ function handleChatConnection(ws, request) {
                         }
                     }
 
+                    // Normalize cwd so the CLI runner uses the correct project path
+                    if (!data.options.cwd && projectPath) {
+                        data.options.cwd = projectPath;
+                    }
+
                     await queryClaudeCLI(data.command, data.options, writer);
                 } else {
                     // Default: use Claude Agents SDK
@@ -1861,15 +1866,17 @@ function handleShellConnection(ws) {
                         buffer: [],
                         timeoutId: null,
                         projectPath,
-                        sessionId
+                        sessionId: resumeSessionId || sessionId
                     });
 
                     // Shell → Chat sync: detect session ID from PTY output
                     // by watching for UUID patterns in early output (e.g. "Resuming Claude session <uuid>")
+                    let sessionDetected = false;
+                    let sessionDetectionTimeout = null;
+                    let sessionDetectionDisposable = null;
+
                     if (provider === 'claude' && !isPlainShell) {
                         const uuidPattern = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/i;
-                        let sessionDetected = false;
-                        let sessionDetectionTimeout = null;
 
                         const sessionDetectionHandler = (outputData) => {
                             if (sessionDetected) return;
@@ -1891,7 +1898,7 @@ function handleShellConnection(ws) {
                         };
 
                         // Listen on PTY output for session ID
-                        const sessionDetectionDisposable = shellProcess.onData(sessionDetectionHandler);
+                        sessionDetectionDisposable = shellProcess.onData(sessionDetectionHandler);
 
                         // Stop listening after 15 seconds if no UUID found
                         sessionDetectionTimeout = setTimeout(() => {
@@ -1982,6 +1989,15 @@ function handleShellConnection(ws) {
                     // Handle process exit
                     shellProcess.onExit((exitCode) => {
                         console.log('🔚 Shell process exited with code:', exitCode.exitCode, 'signal:', exitCode.signal);
+
+                        // Clean up session detection listener/timeout
+                        sessionDetected = true;
+                        sessionDetectionDisposable?.dispose();
+                        if (sessionDetectionTimeout) {
+                            clearTimeout(sessionDetectionTimeout);
+                            sessionDetectionTimeout = null;
+                        }
+
                         const session = ptySessionsMap.get(ptySessionKey);
                         if (session && session.ws && session.ws.readyState === WebSocket.OPEN) {
                             session.ws.send(JSON.stringify({

--- a/server/index.js
+++ b/server/index.js
@@ -1756,6 +1756,7 @@ function handleShellConnection(ws) {
 
                     // Build shell command — use cwd for project path (never interpolate into shell string)
                     let shellCommand;
+                    let resumeSessionId = null;
                     if (isPlainShell) {
                         // Plain shell mode - run the initial command in the project directory
                         shellCommand = initialCommand;
@@ -1808,7 +1809,7 @@ function handleShellConnection(ws) {
                         const command = initialCommand || 'claude';
 
                         // Check for session ID: explicit > registry > none
-                        let resumeSessionId = (hasSession && sessionId) ? sessionId : null;
+                        resumeSessionId = (hasSession && sessionId) ? sessionId : null;
                         if (!resumeSessionId) {
                             // Full REPL Mode: check if Chat created a session for this project
                             const registrySessionId = getProjectSessionId(resolvedProjectPath);

--- a/server/index.js
+++ b/server/index.js
@@ -1470,13 +1470,14 @@ function handleChatConnection(ws, request) {
                     // Full REPL Mode: spawn native claude CLI
                     console.log('[Full REPL v2] Using native CLI');
 
-                    // Kill any active Shell PTY for this project to release the session lock.
-                    // The Shell will auto-resume when the user switches back.
+                    // Kill any active Claude Shell PTY for this project to release the session lock.
+                    // Only targets Claude sessions (UUID session IDs), not plain shell/cursor/codex/gemini.
                     const projectPath = data.options?.cwd || data.options?.projectPath;
+                    const uuidPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
                     if (projectPath) {
                         for (const [key, session] of ptySessionsMap.entries()) {
-                            if (session.projectPath === projectPath && session.pty) {
-                                console.log(`[Full REPL v2] Killing Shell PTY for project handoff: ${key}`);
+                            if (session.projectPath === projectPath && session.pty && session.sessionId && uuidPattern.test(session.sessionId)) {
+                                console.log(`[Full REPL v2] Killing Claude Shell PTY for project handoff: ${key}`);
                                 try { session.pty.kill(); } catch { /* already dead */ }
                                 ptySessionsMap.delete(key);
                             }
@@ -1809,12 +1810,12 @@ function handleShellConnection(ws) {
                             if (registrySessionId && safeSessionIdPattern.test(registrySessionId)) {
                                 resumeSessionId = registrySessionId;
                                 console.log(`[Full REPL v2] Shell resuming Chat session from registry: ${registrySessionId}`);
-
-                                // Kill any active Chat CLI process for this project
-                                if (abortClaudeCLISession(registrySessionId)) {
-                                    console.log(`[Full REPL v2] Killed Chat CLI process for session handoff`);
-                                }
                             }
+                        }
+
+                        // Kill any active Chat CLI process for the session being resumed
+                        if (resumeSessionId && abortClaudeCLISession(resumeSessionId)) {
+                            console.log('[Full REPL v2] Killed Chat CLI process for session handoff');
                         }
 
                         if (resumeSessionId) {

--- a/server/index.js
+++ b/server/index.js
@@ -1806,7 +1806,7 @@ function handleShellConnection(ws) {
                         if (!resumeSessionId) {
                             // Full REPL Mode: check if Chat created a session for this project
                             const registrySessionId = getProjectSessionId(resolvedProjectPath);
-                            if (registrySessionId) {
+                            if (registrySessionId && safeSessionIdPattern.test(registrySessionId)) {
                                 resumeSessionId = registrySessionId;
                                 console.log(`[Full REPL v2] Shell resuming Chat session from registry: ${registrySessionId}`);
 
@@ -1863,24 +1863,54 @@ function handleShellConnection(ws) {
                         sessionId
                     });
 
-                    // Shell → Chat sync: after Shell's claude starts, detect its session ID
-                    // by scanning the project's session files on disk after a delay.
+                    // Shell → Chat sync: detect session ID from PTY output
+                    // by watching for UUID patterns in early output (e.g. "Resuming Claude session <uuid>")
                     if (provider === 'claude' && !isPlainShell) {
-                        setTimeout(async () => {
-                            try {
-                                const latestSession = await findLatestSessionForProject(resolvedProjectPath);
-                                if (latestSession) {
-                                    setProjectSessionId(resolvedProjectPath, latestSession);
-                                    // Also update the PTY session record
-                                    const ptySession = ptySessionsMap.get(ptySessionKey);
-                                    if (ptySession) {
-                                        ptySession.sessionId = latestSession;
-                                    }
+                        const uuidPattern = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/i;
+                        let sessionDetected = false;
+                        let sessionDetectionTimeout = null;
+
+                        const sessionDetectionHandler = (outputData) => {
+                            if (sessionDetected) return;
+                            const match = outputData.match(uuidPattern);
+                            if (match) {
+                                sessionDetected = true;
+                                const detectedSessionId = match[0];
+                                setProjectSessionId(resolvedProjectPath, detectedSessionId);
+                                const ptySession = ptySessionsMap.get(ptySessionKey);
+                                if (ptySession) {
+                                    ptySession.sessionId = detectedSessionId;
                                 }
-                            } catch (err) {
-                                console.error('[Full REPL v2] Failed to detect Shell session:', err.message);
+                                console.log(`[Full REPL v2] Detected Shell session from PTY output: ${detectedSessionId}`);
+                                if (sessionDetectionTimeout) {
+                                    clearTimeout(sessionDetectionTimeout);
+                                    sessionDetectionTimeout = null;
+                                }
                             }
-                        }, 5000);
+                        };
+
+                        // Listen on PTY output for session ID
+                        const sessionDetectionDisposable = shellProcess.onData(sessionDetectionHandler);
+
+                        // Stop listening after 15 seconds if no UUID found
+                        sessionDetectionTimeout = setTimeout(() => {
+                            if (!sessionDetected) {
+                                sessionDetectionDisposable.dispose();
+                                // Fallback: scan disk for latest session file
+                                findLatestSessionForProject(resolvedProjectPath).then(latestSession => {
+                                    if (latestSession) {
+                                        setProjectSessionId(resolvedProjectPath, latestSession);
+                                        const ptySession = ptySessionsMap.get(ptySessionKey);
+                                        if (ptySession) {
+                                            ptySession.sessionId = latestSession;
+                                        }
+                                        console.log(`[Full REPL v2] Fallback: detected Shell session from disk: ${latestSession}`);
+                                    }
+                                }).catch(err => {
+                                    console.error('[Full REPL v2] Failed to detect Shell session:', err.message);
+                                });
+                            }
+                        }, 15000);
                     }
 
                     // Handle data output

--- a/server/routes/settings.js
+++ b/server/routes/settings.js
@@ -284,20 +284,12 @@ router.get('/repl-mode', async (req, res) => {
   try {
     const envMode = process.env.CLAUDE_FULL_REPL_MODE === 'true';
 
-    let settingsExists = false;
-    let permissionCount = 0;
-    let mcpServerCount = 0;
-    let allowedTools = [];
-    let deniedTools = [];
-
-    if (envMode) {
-      const settings = await getSettings();
-      settingsExists = !!settings;
-      allowedTools = settings?.permissions?.allow || [];
-      deniedTools = settings?.permissions?.deny || [];
-      permissionCount = allowedTools.length;
-      mcpServerCount = Object.keys(settings?.mcpServers || {}).length;
-    }
+    const settings = await getSettings();
+    const settingsExists = !!settings;
+    const allowedTools = settings?.permissions?.allow || [];
+    const deniedTools = settings?.permissions?.deny || [];
+    const permissionCount = allowedTools.length;
+    const mcpServerCount = Object.keys(settings?.mcpServers || {}).length;
 
     res.json({
       fullReplMode: envMode,

--- a/server/routes/settings.js
+++ b/server/routes/settings.js
@@ -1,7 +1,10 @@
 import express from 'express';
+import path from 'path';
+import os from 'os';
 import { apiKeysDb, credentialsDb, notificationPreferencesDb, pushSubscriptionsDb } from '../database/db.js';
 import { getPublicKey } from '../services/vapid-keys.js';
 import { createNotificationEvent, notifyUserIfEnabled } from '../services/notification-orchestrator.js';
+import { isFullReplMode, getSettings, SETTINGS_PATH } from '../utils/settings-reader.js';
 
 const router = express.Router();
 
@@ -270,6 +273,44 @@ router.post('/push/unsubscribe', async (req, res) => {
   } catch (error) {
     console.error('Error removing push subscription:', error);
     res.status(500).json({ error: 'Failed to remove push subscription' });
+  }
+});
+
+// ===============================
+// Full REPL Mode Configuration
+// ===============================
+
+router.get('/repl-mode', async (req, res) => {
+  try {
+    const envMode = process.env.CLAUDE_FULL_REPL_MODE === 'true';
+
+    let settingsExists = false;
+    let permissionCount = 0;
+    let mcpServerCount = 0;
+    let allowedTools = [];
+    let deniedTools = [];
+
+    if (envMode) {
+      const settings = await getSettings();
+      settingsExists = !!settings;
+      allowedTools = settings?.permissions?.allow || [];
+      deniedTools = settings?.permissions?.deny || [];
+      permissionCount = allowedTools.length;
+      mcpServerCount = Object.keys(settings?.mcpServers || {}).length;
+    }
+
+    res.json({
+      fullReplMode: envMode,
+      settingsExists,
+      permissionCount,
+      mcpServerCount,
+      allowedTools,
+      deniedTools,
+      settingsPath: SETTINGS_PATH
+    });
+  } catch (error) {
+    console.error('Error fetching REPL mode config:', error);
+    res.status(500).json({ error: 'Failed to fetch REPL mode configuration' });
   }
 });
 

--- a/server/utils/settings-reader.js
+++ b/server/utils/settings-reader.js
@@ -65,8 +65,16 @@ export async function getMcpServersFromSettings() {
 /**
  * Persists a newly-approved tool entry to ~/.claude/settings.json
  * using an atomic read-modify-write pattern (write to temp, rename).
+ * Serialized via a promise chain to prevent concurrent write races.
  */
+let writeQueue = Promise.resolve();
+
 export async function persistAllowedTool(entry) {
+  writeQueue = writeQueue.then(() => _persistAllowedToolImpl(entry)).catch(() => {});
+  return writeQueue;
+}
+
+async function _persistAllowedToolImpl(entry) {
   try {
     // Ensure ~/.claude directory exists
     await fs.mkdir(path.dirname(SETTINGS_PATH), { recursive: true });

--- a/server/utils/settings-reader.js
+++ b/server/utils/settings-reader.js
@@ -1,0 +1,105 @@
+/**
+ * Settings Reader for Full REPL Mode
+ *
+ * Reads, caches, and writes ~/.claude/settings.json to achieve parity
+ * with the native Claude Code CLI permissions and MCP server config.
+ */
+
+import { promises as fs } from 'fs';
+import crypto from 'crypto';
+import path from 'path';
+import os from 'os';
+
+const SETTINGS_PATH = path.join(os.homedir(), '.claude', 'settings.json');
+let cachedSettings = null;
+let cachedMtime = 0;
+
+/**
+ * Returns true when Full REPL Mode is enabled via environment variable.
+ * The frontend can also send a per-request override, but the env var
+ * is the server-wide default.
+ */
+export function isFullReplMode(requestOverride) {
+  if (typeof requestOverride === 'boolean') return requestOverride;
+  return process.env.CLAUDE_FULL_REPL_MODE === 'true';
+}
+
+/**
+ * Reads ~/.claude/settings.json with mtime-based caching.
+ * Returns null when the file is missing or unreadable.
+ */
+export async function getSettings() {
+  try {
+    const stat = await fs.stat(SETTINGS_PATH).catch(() => null);
+    if (!stat) return null;
+
+    if (stat.mtimeMs !== cachedMtime) {
+      const content = await fs.readFile(SETTINGS_PATH, 'utf8');
+      cachedSettings = JSON.parse(content);
+      cachedMtime = stat.mtimeMs;
+    }
+
+    return cachedSettings;
+  } catch (error) {
+    console.error('Failed to read settings.json:', error.message);
+    return null;
+  }
+}
+
+/**
+ * Returns the permissions object from settings.json.
+ */
+export async function getPermissions() {
+  const settings = await getSettings();
+  return settings?.permissions || { allow: [], deny: [] };
+}
+
+/**
+ * Returns MCP servers defined in ~/.claude/settings.json.
+ */
+export async function getMcpServersFromSettings() {
+  const settings = await getSettings();
+  return settings?.mcpServers || {};
+}
+
+/**
+ * Persists a newly-approved tool entry to ~/.claude/settings.json
+ * using an atomic read-modify-write pattern (write to temp, rename).
+ */
+export async function persistAllowedTool(entry) {
+  try {
+    // Ensure ~/.claude directory exists
+    await fs.mkdir(path.dirname(SETTINGS_PATH), { recursive: true });
+
+    let settings = {};
+    try {
+      const content = await fs.readFile(SETTINGS_PATH, 'utf8');
+      settings = JSON.parse(content);
+    } catch {
+      // File missing or corrupt, start fresh
+    }
+
+    if (!settings.permissions) settings.permissions = { allow: [], deny: [] };
+    if (!Array.isArray(settings.permissions.allow)) settings.permissions.allow = [];
+
+    if (settings.permissions.allow.includes(entry)) return;
+
+    settings.permissions.allow.push(entry);
+
+    // Atomic write: temp file with unique suffix + rename
+    const suffix = process.pid + '.' + Date.now() + '.' + crypto.randomBytes(4).toString('hex');
+    const tmpPath = SETTINGS_PATH + '.tmp.' + suffix;
+    await fs.writeFile(tmpPath, JSON.stringify(settings, null, 2), 'utf8');
+    await fs.rename(tmpPath, SETTINGS_PATH);
+
+    // Invalidate cache so the next read picks up the change
+    cachedMtime = 0;
+    cachedSettings = null;
+
+    console.log(`[Full REPL] Persisted allowed tool: ${entry}`);
+  } catch (error) {
+    console.error('Failed to persist allowed tool:', error.message);
+  }
+}
+
+export { SETTINGS_PATH };

--- a/src/components/chat/hooks/useChatComposerState.ts
+++ b/src/components/chat/hooks/useChatComposerState.ts
@@ -671,6 +671,7 @@ export function useChatComposerState({
           },
         });
       } else {
+        const replMode = isFullReplModeActive();
         sendMessage({
           type: 'claude-command',
           command: messageContent,
@@ -684,7 +685,7 @@ export function useChatComposerState({
             model: claudeModel,
             sessionSummary,
             images: uploadedImages,
-            fullReplMode: isFullReplModeActive(),
+            ...(replMode !== undefined && { fullReplMode: replMode }),
           },
         });
       }

--- a/src/components/chat/hooks/useChatComposerState.ts
+++ b/src/components/chat/hooks/useChatComposerState.ts
@@ -13,7 +13,7 @@ import { useDropzone } from 'react-dropzone';
 import { authenticatedFetch } from '../../../utils/api';
 import { thinkingModes } from '../constants/thinkingModes';
 import { grantClaudeToolPermission } from '../utils/chatPermissions';
-import { safeLocalStorage } from '../utils/chatStorage';
+import { isFullReplModeActive, safeLocalStorage } from '../utils/chatStorage';
 import type {
   ChatMessage,
   PendingPermissionRequest,
@@ -684,6 +684,7 @@ export function useChatComposerState({
             model: claudeModel,
             sessionSummary,
             images: uploadedImages,
+            fullReplMode: isFullReplModeActive(),
           },
         });
       }

--- a/src/components/chat/utils/chatStorage.ts
+++ b/src/components/chat/utils/chatStorage.ts
@@ -3,11 +3,13 @@ import type { ClaudeSettings } from '../types/types';
 export const CLAUDE_SETTINGS_KEY = 'claude-settings';
 const FULL_REPL_MODE_KEY = 'claude-full-repl-mode';
 
-export function isFullReplModeActive(): boolean {
+export function isFullReplModeActive(): boolean | undefined {
   try {
-    return localStorage.getItem(FULL_REPL_MODE_KEY) === 'true';
+    const value = localStorage.getItem(FULL_REPL_MODE_KEY);
+    if (value === null) return undefined;
+    return value === 'true';
   } catch {
-    return false;
+    return undefined;
   }
 }
 

--- a/src/components/chat/utils/chatStorage.ts
+++ b/src/components/chat/utils/chatStorage.ts
@@ -1,6 +1,23 @@
 import type { ClaudeSettings } from '../types/types';
 
 export const CLAUDE_SETTINGS_KEY = 'claude-settings';
+const FULL_REPL_MODE_KEY = 'claude-full-repl-mode';
+
+export function isFullReplModeActive(): boolean {
+  try {
+    return localStorage.getItem(FULL_REPL_MODE_KEY) === 'true';
+  } catch {
+    return false;
+  }
+}
+
+export function setFullReplMode(enabled: boolean): void {
+  try {
+    localStorage.setItem(FULL_REPL_MODE_KEY, String(enabled));
+  } catch {
+    // ignore
+  }
+}
 
 export const safeLocalStorage = {
   setItem: (key: string, value: string) => {
@@ -75,6 +92,19 @@ export const safeLocalStorage = {
 };
 
 export function getClaudeSettings(): ClaudeSettings {
+  // In Full REPL Mode, permissions come from ~/.claude/settings.json on the server.
+  // Return empty tool lists so the server-side settings take precedence.
+  if (isFullReplModeActive()) {
+    const raw = safeLocalStorage.getItem(CLAUDE_SETTINGS_KEY);
+    const parsed = raw ? (() => { try { return JSON.parse(raw); } catch { return {}; } })() : {};
+    return {
+      allowedTools: [],
+      disallowedTools: [],
+      skipPermissions: false,
+      projectSortOrder: parsed.projectSortOrder || 'name',
+    };
+  }
+
   const raw = safeLocalStorage.getItem(CLAUDE_SETTINGS_KEY);
   if (!raw) {
     return {

--- a/src/components/chat/view/ChatInterface.tsx
+++ b/src/components/chat/view/ChatInterface.tsx
@@ -344,7 +344,7 @@ function ChatInterface({
         {isFullReplModeActive() && provider === 'claude' && (
           <div className="mx-3 mb-1 flex items-center gap-2 rounded-md border border-purple-200/50 bg-purple-50/30 px-3 py-1.5 text-xs text-purple-300 dark:border-purple-800/30 dark:bg-purple-900/10">
             <Terminal className="h-3 w-3 flex-shrink-0" />
-            <span>Full REPL Mode. For MCP tools (chrome-devtools, figma, etc.), use the Shell tab.</span>
+            <span>Full REPL Mode. MCP server tools are only available in the Shell tab.</span>
           </div>
         )}
 

--- a/src/components/chat/view/ChatInterface.tsx
+++ b/src/components/chat/view/ChatInterface.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
+import { Terminal } from 'lucide-react';
 import { useTasksSettings } from '../../../contexts/TasksSettingsContext';
 import { QuickSettingsPanel } from '../../quick-settings-panel';
 import type { ChatInterfaceProps, Provider  } from '../types/types';
@@ -7,6 +8,7 @@ import { useChatProviderState } from '../hooks/useChatProviderState';
 import { useChatSessionState } from '../hooks/useChatSessionState';
 import { useChatRealtimeHandlers } from '../hooks/useChatRealtimeHandlers';
 import { useChatComposerState } from '../hooks/useChatComposerState';
+import { isFullReplModeActive } from '../utils/chatStorage';
 import ChatMessagesPane from './subcomponents/ChatMessagesPane';
 import ChatComposer from './subcomponents/ChatComposer';
 
@@ -338,6 +340,13 @@ function ChatInterface({
           selectedProject={selectedProject}
           isLoading={isLoading}
         />
+
+        {isFullReplModeActive() && provider === 'claude' && (
+          <div className="mx-3 mb-1 flex items-center gap-2 rounded-md border border-purple-200/50 bg-purple-50/30 px-3 py-1.5 text-xs text-purple-300 dark:border-purple-800/30 dark:bg-purple-900/10">
+            <Terminal className="h-3 w-3 flex-shrink-0" />
+            <span>Full REPL Mode. For MCP tools (chrome-devtools, figma, etc.), use the Shell tab.</span>
+          </div>
+        )}
 
         <ChatComposer
           pendingPermissionRequests={pendingPermissionRequests}

--- a/src/components/settings/view/tabs/agents-settings/sections/content/PermissionsContent.tsx
+++ b/src/components/settings/view/tabs/agents-settings/sections/content/PermissionsContent.tsx
@@ -1,8 +1,10 @@
-import { useState } from 'react';
-import { AlertTriangle, Plus, Shield, X } from 'lucide-react';
+import { useState, useEffect } from 'react';
+import { AlertTriangle, FileText, Plus, Shield, Terminal, X } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { Button, Input } from '../../../../../../../shared/view/ui';
 import type { CodexPermissionMode, GeminiPermissionMode } from '../../../../../types/types';
+import { isFullReplModeActive, setFullReplMode } from '../../../../../chat/utils/chatStorage';
+import { authenticatedFetch } from '../../../../../../../utils/api';
 
 const COMMON_CLAUDE_TOOLS = [
   'Bash(git log:*)',
@@ -59,6 +61,143 @@ type ClaudePermissionsProps = {
   onDisallowedToolsChange: (value: string[]) => void;
 };
 
+type ReplModeConfig = {
+  fullReplMode: boolean;
+  settingsExists: boolean;
+  permissionCount: number;
+  mcpServerCount: number;
+  allowedTools: string[];
+  deniedTools: string[];
+  settingsPath: string;
+};
+
+function FullReplModeSection({ isActive, onActiveChange }: { isActive: boolean; onActiveChange: (enabled: boolean) => void }) {
+  const [replConfig, setReplConfig] = useState<ReplModeConfig | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const initialToggle = isFullReplModeActive();
+    authenticatedFetch('/api/settings/repl-mode')
+      .then(res => res.json())
+      .then(data => {
+        setReplConfig(data);
+        // If env var enables it, sync the local toggle
+        if (data.fullReplMode && !initialToggle) {
+          onActiveChange(true);
+        }
+      })
+      .catch((error) => {
+        console.error('Failed to fetch REPL mode config:', error);
+        setReplConfig(null);
+      })
+      .finally(() => setLoading(false));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const handleToggle = (enabled: boolean) => {
+    onActiveChange(enabled);
+  };
+
+  if (loading) return null;
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center gap-3">
+        <Terminal className="h-5 w-5 text-purple-500" />
+        <h3 className="text-lg font-medium text-foreground">Full REPL Mode</h3>
+      </div>
+
+      <div className={`rounded-lg border p-4 ${isActive
+        ? 'border-purple-400 bg-purple-50 dark:border-purple-600 dark:bg-purple-900/20'
+        : 'border-border bg-card/50'
+      }`}>
+        <label className="flex items-center gap-3">
+          <input
+            type="checkbox"
+            checked={isActive}
+            onChange={(e) => handleToggle(e.target.checked)}
+            className="h-4 w-4 rounded border-input bg-card text-primary focus:ring-2 focus:ring-primary"
+          />
+          <div>
+            <div className="font-medium text-foreground">
+              Use ~/.claude/settings.json for permissions
+            </div>
+            <div className="text-sm text-muted-foreground">
+              Syncs permissions and MCP servers with the native Claude Code CLI.
+              Changes made here or in the CLI are shared bidirectionally.
+            </div>
+          </div>
+        </label>
+
+        {replConfig?.fullReplMode && (
+          <div className="mt-2 text-xs text-muted-foreground">
+            Set via <code className="rounded bg-muted px-1">CLAUDE_FULL_REPL_MODE=true</code> environment variable
+          </div>
+        )}
+      </div>
+
+      {isActive && replConfig?.settingsExists && (
+        <div className="rounded-lg border border-purple-200 bg-purple-50/50 p-4 dark:border-purple-800 dark:bg-purple-900/10">
+          <div className="flex items-center gap-2 mb-3">
+            <FileText className="h-4 w-4 text-purple-500" />
+            <span className="text-sm font-medium text-foreground">
+              {replConfig.settingsPath}
+            </span>
+          </div>
+          <div className="grid grid-cols-2 gap-4 text-sm">
+            <div>
+              <span className="text-muted-foreground">Allowed tools:</span>{' '}
+              <span className="font-mono font-medium text-green-600 dark:text-green-400">{replConfig.permissionCount}</span>
+            </div>
+            <div>
+              <span className="text-muted-foreground">MCP servers:</span>{' '}
+              <span className="font-mono font-medium text-blue-600 dark:text-blue-400">{replConfig.mcpServerCount}</span>
+            </div>
+          </div>
+          {replConfig.allowedTools.length > 0 && (
+            <details className="mt-3 text-sm">
+              <summary className="cursor-pointer text-muted-foreground hover:text-foreground">
+                View allowed tools from settings.json
+              </summary>
+              <div className="mt-2 space-y-1">
+                {replConfig.allowedTools.map((tool) => (
+                  <div key={tool} className="rounded border border-green-200 bg-green-50 px-2 py-1 dark:border-green-800 dark:bg-green-900/20">
+                    <span className="font-mono text-xs text-green-800 dark:text-green-200">{tool}</span>
+                  </div>
+                ))}
+              </div>
+            </details>
+          )}
+          {replConfig.deniedTools.length > 0 && (
+            <details className="mt-2 text-sm">
+              <summary className="cursor-pointer text-muted-foreground hover:text-foreground">
+                View denied tools from settings.json
+              </summary>
+              <div className="mt-2 space-y-1">
+                {replConfig.deniedTools.map((tool) => (
+                  <div key={tool} className="rounded border border-red-200 bg-red-50 px-2 py-1 dark:border-red-800 dark:bg-red-900/20">
+                    <span className="font-mono text-xs text-red-800 dark:text-red-200">{tool}</span>
+                  </div>
+                ))}
+              </div>
+            </details>
+          )}
+        </div>
+      )}
+
+      {isActive && !replConfig?.settingsExists && (
+        <div className="rounded-lg border border-yellow-200 bg-yellow-50 p-3 dark:border-yellow-800 dark:bg-yellow-900/20">
+          <p className="text-sm text-yellow-800 dark:text-yellow-200">
+            <code className="rounded bg-yellow-100 px-1 dark:bg-yellow-800">~/.claude/settings.json</code> not found.
+            Run <code className="rounded bg-yellow-100 px-1 dark:bg-yellow-800">claude config</code> in your terminal to create it,
+            or permissions will fall back to the default (empty) settings.
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}
+
 function ClaudePermissions({
   skipPermissions,
   onSkipPermissionsChange,
@@ -70,6 +209,12 @@ function ClaudePermissions({
   const { t } = useTranslation('settings');
   const [newAllowedTool, setNewAllowedTool] = useState('');
   const [newDisallowedTool, setNewDisallowedTool] = useState('');
+  const [fullReplActive, setFullReplActive] = useState(isFullReplModeActive());
+
+  const handleReplModeChange = (enabled: boolean) => {
+    setFullReplMode(enabled);
+    setFullReplActive(enabled);
+  };
 
   const handleAddAllowedTool = (tool: string) => {
     const updated = addUnique(allowedTools, tool);
@@ -93,167 +238,186 @@ function ClaudePermissions({
 
   return (
     <div className="space-y-6">
-      <div className="space-y-4">
-        <div className="flex items-center gap-3">
-          <AlertTriangle className="h-5 w-5 text-orange-500" />
-          <h3 className="text-lg font-medium text-foreground">{t('permissions.title')}</h3>
-        </div>
-        <div className="rounded-lg border border-orange-200 bg-orange-50 p-4 dark:border-orange-800 dark:bg-orange-900/20">
-          <label className="flex items-center gap-3">
-            <input
-              type="checkbox"
-              checked={skipPermissions}
-              onChange={(event) => onSkipPermissionsChange(event.target.checked)}
-              className="h-4 w-4 rounded border-input bg-card text-primary focus:ring-2 focus:ring-primary"
-            />
-            <div>
-              <div className="font-medium text-orange-900 dark:text-orange-100">
-                {t('permissions.skipPermissions.label')}
-              </div>
-              <div className="text-sm text-orange-700 dark:text-orange-300">
-                {t('permissions.skipPermissions.claudeDescription')}
-              </div>
-            </div>
-          </label>
-        </div>
-      </div>
+      <FullReplModeSection isActive={fullReplActive} onActiveChange={handleReplModeChange} />
 
-      <div className="space-y-4">
-        <div className="flex items-center gap-3">
-          <Shield className="h-5 w-5 text-green-500" />
-          <h3 className="text-lg font-medium text-foreground">{t('permissions.allowedTools.title')}</h3>
-        </div>
-        <p className="text-sm text-muted-foreground">{t('permissions.allowedTools.description')}</p>
-
-        <div className="flex flex-col gap-2 sm:flex-row">
-          <Input
-            value={newAllowedTool}
-            onChange={(event) => setNewAllowedTool(event.target.value)}
-            placeholder={t('permissions.allowedTools.placeholder')}
-            onKeyDown={(event) => {
-              if (event.key === 'Enter') {
-                event.preventDefault();
-                handleAddAllowedTool(newAllowedTool);
-              }
-            }}
-            className="h-10 flex-1"
-          />
-          <Button
-            onClick={() => handleAddAllowedTool(newAllowedTool)}
-            disabled={!newAllowedTool.trim()}
-            size="sm"
-            className="h-10 px-4"
-          >
-            <Plus className="mr-2 h-4 w-4 sm:mr-0" />
-            <span className="sm:hidden">{t('permissions.actions.add')}</span>
-          </Button>
-        </div>
-
-        <div className="space-y-2">
-          <p className="text-sm font-medium text-muted-foreground">
-            {t('permissions.allowedTools.quickAdd')}
+      {fullReplActive && (
+        <div className="rounded-lg border border-purple-200 bg-purple-50 p-4 dark:border-purple-800 dark:bg-purple-900/20">
+          <p className="text-sm text-purple-800 dark:text-purple-200">
+            Full REPL Mode is active. Permissions are managed via{' '}
+            <code className="rounded bg-purple-100 px-1 dark:bg-purple-800">~/.claude/settings.json</code>.
+            The manual permission controls below are disabled.
           </p>
-          <div className="flex flex-wrap gap-2">
-            {COMMON_CLAUDE_TOOLS.map((tool) => (
-              <Button
-                key={tool}
-                variant="outline"
-                size="sm"
-                onClick={() => handleAddAllowedTool(tool)}
-                disabled={allowedTools.includes(tool)}
-                className="h-8 text-xs"
-              >
-                {tool}
-              </Button>
-            ))}
+        </div>
+      )}
+
+      <div className={fullReplActive ? 'pointer-events-none opacity-40' : ''}>
+        <div className="space-y-4">
+          <div className="flex items-center gap-3">
+            <AlertTriangle className="h-5 w-5 text-orange-500" />
+            <h3 className="text-lg font-medium text-foreground">{t('permissions.title')}</h3>
+          </div>
+          <div className="rounded-lg border border-orange-200 bg-orange-50 p-4 dark:border-orange-800 dark:bg-orange-900/20">
+            <label className="flex items-center gap-3">
+              <input
+                type="checkbox"
+                checked={skipPermissions}
+                onChange={(event) => onSkipPermissionsChange(event.target.checked)}
+                className="h-4 w-4 rounded border-input bg-card text-primary focus:ring-2 focus:ring-primary"
+                disabled={fullReplActive}
+              />
+              <div>
+                <div className="font-medium text-orange-900 dark:text-orange-100">
+                  {t('permissions.skipPermissions.label')}
+                </div>
+                <div className="text-sm text-orange-700 dark:text-orange-300">
+                  {t('permissions.skipPermissions.claudeDescription')}
+                </div>
+              </div>
+            </label>
           </div>
         </div>
 
-        <div className="space-y-2">
-          {allowedTools.map((tool) => (
-            <div key={tool} className="flex items-center justify-between rounded-lg border border-green-200 bg-green-50 p-3 dark:border-green-800 dark:bg-green-900/20">
-              <span className="font-mono text-sm text-green-800 dark:text-green-200">{tool}</span>
-              <Button
-                variant="ghost"
-                size="sm"
-                onClick={() => onAllowedToolsChange(removeValue(allowedTools, tool))}
-                className="text-green-600 hover:text-green-700"
-              >
-                <X className="h-4 w-4" />
-              </Button>
-            </div>
-          ))}
-          {allowedTools.length === 0 && (
-            <div className="py-6 text-center text-muted-foreground">
-              {t('permissions.allowedTools.empty')}
-            </div>
-          )}
-        </div>
-      </div>
+        <div className="space-y-4 mt-6">
+          <div className="flex items-center gap-3">
+            <Shield className="h-5 w-5 text-green-500" />
+            <h3 className="text-lg font-medium text-foreground">{t('permissions.allowedTools.title')}</h3>
+          </div>
+          <p className="text-sm text-muted-foreground">{t('permissions.allowedTools.description')}</p>
 
-      <div className="space-y-4">
-        <div className="flex items-center gap-3">
-          <AlertTriangle className="h-5 w-5 text-red-500" />
-          <h3 className="text-lg font-medium text-foreground">{t('permissions.blockedTools.title')}</h3>
-        </div>
-        <p className="text-sm text-muted-foreground">{t('permissions.blockedTools.description')}</p>
+          <div className="flex flex-col gap-2 sm:flex-row">
+            <Input
+              value={newAllowedTool}
+              onChange={(event) => setNewAllowedTool(event.target.value)}
+              placeholder={t('permissions.allowedTools.placeholder')}
+              onKeyDown={(event) => {
+                if (event.key === 'Enter') {
+                  event.preventDefault();
+                  handleAddAllowedTool(newAllowedTool);
+                }
+              }}
+              className="h-10 flex-1"
+              disabled={fullReplActive}
+            />
+            <Button
+              onClick={() => handleAddAllowedTool(newAllowedTool)}
+              disabled={!newAllowedTool.trim() || fullReplActive}
+              size="sm"
+              className="h-10 px-4"
+            >
+              <Plus className="mr-2 h-4 w-4 sm:mr-0" />
+              <span className="sm:hidden">{t('permissions.actions.add')}</span>
+            </Button>
+          </div>
 
-        <div className="flex flex-col gap-2 sm:flex-row">
-          <Input
-            value={newDisallowedTool}
-            onChange={(event) => setNewDisallowedTool(event.target.value)}
-            placeholder={t('permissions.blockedTools.placeholder')}
-            onKeyDown={(event) => {
-              if (event.key === 'Enter') {
-                event.preventDefault();
-                handleAddDisallowedTool(newDisallowedTool);
-              }
-            }}
-            className="h-10 flex-1"
-          />
-          <Button
-            onClick={() => handleAddDisallowedTool(newDisallowedTool)}
-            disabled={!newDisallowedTool.trim()}
-            size="sm"
-            className="h-10 px-4"
-          >
-            <Plus className="mr-2 h-4 w-4 sm:mr-0" />
-            <span className="sm:hidden">{t('permissions.actions.add')}</span>
-          </Button>
-        </div>
-
-        <div className="space-y-2">
-          {disallowedTools.map((tool) => (
-            <div key={tool} className="flex items-center justify-between rounded-lg border border-red-200 bg-red-50 p-3 dark:border-red-800 dark:bg-red-900/20">
-              <span className="font-mono text-sm text-red-800 dark:text-red-200">{tool}</span>
-              <Button
-                variant="ghost"
-                size="sm"
-                onClick={() => onDisallowedToolsChange(removeValue(disallowedTools, tool))}
-                className="text-red-600 hover:text-red-700"
-              >
-                <X className="h-4 w-4" />
-              </Button>
+          <div className="space-y-2">
+            <p className="text-sm font-medium text-muted-foreground">
+              {t('permissions.allowedTools.quickAdd')}
+            </p>
+            <div className="flex flex-wrap gap-2">
+              {COMMON_CLAUDE_TOOLS.map((tool) => (
+                <Button
+                  key={tool}
+                  variant="outline"
+                  size="sm"
+                  onClick={() => handleAddAllowedTool(tool)}
+                  disabled={allowedTools.includes(tool) || fullReplActive}
+                  className="h-8 text-xs"
+                >
+                  {tool}
+                </Button>
+              ))}
             </div>
-          ))}
-          {disallowedTools.length === 0 && (
-            <div className="py-6 text-center text-muted-foreground">
-              {t('permissions.blockedTools.empty')}
-            </div>
-          )}
-        </div>
-      </div>
+          </div>
 
-      <div className="rounded-lg border border-blue-200 bg-blue-50 p-4 dark:border-blue-800 dark:bg-blue-900/20">
-        <h4 className="mb-2 font-medium text-blue-900 dark:text-blue-100">
-          {t('permissions.toolExamples.title')}
-        </h4>
-        <ul className="space-y-1 text-sm text-blue-800 dark:text-blue-200">
-          <li><code className="rounded bg-blue-100 px-1 dark:bg-blue-800">"Bash(git log:*)"</code> {t('permissions.toolExamples.bashGitLog')}</li>
-          <li><code className="rounded bg-blue-100 px-1 dark:bg-blue-800">"Bash(git diff:*)"</code> {t('permissions.toolExamples.bashGitDiff')}</li>
-          <li><code className="rounded bg-blue-100 px-1 dark:bg-blue-800">"Write"</code> {t('permissions.toolExamples.write')}</li>
-          <li><code className="rounded bg-blue-100 px-1 dark:bg-blue-800">"Bash(rm:*)"</code> {t('permissions.toolExamples.bashRm')}</li>
-        </ul>
+          <div className="space-y-2">
+            {allowedTools.map((tool) => (
+              <div key={tool} className="flex items-center justify-between rounded-lg border border-green-200 bg-green-50 p-3 dark:border-green-800 dark:bg-green-900/20">
+                <span className="font-mono text-sm text-green-800 dark:text-green-200">{tool}</span>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => onAllowedToolsChange(removeValue(allowedTools, tool))}
+                  className="text-green-600 hover:text-green-700"
+                  disabled={fullReplActive}
+                >
+                  <X className="h-4 w-4" />
+                </Button>
+              </div>
+            ))}
+            {allowedTools.length === 0 && (
+              <div className="py-6 text-center text-muted-foreground">
+                {t('permissions.allowedTools.empty')}
+              </div>
+            )}
+          </div>
+        </div>
+
+        <div className="space-y-4 mt-6">
+          <div className="flex items-center gap-3">
+            <AlertTriangle className="h-5 w-5 text-red-500" />
+            <h3 className="text-lg font-medium text-foreground">{t('permissions.blockedTools.title')}</h3>
+          </div>
+          <p className="text-sm text-muted-foreground">{t('permissions.blockedTools.description')}</p>
+
+          <div className="flex flex-col gap-2 sm:flex-row">
+            <Input
+              value={newDisallowedTool}
+              onChange={(event) => setNewDisallowedTool(event.target.value)}
+              placeholder={t('permissions.blockedTools.placeholder')}
+              onKeyDown={(event) => {
+                if (event.key === 'Enter') {
+                  event.preventDefault();
+                  handleAddDisallowedTool(newDisallowedTool);
+                }
+              }}
+              className="h-10 flex-1"
+              disabled={fullReplActive}
+            />
+            <Button
+              onClick={() => handleAddDisallowedTool(newDisallowedTool)}
+              disabled={!newDisallowedTool.trim() || fullReplActive}
+              size="sm"
+              className="h-10 px-4"
+            >
+              <Plus className="mr-2 h-4 w-4 sm:mr-0" />
+              <span className="sm:hidden">{t('permissions.actions.add')}</span>
+            </Button>
+          </div>
+
+          <div className="space-y-2">
+            {disallowedTools.map((tool) => (
+              <div key={tool} className="flex items-center justify-between rounded-lg border border-red-200 bg-red-50 p-3 dark:border-red-800 dark:bg-red-900/20">
+                <span className="font-mono text-sm text-red-800 dark:text-red-200">{tool}</span>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => onDisallowedToolsChange(removeValue(disallowedTools, tool))}
+                  className="text-red-600 hover:text-red-700"
+                  disabled={fullReplActive}
+                >
+                  <X className="h-4 w-4" />
+                </Button>
+              </div>
+            ))}
+            {disallowedTools.length === 0 && (
+              <div className="py-6 text-center text-muted-foreground">
+                {t('permissions.blockedTools.empty')}
+              </div>
+            )}
+          </div>
+        </div>
+
+        <div className="rounded-lg border border-blue-200 bg-blue-50 p-4 mt-6 dark:border-blue-800 dark:bg-blue-900/20">
+          <h4 className="mb-2 font-medium text-blue-900 dark:text-blue-100">
+            {t('permissions.toolExamples.title')}
+          </h4>
+          <ul className="space-y-1 text-sm text-blue-800 dark:text-blue-200">
+            <li><code className="rounded bg-blue-100 px-1 dark:bg-blue-800">"Bash(git log:*)"</code> {t('permissions.toolExamples.bashGitLog')}</li>
+            <li><code className="rounded bg-blue-100 px-1 dark:bg-blue-800">"Bash(git diff:*)"</code> {t('permissions.toolExamples.bashGitDiff')}</li>
+            <li><code className="rounded bg-blue-100 px-1 dark:bg-blue-800">"Write"</code> {t('permissions.toolExamples.write')}</li>
+            <li><code className="rounded bg-blue-100 px-1 dark:bg-blue-800">"Bash(rm:*)"</code> {t('permissions.toolExamples.bashRm')}</li>
+          </ul>
+        </div>
       </div>
 
     </div>

--- a/src/components/settings/view/tabs/agents-settings/sections/content/PermissionsContent.tsx
+++ b/src/components/settings/view/tabs/agents-settings/sections/content/PermissionsContent.tsx
@@ -3,7 +3,7 @@ import { AlertTriangle, FileText, Plus, Shield, Terminal, X } from 'lucide-react
 import { useTranslation } from 'react-i18next';
 import { Button, Input } from '../../../../../../../shared/view/ui';
 import type { CodexPermissionMode, GeminiPermissionMode } from '../../../../../types/types';
-import { isFullReplModeActive, setFullReplMode } from '../../../../../chat/utils/chatStorage';
+import { isFullReplModeActive, setFullReplMode } from '../../../../../../chat/utils/chatStorage';
 import { authenticatedFetch } from '../../../../../../../utils/api';
 
 const COMMON_CLAUDE_TOOLS = [

--- a/src/components/settings/view/tabs/agents-settings/sections/content/PermissionsContent.tsx
+++ b/src/components/settings/view/tabs/agents-settings/sections/content/PermissionsContent.tsx
@@ -210,6 +210,7 @@ function ClaudePermissions({
   const [newAllowedTool, setNewAllowedTool] = useState('');
   const [newDisallowedTool, setNewDisallowedTool] = useState('');
   const [fullReplActive, setFullReplActive] = useState(isFullReplModeActive());
+  console.log('[FULL-REPL-MODE] ClaudePermissions rendered, fullReplActive:', fullReplActive);
 
   const handleReplModeChange = (enabled: boolean) => {
     setFullReplMode(enabled);

--- a/src/components/settings/view/tabs/agents-settings/sections/content/PermissionsContent.tsx
+++ b/src/components/settings/view/tabs/agents-settings/sections/content/PermissionsContent.tsx
@@ -210,7 +210,6 @@ function ClaudePermissions({
   const [newAllowedTool, setNewAllowedTool] = useState('');
   const [newDisallowedTool, setNewDisallowedTool] = useState('');
   const [fullReplActive, setFullReplActive] = useState(isFullReplModeActive());
-  console.log('[FULL-REPL-MODE] ClaudePermissions rendered, fullReplActive:', fullReplActive);
 
   const handleReplModeChange = (enabled: boolean) => {
     setFullReplMode(enabled);


### PR DESCRIPTION
Closes #545

## What changed

When Full REPL Mode is enabled (toggle in Settings > Claude > Permissions), the Chat tab spawns the native `claude` CLI instead of using the Agent SDK. This gives Chat the same behavior as the native CLI: same permissions, same session storage, same CLAUDE.md loading, and bidirectional session sync with the Shell tab.

#### New files
- `server/utils/settings-reader.js` - reads/caches `~/.claude/settings.json` for permission parity
- `server/claude-cli-query.js` - spawns `claude --output-format stream-json --print`, parses JSONL events, maps to existing Chat UI WebSocket messages

#### Modified files
- `server/claude-sdk.js` - permission overrides from settings.json when in REPL mode
- `server/routes/settings.js` - `/api/settings/repl-mode` status endpoint
- `server/index.js` - routes Chat queries to CLI or SDK based on mode, session handoff between tabs
- `src/components/chat/utils/chatStorage.ts` - localStorage helpers for mode toggle
- `src/components/chat/hooks/useChatComposerState.ts` - passes `fullReplMode` flag
- `src/components/chat/view/ChatInterface.tsx` - info banner about MCP tools in Shell tab
- `src/components/settings/.../PermissionsContent.tsx` - Full REPL Mode toggle with settings.json status

#### Session sync
- Server-side registry maps `projectPath -> sessionId`
- Chat stores session ID when CLI creates it, Shell picks it up via `--resume`
- Switching tabs kills the previous tab's process and resumes the session in the new tab

#### Scope
- Claude provider only. Other providers (Cursor, Codex, Gemini) are unaffected and could adopt a similar pattern independently
- MCP server tools are available in the Shell tab (interactive REPL) but skipped in Chat's `--print` mode to avoid 30s+ startup overhead from server initialization

## Code review fixes (d3e877b)

Changes made after automated code review:

| Finding | Severity | Fix |
|---|---|---|
| Tri-state REPL preference | Major | `isFullReplModeActive()` returns `undefined` when unset so server env var default applies |
| Registry session ID validation | Major | Validated against `safeSessionIdPattern` before shell interpolation |
| `isNewSession` from wrong source | Major | Track `isResumed` from final `resumeId`, not raw `sessionId` |
| Plaintext CLI errors dropped | Major | Store last non-JSON line, emit `claude-error` on non-zero exit |
| Plan mode downgraded to bypass | Major | Guard `skipDangerousModePermissionPrompt` with `permissionMode !== 'plan'` |
| Fragile 5s setTimeout for session detection | Minor | Replaced with PTY output UUID parsing + 15s disk scan fallback |
| Settings metadata only populated with env var | Major | Always call `getSettings()` regardless of `CLAUDE_FULL_REPL_MODE` |
| Concurrent write race on settings.json | Critical | Added promise chain mutex to serialize `persistAllowedTool` |

## Code review fixes - round 2 (d432125)

| Finding | Severity | Fix |
|---|---|---|
| Project path encoding mismatch | Major | Use `[^a-zA-Z0-9-]` regex to match Claude's actual encoding |
| Image payload format mismatch | Major | Support both data URL and raw base64 formats, handle `mimeType` and `mediaType` |
| PTY handoff kills non-Claude sessions | Major | Only kill PTYs with UUID session IDs (Claude sessions), skip plain shell/cursor/codex/gemini |
| Chat CLI not killed on explicit resume | Major | Moved `abortClaudeCLISession` outside registry branch so it runs for all resume paths |
| Session ownership validation | Critical | Pre-existing upstream pattern, flagged for separate PR |
## Code review fixes - round 3 (33b7e42)

| Finding | Severity | Fix |
|---|---|---|
| PTY record stores null sessionId for registry resumes | Major | Store `resumeSessionId \|\| sessionId` in ptySessionsMap |
| Session detection not cancelled on PTY exit | Major | Dispose listener and clear timeout in onExit handler |
| Duplicated ANSI regex | Nitpick | Extracted to module-level `ANSI_ESCAPE_RE` constant |
| tempDir cleanup races and leaks | Minor | Use async cleanup with `Promise.all` for unlinks before rmdir |
| cwd not normalized before queryClaudeCLI | Major | Set `data.options.cwd = projectPath` when cwd is missing |
## Test plan
- [x] Enable Full REPL Mode in Settings > Claude > Permissions
- [x] Send a message in Chat tab, verify response renders correctly
- [x] Switch to Shell tab, verify it resumes the same session (shows conversation history)
- [x] Type a follow-up in Shell, switch back to Chat, verify session continuity
- [x] Disable Full REPL Mode, verify Chat falls back to SDK behavior
- [x] Verify settings.json permissions are displayed in the toggle UI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Full REPL Mode: CLI-backed Claude sessions with project-scoped persistence, resume/abort, active-session listing, and image attachment support.
  * Server API: REPL settings endpoint and disk-backed settings/permissions loader.

* **Enhancements**
  * UI: REPL config panel in Settings with allow/deny lists and quick-add tools.
  * Chat: Full REPL status banner, client toggle, and routing to shell-based sessions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->