### PR TITLE
feat: clean conversation view with noise stripping and tool grouping

### DIFF
--- a/docs/superpowers/plans/2026-03-19-clean-conversation-view.md
+++ b/docs/superpowers/plans/2026-03-19-clean-conversation-view.md
@@ -1,0 +1,829 @@
+# Clean Conversation View Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a clean/raw view toggle to the chat session viewer that collapses noise (skill definitions, system reminders, read-only tools) while preserving code-change tool visibility.
+
+**Architecture:** The feature threads a `cleanView` boolean through the existing preference system (`useUiPreferences`). Noise stripping and skill detection happen at the **view layer** (in `ChatMessagesPane`), not at the data transform layer — this preserves raw data for raw mode. A grouping layer in `ChatMessagesPane` collapses consecutive read-only tools. Two small new components render the collapsed group and skill chip.
+
+**Tech Stack:** React 18, TypeScript, Tailwind CSS, Lucide icons
+
+**Spec:** `docs/superpowers/specs/2026-03-18-clean-conversation-view-design.md`
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|------|--------|---------------|
+| `src/hooks/useUiPreferences.ts` | Modify | Add `cleanView` preference (default: `true`) |
+| `src/components/chat/types/types.ts` | Modify | Add `isSkillLoad`, `skillName` to `ChatMessage` |
+| `src/components/chat/utils/messageTransforms.ts` | Modify | Skill detection (always, lightweight — sets `isSkillLoad` flag) |
+| `src/components/chat/utils/cleanViewGrouping.ts` | Create | Group consecutive read-only tools for clean view |
+| `src/components/chat/view/subcomponents/SkillLoadChip.tsx` | Create | Compact skill indicator chip |
+| `src/components/chat/view/subcomponents/CollapsedToolGroup.tsx` | Create | Expandable summary for grouped read-only tools |
+| `src/components/chat/utils/cleanViewFilters.ts` | Create | Noise stripping functions (applied at view layer) |
+| `src/components/chat/view/subcomponents/ChatMessagesPane.tsx` | Modify | Wire `cleanView` prop, apply noise stripping + grouping, render groups |
+| `src/components/chat/view/ChatInterface.tsx` | Modify | Pass `cleanView` through |
+| `src/components/main-content/view/MainContent.tsx` | Modify | Extract `cleanView` from preferences, pass to ChatInterface |
+| `src/components/quick-settings-panel/constants.ts` | Modify | Add toggle entry for `cleanView` |
+| `src/components/quick-settings-panel/types.ts` | Modify | Add `cleanView` to preference key union |
+| `src/i18n/locales/en/settings.json` | Modify | Add `cleanView` label string |
+
+---
+
+### Task 1: Add `cleanView` preference to the UI preferences system
+
+**Files:**
+- Modify: `src/hooks/useUiPreferences.ts:3-9` (UiPreferences type), `:35-42` (DEFAULTS)
+- Modify: `src/components/quick-settings-panel/types.ts:5-9`
+- Modify: `src/components/quick-settings-panel/constants.ts:34-50`
+- Modify: `src/i18n/locales/en/settings.json`
+
+- [ ] **Step 1: Add `cleanView` to UiPreferences type and defaults**
+
+In `src/hooks/useUiPreferences.ts`, add `cleanView: boolean` to the `UiPreferences` type and set default to `true`:
+
+```typescript
+type UiPreferences = {
+  autoExpandTools: boolean;
+  showRawParameters: boolean;
+  showThinking: boolean;
+  autoScrollToBottom: boolean;
+  sendByCtrlEnter: boolean;
+  sidebarVisible: boolean;
+  cleanView: boolean;          // <-- add
+};
+
+const DEFAULTS: UiPreferences = {
+  autoExpandTools: false,
+  showRawParameters: false,
+  showThinking: true,
+  autoScrollToBottom: true,
+  sendByCtrlEnter: false,
+  sidebarVisible: true,
+  cleanView: true,             // <-- add (default: clean mode on)
+};
+```
+
+- [ ] **Step 2: Add `cleanView` to quick settings panel type**
+
+In `src/components/quick-settings-panel/types.ts`, add `'cleanView'` to the preference key union type:
+
+```typescript
+export type PreferenceToggleKey =
+  | 'autoExpandTools'
+  | 'showRawParameters'
+  | 'showThinking'
+  | 'autoScrollToBottom'
+  | 'sendByCtrlEnter'
+  | 'cleanView';               // <-- add
+```
+
+- [ ] **Step 3: Add toggle to quick settings constants**
+
+In `src/components/quick-settings-panel/constants.ts`, add to the `TOOL_DISPLAY_TOGGLES` array (import `Sparkles` is already imported):
+
+```typescript
+export const TOOL_DISPLAY_TOGGLES: PreferenceToggleItem[] = [
+  {
+    key: 'autoExpandTools',
+    labelKey: 'quickSettings.autoExpandTools',
+    icon: Maximize2,
+  },
+  {
+    key: 'showRawParameters',
+    labelKey: 'quickSettings.showRawParameters',
+    icon: Eye,
+  },
+  {
+    key: 'showThinking',
+    labelKey: 'quickSettings.showThinking',
+    icon: Brain,
+  },
+  {
+    key: 'cleanView',
+    labelKey: 'quickSettings.cleanView',
+    icon: Sparkles,
+  },
+];
+```
+
+- [ ] **Step 4: Add i18n label**
+
+In `src/i18n/locales/en/settings.json`, add inside the `quickSettings` object:
+
+```json
+"cleanView": "Clean view (hide noise)"
+```
+
+- [ ] **Step 5: Verify build passes**
+
+Run: `cd /home/ubuntu/projects/claudecodeui && npx tsc --noEmit`
+Expected: No errors
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /home/ubuntu/projects/claudecodeui
+git add src/hooks/useUiPreferences.ts src/components/quick-settings-panel/types.ts src/components/quick-settings-panel/constants.ts src/i18n/locales/en/settings.json
+git commit -m "feat: add cleanView preference to UI settings"
+```
+
+---
+
+### Task 2: Add `isSkillLoad` and `skillName` to ChatMessage type
+
+**Files:**
+- Modify: `src/components/chat/types/types.ts:28-49`
+
+- [ ] **Step 1: Add fields to ChatMessage interface**
+
+In `src/components/chat/types/types.ts`, add two optional fields before the index signature:
+
+```typescript
+export interface ChatMessage {
+  type: string;
+  content?: string;
+  timestamp: string | number | Date;
+  images?: ChatImage[];
+  reasoning?: string;
+  isThinking?: boolean;
+  isStreaming?: boolean;
+  isInteractivePrompt?: boolean;
+  isToolUse?: boolean;
+  toolName?: string;
+  toolInput?: unknown;
+  toolResult?: ToolResult | null;
+  toolId?: string;
+  toolCallId?: string;
+  isSubagentContainer?: boolean;
+  subagentState?: {
+    childTools: SubagentChildTool[];
+    currentToolIndex: number;
+    isComplete: boolean;
+  };
+  isSkillLoad?: boolean;
+  skillName?: string;
+  [key: string]: unknown;
+}
+```
+
+- [ ] **Step 2: Verify build passes**
+
+Run: `cd /home/ubuntu/projects/claudecodeui && npx tsc --noEmit`
+Expected: No errors
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /home/ubuntu/projects/claudecodeui
+git add src/components/chat/types/types.ts
+git commit -m "feat: add isSkillLoad and skillName to ChatMessage type"
+```
+
+---
+
+### Task 3: Add skill detection to messageTransforms (data layer — always active)
+
+**Files:**
+- Modify: `src/components/chat/utils/messageTransforms.ts:353-549` (the `convertSessionMessages` function)
+
+**Note:** Noise stripping (system-reminder, command tags) is NOT done here. It is done at the view layer (Task 3b) so that raw mode preserves original content. Only skill detection is added here because it needs to set the `isSkillLoad` flag on the ChatMessage data — a lightweight operation that doesn't destroy data (the original content is not needed since skill definitions are never useful to display).
+
+- [ ] **Step 1: Add skill detection helper**
+
+Add this function above `convertSessionMessages` (around line 353):
+
+```typescript
+/**
+ * Detect if a user message is a skill definition load.
+ * Returns the skill name if detected, null otherwise.
+ */
+const detectSkillLoad = (text: string): string | null => {
+  if (!text.startsWith('Base directory for this skill:')) {
+    return null;
+  }
+  // Extract skill name from path like ".../skills/server-debugging/..."
+  const pathMatch = text.match(/skills\/([^/\n]+)/);
+  return pathMatch ? pathMatch[1] : 'unknown';
+};
+```
+
+- [ ] **Step 2: Add skill detection to user message processing**
+
+In `convertSessionMessages`, find the user message block (around lines 378-427). After the content is assembled (after the `} else {` at line 392), add skill detection BEFORE the existing `shouldSkip` check. Insert this block right after `content = decodeHtmlEntities(String(message.message.content));` (line 392) and before the `const shouldSkip =` line (line 394):
+
+```typescript
+      // Detect skill definitions — flag them so the view layer can render as chips
+      const skillName = detectSkillLoad(content);
+      if (skillName) {
+        converted.push({
+          type: 'user',
+          content,
+          timestamp: message.timestamp || new Date().toISOString(),
+          isSkillLoad: true,
+          skillName,
+        });
+        return;
+      }
+```
+
+**Important:** Keep the existing `shouldSkip` checks unchanged — they handle raw mode filtering. Do NOT add `stripNoiseTags` here.
+
+- [ ] **Step 3: Verify build passes**
+
+Run: `cd /home/ubuntu/projects/claudecodeui && npx tsc --noEmit`
+Expected: No errors
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /home/ubuntu/projects/claudecodeui
+git add src/components/chat/utils/messageTransforms.ts
+git commit -m "feat: add skill detection to message transforms"
+```
+
+---
+
+### Task 3b: Create view-layer noise stripping utility
+
+**Files:**
+- Create: `src/components/chat/utils/cleanViewFilters.ts`
+
+**Note:** These functions are applied at the view layer (in ChatMessagesPane) only when cleanView is enabled. Raw mode gets unmodified messages.
+
+- [ ] **Step 1: Create the utility**
+
+Create `src/components/chat/utils/cleanViewFilters.ts`:
+
+```typescript
+import type { ChatMessage } from '../types/types';
+
+/**
+ * Strip noise tags from user message text that the terminal hides.
+ * Only applied in clean view mode — raw mode preserves original content.
+ */
+export const stripNoiseTags = (text: string): string => {
+  return text
+    .replace(/<system-reminder>[\s\S]*?<\/system-reminder>/g, '')
+    .replace(/<local-command-caveat>[\s\S]*?<\/local-command-caveat>/g, '')
+    .replace(/<local-command-stdout>[\s\S]*?<\/local-command-stdout>/g, '')
+    .replace(/<command-name>[\s\S]*?<\/command-name>/g, '')
+    .replace(/<command-args>[\s\S]*?<\/command-args>/g, '')
+    .replace(/<command-message>[\s\S]*?<\/command-message>/g, '')
+    .trim();
+};
+
+/**
+ * Apply clean view filters to a list of messages.
+ * - Strips noise tags from user messages
+ * - Removes messages that become empty after stripping
+ * Returns a new array (does not mutate input).
+ */
+export const applyCleanViewFilters = (messages: ChatMessage[]): ChatMessage[] => {
+  const result: ChatMessage[] = [];
+
+  for (const msg of messages) {
+    // Only strip noise from user messages (assistant/tool messages don't have these tags)
+    if (msg.type === 'user' && !msg.isSkillLoad && msg.content) {
+      const cleaned = stripNoiseTags(msg.content);
+      if (!cleaned) {
+        // Message was entirely noise tags — skip it
+        continue;
+      }
+      if (cleaned !== msg.content) {
+        // Content changed — create a new message object with cleaned content
+        result.push({ ...msg, content: cleaned });
+        continue;
+      }
+    }
+    result.push(msg);
+  }
+
+  return result;
+};
+```
+
+- [ ] **Step 2: Verify build passes**
+
+Run: `cd /home/ubuntu/projects/claudecodeui && npx tsc --noEmit`
+Expected: No errors
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /home/ubuntu/projects/claudecodeui
+git add src/components/chat/utils/cleanViewFilters.ts
+git commit -m "feat: add view-layer noise stripping for clean view"
+```
+
+---
+
+### Task 4: Create the clean view grouping utility
+
+**Files:**
+- Create: `src/components/chat/utils/cleanViewGrouping.ts`
+
+- [ ] **Step 1: Create the grouping utility**
+
+Create `src/components/chat/utils/cleanViewGrouping.ts`:
+
+```typescript
+import type { ChatMessage } from '../types/types';
+
+/**
+ * Tools classified as "read-only" — collapsed in clean view.
+ * Code-change tools (Edit, Write, Bash, NotebookEdit, ApplyPatch) stay visible.
+ */
+const READ_ONLY_TOOLS = new Set([
+  'Read',
+  'Grep',
+  'Glob',
+  'WebSearch',
+  'WebFetch',
+  'Skill',
+  'TaskCreate',
+  'TaskUpdate',
+  'TaskGet',
+  'TaskList',
+  'TaskOutput',
+  'ToolSearch',
+  'Agent',
+  'LSP',
+  'TodoRead',
+]);
+
+export const isReadOnlyTool = (toolName: string): boolean =>
+  READ_ONLY_TOOLS.has(toolName);
+
+export type CleanViewItem =
+  | { kind: 'message'; message: ChatMessage }
+  | { kind: 'group'; tools: ChatMessage[] };
+
+/**
+ * Groups consecutive read-only tool-use messages into collapsed groups.
+ * Non-tool messages and code-change tools break the group.
+ *
+ * Only active when cleanView is true; otherwise returns all messages as-is.
+ */
+export const groupMessagesForCleanView = (
+  messages: ChatMessage[],
+  cleanView: boolean,
+): CleanViewItem[] => {
+  if (!cleanView) {
+    return messages.map((message) => ({ kind: 'message', message }));
+  }
+
+  const items: CleanViewItem[] = [];
+  let currentGroup: ChatMessage[] = [];
+
+  const flushGroup = () => {
+    if (currentGroup.length > 0) {
+      items.push({ kind: 'group', tools: currentGroup });
+      currentGroup = [];
+    }
+  };
+
+  for (const message of messages) {
+    // Skill loads pass through as individual messages (rendered as chips)
+    if (message.isSkillLoad) {
+      flushGroup();
+      items.push({ kind: 'message', message });
+      continue;
+    }
+
+    // Read-only tool-use messages get grouped
+    if (message.isToolUse && message.toolName && isReadOnlyTool(message.toolName)) {
+      currentGroup.push(message);
+      continue;
+    }
+
+    // Everything else (text, code-change tools, user messages) breaks the group
+    flushGroup();
+    items.push({ kind: 'message', message });
+  }
+
+  flushGroup();
+  return items;
+};
+
+/**
+ * Build a human-readable summary of grouped tools.
+ * e.g. "Read 3 files, Grep 2 patterns, Glob 1 search"
+ */
+export const summarizeToolGroup = (tools: ChatMessage[]): string => {
+  const counts = new Map<string, number>();
+  for (const tool of tools) {
+    const name = tool.toolName || 'Unknown';
+    counts.set(name, (counts.get(name) || 0) + 1);
+  }
+
+  const labels: Record<string, string> = {
+    Read: 'file read',
+    Grep: 'search',
+    Glob: 'file search',
+    WebSearch: 'web search',
+    WebFetch: 'web fetch',
+    Agent: 'subagent',
+    LSP: 'LSP query',
+    TodoRead: 'todo read',
+  };
+
+  const parts: string[] = [];
+  for (const [name, count] of counts) {
+    const label = labels[name] || name.toLowerCase();
+    const plural = count > 1 ? `${label}${label.endsWith('s') ? '' : 'es'}` : label;
+    parts.push(`${count} ${count > 1 ? plural : label}`);
+  }
+
+  return parts.join(', ');
+};
+```
+
+- [ ] **Step 2: Verify build passes**
+
+Run: `cd /home/ubuntu/projects/claudecodeui && npx tsc --noEmit`
+Expected: No errors
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /home/ubuntu/projects/claudecodeui
+git add src/components/chat/utils/cleanViewGrouping.ts
+git commit -m "feat: add clean view grouping utility for read-only tools"
+```
+
+---
+
+### Task 5: Create SkillLoadChip component
+
+**Files:**
+- Create: `src/components/chat/view/subcomponents/SkillLoadChip.tsx`
+
+- [ ] **Step 1: Create the component**
+
+Create `src/components/chat/view/subcomponents/SkillLoadChip.tsx`:
+
+```typescript
+import { useMemo } from 'react';
+import { Zap } from 'lucide-react';
+
+interface SkillLoadChipProps {
+  skillName: string;
+  timestamp: string | number | Date;
+}
+
+export default function SkillLoadChip({ skillName, timestamp }: SkillLoadChipProps) {
+  const formattedTime = useMemo(
+    () => new Date(timestamp).toLocaleTimeString(),
+    [timestamp],
+  );
+
+  return (
+    <div className="flex items-center gap-2 px-3 py-1 sm:px-0">
+      <div className="flex items-center gap-1.5 rounded-full border border-gray-200 bg-gray-50 px-3 py-1 text-xs text-gray-500 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-400">
+        <Zap className="h-3 w-3" />
+        <span>Loaded skill: <span className="font-medium">{skillName}</span></span>
+        <span className="text-gray-400 dark:text-gray-500">{formattedTime}</span>
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Verify build passes**
+
+Run: `cd /home/ubuntu/projects/claudecodeui && npx tsc --noEmit`
+Expected: No errors
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /home/ubuntu/projects/claudecodeui
+git add src/components/chat/view/subcomponents/SkillLoadChip.tsx
+git commit -m "feat: add SkillLoadChip component for clean view"
+```
+
+---
+
+### Task 6: Create CollapsedToolGroup component
+
+**Files:**
+- Create: `src/components/chat/view/subcomponents/CollapsedToolGroup.tsx`
+
+- [ ] **Step 1: Create the component**
+
+Create `src/components/chat/view/subcomponents/CollapsedToolGroup.tsx`:
+
+```typescript
+import { useState } from 'react';
+import { ChevronRight, Search } from 'lucide-react';
+import type { ChatMessage } from '../../types/types';
+import type { Project } from '../../../../types/app';
+import { summarizeToolGroup } from '../../utils/cleanViewGrouping';
+import MessageComponent from './MessageComponent';
+
+interface CollapsedToolGroupProps {
+  tools: ChatMessage[];
+  createDiff: (oldStr: string, newStr: string) => any;
+  onFileOpen?: (filePath: string, diffInfo?: unknown) => void;
+  onShowSettings?: () => void;
+  onGrantToolPermission?: (suggestion: { entry: string; toolName: string }) => { success: boolean };
+  autoExpandTools?: boolean;
+  showRawParameters?: boolean;
+  showThinking?: boolean;
+  selectedProject?: Project | null;
+  provider: string;
+}
+
+export default function CollapsedToolGroup({
+  tools,
+  createDiff,
+  onFileOpen,
+  onShowSettings,
+  onGrantToolPermission,
+  autoExpandTools,
+  showRawParameters,
+  showThinking,
+  selectedProject,
+  provider,
+}: CollapsedToolGroupProps) {
+  const [isExpanded, setIsExpanded] = useState(false);
+  const summary = summarizeToolGroup(tools);
+
+  return (
+    <div className="px-3 sm:px-0">
+      <button
+        type="button"
+        onClick={() => setIsExpanded(!isExpanded)}
+        className="flex w-full items-center gap-2 rounded-lg border border-gray-200 bg-gray-50 px-3 py-1.5 text-left text-xs text-gray-500 transition-colors hover:border-gray-300 hover:bg-gray-100 dark:border-gray-700 dark:bg-gray-800/50 dark:text-gray-400 dark:hover:border-gray-600 dark:hover:bg-gray-800"
+      >
+        <ChevronRight
+          className={`h-3 w-3 flex-shrink-0 transition-transform ${isExpanded ? 'rotate-90' : ''}`}
+        />
+        <Search className="h-3 w-3 flex-shrink-0 text-gray-400 dark:text-gray-500" />
+        <span>
+          Research: {summary}
+        </span>
+        <span className="ml-auto text-gray-400 dark:text-gray-500">
+          {tools.length} {tools.length === 1 ? 'call' : 'calls'}
+        </span>
+      </button>
+
+      {isExpanded && (
+        <div className="mt-1 space-y-1 border-l-2 border-gray-200 pl-3 dark:border-gray-700">
+          {tools.map((tool, index) => (
+            <MessageComponent
+              key={tool.toolId || `group-tool-${index}`}
+              message={tool}
+              prevMessage={index > 0 ? tools[index - 1] : null}
+              createDiff={createDiff}
+              onFileOpen={onFileOpen}
+              onShowSettings={onShowSettings}
+              onGrantToolPermission={onGrantToolPermission}
+              autoExpandTools={autoExpandTools}
+              showRawParameters={showRawParameters}
+              showThinking={showThinking}
+              selectedProject={selectedProject}
+              provider={provider}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Verify build passes**
+
+Run: `cd /home/ubuntu/projects/claudecodeui && npx tsc --noEmit`
+Expected: No errors
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /home/ubuntu/projects/claudecodeui
+git add src/components/chat/view/subcomponents/CollapsedToolGroup.tsx
+git commit -m "feat: add CollapsedToolGroup component for clean view"
+```
+
+---
+
+### Task 7: Wire clean view into ChatMessagesPane
+
+**Files:**
+- Modify: `src/components/chat/view/subcomponents/ChatMessagesPane.tsx`
+
+- [ ] **Step 1: Add `cleanView` prop and imports**
+
+Add imports at top of file:
+
+```typescript
+import { useMemo } from 'react';
+import { groupMessagesForCleanView } from '../../utils/cleanViewGrouping';
+import { applyCleanViewFilters } from '../../utils/cleanViewFilters';
+import SkillLoadChip from './SkillLoadChip';
+import CollapsedToolGroup from './CollapsedToolGroup';
+```
+
+Update the existing `import { useCallback, useRef } from 'react';` to include `useMemo`:
+```typescript
+import { useCallback, useMemo, useRef } from 'react';
+```
+
+Add `cleanView?: boolean;` to the `ChatMessagesPaneProps` interface (after `showThinking?: boolean;` at line 52).
+
+Add `cleanView,` to the destructured props (after `showThinking,` at line 98).
+
+- [ ] **Step 2: Add memoized clean view pipeline**
+
+Inside the component function, before the `return` statement (around line 131), add:
+
+```typescript
+  // Clean view pipeline: strip noise → group read-only tools (memoized)
+  const cleanViewItems = useMemo(() => {
+    const isClean = cleanView ?? true;
+    const filtered = isClean ? applyCleanViewFilters(visibleMessages) : visibleMessages;
+    return groupMessagesForCleanView(filtered, isClean);
+  }, [visibleMessages, cleanView]);
+```
+
+- [ ] **Step 3: Replace the message rendering loop**
+
+Replace the `visibleMessages.map(...)` block (lines 243-261) with grouped rendering:
+
+```typescript
+          {cleanViewItems.map((item, index) => {
+              if (item.kind === 'group') {
+                return (
+                  <CollapsedToolGroup
+                    key={`group-${item.tools[0]?.toolId || index}`}
+                    tools={item.tools}
+                    createDiff={createDiff}
+                    onFileOpen={onFileOpen}
+                    onShowSettings={onShowSettings}
+                    onGrantToolPermission={onGrantToolPermission}
+                    autoExpandTools={autoExpandTools}
+                    showRawParameters={showRawParameters}
+                    showThinking={showThinking}
+                    selectedProject={selectedProject}
+                    provider={provider}
+                  />
+                );
+              }
+
+              const message = item.message;
+
+              // Render skill loads as chips in clean view
+              if (message.isSkillLoad && (cleanView ?? true)) {
+                return (
+                  <SkillLoadChip
+                    key={getMessageKey(message)}
+                    skillName={message.skillName || 'unknown'}
+                    timestamp={message.timestamp}
+                  />
+                );
+              }
+
+              // Find previous non-group message for grouping logic
+              let prevMessage: ChatMessage | null = null;
+              for (let i = index - 1; i >= 0; i--) {
+                const prev = items[i];
+                if (prev.kind === 'message') {
+                  prevMessage = prev.message;
+                  break;
+                }
+              }
+
+              return (
+                <MessageComponent
+                  key={getMessageKey(message)}
+                  message={message}
+                  prevMessage={prevMessage}
+                  createDiff={createDiff}
+                  onFileOpen={onFileOpen}
+                  onShowSettings={onShowSettings}
+                  onGrantToolPermission={onGrantToolPermission}
+                  autoExpandTools={autoExpandTools}
+                  showRawParameters={showRawParameters}
+                  showThinking={showThinking}
+                  selectedProject={selectedProject}
+                  provider={provider}
+                />
+              );
+            })}
+```
+
+- [ ] **Step 3: Verify build passes**
+
+Run: `cd /home/ubuntu/projects/claudecodeui && npx tsc --noEmit`
+Expected: No errors
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /home/ubuntu/projects/claudecodeui
+git add src/components/chat/view/subcomponents/ChatMessagesPane.tsx
+git commit -m "feat: wire clean view grouping into ChatMessagesPane"
+```
+
+---
+
+### Task 8: Thread `cleanView` prop through ChatInterface and MainContent
+
+**Files:**
+- Modify: `src/components/chat/types/types.ts:94-118` (ChatInterfaceProps)
+- Modify: `src/components/chat/view/ChatInterface.tsx:37,318`
+- Modify: `src/components/main-content/view/MainContent.tsx:53,132`
+
+- [ ] **Step 1: Add to ChatInterface**
+
+In `src/components/chat/view/ChatInterface.tsx`:
+
+Find where `showThinking` is destructured from props (line 37) and add `cleanView` next to it:
+
+```typescript
+  showThinking,
+  cleanView,
+```
+
+Find where `showThinking={showThinking}` is passed to `ChatMessagesPane` (line 318) and add:
+
+```typescript
+                showThinking={showThinking}
+                cleanView={cleanView}
+```
+
+Also add `cleanView?: boolean;` to the `ChatInterfaceProps` in `src/components/chat/types/types.ts` (around line 113, after `showThinking`):
+
+```typescript
+  showThinking?: boolean;
+  cleanView?: boolean;
+```
+
+- [ ] **Step 2: Add to MainContent**
+
+In `src/components/main-content/view/MainContent.tsx`:
+
+Find where preferences are destructured (line 53) and add `cleanView`:
+
+```typescript
+  const { autoExpandTools, showRawParameters, showThinking, autoScrollToBottom, sendByCtrlEnter, cleanView } = preferences;
+```
+
+Find where `showThinking` is passed to ChatInterface (line 132) and add:
+
+```typescript
+                showThinking={showThinking}
+                cleanView={cleanView}
+```
+
+- [ ] **Step 3: Verify build passes**
+
+Run: `cd /home/ubuntu/projects/claudecodeui && npx tsc --noEmit`
+Expected: No errors
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /home/ubuntu/projects/claudecodeui
+git add src/components/chat/view/ChatInterface.tsx src/components/main-content/view/MainContent.tsx src/components/chat/types/types.ts
+git commit -m "feat: thread cleanView prop through ChatInterface and MainContent"
+```
+
+---
+
+### Task 9: Manual integration test
+
+**Files:** None (verification only)
+
+- [ ] **Step 1: Build the project**
+
+Run: `cd /home/ubuntu/projects/claudecodeui && npm run build`
+Expected: Build succeeds with no errors
+
+- [ ] **Step 2: Restart the service**
+
+Run: `sudo systemctl restart claudecodeui` (or whatever the service name is — check with `systemctl list-units | grep claude`)
+
+- [ ] **Step 3: Test in browser**
+
+Open the UI and navigate to the session `3cc9ab2a-4437-4685-aee9-3249e6908e18` in the spend-tracker project. Verify:
+
+1. Skill definitions show as compact chips (e.g., "Loaded skill: server-debugging")
+2. System reminders are stripped from user messages
+3. Consecutive Read/Grep/Glob calls are collapsed into summary lines
+4. Edit/Write/Bash tools remain fully visible with diffs
+5. Clicking a collapsed group expands to show individual tools
+6. The clean/raw toggle in quick settings works
+7. Toggling to raw mode shows everything as before
+
+- [ ] **Step 4: Final commit if any fixes needed**
+
+```bash
+cd /home/ubuntu/projects/claudecodeui
+git add -A
+git commit -m "fix: integration test fixes for clean view"
+```

--- a/docs/superpowers/plans/2026-03-19-clean-conversation-view.md
+++ b/docs/superpowers/plans/2026-03-19-clean-conversation-view.md
@@ -205,7 +205,7 @@ const detectSkillLoad = (text: string): string | null => {
     return null;
   }
   // Extract skill name from path like ".../skills/server-debugging/..."
-  const pathMatch = text.match(/skills\/([^/\n]+)/);
+  const pathMatch = text.match(/skills[\\/]+([^/\\\n]+)/);
   return pathMatch ? pathMatch[1] : 'unknown';
 };
 ```

--- a/docs/superpowers/plans/2026-03-19-clean-conversation-view.md
+++ b/docs/superpowers/plans/2026-03-19-clean-conversation-view.md
@@ -690,7 +690,7 @@ Replace the `visibleMessages.map(...)` block (lines 243-261) with grouped render
               // Find previous non-group message for grouping logic
               let prevMessage: ChatMessage | null = null;
               for (let i = index - 1; i >= 0; i--) {
-                const prev = items[i];
+                const prev = cleanViewItems[i];
                 if (prev.kind === 'message') {
                   prevMessage = prev.message;
                   break;

--- a/docs/superpowers/specs/2026-03-18-clean-conversation-view-design.md
+++ b/docs/superpowers/specs/2026-03-18-clean-conversation-view-design.md
@@ -1,0 +1,112 @@
+# Clean Conversation View Mode
+
+## Problem
+
+When viewing Claude Code session history in the UI, the conversation is cluttered with content that the terminal hides: skill definitions (2-11KB each) rendered as full user messages, `<system-reminder>` blocks embedded in user text, and consecutive read-only tool calls that obscure the actual conversation flow. This makes auditing sessions significantly harder than reading them in the terminal.
+
+## Solution
+
+Add a **clean/raw view toggle** (clean as default) that filters noise and collapses read-only tool operations while preserving code-change visibility.
+
+## View Modes
+
+### Clean Mode (default)
+
+1. **Skill definitions** shown as a compact chip: `Loaded skill: server-debugging`
+2. **System reminders** stripped from user message text (regex removal of `<system-reminder>...</system-reminder>` blocks)
+3. **Read-only tools** (Read, Grep, Glob, WebSearch, WebFetch, Skill, TaskCreate, TaskUpdate, TaskGet, TaskList, TaskOutput, ToolSearch, Agent, LSP) collapsed into a summary line per consecutive group, expandable on click
+4. **Code-change tools** (Edit, Write, Bash, NotebookEdit, ApplyPatch) remain fully visible with diffs/output
+5. **Thinking blocks** hidden by default (existing toggle still works)
+6. **`<local-command-caveat>`, `<local-command-stdout>`, `<command-name>`, `<command-args>`** stripped from user text
+
+### Raw Mode
+
+Current behavior unchanged. All content visible including skill text, system reminders, all tool details.
+
+## Detection Rules
+
+### Skill Definition Detection
+
+User messages where text content starts with `"Base directory for this skill:"` are skill loads. Extract skill name from the path (last segment before any filename). Convert to a `ChatMessage` with `isSkillLoad: true` and `skillName: string`.
+
+### System Reminder Stripping
+
+Regex: `/<system-reminder>[\s\S]*?<\/system-reminder>/g`
+
+Applied to user message text parts. If after stripping all reminders the text is empty, skip the message entirely.
+
+### Embedded Noise Tag Stripping
+
+Also strip these patterns from user text:
+- `<local-command-caveat>[\s\S]*?<\/local-command-caveat>`
+- `<local-command-stdout>[\s\S]*?<\/local-command-stdout>`
+
+### Read-Only Tool Grouping
+
+Consecutive tool-use messages where `toolName` is in the read-only set get grouped. The group breaks when:
+- A text message (user or assistant) appears
+- A code-change tool appears
+- A non-tool message appears
+
+Group display: `"Research: Read 3 files, Grep 2 patterns, Glob 1 search"` — clicking expands to show individual tool calls with their existing rendering.
+
+## Data Model Changes
+
+### ChatMessage type additions
+
+```typescript
+interface ChatMessage {
+  // ... existing fields
+  isSkillLoad?: boolean;
+  skillName?: string;
+}
+```
+
+### New component props
+
+```typescript
+interface CollapsedToolGroupProps {
+  tools: ChatMessage[];
+  isExpanded: boolean;
+  onToggle: () => void;
+}
+
+interface SkillLoadChipProps {
+  skillName: string;
+  timestamp: string;
+}
+```
+
+## View Mode State
+
+- State: `viewMode: 'clean' | 'raw'`
+- Stored in `localStorage` key `ccui-view-mode`
+- Default: `'clean'`
+- Toggle: button in chat toolbar area (eye icon or similar)
+- The toggle controls which messages are visible and how they render; the underlying message data is unchanged
+
+## Files to Modify
+
+| File | Change |
+|------|--------|
+| `src/components/chat/utils/messageTransforms.ts` | Skill detection, system-reminder/noise stripping |
+| `src/components/chat/types/types.ts` | `isSkillLoad`, `skillName` fields |
+| `src/components/chat/view/subcomponents/ChatMessagesPane.tsx` | viewMode state, grouping logic, toggle UI |
+| `src/components/chat/view/subcomponents/MessageComponent.tsx` | Skill chip rendering, respect viewMode |
+| New: `src/components/chat/view/subcomponents/CollapsedToolGroup.tsx` | Summary line with expand/collapse |
+| New: `src/components/chat/view/subcomponents/SkillLoadChip.tsx` | Compact skill indicator |
+
+## Files NOT Modified
+
+- `server/projects.js` — server-side parsing unchanged
+- `src/components/chat/tools/configs/toolConfigs.ts` — tool configs unchanged
+- `src/components/chat/tools/ToolRenderer.tsx` — tool rendering unchanged (used when expanded)
+
+## Edge Cases
+
+- User message contains both real text AND a system-reminder: strip reminder, keep text
+- User message is ONLY a system-reminder after stripping: skip entirely
+- Skill definition is the only content in a user message: replace with chip
+- Multiple skill loads in sequence: each gets its own chip
+- A Bash tool that only reads (e.g., `ls`, `cat`) vs one that writes: we classify ALL Bash as code-change since we can't reliably distinguish. This is intentional — Bash commands are worth seeing.
+- Agent tool calls: classified as read-only (collapsed) since they spawn subagents whose results appear separately

--- a/docs/superpowers/specs/2026-03-21-session-context-tracking-design.md
+++ b/docs/superpowers/specs/2026-03-21-session-context-tracking-design.md
@@ -1,0 +1,324 @@
+# Session Context Tracking
+
+## Problem
+
+When working with Claude Code on multi-step features (brainstorm → plan → implement → validate), work spans 2-4 separate sessions. With multiple features in flight, navigating between sessions becomes difficult — which session is the executor? Which one has the spec context? Which is stale waiting for implementation to finish? The current flat session list per project provides no grouping or lifecycle tracking.
+
+## Solution
+
+Add a **Contexts tab** in the sidebar that groups sessions by superpowers plan, with plan lifecycle state tracking and a context header bar in the main content area for navigating between sessions within a context.
+
+## Key Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Data store | `docs/superpowers/session-tracking.json` per project | Single source of truth, git-trackable, no DB needed |
+| Plan state tracking | State field in tracking file (not directory-based) | Cleaner git history, single source of truth |
+| Agent involvement | None — UI-only | Avoids context bloat on agents, unnecessary complexity |
+| Sidebar organization | Separate "Contexts" tab | Existing Sessions tab untouched, clean separation |
+| Context detail view | Header bar with session tabs in main content | Quick session switching within a context |
+| Unassigned sessions | Stay in Sessions tab with "Link to plan" action | Contexts tab stays focused on plan-linked work |
+
+## Data Model
+
+### `docs/superpowers/session-tracking.json`
+
+```json
+{
+  "version": 1,
+  "plans": {
+    "docs/superpowers/plans/2026-03-19-clean-conversation-view.md": {
+      "name": "Clean conversation view",
+      "state": "progress",
+      "sessions": [
+        {
+          "sessionId": "3cc9ab2a-4437-4685-aee9-3249e6908e18",
+          "name": "Spec & planning",
+          "role": "planner",
+          "addedAt": "2026-03-19T10:00:00Z"
+        },
+        {
+          "sessionId": "f1a2b3c4-d5e6-7890-abcd-ef1234567890",
+          "name": "Implementing (3/9)",
+          "role": "executor",
+          "addedAt": "2026-03-19T12:30:00Z"
+        }
+      ]
+    }
+  }
+}
+```
+
+### Plan States
+
+| State | Meaning | Badge Color |
+|-------|---------|-------------|
+| `todo` | Plan written, not started | Gray |
+| `progress` | Active implementation | Blue |
+| `validate` | Implementation done, testing/reviewing | Amber |
+| `closed` | Complete, archived | Gray (dimmed) |
+
+Transitions: any state → any state (no enforced order). Forward and reverse movement supported.
+
+### Session Roles
+
+| Role | Meaning | Typical Use |
+|------|---------|-------------|
+| `planner` | Brainstorm/spec/plan session | Has full context of requirements |
+| `executor` | Implementing the plan | Fresh session, less context bloat |
+| `reviewer` | Testing/validation session | Validates after implementation |
+| `origin` | Where the issue was discovered | Original debugging session |
+
+Roles are informational labels. The UI displays them but doesn't enforce behavior.
+
+### File Ownership
+
+- **Written by:** claudecodeui server only (via API endpoints)
+- **Read by:** claudecodeui frontend
+- **Agents:** Do not read or write this file
+
+## UI Architecture
+
+### Sidebar: Contexts Tab
+
+A new tab alongside the existing Sessions tab in the sidebar.
+
+**Tab bar:** Two tabs — "Sessions" (existing, default) and "Contexts" (new).
+
+**Contexts tab content per project:**
+
+1. **Active contexts** (state: `todo`, `progress`, `validate`) — shown as cards:
+   - Plan name (editable inline)
+   - State badge with color
+   - Stacked session list showing: name, role, active/stale status
+   - Session status: "active" (activity < 10 min), "stale Xh/Xd" (relative time)
+
+2. **Closed contexts** — shown dimmed at bottom, collapsed by default, expandable
+
+3. **Untracked plans** — Plan files in `docs/superpowers/plans/` not yet in `session-tracking.json` appear with an "Add to tracking" action, prompting the user to start tracking and link sessions.
+
+**Search on Contexts tab:** The existing search bar filters context cards by plan name (simple text match). No conversation-level search on this tab — use the Sessions tab for that.
+
+### Main Content: Context Header Bar
+
+When a context is selected (by clicking a context card in sidebar), a header bar appears above the chat view:
+
+**Header bar contains:**
+- Plan name (editable)
+- State badge with dropdown to transition (forward and reverse)
+- Horizontal session tabs within the context
+- Each tab shows: session name, role badge, active/stale indicator
+- "+ Add session" button to link an existing session
+- Clicking a session tab loads its chat below
+
+**When no context is selected** (user clicks a session directly from Sessions tab), header bar is hidden — current behavior unchanged.
+
+**Initial session on context click:** Load the most recently active session. If no sessions have activity metadata, load the first session in the list.
+
+**ContextHeader placement:** Renders as a child of `MainContent`, inserted between `MainContentHeader` and the chat tab content area. It does NOT replace `MainContentHeader`.
+
+### Sessions Tab: Link to Plan Action
+
+Each session in the existing Sessions tab gets a new action in its kebab/context menu:
+
+- **"Link to plan..."** — Opens a dropdown/modal listing available plans. Selecting one adds the session to that plan's `sessions` array in the tracking file. User provides a name and role.
+
+## API Endpoints
+
+### `GET /api/projects/:name/contexts`
+
+Returns all tracked plans with merged session metadata.
+
+**Response:**
+```json
+{
+  "contexts": [
+    {
+      "planPath": "docs/superpowers/plans/2026-03-19-clean-conversation-view.md",
+      "name": "Clean conversation view",
+      "state": "progress",
+      "sessions": [
+        {
+          "sessionId": "3cc9ab2a-...",
+          "name": "Spec & planning",
+          "role": "planner",
+          "addedAt": "2026-03-19T10:00:00Z",
+          "lastActivity": "2026-03-19T14:30:00Z",
+          "messageCount": 42,
+          "isActive": false
+        }
+      ]
+    }
+  ],
+  "untracked": [
+    {
+      "planPath": "docs/superpowers/plans/2026-03-20-batch-result-polling.md",
+      "name": "Batch result polling"
+    }
+  ]
+}
+```
+
+**Server logic:**
+1. Resolve project working directory using `extractProjectDirectory(projectName)` from `projects.js`
+2. Read `<projectDir>/docs/superpowers/session-tracking.json` (return empty if not exists)
+3. Scan `<projectDir>/docs/superpowers/plans/` for `.md` files not yet tracked → return as `untracked`
+4. For untracked plans, derive name by stripping date prefix (`YYYY-MM-DD-`) and extension, replacing hyphens with spaces, title-casing
+5. For each tracked session, merge with actual session metadata (lastActivity, messageCount) from the already-parsed project session cache (reuse `getProjects()`/`getSessions()` data, do NOT re-parse JSONLs)
+6. Compute `isActive` based on lastActivity < 10 minutes
+
+**Session ordering:** Sessions within a plan are sorted by `addedAt` ascending in both the API response and the UI.
+
+### `PUT /api/projects/:name/contexts`
+
+Updates `session-tracking.json`. Supports these operations via request body:
+
+```json
+{
+  "action": "setState",
+  "planPath": "docs/superpowers/plans/...",
+  "state": "validate"
+}
+```
+
+```json
+{
+  "action": "renamePlan",
+  "planPath": "docs/superpowers/plans/...",
+  "name": "New name"
+}
+```
+
+```json
+{
+  "action": "linkSession",
+  "planPath": "docs/superpowers/plans/...",
+  "session": {
+    "sessionId": "abc-123",
+    "name": "Implementation",
+    "role": "executor"
+  }
+}
+```
+
+```json
+{
+  "action": "unlinkSession",
+  "planPath": "docs/superpowers/plans/...",
+  "sessionId": "abc-123"
+}
+```
+
+```json
+{
+  "action": "renameSession",
+  "planPath": "docs/superpowers/plans/...",
+  "sessionId": "abc-123",
+  "name": "New session name"
+}
+```
+
+```json
+{
+  "action": "updateSessionRole",
+  "planPath": "docs/superpowers/plans/...",
+  "sessionId": "abc-123",
+  "role": "reviewer"
+}
+```
+
+```json
+{
+  "action": "trackPlan",
+  "planPath": "docs/superpowers/plans/...",
+  "name": "Plan display name"
+}
+```
+
+```json
+{
+  "action": "untrackPlan",
+  "planPath": "docs/superpowers/plans/..."
+}
+```
+
+**Server logic:**
+1. Read current `session-tracking.json` (create with `{"version": 1, "plans": {}}` if not exists)
+2. Apply the mutation
+3. Write atomically: write to `docs/superpowers/.session-tracking.json.tmp` (same directory), then `fs.rename()` to `session-tracking.json`
+4. Return updated context
+
+## Components
+
+### New Components
+
+| Component | Location | Responsibility |
+|-----------|----------|---------------|
+| `SidebarTabBar` | `src/components/sidebar/view/subcomponents/` | Sessions/Contexts tab switcher |
+| `SidebarContextsTab` | `src/components/sidebar/view/subcomponents/` | Contexts tab content — lists context cards grouped by project |
+| `ContextCard` | `src/components/sidebar/view/subcomponents/` | Individual plan card: name, state badge, session list |
+| `ContextHeader` | `src/components/context-header/view/` | Main content header bar with plan info and session tabs |
+| `ContextSessionTab` | `src/components/context-header/view/` | Individual session tab within context header |
+| `LinkToPlanModal` | `src/components/sidebar/view/subcomponents/` | Modal/dropdown for linking a session to a plan |
+| `useContextState` | `src/hooks/` | All context state: data fetching, mutations, active context/tab selection, sidebar tab (Sessions vs Contexts). Keeps `useSidebarController` unchanged. |
+| `contexts.js` | `server/routes/` | API endpoints for context CRUD |
+
+### Modified Components
+
+| Component | Change |
+|-----------|--------|
+| `Sidebar.tsx` | Accept `useContextState` output, pass to SidebarContent |
+| `SidebarContent.tsx` | Render SidebarTabBar above scroll area; conditionally show Contexts or Sessions based on active tab |
+| `SidebarSessionItem.tsx` | Add "Link to plan" action in kebab menu |
+| `MainContent.tsx` | Render ContextHeader between MainContentHeader and chat area when a context is active |
+| `AppContent.tsx` | Call `useContextState`, pass output to Sidebar and MainContent |
+
+## User Workflows
+
+### Starting a new feature
+
+1. Write spec/plan via superpowers brainstorming + writing-plans skills
+2. Open claudecodeui, go to Contexts tab
+3. Auto-discovered plan appears as `todo` — click to start tracking
+4. Current brainstorming session automatically offered for linking (by matching session ID from Claude Code)
+5. Give it a name ("Spec & planning") and role ("planner")
+6. Change state to `progress` when starting implementation
+
+### Switching between sessions
+
+1. Click context card in sidebar
+2. Context header appears with session tabs
+3. Click between "Spec & planning" and "Implementing (3/9)" tabs
+4. Chat view updates instantly
+
+### Linking an ad-hoc session
+
+1. In Sessions tab, find a session that discovered a bug
+2. Click kebab menu → "Link to plan..."
+3. Select the relevant plan
+4. Name it "Origin: auth debugging", role: "origin"
+5. Session now appears in the context's session list
+
+### Completing a feature
+
+1. All sessions done → switch context state to `validate`
+2. After testing → switch to `closed`
+3. Context card dims and moves to bottom of list
+4. Still viewable and navigable, just visually de-emphasized
+
+## Edge Cases
+
+- **Plan file deleted from disk** — Show as "orphaned" with warning icon, allow cleanup (remove from tracking)
+- **Session JSONL deleted** — Show as "missing" in session list, allow unlinking
+- **No `session-tracking.json` yet** — Untracked plans shown from filesystem scan, tracking file created on first mutation
+- **Multiple projects** — Each project has its own tracking file in its own working directory
+- **Concurrent UI writes** — Last-write-wins via atomic file replacement (single user, acceptable)
+- **Plan path changes** — Not handled automatically; user can untrack old path and track new one
+- **Session linked to multiple plans** — Allowed (a debugging session could be relevant to multiple contexts)
+
+## Files NOT Modified
+
+- `server/projects.js` — Existing session/project parsing unchanged
+- `session-tracking.json` is never read or written by Claude Code agents
+- Existing session selection flow in Sessions tab unchanged
+- No changes to the chat interface or message rendering

--- a/server/index.js
+++ b/server/index.js
@@ -72,26 +72,8 @@ import { IS_PLATFORM } from './constants/config.js';
 
 const VALID_PROVIDERS = ['claude', 'codex', 'cursor', 'gemini'];
 
-// File system watchers for provider project/session folders
-const PROVIDER_WATCH_PATHS = [
-    { provider: 'claude', rootPath: path.join(os.homedir(), '.claude', 'projects') },
-    { provider: 'cursor', rootPath: path.join(os.homedir(), '.cursor', 'chats') },
-    { provider: 'codex', rootPath: path.join(os.homedir(), '.codex', 'sessions') },
-    { provider: 'gemini', rootPath: path.join(os.homedir(), '.gemini', 'projects') },
-    { provider: 'gemini_sessions', rootPath: path.join(os.homedir(), '.gemini', 'sessions') }
-];
-const WATCHER_IGNORED_PATTERNS = [
-    '**/node_modules/**',
-    '**/.git/**',
-    '**/dist/**',
-    '**/build/**',
-    '**/*.tmp',
-    '**/*.swp',
-    '**/.DS_Store'
-];
-const WATCHER_DEBOUNCE_MS = 300;
-let projectsWatchers = [];
-let projectsWatcherDebounceTimer = null;
+// File watcher removed - was causing 100%+ CPU with chokidar polling 4000+ files
+// Projects now refresh via WebSocket events or manual API call
 const connectedClients = new Set();
 let isGetProjectsRunning = false; // Flag to prevent reentrant calls
 
@@ -108,111 +90,10 @@ function broadcastProgress(progress) {
     });
 }
 
-// Setup file system watchers for Claude, Cursor, and Codex project/session folders
+// File watcher disabled - was causing 100%+ CPU with chokidar polling 4000+ files.
+// Projects refresh via WebSocket events or manual API call.
 async function setupProjectsWatcher() {
-    const chokidar = (await import('chokidar')).default;
-
-    if (projectsWatcherDebounceTimer) {
-        clearTimeout(projectsWatcherDebounceTimer);
-        projectsWatcherDebounceTimer = null;
-    }
-
-    await Promise.all(
-        projectsWatchers.map(async (watcher) => {
-            try {
-                await watcher.close();
-            } catch (error) {
-                console.error('[WARN] Failed to close watcher:', error);
-            }
-        })
-    );
-    projectsWatchers = [];
-
-    const debouncedUpdate = (eventType, filePath, provider, rootPath) => {
-        if (projectsWatcherDebounceTimer) {
-            clearTimeout(projectsWatcherDebounceTimer);
-        }
-
-        projectsWatcherDebounceTimer = setTimeout(async () => {
-            // Prevent reentrant calls
-            if (isGetProjectsRunning) {
-                return;
-            }
-
-            try {
-                isGetProjectsRunning = true;
-
-                // Clear project directory cache when files change
-                clearProjectDirectoryCache();
-
-                // Get updated projects list
-                const updatedProjects = await getProjects(broadcastProgress);
-
-                // Notify all connected clients about the project changes
-                const updateMessage = JSON.stringify({
-                    type: 'projects_updated',
-                    projects: updatedProjects,
-                    timestamp: new Date().toISOString(),
-                    changeType: eventType,
-                    changedFile: path.relative(rootPath, filePath),
-                    watchProvider: provider
-                });
-
-                connectedClients.forEach(client => {
-                    if (client.readyState === WebSocket.OPEN) {
-                        client.send(updateMessage);
-                    }
-                });
-
-            } catch (error) {
-                console.error('[ERROR] Error handling project changes:', error);
-            } finally {
-                isGetProjectsRunning = false;
-            }
-        }, WATCHER_DEBOUNCE_MS);
-    };
-
-    for (const { provider, rootPath } of PROVIDER_WATCH_PATHS) {
-        try {
-            // chokidar v4 emits ENOENT via the "error" event for missing roots and will not auto-recover.
-            // Ensure provider folders exist before creating the watcher so watching stays active.
-            await fsPromises.mkdir(rootPath, { recursive: true });
-
-            // Initialize chokidar watcher with optimized settings
-            const watcher = chokidar.watch(rootPath, {
-                ignored: WATCHER_IGNORED_PATTERNS,
-                persistent: true,
-                ignoreInitial: true, // Don't fire events for existing files on startup
-                followSymlinks: false,
-                depth: 10, // Reasonable depth limit
-                awaitWriteFinish: {
-                    stabilityThreshold: 100, // Wait 100ms for file to stabilize
-                    pollInterval: 50
-                }
-            });
-
-            // Set up event listeners
-            watcher
-                .on('add', (filePath) => debouncedUpdate('add', filePath, provider, rootPath))
-                .on('change', (filePath) => debouncedUpdate('change', filePath, provider, rootPath))
-                .on('unlink', (filePath) => debouncedUpdate('unlink', filePath, provider, rootPath))
-                .on('addDir', (dirPath) => debouncedUpdate('addDir', dirPath, provider, rootPath))
-                .on('unlinkDir', (dirPath) => debouncedUpdate('unlinkDir', dirPath, provider, rootPath))
-                .on('error', (error) => {
-                    console.error(`[ERROR] ${provider} watcher error:`, error);
-                })
-                .on('ready', () => {
-                });
-
-            projectsWatchers.push(watcher);
-        } catch (error) {
-            console.error(`[ERROR] Failed to setup ${provider} watcher for ${rootPath}:`, error);
-        }
-    }
-
-    if (projectsWatchers.length === 0) {
-        console.error('[ERROR] Failed to setup any provider watchers');
-    }
+    console.log('[INFO] Projects auto-refresh disabled (manual refresh via API)');
 }
 
 

--- a/server/routes/commands.js
+++ b/server/routes/commands.js
@@ -126,6 +126,24 @@ const builtInCommands = [
     description: 'Rewind the conversation to a previous state',
     namespace: 'builtin',
     metadata: { type: 'builtin' }
+  },
+  {
+    name: '/compact',
+    description: 'Compact the conversation to reduce token usage',
+    namespace: 'builtin',
+    metadata: { type: 'builtin' }
+  },
+  {
+    name: '/export',
+    description: 'Export the conversation to a file',
+    namespace: 'builtin',
+    metadata: { type: 'builtin' }
+  },
+  {
+    name: '/context',
+    description: 'Show context window usage and token information',
+    namespace: 'builtin',
+    metadata: { type: 'builtin' }
   }
 ];
 
@@ -394,6 +412,75 @@ Custom commands can be created in:
       data: {
         steps,
         message: `Rewinding conversation by ${steps} step${steps > 1 ? 's' : ''}...`
+      }
+    };
+  },
+
+  '/compact': async (args, context) => {
+    const focusInstructions = args.join(' ') || null;
+    return {
+      type: 'builtin',
+      action: 'compact',
+      data: {
+        focusInstructions,
+        sessionId: context?.sessionId,
+        message: focusInstructions
+          ? `Compacting conversation with focus: "${focusInstructions}"...`
+          : 'Compacting conversation to reduce token usage...'
+      }
+    };
+  },
+
+  '/export': async (args, context) => {
+    const filename = args[0] || null;
+    const projectPath = context?.projectPath;
+    return {
+      type: 'builtin',
+      action: 'export',
+      data: {
+        filename,
+        projectPath,
+        sessionId: context?.sessionId,
+        message: filename
+          ? `Exporting conversation to ${filename}...`
+          : 'Exporting conversation...'
+      }
+    };
+  },
+
+  '/context': async (args, context) => {
+    const tokenUsage = context?.tokenUsage || { used: 0, total: 200000 };
+    const percentage = ((tokenUsage.used / tokenUsage.total) * 100);
+    const barLength = 40;
+    const filledLength = Math.round((percentage / 100) * barLength);
+    const emptyLength = barLength - filledLength;
+
+    let status = 'healthy';
+    let statusEmoji = '🟢';
+    if (percentage > 80) {
+      status = 'critical';
+      statusEmoji = '🔴';
+    } else if (percentage > 60) {
+      status = 'warning';
+      statusEmoji = '🟡';
+    }
+
+    const progressBar = '█'.repeat(filledLength) + '░'.repeat(emptyLength);
+
+    return {
+      type: 'builtin',
+      action: 'context',
+      data: {
+        tokenUsage: {
+          used: tokenUsage.used,
+          total: tokenUsage.total,
+          percentage: percentage.toFixed(1),
+          remaining: tokenUsage.total - tokenUsage.used
+        },
+        progressBar,
+        status,
+        statusEmoji,
+        sessionId: context?.sessionId
       }
     };
   }

--- a/src/components/chat/hooks/useChatSessionState.ts
+++ b/src/components/chat/hooks/useChatSessionState.ts
@@ -88,6 +88,7 @@ export function useChatSessionState({
   const isLoadingMoreRef = useRef(false);
   const allMessagesLoadedRef = useRef(false);
   const topLoadLockRef = useRef(false);
+  const scrollThrottleRef = useRef<number | null>(null);
   const pendingScrollRestoreRef = useRef<ScrollRestoreState | null>(null);
   const pendingInitialScrollRef = useRef(true);
   const messagesOffsetRef = useRef(0);
@@ -262,8 +263,14 @@ export function useChatSessionState({
       return;
     }
 
-    const nearBottom = isNearBottom();
-    setIsUserScrolledUp(!nearBottom);
+    // Throttle isUserScrolledUp state updates via rAF to reduce re-renders during fast scrolling
+    if (!scrollThrottleRef.current) {
+      scrollThrottleRef.current = requestAnimationFrame(() => {
+        scrollThrottleRef.current = null;
+        const nearBottom = isNearBottom();
+        setIsUserScrolledUp(!nearBottom);
+      });
+    }
 
     if (!allMessagesLoadedRef.current) {
       const scrolledNearTop = container.scrollTop < 100;
@@ -860,6 +867,16 @@ export function useChatSessionState({
 
   const loadEarlierMessages = useCallback(() => {
     setVisibleMessageCount((previousCount) => previousCount + 100);
+  }, []);
+
+  // Cleanup scroll throttle on unmount
+  useEffect(() => {
+    return () => {
+      if (scrollThrottleRef.current) {
+        cancelAnimationFrame(scrollThrottleRef.current);
+        scrollThrottleRef.current = null;
+      }
+    };
   }, []);
 
   return {

--- a/src/components/chat/types/types.ts
+++ b/src/components/chat/types/types.ts
@@ -46,6 +46,8 @@ export interface ChatMessage {
     currentToolIndex: number;
     isComplete: boolean;
   };
+  isSkillLoad?: boolean;
+  skillName?: string;
   [key: string]: unknown;
 }
 

--- a/src/components/chat/types/types.ts
+++ b/src/components/chat/types/types.ts
@@ -112,6 +112,7 @@ export interface ChatInterfaceProps {
   autoExpandTools?: boolean;
   showRawParameters?: boolean;
   showThinking?: boolean;
+  cleanView?: boolean;
   autoScrollToBottom?: boolean;
   sendByCtrlEnter?: boolean;
   externalMessageUpdate?: number;

--- a/src/components/chat/utils/cleanViewFilters.ts
+++ b/src/components/chat/utils/cleanViewFilters.ts
@@ -1,0 +1,45 @@
+import type { ChatMessage } from '../types/types';
+
+/**
+ * Strip noise tags from user message text that the terminal hides.
+ * Only applied in clean view mode — raw mode preserves original content.
+ */
+export const stripNoiseTags = (text: string): string => {
+  return text
+    .replace(/<system-reminder>[\s\S]*?<\/system-reminder>/g, '')
+    .replace(/<local-command-caveat>[\s\S]*?<\/local-command-caveat>/g, '')
+    .replace(/<local-command-stdout>[\s\S]*?<\/local-command-stdout>/g, '')
+    .replace(/<command-name>[\s\S]*?<\/command-name>/g, '')
+    .replace(/<command-args>[\s\S]*?<\/command-args>/g, '')
+    .replace(/<command-message>[\s\S]*?<\/command-message>/g, '')
+    .trim();
+};
+
+/**
+ * Apply clean view filters to a list of messages.
+ * - Strips noise tags from user messages
+ * - Removes messages that become empty after stripping
+ * Returns a new array (does not mutate input).
+ */
+export const applyCleanViewFilters = (messages: ChatMessage[]): ChatMessage[] => {
+  const result: ChatMessage[] = [];
+
+  for (const msg of messages) {
+    // Only strip noise from user messages (assistant/tool messages don't have these tags)
+    if (msg.type === 'user' && !msg.isSkillLoad && msg.content) {
+      const cleaned = stripNoiseTags(msg.content);
+      if (!cleaned) {
+        // Message was entirely noise tags — skip it
+        continue;
+      }
+      if (cleaned !== msg.content) {
+        // Content changed — create a new message object with cleaned content
+        result.push({ ...msg, content: cleaned });
+        continue;
+      }
+    }
+    result.push(msg);
+  }
+
+  return result;
+};

--- a/src/components/chat/utils/cleanViewGrouping.ts
+++ b/src/components/chat/utils/cleanViewGrouping.ts
@@ -1,0 +1,109 @@
+import type { ChatMessage } from '../types/types';
+
+/**
+ * Tools classified as "read-only" — collapsed in clean view.
+ * Code-change tools (Edit, Write, Bash, NotebookEdit, ApplyPatch) stay visible.
+ */
+const READ_ONLY_TOOLS = new Set([
+  'Read',
+  'Grep',
+  'Glob',
+  'WebSearch',
+  'WebFetch',
+  'Skill',
+  'TaskCreate',
+  'TaskUpdate',
+  'TaskGet',
+  'TaskList',
+  'TaskOutput',
+  'ToolSearch',
+  'Agent',
+  'LSP',
+  'TodoRead',
+]);
+
+export const isReadOnlyTool = (toolName: string): boolean =>
+  READ_ONLY_TOOLS.has(toolName);
+
+export type CleanViewItem =
+  | { kind: 'message'; message: ChatMessage }
+  | { kind: 'group'; tools: ChatMessage[] };
+
+/**
+ * Groups consecutive read-only tool-use messages into collapsed groups.
+ * Non-tool messages and code-change tools break the group.
+ *
+ * Only active when cleanView is true; otherwise returns all messages as-is.
+ */
+export const groupMessagesForCleanView = (
+  messages: ChatMessage[],
+  cleanView: boolean,
+): CleanViewItem[] => {
+  if (!cleanView) {
+    return messages.map((message) => ({ kind: 'message', message }));
+  }
+
+  const items: CleanViewItem[] = [];
+  let currentGroup: ChatMessage[] = [];
+
+  const flushGroup = () => {
+    if (currentGroup.length > 0) {
+      items.push({ kind: 'group', tools: currentGroup });
+      currentGroup = [];
+    }
+  };
+
+  for (const message of messages) {
+    // Skill loads pass through as individual messages (rendered as chips)
+    if (message.isSkillLoad) {
+      flushGroup();
+      items.push({ kind: 'message', message });
+      continue;
+    }
+
+    // Read-only tool-use messages get grouped
+    if (message.isToolUse && message.toolName && isReadOnlyTool(message.toolName)) {
+      currentGroup.push(message);
+      continue;
+    }
+
+    // Everything else (text, code-change tools, user messages) breaks the group
+    flushGroup();
+    items.push({ kind: 'message', message });
+  }
+
+  flushGroup();
+  return items;
+};
+
+/**
+ * Build a human-readable summary of grouped tools.
+ * e.g. "Read 3 files, Grep 2 patterns, Glob 1 search"
+ */
+export const summarizeToolGroup = (tools: ChatMessage[]): string => {
+  const counts = new Map<string, number>();
+  for (const tool of tools) {
+    const name = tool.toolName || 'Unknown';
+    counts.set(name, (counts.get(name) || 0) + 1);
+  }
+
+  const labels: Record<string, string> = {
+    Read: 'file read',
+    Grep: 'search',
+    Glob: 'file search',
+    WebSearch: 'web search',
+    WebFetch: 'web fetch',
+    Agent: 'subagent',
+    LSP: 'LSP query',
+    TodoRead: 'todo read',
+  };
+
+  const parts: string[] = [];
+  for (const [name, count] of counts) {
+    const label = labels[name] || name.toLowerCase();
+    const plural = count > 1 ? `${label}${label.endsWith('s') ? '' : 'es'}` : label;
+    parts.push(`${count} ${count > 1 ? plural : label}`);
+  }
+
+  return parts.join(', ');
+};

--- a/src/components/chat/utils/cleanViewGrouping.ts
+++ b/src/components/chat/utils/cleanViewGrouping.ts
@@ -87,22 +87,21 @@ export const summarizeToolGroup = (tools: ChatMessage[]): string => {
     counts.set(name, (counts.get(name) || 0) + 1);
   }
 
-  const labels: Record<string, string> = {
-    Read: 'file read',
-    Grep: 'search',
-    Glob: 'file search',
-    WebSearch: 'web search',
-    WebFetch: 'web fetch',
-    Agent: 'subagent',
-    LSP: 'LSP query',
-    TodoRead: 'todo read',
+  const labels: Record<string, [string, string]> = {
+    Read: ['file read', 'file reads'],
+    Grep: ['search', 'searches'],
+    Glob: ['file search', 'file searches'],
+    WebSearch: ['web search', 'web searches'],
+    WebFetch: ['web fetch', 'web fetches'],
+    Agent: ['subagent', 'subagents'],
+    LSP: ['LSP query', 'LSP queries'],
+    TodoRead: ['todo read', 'todo reads'],
   };
 
   const parts: string[] = [];
   for (const [name, count] of counts) {
-    const label = labels[name] || name.toLowerCase();
-    const plural = count > 1 ? `${label}${label.endsWith('s') ? '' : 'es'}` : label;
-    parts.push(`${count} ${count > 1 ? plural : label}`);
+    const [singular, plural] = labels[name] || [name.toLowerCase(), `${name.toLowerCase()}s`];
+    parts.push(`${count} ${count > 1 ? plural : singular}`);
   }
 
   return parts.join(', ');

--- a/src/components/chat/utils/messageTransforms.ts
+++ b/src/components/chat/utils/messageTransforms.ts
@@ -359,7 +359,7 @@ const detectSkillLoad = (text: string): string | null => {
     return null;
   }
   // Extract skill name from path like ".../skills/server-debugging/..."
-  const pathMatch = text.match(/skills\/([^/\n]+)/);
+  const pathMatch = text.match(/skills[\\/]+([^/\\\n]+)/);
   return pathMatch ? pathMatch[1] : 'unknown';
 };
 

--- a/src/components/chat/utils/messageTransforms.ts
+++ b/src/components/chat/utils/messageTransforms.ts
@@ -350,6 +350,19 @@ export const convertCursorSessionMessages = (blobs: CursorBlob[], projectPath: s
   return converted;
 };
 
+/**
+ * Detect if a user message is a skill definition load.
+ * Returns the skill name if detected, null otherwise.
+ */
+const detectSkillLoad = (text: string): string | null => {
+  if (!text.startsWith('Base directory for this skill:')) {
+    return null;
+  }
+  // Extract skill name from path like ".../skills/server-debugging/..."
+  const pathMatch = text.match(/skills\/([^/\n]+)/);
+  return pathMatch ? pathMatch[1] : 'unknown';
+};
+
 export const convertSessionMessages = (rawMessages: any[]): ChatMessage[] => {
   const converted: ChatMessage[] = [];
   const toolResults = new Map<
@@ -389,6 +402,19 @@ export const convertSessionMessages = (rawMessages: any[]): ChatMessage[] => {
         content = decodeHtmlEntities(message.message.content);
       } else {
         content = decodeHtmlEntities(String(message.message.content));
+      }
+
+      // Detect skill definitions — flag them so the view layer can render as chips
+      const skillName = detectSkillLoad(content);
+      if (skillName) {
+        converted.push({
+          type: 'user',
+          content,
+          timestamp: message.timestamp || new Date().toISOString(),
+          isSkillLoad: true,
+          skillName,
+        });
+        return;
       }
 
       const shouldSkip =

--- a/src/components/chat/view/ChatInterface.tsx
+++ b/src/components/chat/view/ChatInterface.tsx
@@ -35,6 +35,7 @@ function ChatInterface({
   autoExpandTools,
   showRawParameters,
   showThinking,
+  cleanView,
   autoScrollToBottom,
   sendByCtrlEnter,
   externalMessageUpdate,
@@ -316,6 +317,7 @@ function ChatInterface({
           autoExpandTools={autoExpandTools}
           showRawParameters={showRawParameters}
           showThinking={showThinking}
+          cleanView={cleanView}
           selectedProject={selectedProject}
           isLoading={isLoading}
         />

--- a/src/components/chat/view/subcomponents/ChatMessagesPane.tsx
+++ b/src/components/chat/view/subcomponents/ChatMessagesPane.tsx
@@ -285,12 +285,15 @@ export default function ChatMessagesPane({
                 );
               }
 
-              // Find previous non-group message for grouping logic
+              // Find previous message — groups break visual continuity
               let prevMessage: ChatMessage | null = null;
               for (let i = index - 1; i >= 0; i--) {
                 const prev = cleanViewItems[i];
                 if (prev.kind === 'message') {
                   prevMessage = prev.message;
+                  break;
+                }
+                if (prev.kind === 'group') {
                   break;
                 }
               }

--- a/src/components/chat/view/subcomponents/ChatMessagesPane.tsx
+++ b/src/components/chat/view/subcomponents/ChatMessagesPane.tsx
@@ -1,10 +1,14 @@
 import { useTranslation } from 'react-i18next';
-import { useCallback, useRef } from 'react';
+import { useCallback, useMemo, useRef } from 'react';
 import type { Dispatch, RefObject, SetStateAction } from 'react';
 import type { ChatMessage } from '../../types/types';
 import type { Project, ProjectSession, SessionProvider } from '../../../../types/app';
 import { getIntrinsicMessageKey } from '../../utils/messageKeys';
+import { groupMessagesForCleanView } from '../../utils/cleanViewGrouping';
+import { applyCleanViewFilters } from '../../utils/cleanViewFilters';
 import MessageComponent from './MessageComponent';
+import SkillLoadChip from './SkillLoadChip';
+import CollapsedToolGroup from './CollapsedToolGroup';
 import ProviderSelectionEmptyState from './ProviderSelectionEmptyState';
 import AssistantThinkingIndicator from './AssistantThinkingIndicator';
 
@@ -50,6 +54,7 @@ interface ChatMessagesPaneProps {
   autoExpandTools?: boolean;
   showRawParameters?: boolean;
   showThinking?: boolean;
+  cleanView?: boolean;
   selectedProject: Project;
   isLoading: boolean;
 }
@@ -96,6 +101,7 @@ export default function ChatMessagesPane({
   autoExpandTools,
   showRawParameters,
   showThinking,
+  cleanView,
   selectedProject,
   isLoading,
 }: ChatMessagesPaneProps) {
@@ -127,6 +133,13 @@ export default function ChatMessagesPane({
     messageKeyMapRef.current.set(message, candidateKey);
     return candidateKey;
   }, []);
+
+  // Clean view pipeline: strip noise → group read-only tools (memoized)
+  const cleanViewItems = useMemo(() => {
+    const isClean = cleanView ?? true;
+    const filtered = isClean ? applyCleanViewFilters(visibleMessages) : visibleMessages;
+    return groupMessagesForCleanView(filtered, isClean);
+  }, [visibleMessages, cleanView]);
 
   return (
     <div
@@ -240,25 +253,65 @@ export default function ChatMessagesPane({
             </div>
           )}
 
-          {visibleMessages.map((message, index) => {
-            const prevMessage = index > 0 ? visibleMessages[index - 1] : null;
-            return (
-              <MessageComponent
-                key={getMessageKey(message)}
-                message={message}
-                prevMessage={prevMessage}
-                createDiff={createDiff}
-                onFileOpen={onFileOpen}
-                onShowSettings={onShowSettings}
-                onGrantToolPermission={onGrantToolPermission}
-                autoExpandTools={autoExpandTools}
-                showRawParameters={showRawParameters}
-                showThinking={showThinking}
-                selectedProject={selectedProject}
-                provider={provider}
-              />
-            );
-          })}
+          {cleanViewItems.map((item, index) => {
+              if (item.kind === 'group') {
+                return (
+                  <CollapsedToolGroup
+                    key={`group-${item.tools[0]?.toolId || index}`}
+                    tools={item.tools}
+                    createDiff={createDiff}
+                    onFileOpen={onFileOpen}
+                    onShowSettings={onShowSettings}
+                    onGrantToolPermission={onGrantToolPermission}
+                    autoExpandTools={autoExpandTools}
+                    showRawParameters={showRawParameters}
+                    showThinking={showThinking}
+                    selectedProject={selectedProject}
+                    provider={provider}
+                  />
+                );
+              }
+
+              const message = item.message;
+
+              // Render skill loads as chips in clean view
+              if (message.isSkillLoad && (cleanView ?? true)) {
+                return (
+                  <SkillLoadChip
+                    key={getMessageKey(message)}
+                    skillName={message.skillName || 'unknown'}
+                    timestamp={message.timestamp}
+                  />
+                );
+              }
+
+              // Find previous non-group message for grouping logic
+              let prevMessage: ChatMessage | null = null;
+              for (let i = index - 1; i >= 0; i--) {
+                const prev = cleanViewItems[i];
+                if (prev.kind === 'message') {
+                  prevMessage = prev.message;
+                  break;
+                }
+              }
+
+              return (
+                <MessageComponent
+                  key={getMessageKey(message)}
+                  message={message}
+                  prevMessage={prevMessage}
+                  createDiff={createDiff}
+                  onFileOpen={onFileOpen}
+                  onShowSettings={onShowSettings}
+                  onGrantToolPermission={onGrantToolPermission}
+                  autoExpandTools={autoExpandTools}
+                  showRawParameters={showRawParameters}
+                  showThinking={showThinking}
+                  selectedProject={selectedProject}
+                  provider={provider}
+                />
+              );
+            })}
         </>
       )}
 

--- a/src/components/chat/view/subcomponents/CollapsedToolGroup.tsx
+++ b/src/components/chat/view/subcomponents/CollapsedToolGroup.tsx
@@ -1,6 +1,6 @@
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { ChevronRight, Search } from 'lucide-react';
-import type { ChatMessage } from '../../types/types';
+import type { ChatMessage, ClaudePermissionSuggestion, PermissionGrantResult } from '../../types/types';
 import type { Project } from '../../../../types/app';
 import { summarizeToolGroup } from '../../utils/cleanViewGrouping';
 import MessageComponent from './MessageComponent';
@@ -10,7 +10,7 @@ interface CollapsedToolGroupProps {
   createDiff: (oldStr: string, newStr: string) => any;
   onFileOpen?: (filePath: string, diffInfo?: unknown) => void;
   onShowSettings?: () => void;
-  onGrantToolPermission?: (suggestion: { entry: string; toolName: string }) => { success: boolean };
+  onGrantToolPermission?: (suggestion: ClaudePermissionSuggestion) => PermissionGrantResult | null | undefined;
   autoExpandTools?: boolean;
   showRawParameters?: boolean;
   showThinking?: boolean;
@@ -31,7 +31,7 @@ export default function CollapsedToolGroup({
   provider,
 }: CollapsedToolGroupProps) {
   const [isExpanded, setIsExpanded] = useState(false);
-  const summary = summarizeToolGroup(tools);
+  const summary = useMemo(() => summarizeToolGroup(tools), [tools]);
 
   return (
     <div className="px-3 sm:px-0">

--- a/src/components/chat/view/subcomponents/CollapsedToolGroup.tsx
+++ b/src/components/chat/view/subcomponents/CollapsedToolGroup.tsx
@@ -1,0 +1,77 @@
+import { useState } from 'react';
+import { ChevronRight, Search } from 'lucide-react';
+import type { ChatMessage } from '../../types/types';
+import type { Project } from '../../../../types/app';
+import { summarizeToolGroup } from '../../utils/cleanViewGrouping';
+import MessageComponent from './MessageComponent';
+
+interface CollapsedToolGroupProps {
+  tools: ChatMessage[];
+  createDiff: (oldStr: string, newStr: string) => any;
+  onFileOpen?: (filePath: string, diffInfo?: unknown) => void;
+  onShowSettings?: () => void;
+  onGrantToolPermission?: (suggestion: { entry: string; toolName: string }) => { success: boolean };
+  autoExpandTools?: boolean;
+  showRawParameters?: boolean;
+  showThinking?: boolean;
+  selectedProject?: Project | null;
+  provider: string;
+}
+
+export default function CollapsedToolGroup({
+  tools,
+  createDiff,
+  onFileOpen,
+  onShowSettings,
+  onGrantToolPermission,
+  autoExpandTools,
+  showRawParameters,
+  showThinking,
+  selectedProject,
+  provider,
+}: CollapsedToolGroupProps) {
+  const [isExpanded, setIsExpanded] = useState(false);
+  const summary = summarizeToolGroup(tools);
+
+  return (
+    <div className="px-3 sm:px-0">
+      <button
+        type="button"
+        onClick={() => setIsExpanded(!isExpanded)}
+        className="flex w-full items-center gap-2 rounded-lg border border-gray-200 bg-gray-50 px-3 py-1.5 text-left text-xs text-gray-500 transition-colors hover:border-gray-300 hover:bg-gray-100 dark:border-gray-700 dark:bg-gray-800/50 dark:text-gray-400 dark:hover:border-gray-600 dark:hover:bg-gray-800"
+      >
+        <ChevronRight
+          className={`h-3 w-3 flex-shrink-0 transition-transform ${isExpanded ? 'rotate-90' : ''}`}
+        />
+        <Search className="h-3 w-3 flex-shrink-0 text-gray-400 dark:text-gray-500" />
+        <span>
+          Research: {summary}
+        </span>
+        <span className="ml-auto text-gray-400 dark:text-gray-500">
+          {tools.length} {tools.length === 1 ? 'call' : 'calls'}
+        </span>
+      </button>
+
+      {isExpanded && (
+        <div className="mt-1 space-y-1 border-l-2 border-gray-200 pl-3 dark:border-gray-700">
+          {tools.map((tool, index) => (
+            <MessageComponent
+              key={tool.toolId || `group-tool-${index}`}
+              message={tool}
+              prevMessage={index > 0 ? tools[index - 1] : null}
+              createDiff={createDiff}
+              onFileOpen={onFileOpen}
+              onShowSettings={onShowSettings}
+              onGrantToolPermission={onGrantToolPermission}
+              autoExpandTools={autoExpandTools}
+              showRawParameters={showRawParameters}
+              showThinking={showThinking}
+              selectedProject={selectedProject}
+              provider={provider}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/chat/view/subcomponents/SkillLoadChip.tsx
+++ b/src/components/chat/view/subcomponents/SkillLoadChip.tsx
@@ -1,4 +1,5 @@
 import { useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
 import { Zap } from 'lucide-react';
 
 interface SkillLoadChipProps {
@@ -7,17 +8,19 @@ interface SkillLoadChipProps {
 }
 
 export default function SkillLoadChip({ skillName, timestamp }: SkillLoadChipProps) {
-  const formattedTime = useMemo(
-    () => new Date(timestamp).toLocaleTimeString(),
-    [timestamp],
-  );
+  const { t } = useTranslation('chat');
+
+  const formattedTime = useMemo(() => {
+    const date = new Date(timestamp);
+    return Number.isNaN(date.getTime()) ? null : date.toLocaleTimeString();
+  }, [timestamp]);
 
   return (
     <div className="flex items-center gap-2 px-3 py-1 sm:px-0">
       <div className="flex items-center gap-1.5 rounded-full border border-gray-200 bg-gray-50 px-3 py-1 text-xs text-gray-500 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-400">
         <Zap className="h-3 w-3" />
-        <span>Loaded skill: <span className="font-medium">{skillName}</span></span>
-        <span className="text-gray-400 dark:text-gray-500">{formattedTime}</span>
+        <span>{t('cleanView.loadedSkill', { defaultValue: 'Loaded skill:' })} <span className="font-medium">{skillName}</span></span>
+        {formattedTime && <span className="text-gray-400 dark:text-gray-500">{formattedTime}</span>}
       </div>
     </div>
   );

--- a/src/components/chat/view/subcomponents/SkillLoadChip.tsx
+++ b/src/components/chat/view/subcomponents/SkillLoadChip.tsx
@@ -12,14 +12,14 @@ export default function SkillLoadChip({ skillName, timestamp }: SkillLoadChipPro
 
   const formattedTime = useMemo(() => {
     const date = new Date(timestamp);
-    return Number.isNaN(date.getTime()) ? null : date.toLocaleTimeString();
+    return isNaN(date.getTime()) ? null : date.toLocaleTimeString();
   }, [timestamp]);
 
   return (
     <div className="flex items-center gap-2 px-3 py-1 sm:px-0">
       <div className="flex items-center gap-1.5 rounded-full border border-gray-200 bg-gray-50 px-3 py-1 text-xs text-gray-500 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-400">
         <Zap className="h-3 w-3" />
-        <span>{t('cleanView.loadedSkill', { defaultValue: 'Loaded skill:' })} <span className="font-medium">{skillName}</span></span>
+        <span>{t('cleanView.skillLoaded', { defaultValue: 'Loaded skill:' })} <span className="font-medium">{skillName}</span></span>
         {formattedTime && <span className="text-gray-400 dark:text-gray-500">{formattedTime}</span>}
       </div>
     </div>

--- a/src/components/chat/view/subcomponents/SkillLoadChip.tsx
+++ b/src/components/chat/view/subcomponents/SkillLoadChip.tsx
@@ -1,0 +1,24 @@
+import { useMemo } from 'react';
+import { Zap } from 'lucide-react';
+
+interface SkillLoadChipProps {
+  skillName: string;
+  timestamp: string | number | Date;
+}
+
+export default function SkillLoadChip({ skillName, timestamp }: SkillLoadChipProps) {
+  const formattedTime = useMemo(
+    () => new Date(timestamp).toLocaleTimeString(),
+    [timestamp],
+  );
+
+  return (
+    <div className="flex items-center gap-2 px-3 py-1 sm:px-0">
+      <div className="flex items-center gap-1.5 rounded-full border border-gray-200 bg-gray-50 px-3 py-1 text-xs text-gray-500 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-400">
+        <Zap className="h-3 w-3" />
+        <span>Loaded skill: <span className="font-medium">{skillName}</span></span>
+        <span className="text-gray-400 dark:text-gray-500">{formattedTime}</span>
+      </div>
+    </div>
+  );
+}

--- a/src/components/main-content/view/MainContent.tsx
+++ b/src/components/main-content/view/MainContent.tsx
@@ -50,7 +50,7 @@ function MainContent({
   externalMessageUpdate,
 }: MainContentProps) {
   const { preferences } = useUiPreferences();
-  const { autoExpandTools, showRawParameters, showThinking, autoScrollToBottom, sendByCtrlEnter } = preferences;
+  const { autoExpandTools, showRawParameters, showThinking, autoScrollToBottom, sendByCtrlEnter, cleanView } = preferences;
 
   const { currentProject, setCurrentProject } = useTaskMaster() as TaskMasterContextValue;
   const { tasksEnabled, isTaskMasterInstalled } = useTasksSettings() as TasksSettingsContextValue;
@@ -130,6 +130,7 @@ function MainContent({
                 autoExpandTools={autoExpandTools}
                 showRawParameters={showRawParameters}
                 showThinking={showThinking}
+                cleanView={cleanView}
                 autoScrollToBottom={autoScrollToBottom}
                 sendByCtrlEnter={sendByCtrlEnter}
                 externalMessageUpdate={externalMessageUpdate}

--- a/src/components/quick-settings-panel/constants.ts
+++ b/src/components/quick-settings-panel/constants.ts
@@ -47,6 +47,11 @@ export const TOOL_DISPLAY_TOGGLES: PreferenceToggleItem[] = [
     labelKey: 'quickSettings.showThinking',
     icon: Brain,
   },
+  {
+    key: 'cleanView',
+    labelKey: 'quickSettings.cleanView',
+    icon: Sparkles,
+  },
 ];
 
 export const VIEW_OPTION_TOGGLES: PreferenceToggleItem[] = [

--- a/src/components/quick-settings-panel/types.ts
+++ b/src/components/quick-settings-panel/types.ts
@@ -6,7 +6,8 @@ export type PreferenceToggleKey =
   | 'showRawParameters'
   | 'showThinking'
   | 'autoScrollToBottom'
-  | 'sendByCtrlEnter';
+  | 'sendByCtrlEnter'
+  | 'cleanView';
 
 export type QuickSettingsPreferences = Record<PreferenceToggleKey, boolean>;
 

--- a/src/components/quick-settings-panel/view/QuickSettingsPanelView.tsx
+++ b/src/components/quick-settings-panel/view/QuickSettingsPanelView.tsx
@@ -27,12 +27,14 @@ export default function QuickSettingsPanelView() {
     showThinking: preferences.showThinking,
     autoScrollToBottom: preferences.autoScrollToBottom,
     sendByCtrlEnter: preferences.sendByCtrlEnter,
+    cleanView: preferences.cleanView,
   }), [
     preferences.autoExpandTools,
     preferences.autoScrollToBottom,
     preferences.sendByCtrlEnter,
     preferences.showRawParameters,
     preferences.showThinking,
+    preferences.cleanView,
   ]);
 
   const handlePreferenceChange = useCallback(

--- a/src/components/settings/hooks/useSettingsController.ts
+++ b/src/components/settings/hooks/useSettingsController.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useTheme } from '../../../contexts/ThemeContext';
-import { authenticatedFetch } from '../../../utils/api';
+import { authenticatedFetch, getDisabledProviders, setProviderEnabled } from '../../../utils/api';
 import {
   AUTH_STATUS_ENDPOINTS,
   DEFAULT_AUTH_STATUS,
@@ -206,6 +206,14 @@ export function useSettingsController({ isOpen, initialTab, projects, onClose }:
     createEmptyCursorPermissions()
   ));
   const [codexPermissionMode, setCodexPermissionMode] = useState<CodexPermissionMode>('default');
+
+  const [disabledProviders, setDisabledProviders] = useState<string[]>(() => getDisabledProviders());
+
+  const toggleProvider = useCallback((provider: string) => {
+    const isCurrentlyEnabled = !disabledProviders.includes(provider);
+    setProviderEnabled(provider, !isCurrentlyEnabled);
+    setDisabledProviders(getDisabledProviders());
+  }, [disabledProviders]);
   const [geminiPermissionMode, setGeminiPermissionMode] = useState<GeminiPermissionMode>('default');
 
   const [mcpServers, setMcpServers] = useState<McpServer[]>([]);
@@ -862,5 +870,7 @@ export function useSettingsController({ isOpen, initialTab, projects, onClose }:
     selectedProject,
     handleLoginComplete,
     saveSettings,
+    disabledProviders,
+    toggleProvider,
   };
 }

--- a/src/components/settings/view/Settings.tsx
+++ b/src/components/settings/view/Settings.tsx
@@ -65,6 +65,8 @@ function Settings({ isOpen, onClose, projects = [], initialTab = 'agents' }: Set
     selectedProject,
     handleLoginComplete,
     saveSettings,
+    disabledProviders,
+    toggleProvider,
   } = useSettingsController({
     isOpen,
     initialTab,
@@ -122,37 +124,76 @@ function Settings({ isOpen, onClose, projects = [], initialTab = 'agents' }: Set
             {activeTab === 'git' && <GitSettingsTab />}
 
             {activeTab === 'agents' && (
-              <AgentsSettingsTab
-                claudeAuthStatus={claudeAuthStatus}
-                cursorAuthStatus={cursorAuthStatus}
-                codexAuthStatus={codexAuthStatus}
-                geminiAuthStatus={geminiAuthStatus}
-                onClaudeLogin={() => openLoginForProvider('claude')}
-                onCursorLogin={() => openLoginForProvider('cursor')}
-                onCodexLogin={() => openLoginForProvider('codex')}
-                onGeminiLogin={() => openLoginForProvider('gemini')}
-                claudePermissions={claudePermissions}
-                onClaudePermissionsChange={setClaudePermissions}
-                cursorPermissions={cursorPermissions}
-                onCursorPermissionsChange={setCursorPermissions}
-                codexPermissionMode={codexPermissionMode}
-                onCodexPermissionModeChange={setCodexPermissionMode}
-                geminiPermissionMode={geminiPermissionMode}
-                onGeminiPermissionModeChange={setGeminiPermissionMode}
-                mcpServers={mcpServers}
-                cursorMcpServers={cursorMcpServers}
-                codexMcpServers={codexMcpServers}
-                mcpTestResults={mcpTestResults}
-                mcpServerTools={mcpServerTools}
-                mcpToolsLoading={mcpToolsLoading}
-                onOpenMcpForm={openMcpForm}
-                onDeleteMcpServer={handleMcpDelete}
-                onTestMcpServer={handleMcpTest}
-                onDiscoverMcpTools={handleMcpToolsDiscovery}
-                onOpenCodexMcpForm={openCodexMcpForm}
-                onDeleteCodexMcpServer={handleCodexMcpDelete}
-                deleteError={deleteError}
-              />
+              <>
+                <AgentsSettingsTab
+                  claudeAuthStatus={claudeAuthStatus}
+                  cursorAuthStatus={cursorAuthStatus}
+                  codexAuthStatus={codexAuthStatus}
+                  geminiAuthStatus={geminiAuthStatus}
+                  onClaudeLogin={() => openLoginForProvider('claude')}
+                  onCursorLogin={() => openLoginForProvider('cursor')}
+                  onCodexLogin={() => openLoginForProvider('codex')}
+                  onGeminiLogin={() => openLoginForProvider('gemini')}
+                  claudePermissions={claudePermissions}
+                  onClaudePermissionsChange={setClaudePermissions}
+                  cursorPermissions={cursorPermissions}
+                  onCursorPermissionsChange={setCursorPermissions}
+                  codexPermissionMode={codexPermissionMode}
+                  onCodexPermissionModeChange={setCodexPermissionMode}
+                  geminiPermissionMode={geminiPermissionMode}
+                  onGeminiPermissionModeChange={setGeminiPermissionMode}
+                  mcpServers={mcpServers}
+                  cursorMcpServers={cursorMcpServers}
+                  codexMcpServers={codexMcpServers}
+                  mcpTestResults={mcpTestResults}
+                  mcpServerTools={mcpServerTools}
+                  mcpToolsLoading={mcpToolsLoading}
+                  onOpenMcpForm={openMcpForm}
+                  onDeleteMcpServer={handleMcpDelete}
+                  onTestMcpServer={handleMcpTest}
+                  onDiscoverMcpTools={handleMcpToolsDiscovery}
+                  onOpenCodexMcpForm={openCodexMcpForm}
+                  onDeleteCodexMcpServer={handleCodexMcpDelete}
+                  deleteError={deleteError}
+                />
+
+                {/* Provider Integrations */}
+                <div className="space-y-4">
+                  <h3 className="text-lg font-semibold text-foreground">Provider Integrations</h3>
+                  <p className="text-sm text-muted-foreground">
+                    Disable unused providers to improve app load time. Requires page refresh.
+                  </p>
+
+                  {[
+                    { id: 'cursor', label: 'Cursor', desc: 'Enable Cursor AI integration' },
+                    { id: 'codex', label: 'Codex', desc: 'Enable OpenAI Codex integration' },
+                    { id: 'taskmaster', label: 'TaskMaster', desc: 'Enable TaskMaster task management' },
+                  ].map(({ id, label, desc }) => (
+                    <div key={id} className="rounded-lg border border-border bg-muted/30 p-4">
+                      <div className="flex items-center justify-between">
+                        <div>
+                          <div className="font-medium text-foreground">{label}</div>
+                          <div className="text-sm text-muted-foreground">{desc}</div>
+                        </div>
+                        <button
+                          onClick={() => toggleProvider(id)}
+                          className={`relative inline-flex h-8 w-14 items-center rounded-full transition-colors duration-200 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 ${
+                            !disabledProviders.includes(id) ? 'bg-primary' : 'bg-muted-foreground/30'
+                          }`}
+                          role="switch"
+                          aria-checked={!disabledProviders.includes(id)}
+                        >
+                          <span
+                            className={`${
+                              !disabledProviders.includes(id) ? 'translate-x-7' : 'translate-x-1'
+                            } inline-block h-6 w-6 transform rounded-full bg-white shadow-lg transition-transform duration-200`}
+                          />
+                        </button>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </>
             )}
 
             {activeTab === 'tasks' && (

--- a/src/components/task-master/context/TaskMasterContext.tsx
+++ b/src/components/task-master/context/TaskMasterContext.tsx
@@ -1,5 +1,5 @@
 import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
-import { api } from '../../../utils/api';
+import { api, isProviderEnabled } from '../../../utils/api';
 import { useAuth } from '../../auth/context/AuthContext';
 import { useWebSocket } from '../../../contexts/WebSocketContext';
 import type {
@@ -197,6 +197,7 @@ export function TaskMasterProvider({ children }: { children: React.ReactNode }) 
   }, [clearError, handleError, token, user]);
 
   useEffect(() => {
+    if (!isProviderEnabled('taskmaster')) return;
     if (!isAuthLoading && user && token) {
       void refreshProjects();
       void refreshMCPStatus();
@@ -204,12 +205,14 @@ export function TaskMasterProvider({ children }: { children: React.ReactNode }) 
   }, [isAuthLoading, refreshMCPStatus, refreshProjects, token, user]);
 
   useEffect(() => {
+    if (!isProviderEnabled('taskmaster')) return;
     if (currentProject?.name && user && token) {
       void refreshTasks();
     }
   }, [currentProject?.name, refreshTasks, token, user]);
 
   useEffect(() => {
+    if (!isProviderEnabled('taskmaster')) return;
     const message = latestMessage as TaskMasterWebSocketMessage | null;
     if (!isTaskMasterMessage(message)) {
       return;

--- a/src/hooks/useUiPreferences.ts
+++ b/src/hooks/useUiPreferences.ts
@@ -7,6 +7,7 @@ type UiPreferences = {
   autoScrollToBottom: boolean;
   sendByCtrlEnter: boolean;
   sidebarVisible: boolean;
+  cleanView: boolean;
 };
 
 type UiPreferenceKey = keyof UiPreferences;
@@ -39,6 +40,7 @@ const DEFAULTS: UiPreferences = {
   autoScrollToBottom: true,
   sendByCtrlEnter: false,
   sidebarVisible: true,
+  cleanView: true,
 };
 
 const PREFERENCE_KEYS = Object.keys(DEFAULTS) as UiPreferenceKey[];

--- a/src/i18n/locales/en/settings.json
+++ b/src/i18n/locales/en/settings.json
@@ -65,6 +65,7 @@
     "autoScrollToBottom": "Auto-scroll to bottom",
     "sendByCtrlEnter": "Send by Ctrl+Enter",
     "sendByCtrlEnterDescription": "When enabled, pressing Ctrl+Enter will send the message instead of just Enter. This is useful for IME users to avoid accidental sends.",
+    "cleanView": "Clean view (hide noise)",
     "dragHandle": {
       "dragging": "Dragging handle",
       "closePanel": "Close settings panel",

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -1,3 +1,39 @@
+// Provider enable/disable utilities
+// Unused providers are disabled by default for faster load times
+const DISABLED_PROVIDERS_KEY = 'disabled-providers';
+const DEFAULT_DISABLED = ['cursor', 'codex', 'taskmaster'];
+
+export const isProviderEnabled = (provider) => {
+  try {
+    const disabled = JSON.parse(localStorage.getItem(DISABLED_PROVIDERS_KEY)) || DEFAULT_DISABLED;
+    return !disabled.includes(provider);
+  } catch {
+    return !DEFAULT_DISABLED.includes(provider);
+  }
+};
+
+export const setProviderEnabled = (provider, enabled) => {
+  try {
+    let disabled = JSON.parse(localStorage.getItem(DISABLED_PROVIDERS_KEY)) || DEFAULT_DISABLED;
+    if (enabled) {
+      disabled = disabled.filter(p => p !== provider);
+    } else if (!disabled.includes(provider)) {
+      disabled.push(provider);
+    }
+    localStorage.setItem(DISABLED_PROVIDERS_KEY, JSON.stringify(disabled));
+  } catch {
+    // Ignore localStorage errors
+  }
+};
+
+export const getDisabledProviders = () => {
+  try {
+    return JSON.parse(localStorage.getItem(DISABLED_PROVIDERS_KEY)) || DEFAULT_DISABLED;
+  } catch {
+    return DEFAULT_DISABLED;
+  }
+};
+
 import { IS_PLATFORM } from "../constants/config";
 
 // Utility function for authenticated API calls


### PR DESCRIPTION
## Summary

- Adds a **clean view** toggle (default: on) in Quick Settings that collapses noise in conversation sessions
- **Strips noise tags** (system-reminders, command tags) from user messages at the view layer, preserving raw data for raw mode
- **Groups consecutive read-only tools** (Read, Grep, Glob, etc.) into collapsible "Research" summary bars with expand/collapse
- **Renders skill definition loads** as compact chips instead of full definition text
- Threads `cleanView` preference through MainContent → ChatInterface → ChatMessagesPane

## Architecture

- Skill detection at the **data layer** (`messageTransforms.ts`) — lightweight flag, no data destruction
- Noise stripping + tool grouping at the **view layer** (`cleanViewFilters.ts`, `cleanViewGrouping.ts`) — only when cleanView is enabled
- Two new components: `SkillLoadChip` (pill-shaped skill indicator) and `CollapsedToolGroup` (expandable tool summary)
- Memoized pipeline in `ChatMessagesPane` with `useMemo` keyed on `[visibleMessages, cleanView]`

## Test plan

- [ ] Toggle clean view on/off in Quick Settings panel — verify toggle works and persists
- [ ] Open a session with skill loads — verify they appear as compact chips
- [ ] Open a session with system-reminder tags — verify they are stripped in clean mode, visible in raw mode
- [ ] Open a session with consecutive Read/Grep/Glob calls — verify they collapse into a summary bar
- [ ] Click a collapsed group — verify it expands to show individual tools
- [ ] Verify Edit/Write/Bash tools remain fully visible (not collapsed)
- [ ] Verify `npx tsc --noEmit` and `npm run build` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Clean View toggle (default on): collapses consecutive read-only tool calls, shows compact skill-load chips, and strips view-layer noise while preserving raw mode; persisted via quick settings.
  * New slash commands: /compact, /export, /context.
  * Provider integration toggles (Cursor, Codex, TaskMaster) in Settings.

* **Performance**
  * Improved scroll responsiveness via throttled scroll updates.

* **Documentation**
  * Added Clean View design/plan and Session Context Tracking spec.

* **Chores**
  * Server auto-refresh/watch disabled; project refresh now manual or via API.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->