### PR TITLE
fix: remove /exit command from claude login flow during onboarding

### DIFF
--- a/src/components/onboarding/view/Onboarding.tsx
+++ b/src/components/onboarding/view/Onboarding.tsx
@@ -281,7 +281,6 @@ export default function Onboarding({ onComplete }: OnboardingProps) {
           provider={activeLoginProvider}
           project={selectedProject}
           onComplete={handleLoginComplete}
-          isOnboarding={true}
         />
       )}
     </>

--- a/src/components/provider-auth/view/ProviderLoginModal.tsx
+++ b/src/components/provider-auth/view/ProviderLoginModal.tsx
@@ -19,19 +19,16 @@ type ProviderLoginModalProps = {
   onComplete?: (exitCode: number) => void;
   customCommand?: string;
   isAuthenticated?: boolean;
-  isOnboarding?: boolean;
 };
 
 const getProviderCommand = ({
   provider,
   customCommand,
   isAuthenticated,
-  isOnboarding,
 }: {
   provider: CliProvider;
   customCommand?: string;
   isAuthenticated: boolean;
-  isOnboarding: boolean;
 }) => {
   if (customCommand) {
     return customCommand;
@@ -41,9 +38,7 @@ const getProviderCommand = ({
     if (isAuthenticated) {
       return 'claude setup-token --dangerously-skip-permissions';
     }
-    return isOnboarding
-      ? 'claude /exit --dangerously-skip-permissions'
-      : 'claude /login --dangerously-skip-permissions';
+    return 'claude /login --dangerously-skip-permissions';
   }
 
   if (provider === 'cursor') {
@@ -84,13 +79,12 @@ export default function ProviderLoginModal({
   onComplete,
   customCommand,
   isAuthenticated = false,
-  isOnboarding = false,
 }: ProviderLoginModalProps) {
   if (!isOpen) {
     return null;
   }
 
-  const command = getProviderCommand({ provider, customCommand, isAuthenticated, isOnboarding });
+  const command = getProviderCommand({ provider, customCommand, isAuthenticated });
   const title = getProviderTitle(provider);
   const shellProject = normalizeProject(project);
 


### PR DESCRIPTION
During onboarding, the exit command was passed to claude. If we remove that command, the issue is fixed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified provider authentication modal logic by streamlining the authentication flow for third-party providers. The modal's prop interface has been updated accordingly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->