### PR TITLE
fix: prevent scroll jumping to top during streaming responses

### DIFF
--- a/src/components/chat/hooks/useChatSessionState.ts
+++ b/src/components/chat/hooks/useChatSessionState.ts
@@ -108,6 +108,7 @@ export function useChatSessionState({
   const [totalMessages, setTotalMessages] = useState(0);
   const [canAbortSession, setCanAbortSession] = useState(false);
   const [isUserScrolledUp, setIsUserScrolledUp] = useState(false);
+  const userManuallyScrolledRef = useRef(false);
   const [tokenBudget, setTokenBudget] = useState<Record<string, unknown> | null>(null);
   const [visibleMessageCount, setVisibleMessageCount] = useState(INITIAL_VISIBLE_MESSAGES);
   const [claudeStatus, setClaudeStatus] = useState<{ text: string; tokens: number; can_interrupt: boolean } | null>(null);
@@ -222,7 +223,7 @@ export function useChatSessionState({
     const container = scrollContainerRef.current;
     if (!container) return false;
     const { scrollTop, scrollHeight, clientHeight } = container;
-    return scrollHeight - scrollTop - clientHeight < 50;
+    return scrollHeight - scrollTop - clientHeight < 150;
   }, []);
 
   const loadOlderMessages = useCallback(
@@ -259,12 +260,28 @@ export function useChatSessionState({
     [hasMoreMessages, isLoadingMoreMessages, selectedProject, selectedSession, sessionStore],
   );
 
+  // Mark that user physically scrolled (wheel/touch) — used to distinguish
+  // user-initiated scroll-up from programmatic scroll position drift during streaming.
+  const handleUserInteractionScroll = useCallback(() => {
+    userManuallyScrolledRef.current = true;
+  }, []);
+
   const handleScroll = useCallback(async () => {
     const container = scrollContainerRef.current;
     if (!container) return;
 
     const nearBottom = isNearBottom();
-    setIsUserScrolledUp(!nearBottom);
+
+    // Only set isUserScrolledUp=true if the user physically interacted (wheel/touch).
+    // During streaming, content grows and the bottom moves away — but if the user
+    // didn't manually scroll, we should keep auto-scrolling to bottom.
+    if (userManuallyScrolledRef.current) {
+      setIsUserScrolledUp(!nearBottom);
+      userManuallyScrolledRef.current = false;
+    } else if (nearBottom) {
+      // Programmatic scroll landed near bottom → clear scrolled-up state
+      setIsUserScrolledUp(false);
+    }
 
     if (!allMessagesLoadedRef.current) {
       const scrolledNearTop = container.scrollTop < 100;
@@ -296,6 +313,7 @@ export function useChatSessionState({
     topLoadLockRef.current = false;
     pendingScrollRestoreRef.current = null;
     setIsUserScrolledUp(false);
+    userManuallyScrolledRef.current = false;
   }, [selectedProject?.name, selectedSession?.id]);
 
   // Initial scroll to bottom
@@ -569,30 +587,42 @@ export function useChatSessionState({
     return chatMessages.slice(-visibleMessageCount);
   }, [chatMessages, visibleMessageCount]);
 
-  useEffect(() => {
+  // Save scroll position snapshot for non-autoScroll mode.
+  // Uses useLayoutEffect to capture position BEFORE the browser paints,
+  // and only runs when chatMessages actually changes (not every render).
+  const prevChatMessagesRef = useRef(chatMessages);
+  useLayoutEffect(() => {
     if (!autoScrollToBottom && scrollContainerRef.current) {
       const container = scrollContainerRef.current;
       scrollPositionRef.current = { height: container.scrollHeight, top: container.scrollTop };
     }
-  });
+    prevChatMessagesRef.current = chatMessages;
+  }, [autoScrollToBottom, chatMessages]);
 
+  // Auto-scroll to bottom when content changes.
+  // Key fix: depend on `chatMessages` identity (not just .length) so streaming
+  // updates — which replace message content without changing array length — still
+  // trigger the scroll. Use rAF for a paint-aligned, flicker-free scroll.
   useEffect(() => {
     if (!scrollContainerRef.current || chatMessages.length === 0) return;
     if (isLoadingMoreRef.current || isLoadingMoreMessages || pendingScrollRestoreRef.current) return;
     if (searchScrollActiveRef.current) return;
 
     if (autoScrollToBottom) {
-      if (!isUserScrolledUp) setTimeout(() => scrollToBottom(), 50);
+      if (!isUserScrolledUp) {
+        requestAnimationFrame(() => scrollToBottom());
+      }
       return;
     }
 
+    // Non-autoScroll mode: anchor scroll position so new content doesn't push viewport
     const container = scrollContainerRef.current;
     const prevHeight = scrollPositionRef.current.height;
     const prevTop = scrollPositionRef.current.top;
     const newHeight = container.scrollHeight;
     const heightDiff = newHeight - prevHeight;
     if (heightDiff > 0 && prevTop > 0) container.scrollTop = prevTop + heightDiff;
-  }, [autoScrollToBottom, chatMessages.length, isLoadingMoreMessages, isUserScrolledUp, scrollToBottom]);
+  }, [autoScrollToBottom, chatMessages, isLoadingMoreMessages, isUserScrolledUp, scrollToBottom]);
 
   useEffect(() => {
     const container = scrollContainerRef.current;
@@ -731,5 +761,6 @@ export function useChatSessionState({
     scrollToBottomAndReset,
     isNearBottom,
     handleScroll,
+    handleUserInteractionScroll,
   };
 }

--- a/src/components/chat/view/ChatInterface.tsx
+++ b/src/components/chat/view/ChatInterface.tsx
@@ -113,6 +113,7 @@ function ChatInterface({
     scrollToBottom,
     scrollToBottomAndReset,
     handleScroll,
+    handleUserInteractionScroll,
   } = useChatSessionState({
     selectedProject,
     selectedSession,
@@ -297,8 +298,8 @@ function ChatInterface({
       <div className="flex h-full flex-col">
         <ChatMessagesPane
           scrollContainerRef={scrollContainerRef}
-          onWheel={handleScroll}
-          onTouchMove={handleScroll}
+          onWheel={handleUserInteractionScroll}
+          onTouchMove={handleUserInteractionScroll}
           isLoadingSessionMessages={isLoadingSessionMessages}
           chatMessages={chatMessages}
           selectedSession={selectedSession}

--- a/src/index.css
+++ b/src/index.css
@@ -566,6 +566,10 @@
     .overflow-y-auto, [data-scroll-container] {
       touch-action: pan-y;
       -webkit-overflow-scrolling: touch;
+      /* Disable browser scroll anchoring — we manage scroll position in JS.
+         Browser anchoring can conflict with our auto-scroll-to-bottom logic
+         and cause the viewport to jump to the top during streaming. */
+      overflow-anchor: none;
     }
     
     /* Preserve checkbox visibility */


### PR DESCRIPTION
## Problem

When Claude is streaming a response (adding lines in real-time), the chat view **jumps back to the top of the conversation**, forcing the user to manually scroll back down to see the new content. This happens repeatedly during every streaming response, making the UI essentially unusable during long outputs. The user has to fight the scroll to follow what Claude is saying.

## Summary

- **Fix auto-scroll failing during streaming**: the scroll effect depended on `chatMessages.length` which doesn't change during streaming (content updates replace message text, not array length). Changed to depend on `chatMessages` identity so every store update triggers scroll-to-bottom.
- **Fix false "user scrolled up" detection**: `handleScroll` was unconditionally setting `isUserScrolledUp` on every scroll event — including programmatic ones caused by content growth. Now only real user interactions (wheel/touch) can set this flag, via a new `handleUserInteractionScroll` callback.
- **Fix position-save effect running every render**: the `useEffect` that saved scroll position had no dependency array, causing stale snapshots. Replaced with `useLayoutEffect` + proper deps.

### Additional improvements
- Increased near-bottom threshold (50px → 150px) for more forgiving auto-scroll activation
- Added `overflow-anchor: none` CSS to prevent browser scroll anchoring from conflicting with JS-managed scroll position
- Replaced `setTimeout` with `requestAnimationFrame` for flicker-free scroll
- Use `useLayoutEffect` for position snapshots (captures before paint)

## Root Cause

Three interacting bugs in `useChatSessionState.ts`:

1. **Wrong dependency** — `chatMessages.length` stays constant during streaming because `updateStreaming()` replaces message content in-place. The `chatMessages` array reference changes (new merged array from session store), but `.length` doesn't, so the auto-scroll effect never fires.

2. **Scroll event misattribution** — When auto-scroll pushes new content down, the browser fires a `scroll` event. `handleScroll` treated this as user intent and set `isUserScrolledUp = true`, permanently blocking further auto-scrolls until the user manually scrolled back to bottom.

3. **Stale position saves** — The effect that captured `scrollHeight`/`scrollTop` for non-autoScroll mode ran on every render (no deps), overwriting the snapshot with intermediate values.

## Files Changed

| File | What changed |
|------|-------------|
| `src/components/chat/hooks/useChatSessionState.ts` | Core scroll logic fixes (all 3 bugs) |
| `src/components/chat/view/ChatInterface.tsx` | Wire `handleUserInteractionScroll` to wheel/touch events |
| `src/index.css` | Add `overflow-anchor: none` to scroll containers |

## Test plan

- [ ] Open a chat session with streaming enabled (autoScrollToBottom = true)
- [ ] Send a message that triggers a long streaming response
- [ ] Verify the view stays at the bottom as new content streams in
- [ ] Manually scroll up during streaming — verify it stays where you scrolled
- [ ] Scroll back to bottom — verify auto-scroll resumes
- [ ] Test on mobile (touch scroll)
- [ ] Test with autoScrollToBottom = false — verify position anchoring works

🤖 Generated with [Claude Code](https://claude.com/claude-code)