### PR TITLE
feat: add --settings flag for custom Claude settings path

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -42,4 +42,8 @@ HOST=0.0.0.0
 VITE_CONTEXT_WINDOW=160000
 CONTEXT_WINDOW=160000
 
-
+# Optional: Path to a custom Claude settings JSON file.
+# Accepts the same structure as ~/.claude/settings.json
+# (allowedTools, disallowedTools, permissionMode, etc.).
+# CLI flag --settings <path> takes precedence over this variable.
+# CLAUDE_SETTINGS_PATH=/path/to/my-settings.json

--- a/server/claude-sdk.js
+++ b/server/claude-sdk.js
@@ -26,6 +26,7 @@ import {
 } from './services/notification-orchestrator.js';
 import { claudeAdapter } from './providers/claude/adapter.js';
 import { createNormalizedMessage } from './providers/types.js';
+import { CLAUDE_SETTINGS_PATH } from './constants/config.js';
 
 const activeSessions = new Map();
 const pendingToolApprovals = new Map();
@@ -139,11 +140,65 @@ function matchesToolPermission(entry, toolName, input) {
 }
 
 /**
- * Maps CLI options to SDK-compatible options format
+ * Loads and validates a custom Claude settings JSON file.
+ * Supports the same structure as ~/.claude/settings.json.
+ * Returns null (with a console warning) on any error so callers can fall back gracefully.
+ *
+ * @param {string} settingsPath - Absolute or relative path to the settings JSON file
+ * @returns {Promise<Object|null>} Parsed settings object, or null on failure
+ */
+async function loadCustomSettings(settingsPath) {
+  if (!settingsPath) return null;
+
+  // Resolve relative paths against cwd
+  const resolvedPath = path.isAbsolute(settingsPath)
+    ? settingsPath
+    : path.resolve(process.cwd(), settingsPath);
+
+  // Check the file exists and is accessible
+  try {
+    await fs.access(resolvedPath);
+  } catch {
+    console.warn(`[WARN] Custom settings file not found: ${resolvedPath}`);
+    return null;
+  }
+
+  // Read the file
+  let raw;
+  try {
+    raw = await fs.readFile(resolvedPath, 'utf8');
+  } catch (err) {
+    console.warn(`[WARN] Could not read custom settings file ${resolvedPath}: ${err.message}`);
+    return null;
+  }
+
+  // Parse as JSON
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    console.warn(`[WARN] Custom settings file is not valid JSON (${resolvedPath}): ${err.message}`);
+    return null;
+  }
+
+  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+    console.warn(`[WARN] Custom settings file must be a JSON object: ${resolvedPath}`);
+    return null;
+  }
+
+  console.log(`[INFO] Loaded custom Claude settings from ${resolvedPath}`);
+  return parsed;
+}
+
+/**
+ * Maps CLI options to SDK-compatible options format.
+ * When customSettings is provided, its values take precedence over the defaults
+ * derived from toolsSettings/permissionMode in options.
  * @param {Object} options - CLI options
+ * @param {Object|null} customSettings - Parsed custom settings JSON (optional)
  * @returns {Object} SDK-compatible options
  */
