### PR TITLE
feat: add Opus [1M] model option to model selector

### DIFF
--- a/server/claude-sdk.js
+++ b/server/claude-sdk.js
@@ -193,7 +193,7 @@ function mapCliOptionsToSDK(options = {}) {
   sdkOptions.disallowedTools = settings.disallowedTools || [];
 
   // Map model (default to sonnet)
-  // Valid models: sonnet, opus, haiku, opusplan, sonnet[1m]
+  // Valid models: sonnet, opus, haiku, opusplan, sonnet[1m], opus[1m]
   sdkOptions.model = options.model || CLAUDE_MODELS.DEFAULT;
   // Model logged at query start below
 

--- a/server/routes/agent.js
+++ b/server/routes/agent.js
@@ -643,7 +643,7 @@ class ResponseCollector {
  *
  * @param {string} model - (Optional) Model identifier for providers.
  *
- *                        Claude models: 'sonnet' (default), 'opus', 'haiku', 'opusplan', 'sonnet[1m]'
+ *                        Claude models: 'sonnet' (default), 'opus', 'haiku', 'opusplan', 'sonnet[1m]', 'opus[1m]'
  *                        Cursor models: 'gpt-5' (default), 'gpt-5.2', 'gpt-5.2-high', 'sonnet-4.5', 'opus-4.5',
  *                                       'gemini-3-pro', 'composer-1', 'auto', 'gpt-5.1', 'gpt-5.1-high',
  *                                       'gpt-5.1-codex', 'gpt-5.1-codex-high', 'gpt-5.1-codex-max',

--- a/shared/modelConstants.js
+++ b/shared/modelConstants.js
@@ -18,6 +18,7 @@ export const CLAUDE_MODELS = {
     { value: "haiku", label: "Haiku" },
     { value: "opusplan", label: "Opus Plan" },
     { value: "sonnet[1m]", label: "Sonnet [1M]" },
+    { value: "opus[1m]", label: "Opus [1M]" },
   ],
 
   DEFAULT: "sonnet",


### PR DESCRIPTION
## Summary

- Adds `opus[1m]` to `CLAUDE_MODELS.OPTIONS` in `shared/modelConstants.js`, alongside the existing `sonnet[1m]` entry
- Allows users to select the Opus model with 1M context window from the UI model picker

Closes #579

## Test plan

- [ ] Verify `Opus [1M]` appears in the model selector dropdown
- [ ] Verify selecting `Opus [1M]` correctly passes `opus[1m]` to the Claude SDK
- [ ] Verify existing model options still work as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Claude Opus [1M] as a selectable model option in the model selection interface.

* **Documentation**
  * Updated model-listing documentation and API docs to include the new Opus [1M] model option.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->