### PR TITLE
feat: configurable base path via BASE_PATH env var

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,6 +25,11 @@ VITE_PORT=5173
 # Use 127.0.0.1 to restrict to localhost only
 HOST=0.0.0.0
 
+# Base path prefix for all routes and assets (default: /)
+# Useful when serving behind a reverse proxy at a sub-path.
+# Requires a frontend rebuild (npm run build) after changing.
+# BASE_PATH=/cloudcli
+
 # Uncomment the following line if you have a custom claude cli path other than the default "claude"
 # CLAUDE_CLI_PATH=claude
 

--- a/index.html
+++ b/index.html
@@ -29,20 +29,5 @@
   <body>
     <div id="root"></div>
     <script type="module" src="/src/main.jsx"></script>
-    
-    <!-- Service Worker Registration -->
-    <script>
-      if ('serviceWorker' in navigator) {
-        window.addEventListener('load', () => {
-          navigator.serviceWorker.register('/sw.js')
-            .then(registration => {
-              console.log('SW registered: ', registration);
-            })
-            .catch(registrationError => {
-              console.log('SW registration failed: ', registrationError);
-            });
-        });
-      }
-    </script>
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -35,7 +35,8 @@
       if ('serviceWorker' in navigator) {
         // Derive base path from the manifest link href which Vite transforms with the correct base
         var m = document.querySelector('link[rel="manifest"]');
-        var base = m ? m.getAttribute('href').replace('/manifest.json', '') || '' : '';
+        var manifestHref = m ? m.getAttribute('href') : '';
+        var base = manifestHref ? manifestHref.replace(/\/manifest\.json(?:[?#].*)?$/, '') : '';
         window.addEventListener('load', function() {
           navigator.serviceWorker.register(base + '/sw.js')
             .then(function(registration) {

--- a/index.html
+++ b/index.html
@@ -29,5 +29,23 @@
   <body>
     <div id="root"></div>
     <script type="module" src="/src/main.jsx"></script>
+
+    <!-- Service Worker Registration -->
+    <script>
+      if ('serviceWorker' in navigator) {
+        // Derive base path from the manifest link href which Vite transforms with the correct base
+        var m = document.querySelector('link[rel="manifest"]');
+        var base = m ? m.getAttribute('href').replace('/manifest.json', '') || '' : '';
+        window.addEventListener('load', function() {
+          navigator.serviceWorker.register(base + '/sw.js')
+            .then(function(registration) {
+              console.log('SW registered: ', registration);
+            })
+            .catch(function(registrationError) {
+              console.log('SW registration failed: ', registrationError);
+            });
+        });
+      }
+    </script>
   </body>
 </html>

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -2,57 +2,57 @@
   "name": "CloudCLI UI",
   "short_name": "CloudCLI UI",
   "description": "CloudCLI UI web application",
-  "start_url": "/",
+  "start_url": "./",
   "display": "standalone",
   "background_color": "#ffffff",
   "theme_color": "#ffffff",
   "orientation": "portrait-primary",
-  "scope": "/",
+  "scope": "./",
   "icons": [
     {
-      "src": "/icons/icon-72x72.png",
+      "src": "icons/icon-72x72.png",
       "sizes": "72x72",
       "type": "image/png",
       "purpose": "maskable any"
     },
     {
-      "src": "/icons/icon-96x96.png",
+      "src": "icons/icon-96x96.png",
       "sizes": "96x96",
       "type": "image/png",
       "purpose": "maskable any"
     },
     {
-      "src": "/icons/icon-128x128.png",
+      "src": "icons/icon-128x128.png",
       "sizes": "128x128",
       "type": "image/png",
       "purpose": "maskable any"
     },
     {
-      "src": "/icons/icon-144x144.png",
+      "src": "icons/icon-144x144.png",
       "sizes": "144x144",
       "type": "image/png",
       "purpose": "maskable any"
     },
     {
-      "src": "/icons/icon-152x152.png",
+      "src": "icons/icon-152x152.png",
       "sizes": "152x152",
       "type": "image/png",
       "purpose": "maskable any"
     },
     {
-      "src": "/icons/icon-192x192.png",
+      "src": "icons/icon-192x192.png",
       "sizes": "192x192",
       "type": "image/png",
       "purpose": "maskable any"
     },
     {
-      "src": "/icons/icon-384x384.png",
+      "src": "icons/icon-384x384.png",
       "sizes": "384x384",
       "type": "image/png",
       "purpose": "maskable any"
     },
     {
-      "src": "/icons/icon-512x512.png",
+      "src": "icons/icon-512x512.png",
       "sizes": "512x512",
       "type": "image/png",
       "purpose": "maskable any"

--- a/public/sw.js
+++ b/public/sw.js
@@ -31,11 +31,11 @@ self.addEventListener('fetch', event => {
   // Navigation requests (HTML) — always go to network, no caching
   if (event.request.mode === 'navigate') {
     event.respondWith(
-      fetch(event.request).catch(() => caches.match(`${BASE_PATH}/manifest.json`).then(() =>
+      fetch(event.request).catch(() =>
         new Response('<h1>Offline</h1><p>Please check your connection.</p>', {
           headers: { 'Content-Type': 'text/html' }
         })
-      ))
+      )
     );
     return;
   }

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,9 +1,13 @@
 // Service Worker for Claude Code UI PWA
 // Cache only manifest (needed for PWA install). HTML and JS are never pre-cached
 // so a rebuild + refresh always picks up the latest assets.
+
+// Derive base path from service worker URL (e.g. /prefix/sw.js → /prefix)
+const BASE_PATH = new URL('.', self.location).pathname.replace(/\/$/, '');
+
 const CACHE_NAME = 'claude-ui-v2';
 const urlsToCache = [
-  '/manifest.json'
+  `${BASE_PATH}/manifest.json`
 ];
 
 // Install event
@@ -20,14 +24,14 @@ self.addEventListener('fetch', event => {
   const url = event.request.url;
 
   // Never intercept API requests or WebSocket upgrades
-  if (url.includes('/api/') || url.includes('/ws')) {
+  if (url.includes(`${BASE_PATH}/api/`) || url.includes(`${BASE_PATH}/ws`)) {
     return;
   }
 
   // Navigation requests (HTML) — always go to network, no caching
   if (event.request.mode === 'navigate') {
     event.respondWith(
-      fetch(event.request).catch(() => caches.match('/manifest.json').then(() =>
+      fetch(event.request).catch(() => caches.match(`${BASE_PATH}/manifest.json`).then(() =>
         new Response('<h1>Offline</h1><p>Please check your connection.</p>', {
           headers: { 'Content-Type': 'text/html' }
         })
@@ -37,7 +41,7 @@ self.addEventListener('fetch', event => {
   }
 
   // Hashed assets (JS/CSS in /assets/) — cache-first since filenames change per build
-  if (url.includes('/assets/')) {
+  if (url.includes(`${BASE_PATH}/assets/`)) {
     event.respondWith(
       caches.match(event.request).then(cached => {
         if (cached) return cached;
@@ -84,8 +88,8 @@ self.addEventListener('push', event => {
 
   const options = {
     body: payload.body || '',
-    icon: '/logo-256.png',
-    badge: '/logo-128.png',
+    icon: `${BASE_PATH}/logo-256.png`,
+    badge: `${BASE_PATH}/logo-128.png`,
     data: payload.data || {},
     tag: payload.data?.tag || `${payload.data?.sessionId || 'global'}:${payload.data?.code || 'default'}`,
     renotify: true
@@ -102,7 +106,7 @@ self.addEventListener('notificationclick', event => {
 
   const sessionId = event.notification.data?.sessionId;
   const provider = event.notification.data?.provider || null;
-  const urlPath = sessionId ? `/session/${sessionId}` : '/';
+  const urlPath = sessionId ? `${BASE_PATH}/session/${sessionId}` : `${BASE_PATH}/`;
 
   event.waitUntil(
     self.clients.matchAll({ type: 'window', includeUncontrolled: true }).then(async clientList => {

--- a/server/index.js
+++ b/server/index.js
@@ -344,8 +344,11 @@ app.use(express.json({
 }));
 app.use(express.urlencoded({ limit: '50mb', extended: true }));
 
+// Application base path — configurable via BASE_PATH env var, defaults to /
+const BASE_PATH = (process.env.BASE_PATH || '/').replace(/\/+$/, '');
+
 // Public health check endpoint (no authentication required)
-app.get('/health', (req, res) => {
+app.get(`${BASE_PATH}/health`, (req, res) => {
     res.json({
         status: 'ok',
         timestamp: new Date().toISOString(),
@@ -353,63 +356,68 @@ app.get('/health', (req, res) => {
     });
 });
 
+// Redirect root to base path (only when a non-root base path is configured)
+if (BASE_PATH) {
+    app.get('/', (req, res) => res.redirect(`${BASE_PATH}/`));
+}
+
 // Optional API key validation (if configured)
-app.use('/api', validateApiKey);
+app.use(`${BASE_PATH}/api`, validateApiKey);
 
 // Authentication routes (public)
-app.use('/api/auth', authRoutes);
+app.use(`${BASE_PATH}/api/auth`, authRoutes);
 
 // Projects API Routes (protected)
-app.use('/api/projects', authenticateToken, projectsRoutes);
+app.use(`${BASE_PATH}/api/projects`, authenticateToken, projectsRoutes);
 
 // Git API Routes (protected)
-app.use('/api/git', authenticateToken, gitRoutes);
+app.use(`${BASE_PATH}/api/git`, authenticateToken, gitRoutes);
 
 // MCP API Routes (protected)
-app.use('/api/mcp', authenticateToken, mcpRoutes);
+app.use(`${BASE_PATH}/api/mcp`, authenticateToken, mcpRoutes);
 
 // Cursor API Routes (protected)
-app.use('/api/cursor', authenticateToken, cursorRoutes);
+app.use(`${BASE_PATH}/api/cursor`, authenticateToken, cursorRoutes);
 
 // TaskMaster API Routes (protected)
-app.use('/api/taskmaster', authenticateToken, taskmasterRoutes);
+app.use(`${BASE_PATH}/api/taskmaster`, authenticateToken, taskmasterRoutes);
 
 // MCP utilities
-app.use('/api/mcp-utils', authenticateToken, mcpUtilsRoutes);
+app.use(`${BASE_PATH}/api/mcp-utils`, authenticateToken, mcpUtilsRoutes);
 
 // Commands API Routes (protected)
-app.use('/api/commands', authenticateToken, commandsRoutes);
+app.use(`${BASE_PATH}/api/commands`, authenticateToken, commandsRoutes);
 
 // Settings API Routes (protected)
-app.use('/api/settings', authenticateToken, settingsRoutes);
+app.use(`${BASE_PATH}/api/settings`, authenticateToken, settingsRoutes);
 
 // CLI Authentication API Routes (protected)
-app.use('/api/cli', authenticateToken, cliAuthRoutes);
+app.use(`${BASE_PATH}/api/cli`, authenticateToken, cliAuthRoutes);
 
 // User API Routes (protected)
-app.use('/api/user', authenticateToken, userRoutes);
+app.use(`${BASE_PATH}/api/user`, authenticateToken, userRoutes);
 
 // Codex API Routes (protected)
-app.use('/api/codex', authenticateToken, codexRoutes);
+app.use(`${BASE_PATH}/api/codex`, authenticateToken, codexRoutes);
 
 // Gemini API Routes (protected)
-app.use('/api/gemini', authenticateToken, geminiRoutes);
+app.use(`${BASE_PATH}/api/gemini`, authenticateToken, geminiRoutes);
 
 // Plugins API Routes (protected)
-app.use('/api/plugins', authenticateToken, pluginsRoutes);
+app.use(`${BASE_PATH}/api/plugins`, authenticateToken, pluginsRoutes);
 
 // Unified session messages route (protected)
-app.use('/api/sessions', authenticateToken, messagesRoutes);
+app.use(`${BASE_PATH}/api/sessions`, authenticateToken, messagesRoutes);
 
 // Agent API Routes (uses API key authentication)
-app.use('/api/agent', agentRoutes);
+app.use(`${BASE_PATH}/api/agent`, agentRoutes);
 
 // Serve public files (like api-docs.html)
-app.use(express.static(path.join(__dirname, '../public')));
+app.use(`${BASE_PATH}`, express.static(path.join(__dirname, '../public')));
 
 // Static files served after API routes
 // Add cache control: HTML files should not be cached, but assets can be cached
-app.use(express.static(path.join(__dirname, '../dist'), {
+app.use(`${BASE_PATH}`, express.static(path.join(__dirname, '../dist'), {
     setHeaders: (res, filePath) => {
         if (filePath.endsWith('.html')) {
             // Prevent HTML caching to avoid service worker issues after builds
@@ -428,7 +436,7 @@ app.use(express.static(path.join(__dirname, '../dist'), {
 // Frontend now uses window.location for WebSocket URLs
 
 // System update endpoint
-app.post('/api/system/update', authenticateToken, async (req, res) => {
+app.post(`${BASE_PATH}/api/system/update`, authenticateToken, async (req, res) => {
     try {
         // Get the project root directory (parent of server directory)
         const projectRoot = path.join(__dirname, '..');
@@ -494,7 +502,7 @@ app.post('/api/system/update', authenticateToken, async (req, res) => {
     }
 });
 
-app.get('/api/projects', authenticateToken, async (req, res) => {
+app.get(`${BASE_PATH}/api/projects`, authenticateToken, async (req, res) => {
     try {
         const projects = await getProjects(broadcastProgress);
         res.json(projects);
@@ -503,7 +511,7 @@ app.get('/api/projects', authenticateToken, async (req, res) => {
     }
 });
 
-app.get('/api/projects/:projectName/sessions', authenticateToken, async (req, res) => {
+app.get(`${BASE_PATH}/api/projects/:projectName/sessions`, authenticateToken, async (req, res) => {
     try {
         const { limit = 5, offset = 0 } = req.query;
         const result = await getSessions(req.params.projectName, parseInt(limit), parseInt(offset));
@@ -515,7 +523,7 @@ app.get('/api/projects/:projectName/sessions', authenticateToken, async (req, re
 });
 
 // Rename project endpoint
-app.put('/api/projects/:projectName/rename', authenticateToken, async (req, res) => {
+app.put(`${BASE_PATH}/api/projects/:projectName/rename`, authenticateToken, async (req, res) => {
     try {
         const { displayName } = req.body;
         await renameProject(req.params.projectName, displayName);
@@ -526,7 +534,7 @@ app.put('/api/projects/:projectName/rename', authenticateToken, async (req, res)
 });
 
 // Delete session endpoint
-app.delete('/api/projects/:projectName/sessions/:sessionId', authenticateToken, async (req, res) => {
+app.delete(`${BASE_PATH}/api/projects/:projectName/sessions/:sessionId`, authenticateToken, async (req, res) => {
     try {
         const { projectName, sessionId } = req.params;
         console.log(`[API] Deleting session: ${sessionId} from project: ${projectName}`);
@@ -541,7 +549,7 @@ app.delete('/api/projects/:projectName/sessions/:sessionId', authenticateToken, 
 });
 
 // Rename session endpoint
-app.put('/api/sessions/:sessionId/rename', authenticateToken, async (req, res) => {
+app.put(`${BASE_PATH}/api/sessions/:sessionId/rename`, authenticateToken, async (req, res) => {
     try {
         const { sessionId } = req.params;
         const safeSessionId = String(sessionId).replace(/[^a-zA-Z0-9._-]/g, '');
@@ -567,7 +575,7 @@ app.put('/api/sessions/:sessionId/rename', authenticateToken, async (req, res) =
 });
 
 // Delete project endpoint (force=true to delete with sessions)
-app.delete('/api/projects/:projectName', authenticateToken, async (req, res) => {
+app.delete(`${BASE_PATH}/api/projects/:projectName`, authenticateToken, async (req, res) => {
     try {
         const { projectName } = req.params;
         const force = req.query.force === 'true';
@@ -579,7 +587,7 @@ app.delete('/api/projects/:projectName', authenticateToken, async (req, res) => 
 });
 
 // Create project endpoint
-app.post('/api/projects/create', authenticateToken, async (req, res) => {
+app.post(`${BASE_PATH}/api/projects/create`, authenticateToken, async (req, res) => {
     try {
         const { path: projectPath } = req.body;
 
@@ -596,7 +604,7 @@ app.post('/api/projects/create', authenticateToken, async (req, res) => {
 });
 
 // Search conversations content (SSE streaming)
-app.get('/api/search/conversations', authenticateToken, async (req, res) => {
+app.get(`${BASE_PATH}/api/search/conversations`, authenticateToken, async (req, res) => {
     const query = typeof req.query.q === 'string' ? req.query.q.trim() : '';
     const parsedLimit = Number.parseInt(String(req.query.limit), 10);
     const limit = Number.isNaN(parsedLimit) ? 50 : Math.max(1, Math.min(parsedLimit, 100));
@@ -652,7 +660,7 @@ const expandWorkspacePath = (inputPath) => {
 };
 
 // Browse filesystem endpoint for project suggestions - uses existing getFileTree
-app.get('/api/browse-filesystem', authenticateToken, async (req, res) => {
+app.get(`${BASE_PATH}/api/browse-filesystem`, authenticateToken, async (req, res) => {
     try {
         const { path: dirPath } = req.query;
 
@@ -732,7 +740,7 @@ app.get('/api/browse-filesystem', authenticateToken, async (req, res) => {
     }
 });
 
-app.post('/api/create-folder', authenticateToken, async (req, res) => {
+app.post(`${BASE_PATH}/api/create-folder`, authenticateToken, async (req, res) => {
     try {
         const { path: folderPath } = req.body;
         if (!folderPath) {
@@ -773,7 +781,7 @@ app.post('/api/create-folder', authenticateToken, async (req, res) => {
 });
 
 // Read file content endpoint
-app.get('/api/projects/:projectName/file', authenticateToken, async (req, res) => {
+app.get(`${BASE_PATH}/api/projects/:projectName/file`, authenticateToken, async (req, res) => {
     try {
         const { projectName } = req.params;
         const { filePath } = req.query;
@@ -813,7 +821,7 @@ app.get('/api/projects/:projectName/file', authenticateToken, async (req, res) =
 });
 
 // Serve binary file content endpoint (for images, etc.)
-app.get('/api/projects/:projectName/files/content', authenticateToken, async (req, res) => {
+app.get(`${BASE_PATH}/api/projects/:projectName/files/content`, authenticateToken, async (req, res) => {
     try {
         const { projectName } = req.params;
         const { path: filePath } = req.query;
@@ -866,7 +874,7 @@ app.get('/api/projects/:projectName/files/content', authenticateToken, async (re
 });
 
 // Save file content endpoint
-app.put('/api/projects/:projectName/file', authenticateToken, async (req, res) => {
+app.put(`${BASE_PATH}/api/projects/:projectName/file`, authenticateToken, async (req, res) => {
     try {
         const { projectName } = req.params;
         const { filePath, content } = req.body;
@@ -915,7 +923,7 @@ app.put('/api/projects/:projectName/file', authenticateToken, async (req, res) =
     }
 });
 
-app.get('/api/projects/:projectName/files', authenticateToken, async (req, res) => {
+app.get(`${BASE_PATH}/api/projects/:projectName/files`, authenticateToken, async (req, res) => {
     try {
 
         // Using fsPromises from import
@@ -993,7 +1001,7 @@ function validateFilename(name) {
 }
 
 // POST /api/projects/:projectName/files/create - Create new file or directory
-app.post('/api/projects/:projectName/files/create', authenticateToken, async (req, res) => {
+app.post(`${BASE_PATH}/api/projects/:projectName/files/create`, authenticateToken, async (req, res) => {
     try {
         const { projectName } = req.params;
         const { path: parentPath, type, name } = req.body;
@@ -1070,7 +1078,7 @@ app.post('/api/projects/:projectName/files/create', authenticateToken, async (re
 });
 
 // PUT /api/projects/:projectName/files/rename - Rename file or directory
-app.put('/api/projects/:projectName/files/rename', authenticateToken, async (req, res) => {
+app.put(`${BASE_PATH}/api/projects/:projectName/files/rename`, authenticateToken, async (req, res) => {
     try {
         const { projectName } = req.params;
         const { oldPath, newName } = req.body;
@@ -1147,7 +1155,7 @@ app.put('/api/projects/:projectName/files/rename', authenticateToken, async (req
 });
 
 // DELETE /api/projects/:projectName/files - Delete file or directory
-app.delete('/api/projects/:projectName/files', authenticateToken, async (req, res) => {
+app.delete(`${BASE_PATH}/api/projects/:projectName/files`, authenticateToken, async (req, res) => {
     try {
         const { projectName } = req.params;
         const { path: targetPath, type } = req.body;
@@ -1373,14 +1381,14 @@ const uploadFilesHandler = async (req, res) => {
     });
 };
 
-app.post('/api/projects/:projectName/files/upload', authenticateToken, uploadFilesHandler);
+app.post(`${BASE_PATH}/api/projects/:projectName/files/upload`, authenticateToken, uploadFilesHandler);
 
 /**
  * Proxy an authenticated client WebSocket to a plugin's internal WS server.
  * Auth is enforced by verifyClient before this function is reached.
  */
 function handlePluginWsProxy(clientWs, pathname) {
-    const pluginName = pathname.replace('/plugin-ws/', '');
+    const pluginName = pathname.replace(`${BASE_PATH}/plugin-ws/`, '');
     if (!pluginName || /[^a-zA-Z0-9_-]/.test(pluginName)) {
         clientWs.close(4400, 'Invalid plugin name');
         return;
@@ -1428,11 +1436,11 @@ wss.on('connection', (ws, request) => {
     const urlObj = new URL(url, 'http://localhost');
     const pathname = urlObj.pathname;
 
-    if (pathname === '/shell') {
+    if (pathname === `${BASE_PATH}/shell`) {
         handleShellConnection(ws);
-    } else if (pathname === '/ws') {
+    } else if (pathname === `${BASE_PATH}/ws`) {
         handleChatConnection(ws, request);
-    } else if (pathname.startsWith('/plugin-ws/')) {
+    } else if (pathname.startsWith(`${BASE_PATH}/plugin-ws/`)) {
         handlePluginWsProxy(ws, pathname);
     } else {
         console.log('[WARN] Unknown WebSocket path:', pathname);
@@ -1981,7 +1989,7 @@ function handleShellConnection(ws) {
     });
 }
 // Audio transcription endpoint
-app.post('/api/transcribe', authenticateToken, async (req, res) => {
+app.post(`${BASE_PATH}/api/transcribe`, authenticateToken, async (req, res) => {
     try {
         const multer = (await import('multer')).default;
         const upload = multer({ storage: multer.memoryStorage() });
@@ -2130,7 +2138,7 @@ Agent instructions:`;
 });
 
 // Image upload endpoint
-app.post('/api/projects/:projectName/upload-images', authenticateToken, async (req, res) => {
+app.post(`${BASE_PATH}/api/projects/:projectName/upload-images`, authenticateToken, async (req, res) => {
     try {
         const multer = (await import('multer')).default;
         const path = (await import('path')).default;
@@ -2215,7 +2223,7 @@ app.post('/api/projects/:projectName/upload-images', authenticateToken, async (r
 });
 
 // Get token usage for a specific session
-app.get('/api/projects/:projectName/sessions/:sessionId/token-usage', authenticateToken, async (req, res) => {
+app.get(`${BASE_PATH}/api/projects/:projectName/sessions/:sessionId/token-usage`, authenticateToken, async (req, res) => {
     try {
         const { projectName, sessionId } = req.params;
         const { provider = 'claude' } = req.query;
@@ -2402,8 +2410,8 @@ app.get('/api/projects/:projectName/sessions/:sessionId/token-usage', authentica
     }
 });
 
-// Serve React app for all other routes (excluding static files)
-app.get('*', (req, res) => {
+// Serve React app for all other routes under BASE_PATH (excluding static files)
+app.get(`${BASE_PATH}/*`, (req, res) => {
     // Skip requests for static assets (files with extensions)
     if (path.extname(req.path)) {
         return res.status(404).send('Not found');
@@ -2534,10 +2542,10 @@ async function startServer() {
         console.log('');
 
         if (isProduction) {
-            console.log(`${c.info('[INFO]')} To run in production mode, go to http://${DISPLAY_HOST}:${SERVER_PORT}`);            
+            console.log(`${c.info('[INFO]')} To run in production mode, go to http://${DISPLAY_HOST}:${SERVER_PORT}${BASE_PATH}/`);
         }
 
-        console.log(`${c.info('[INFO]')} To run in development mode with hot-module replacement, go to http://${DISPLAY_HOST}:${VITE_PORT}`);
+        console.log(`${c.info('[INFO]')} To run in development mode with hot-module replacement, go to http://${DISPLAY_HOST}:${VITE_PORT}${BASE_PATH}/`);
    
         server.listen(SERVER_PORT, HOST, async () => {
             const appInstallPath = path.join(__dirname, '..');

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import { WebSocketProvider } from './contexts/WebSocketContext';
 import { PluginsProvider } from './contexts/PluginsContext';
 import AppContent from './components/app/AppContent';
 import i18n from './i18n/config.js';
+import { BASE_PATH } from './utils/api';
 
 export default function App() {
   return (
@@ -19,7 +20,7 @@ export default function App() {
               <TasksSettingsProvider>
                 <TaskMasterProvider>
                 <ProtectedRoute>
-                  <Router basename={window.__ROUTER_BASENAME__ || ''}>
+                  <Router basename={BASE_PATH}>
                     <Routes>
                       <Route path="/" element={<AppContent />} />
                       <Route path="/session/:sessionId" element={<AppContent />} />

--- a/src/components/auth/view/SetupForm.tsx
+++ b/src/components/auth/view/SetupForm.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useState } from 'react';
 import type { FormEvent } from 'react';
+import { BASE_PATH } from '../../../utils/api';
 import { useAuth } from '../context/AuthContext';
 import AuthErrorAlert from './AuthErrorAlert';
 import AuthInputField from './AuthInputField';
@@ -85,7 +86,7 @@ export default function SetupForm() {
       title="Welcome to Claude Code UI"
       description="Set up your account to get started"
       footerText="This is a single-user system. Only one account can be created."
-      logo={<img src="/logo.svg" alt="CloudCLI" className="h-16 w-16" />}
+      logo={<img src={`${BASE_PATH}/logo.svg`} alt="CloudCLI" className="h-16 w-16" />}
     >
       <form onSubmit={handleSubmit} className="space-y-4">
         <AuthInputField

--- a/src/components/llm-logo-provider/ClaudeLogo.tsx
+++ b/src/components/llm-logo-provider/ClaudeLogo.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { BASE_PATH } from '../../utils/api';
 
 type ClaudeLogoProps = {
   className?: string;
@@ -6,7 +7,7 @@ type ClaudeLogoProps = {
 
 const ClaudeLogo = ({ className = 'w-5 h-5' }: ClaudeLogoProps) => {
   return (
-    <img src="/icons/claude-ai-icon.svg" alt="Claude" className={className} />
+    <img src={`${BASE_PATH}/icons/claude-ai-icon.svg`} alt="Claude" className={className} />
   );
 };
 

--- a/src/components/llm-logo-provider/CodexLogo.tsx
+++ b/src/components/llm-logo-provider/CodexLogo.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { useTheme } from '../../contexts/ThemeContext';
+import { BASE_PATH } from '../../utils/api';
 
 type CodexLogoProps = {
   className?: string;
@@ -10,7 +11,7 @@ const CodexLogo = ({ className = 'w-5 h-5' }: CodexLogoProps) => {
 
   return (
     <img
-      src={isDarkMode ? "/icons/codex-white.svg" : "/icons/codex.svg"}
+      src={isDarkMode ? `${BASE_PATH}/icons/codex-white.svg` : `${BASE_PATH}/icons/codex.svg`}
       alt="Codex"
       className={className}
     />

--- a/src/components/llm-logo-provider/CursorLogo.tsx
+++ b/src/components/llm-logo-provider/CursorLogo.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { useTheme } from '../../contexts/ThemeContext';
+import { BASE_PATH } from '../../utils/api';
 
 type CursorLogoProps = {
   className?: string;
@@ -10,7 +11,7 @@ const CursorLogo = ({ className = 'w-5 h-5' }: CursorLogoProps) => {
 
   return (
     <img
-      src={isDarkMode ? "/icons/cursor-white.svg" : "/icons/cursor.svg"}
+      src={isDarkMode ? `${BASE_PATH}/icons/cursor-white.svg` : `${BASE_PATH}/icons/cursor.svg`}
       alt="Cursor"
       className={className}
     />

--- a/src/components/llm-logo-provider/GeminiLogo.tsx
+++ b/src/components/llm-logo-provider/GeminiLogo.tsx
@@ -1,6 +1,8 @@
+import { BASE_PATH } from '../../utils/api';
+
 const GeminiLogo = ({className = 'w-5 h-5'}) => {
   return (
-    <img src="/icons/gemini-ai-icon.svg" alt="Gemini" className={className} />
+    <img src={`${BASE_PATH}/icons/gemini-ai-icon.svg`} alt="Gemini" className={className} />
   );
 };
 

--- a/src/components/project-creation-wizard/data/workspaceApi.ts
+++ b/src/components/project-creation-wizard/data/workspaceApi.ts
@@ -1,4 +1,4 @@
-import { api } from '../../../utils/api';
+import { api, BASE_PATH } from '../../../utils/api';
 import type {
   BrowseFilesystemResponse,
   CloneProgressEvent,
@@ -110,7 +110,7 @@ export const cloneWorkspaceWithProgress = (
 ) =>
   new Promise<Record<string, unknown> | undefined>((resolve, reject) => {
     const query = buildCloneProgressQuery(params);
-    const eventSource = new EventSource(`/api/projects/clone-progress?${query}`);
+    const eventSource = new EventSource(`${BASE_PATH}/api/projects/clone-progress?${query}`);
     let settled = false;
 
     const settle = (callback: () => void) => {

--- a/src/components/shell/utils/socket.ts
+++ b/src/components/shell/utils/socket.ts
@@ -1,11 +1,12 @@
 import { IS_PLATFORM } from '../../../constants/config';
+import { BASE_PATH } from '../../../utils/api';
 import type { ShellIncomingMessage, ShellOutgoingMessage } from '../types/types';
 
 export function getShellWebSocketUrl(): string | null {
   const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
 
   if (IS_PLATFORM) {
-    return `${protocol}//${window.location.host}/shell`;
+    return `${protocol}//${window.location.host}${BASE_PATH}/shell`;
   }
 
   const token = localStorage.getItem('auth-token');
@@ -14,7 +15,7 @@ export function getShellWebSocketUrl(): string | null {
     return null;
   }
 
-  return `${protocol}//${window.location.host}/shell?token=${encodeURIComponent(token)}`;
+  return `${protocol}//${window.location.host}${BASE_PATH}/shell?token=${encodeURIComponent(token)}`;
 }
 
 export function parseShellMessage(payload: string): ShellIncomingMessage | null {

--- a/src/contexts/WebSocketContext.tsx
+++ b/src/contexts/WebSocketContext.tsx
@@ -1,6 +1,7 @@
 import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
 import { useAuth } from '../components/auth/context/AuthContext';
 import { IS_PLATFORM } from '../constants/config';
+import { BASE_PATH } from '../utils/api';
 
 type WebSocketContextType = {
   ws: WebSocket | null;
@@ -21,9 +22,9 @@ export const useWebSocket = () => {
 
 const buildWebSocketUrl = (token: string | null) => {
   const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
-  if (IS_PLATFORM) return `${protocol}//${window.location.host}/ws`; // Platform mode: Use same domain as the page (goes through proxy)
+  if (IS_PLATFORM) return `${protocol}//${window.location.host}${BASE_PATH}/ws`; // Platform mode: Use same domain as the page (goes through proxy)
   if (!token) return null;
-  return `${protocol}//${window.location.host}/ws?token=${encodeURIComponent(token)}`; // OSS mode: Use same host:port that served the page
+  return `${protocol}//${window.location.host}${BASE_PATH}/ws?token=${encodeURIComponent(token)}`; // OSS mode: Use same host:port that served the page
 };
 
 const useWebSocketProviderState = (): WebSocketContextType => {

--- a/src/hooks/useVersionCheck.ts
+++ b/src/hooks/useVersionCheck.ts
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react';
 import { version } from '../../package.json';
 import { ReleaseInfo } from '../types/sharedTypes';
+import { BASE_PATH } from '../utils/api';
 
 /**
  * Compare two semantic version strings
@@ -32,7 +33,7 @@ export const useVersionCheck = (owner: string, repo: string) => {
   useEffect(() => {
     const fetchInstallMode = async () => {
       try {
-        const response = await fetch('/health');
+        const response = await fetch(`${BASE_PATH}/health`);
         const data = await response.json();
         if (data.installMode === 'npm' || data.installMode === 'git') {
           setInstallMode(data.installMode);

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -9,7 +9,7 @@ import './i18n/config.js'
 
 // Register service worker for PWA + Web Push support
 if ('serviceWorker' in navigator) {
-  navigator.serviceWorker.register('/sw.js').catch(err => {
+  navigator.serviceWorker.register(`${import.meta.env.BASE_URL}sw.js`).catch(err => {
     console.warn('Service worker registration failed:', err);
   });
 }

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -2,7 +2,6 @@ export {};
 
 declare global {
   interface Window {
-    __ROUTER_BASENAME__?: string;
     refreshProjects?: () => void | Promise<void>;
     openSettings?: (tab?: string) => void;
   }

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -2,6 +2,7 @@ export {};
 
 declare global {
   interface Window {
+    __ROUTER_BASENAME__?: string;
     refreshProjects?: () => void | Promise<void>;
     openSettings?: (tab?: string) => void;
   }

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -1,5 +1,16 @@
 import { IS_PLATFORM } from "../constants/config";
 
+// Derived from Vite's base config (which reads the BASE_PATH env var, defaulting to /)
+export const BASE_PATH = import.meta.env.BASE_URL.replace(/\/+$/, '');
+
+// Prefix relative URLs with the application base path
+const prefixUrl = (url) => {
+  if (typeof url === 'string' && url.startsWith('/')) {
+    return `${BASE_PATH}${url}`;
+  }
+  return url;
+};
+
 // Utility function for authenticated API calls
 export const authenticatedFetch = (url, options = {}) => {
   const token = localStorage.getItem('auth-token');
@@ -15,7 +26,7 @@ export const authenticatedFetch = (url, options = {}) => {
     defaultHeaders['Authorization'] = `Bearer ${token}`;
   }
 
-  return fetch(url, {
+  return fetch(prefixUrl(url), {
     ...options,
     headers: {
       ...defaultHeaders,
@@ -34,13 +45,13 @@ export const authenticatedFetch = (url, options = {}) => {
 export const api = {
   // Auth endpoints (no token required)
   auth: {
-    status: () => fetch('/api/auth/status'),
-    login: (username, password) => fetch('/api/auth/login', {
+    status: () => fetch(prefixUrl('/api/auth/status')),
+    login: (username, password) => fetch(prefixUrl('/api/auth/login'), {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ username, password }),
     }),
-    register: (username, password) => fetch('/api/auth/register', {
+    register: (username, password) => fetch(prefixUrl('/api/auth/register'), {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ username, password }),
@@ -97,7 +108,7 @@ export const api = {
     const token = localStorage.getItem('auth-token');
     const params = new URLSearchParams({ q: query, limit: String(limit) });
     if (token) params.set('token', token);
-    return `/api/search/conversations?${params.toString()}`;
+    return `${BASE_PATH}/api/search/conversations?${params.toString()}`;
   },
   createProject: (path) =>
     authenticatedFetch('/api/projects/create', {

--- a/vite.config.js
+++ b/vite.config.js
@@ -17,20 +17,30 @@ export default defineConfig(({ mode }) => {
   // TODO: Remove support for legacy PORT variables in all locations in a future major release, leaving only SERVER_PORT.
   const serverPort = env.SERVER_PORT || env.PORT || 3001
 
+  // Application base path — configurable via BASE_PATH env var, defaults to /
+  const basePath = (env.BASE_PATH || '/').replace(/\/+$/, '')
+  const base = `${basePath}/`
+
   return {
+    base,
     plugins: [react()],
     server: {
       host,
       port: parseInt(env.VITE_PORT) || 5173,
       proxy: {
-        '/api': `http://${proxyHost}:${serverPort}`,
-        '/ws': {
-          target: `ws://${proxyHost}:${serverPort}`,
-          ws: true
+        [`${basePath}/api`]: {
+          target: `http://${proxyHost}:${serverPort}`,
+          rewrite: (path) => path
         },
-        '/shell': {
+        [`${basePath}/ws`]: {
           target: `ws://${proxyHost}:${serverPort}`,
-          ws: true
+          ws: true,
+          rewrite: (path) => path
+        },
+        [`${basePath}/shell`]: {
+          target: `ws://${proxyHost}:${serverPort}`,
+          ws: true,
+          rewrite: (path) => path
         }
       }
     },


### PR DESCRIPTION
## Summary
- Add support for serving the application under a configurable sub-path prefix via the `BASE_PATH` environment variable (defaults to `/`)
- All routes (API, WebSocket, static assets), React Router basename, service worker, and PWA manifest resolve correctly under the configured prefix
- A root `/` → `BASE_PATH/` redirect is added automatically when a non-root base path is set

## Details
- **Backend**: Express routes, WebSocket pathname checks, static file serving, and SPA fallback are all scoped to `BASE_PATH`
- **Frontend**: `authenticatedFetch` auto-prefixes API calls; WebSocket URLs, logo assets, EventSource, and Router basename all derive from `import.meta.env.BASE_URL`
- **Service worker**: derives its base path at runtime from `self.location`
- **PWA manifest**: uses relative paths so icons and scope resolve correctly for any prefix
- **Vite config**: reads `BASE_PATH` from env, sets `base` and proxy rules accordingly

## Test plan
- [ ] Run `npm run dev` without `BASE_PATH` set — app should work at `http://localhost:5173/` (original behavior)
- [ ] Set `BASE_PATH=/cloudcli` in `.env`, restart dev server — app should work at `http://localhost:5173/cloudcli/`
- [ ] Verify API calls, WebSocket connections, shell terminal, file tree, and git panel all function under the prefix
- [ ] Run `npm start` and verify production mode serves correctly under the configured prefix
- [ ] Verify PWA install prompt and push notification icons load correctly


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * App now supports deployment under a configurable base path (BASE_PATH) to run from a sub‑directory behind a reverse proxy.

* **Chores**
  * Routing, static assets, service worker, WebSocket endpoints, API requests, and notifications now honor the configured base path.
  * PWA manifest and asset paths use relative paths for correct offline/install behavior.

* **Documentation**
  * .env example updated with optional BASE_PATH entry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->