### PR TITLE
fix: prevent split on undefined（#491）

### DIFF
--- a/src/components/chat/tools/components/ToolDiffViewer.tsx
+++ b/src/components/chat/tools/components/ToolDiffViewer.tsx
@@ -33,7 +33,12 @@ export const ToolDiffViewer: React.FC<ToolDiffViewerProps> = ({
     : 'bg-gray-100 dark:bg-gray-800 text-gray-500 dark:text-gray-400';
 
   const diffLines = useMemo(
-    () => createDiff(oldContent, newContent),
+    () => {
+      if (oldContent === undefined || newContent === undefined) {
+        return [];
+      }
+      return createDiff(oldContent, newContent)
+    },
     [createDiff, oldContent, newContent]
   );
 


### PR DESCRIPTION
This issue occurs during Claude Code interaction with code comparison. The asynchronous frontend code loads comparison data, but split is called before data is fully loaded, causing an undefined error.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Diff viewer now safely handles missing or undefined content by returning an empty diff instead of attempting a comparison, preventing errors or unexpected behavior in tool comparison displays.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->