### PR TITLE
fix: reduce CPU usage from PTY URL parsing and file watchers

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -93,7 +93,7 @@ const WATCHER_IGNORED_PATTERNS = [
     '**/*.swp',
     '**/.DS_Store'
 ];
-const WATCHER_DEBOUNCE_MS = 300;
+const WATCHER_DEBOUNCE_MS = 2000;
 let projectsWatchers = [];
 let projectsWatcherDebounceTimer = null;
 const connectedClients = new Set();
@@ -188,11 +188,7 @@ async function setupProjectsWatcher() {
                 persistent: true,
                 ignoreInitial: true, // Don't fire events for existing files on startup
                 followSymlinks: false,
-                depth: 10, // Reasonable depth limit
-                awaitWriteFinish: {
-                    stabilityThreshold: 100, // Wait 100ms for file to stabilize
-                    pollInterval: 50
-                }
+                depth: 3
             });
 
             // Set up event listeners
@@ -225,7 +221,8 @@ const server = http.createServer(app);
 
 const ptySessionsMap = new Map();
 const PTY_SESSION_TIMEOUT = 30 * 60 * 1000;
-const SHELL_URL_PARSE_BUFFER_LIMIT = 32768;
+const SHELL_URL_PARSE_BUFFER_LIMIT = 8192;
+const URL_PARSE_THROTTLE_MS = 2000;
 const ANSI_ESCAPE_SEQUENCE_REGEX = /\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~]|\][^\x07]*(?:\x07|\x1B\\))/g;
 const TRAILING_URL_PUNCTUATION_REGEX = /[)\]}>.,;:!?]+$/;
 
@@ -1628,7 +1625,9 @@ function handleShellConnection(ws) {
     let shellProcess = null;
     let ptySessionKey = null;
     let urlDetectionBuffer = '';
-    const announcedAuthUrls = new Set();
+    let urlParseTimer = null;
+    let urlParsePending = false;
+    const announcedAuthUrls = new Map();
 
     ws.on('message', async (message) => {
         try {
@@ -1860,38 +1859,56 @@ function handleShellConnection(ws) {
                                 '[INFO] Opening in browser: $1'
                             );
 
-                            const emitAuthUrl = (detectedUrl, autoOpen = false) => {
-                                const normalizedUrl = normalizeDetectedUrl(detectedUrl);
-                                if (!normalizedUrl) return;
+                            const runUrlDetection = (forceAutoOpen = false) => {
+                                const emitAuthUrl = (detectedUrl, autoOpen = false) => {
+                                    const normalizedUrl = normalizeDetectedUrl(detectedUrl);
+                                    if (!normalizedUrl) return;
+                                    const alreadyAutoOpened = announcedAuthUrls.get(normalizedUrl);
+                                    if (alreadyAutoOpened === undefined || (autoOpen && !alreadyAutoOpened)) {
+                                        announcedAuthUrls.set(normalizedUrl, autoOpen);
+                                        const s = ptySessionsMap.get(ptySessionKey);
+                                        if (s && s.ws && s.ws.readyState === WebSocket.OPEN) {
+                                            s.ws.send(JSON.stringify({ type: 'auth_url', url: normalizedUrl, autoOpen }));
+                                        }
+                                    }
+                                };
 
-                                const isNewUrl = !announcedAuthUrls.has(normalizedUrl);
-                                if (isNewUrl) {
-                                    announcedAuthUrls.add(normalizedUrl);
-                                    session.ws.send(JSON.stringify({
-                                        type: 'auth_url',
-                                        url: normalizedUrl,
-                                        autoOpen
-                                    }));
+                                const normalizedDetectedUrls = extractUrlsFromText(urlDetectionBuffer)
+                                    .map((url) => normalizeDetectedUrl(url))
+                                    .filter(Boolean);
+
+                                const dedupedDetectedUrls = Array.from(new Set(normalizedDetectedUrls)).filter((url, _, urls) =>
+                                    !urls.some((otherUrl) => otherUrl !== url && otherUrl.startsWith(url))
+                                );
+
+                                if (forceAutoOpen && dedupedDetectedUrls.length > 0) {
+                                    const bestUrl = dedupedDetectedUrls.reduce((longest, current) =>
+                                        current.length > longest.length ? current : longest
+                                    );
+                                    emitAuthUrl(bestUrl, true);
                                 }
 
+                                dedupedDetectedUrls.forEach((url) => emitAuthUrl(url, false));
                             };
 
-                            const normalizedDetectedUrls = extractUrlsFromText(urlDetectionBuffer)
-                                .map((url) => normalizeDetectedUrl(url))
-                                .filter(Boolean);
-
-                            // Prefer the most complete URL if shorter prefix variants are also present.
-                            const dedupedDetectedUrls = Array.from(new Set(normalizedDetectedUrls)).filter((url, _, urls) =>
-                                !urls.some((otherUrl) => otherUrl !== url && otherUrl.startsWith(url))
-                            );
-
-                            dedupedDetectedUrls.forEach((url) => emitAuthUrl(url, false));
-
-                            if (shouldAutoOpenUrlFromOutput(cleanChunk) && dedupedDetectedUrls.length > 0) {
-                                const bestUrl = dedupedDetectedUrls.reduce((longest, current) =>
-                                    current.length > longest.length ? current : longest
-                                );
-                                emitAuthUrl(bestUrl, true);
+                            if (shouldAutoOpenUrlFromOutput(cleanChunk)) {
+                                if (urlParseTimer) {
+                                    clearTimeout(urlParseTimer);
+                                    urlParseTimer = null;
+                                }
+                                urlParsePending = false;
+                                runUrlDetection(true);
+                            } else if (!urlParseTimer) {
+                                urlParsePending = true;
+                                urlParseTimer = setTimeout(() => {
+                                    urlParseTimer = null;
+                                    if (urlParsePending) {
+                                        urlParsePending = false;
+                                        runUrlDetection(false);
+                                    }
+                                }, URL_PARSE_THROTTLE_MS);
+                            } else {
+                                urlParsePending = true;
                             }
 
                             // Send regular output


### PR DESCRIPTION
## Summary

- **Throttle URL detection** in PTY `onData` handler: `extractUrlsFromText()` (O(n²) regex on large buffer) was called on every data chunk — now throttled to once every 2s, with immediate execution preserved for auto-open triggers
- **Remove chokidar `awaitWriteFinish` polling**: was `stat()`-ing every 50ms on ~2000 watched files; reduce `depth` from 10 to 3
- **Increase watcher debounce** from 300ms to 2s to reduce heavy `getProjects()` scan frequency
- **Reduce URL buffer** from 32KB to 8KB

## Root cause

After running for several hours, `node server/index.js` reached 94% CPU / 574MB RAM. Three compounding causes:
1. `extractUrlsFromText()` ran a nested O(n²) loop + regex on a 32KB buffer **on every PTY chunk** (hundreds/sec during active Claude sessions)
2. chokidar with `awaitWriteFinish: { pollInterval: 50 }` polled ~2000 files every 50ms
3. `getProjects()` (heavy directory scan) triggered every 300ms by file changes

After fix: ~12% CPU / 100MB stable after 5 min, trending to idle.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Adjustments**
  * Less frequent file-change refreshes and reduced directory scanning to cut CPU and UI flapping.
  * URL detection now batches and throttles parsing to lower resource use while still promptly opening important links.
* **Reliability Fixes**
  * More robust URL auto-open logic to avoid duplicate detections and prefer the best link.
  * Session messages are sent only to active, ready connections to reduce delivery errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->