-function mapCliOptionsToSDK(options = {}) {
+function mapCliOptionsToSDK(options = {}, customSettings = null) {
   const { sessionId, cwd, toolsSettings, permissionMode } = options;
 
   const sdkOptions = {};
@@ -153,20 +208,31 @@ function mapCliOptionsToSDK(options = {}) {
     sdkOptions.cwd = cwd;
   }
 
-  // Map permission mode
-  if (permissionMode && permissionMode !== 'default') {
-    sdkOptions.permissionMode = permissionMode;
+  // Determine effective permission mode:
+  // custom settings file wins if it specifies one, then fall back to per-request option
+  const effectivePermissionMode = customSettings?.permissionMode || permissionMode;
+
+  if (effectivePermissionMode && effectivePermissionMode !== 'default') {
+    sdkOptions.permissionMode = effectivePermissionMode;
   }
 
-  // Map tool settings
-  const settings = toolsSettings || {
+  // Build effective tool settings by merging:
+  //   1. per-request toolsSettings (from UI/caller)
+  //   2. custom settings file (wins on overlap)
+  const baseSettings = toolsSettings || {
     allowedTools: [],
     disallowedTools: [],
     skipPermissions: false
   };
 
+  const settings = {
+    allowedTools: customSettings?.allowedTools ?? baseSettings.allowedTools ?? [],
+    disallowedTools: customSettings?.disallowedTools ?? baseSettings.disallowedTools ?? [],
+    skipPermissions: customSettings?.skipPermissions ?? baseSettings.skipPermissions ?? false,
+  };
+
   // Handle tool permissions
-  if (settings.skipPermissions && permissionMode !== 'plan') {
+  if (settings.skipPermissions && effectivePermissionMode !== 'plan') {
     // When skipping permissions, use bypassPermissions mode
     sdkOptions.permissionMode = 'bypassPermissions';
   }
@@ -174,7 +240,7 @@ function mapCliOptionsToSDK(options = {}) {
   let allowedTools = [...(settings.allowedTools || [])];
 
   // Add plan mode default tools
-  if (permissionMode === 'plan') {
+  if (effectivePermissionMode === 'plan') {
     const planModeTools = ['Read', 'Task', 'exit_plan_mode', 'TodoRead', 'TodoWrite', 'WebFetch', 'WebSearch'];
     for (const tool of planModeTools) {
       if (!allowedTools.includes(tool)) {
@@ -194,7 +260,7 @@ function mapCliOptionsToSDK(options = {}) {
 
   // Map model (default to sonnet)
   // Valid models: sonnet, opus, haiku, opusplan, sonnet[1m]
-  sdkOptions.model = options.model || CLAUDE_MODELS.DEFAULT;
+  sdkOptions.model = options.model || customSettings?.model || CLAUDE_MODELS.DEFAULT;
   // Model logged at query start below
 
   // Map system prompt configuration
@@ -481,8 +547,12 @@ async function queryClaudeSDK(command, options = {}, ws) {
   };
 
   try {
+    // Load custom settings file if configured (CLI flag > env var)
+    const settingsFilePath = options.settingsPath || CLAUDE_SETTINGS_PATH;
+    const customSettings = await loadCustomSettings(settingsFilePath);
+
     // Map CLI options to SDK format
-    const sdkOptions = mapCliOptionsToSDK(options);
+    const sdkOptions = mapCliOptionsToSDK(options, customSettings);
 
     // Load MCP configuration
     const mcpServers = await loadMcpConfig(options.cwd);

--- a/server/cli.js
+++ b/server/cli.js
@@ -114,6 +114,7 @@ function showStatus() {
     console.log(`       DATABASE_PATH: ${c.dim(process.env.DATABASE_PATH || '(using default location)')}`);
     console.log(`       CLAUDE_CLI_PATH: ${c.dim(process.env.CLAUDE_CLI_PATH || 'claude (default)')}`);
     console.log(`       CONTEXT_WINDOW: ${c.dim(process.env.CONTEXT_WINDOW || '160000 (default)')}`);
+    console.log(`       CLAUDE_SETTINGS_PATH: ${c.dim(process.env.CLAUDE_SETTINGS_PATH || '(not set, using defaults)')}`);
 
     // Claude projects folder
     const claudeProjectsPath = path.join(os.homedir(), '.claude', 'projects');
@@ -158,6 +159,8 @@ Commands:
 Options:
   -p, --port <port>           Set server port (default: 3001)
   --database-path <path>      Set custom database location
+  --settings <path>           Path to a custom Claude settings JSON file
+                              (same structure as ~/.claude/settings.json)
   -h, --help                  Show this help information
   -v, --version               Show version information
 
@@ -169,11 +172,12 @@ Examples:
   $ cloudcli status                 # Show configuration
 
 Environment Variables:
-  SERVER_PORT         Set server port (default: 3001)
-  PORT                Set server port (default: 3001) (LEGACY)
-  DATABASE_PATH       Set custom database location
-  CLAUDE_CLI_PATH     Set custom Claude CLI path
-  CONTEXT_WINDOW      Set context window size (default: 160000)
+  SERVER_PORT           Set server port (default: 3001)
+  PORT                  Set server port (default: 3001) (LEGACY)
+  DATABASE_PATH         Set custom database location
+  CLAUDE_CLI_PATH       Set custom Claude CLI path
+  CONTEXT_WINDOW        Set context window size (default: 160000)
+  CLAUDE_SETTINGS_PATH  Path to a custom Claude settings JSON file
 
 Documentation:
   ${packageJson.homepage || 'https://github.com/siteboon/claudecodeui'}
@@ -268,6 +272,10 @@ function parseArgs(args) {
             parsed.options.databasePath = args[++i];
         } else if (arg.startsWith('--database-path=')) {
             parsed.options.databasePath = arg.split('=')[1];
+        } else if (arg === '--settings') {
+            parsed.options.settingsPath = args[++i];
+        } else if (arg.startsWith('--settings=')) {
+            parsed.options.settingsPath = arg.split('=').slice(1).join('=');
         } else if (arg === '--help' || arg === '-h') {
             parsed.command = 'help';
         } else if (arg === '--version' || arg === '-v') {
@@ -293,6 +301,9 @@ async function main() {
     }
     if (options.databasePath) {
         process.env.DATABASE_PATH = options.databasePath;
+    }
+    if (options.settingsPath) {
+        process.env.CLAUDE_SETTINGS_PATH = options.settingsPath;
     }
 
     switch (command) {

--- a/server/constants/config.js
+++ b/server/constants/config.js
@@ -3,3 +3,10 @@
  * Indicates if the app is running in Platform mode (hosted) or OSS mode (self-hosted)
  */
 export const IS_PLATFORM = process.env.VITE_IS_PLATFORM === 'true';
+
+/**
+ * Optional path to a custom Claude settings JSON file.
+ * Mirrors the structure of ~/.claude/settings.json (allowedTools, disallowedTools, permissionMode, etc.).
+ * Set via CLAUDE_SETTINGS_PATH env var or the --settings CLI flag.
+ */
+export const CLAUDE_SETTINGS_PATH = process.env.CLAUDE_SETTINGS_PATH || null;


### PR DESCRIPTION
- Add --settings <path> CLI flag (--settings=path form also supported)
- Add CLAUDE_SETTINGS_PATH env var support
- Add loadCustomSettings() for reading/validating custom JSON settings
- Update mapCliOptionsToSDK() to merge custom settings over defaults
- Custom settings override: allowedTools, disallowedTools, skipPermissions, permissionMode, model
- Graceful error handling: missing file, invalid JSON, wrong type → warn + fallback
- Document in CLI help text and .env.example

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
- Added `--settings` CLI option to specify a custom Claude settings JSON file path
- Custom settings path is now displayed in the application's status output

**Documentation**
- Added documentation for the new `CLAUDE_SETTINGS_PATH` environment variable
- Updated help text to include the new `--settings` CLI flag option

<!-- end of auto-generated comment: release notes by coderabbit.ai -->