### PR TITLE
fix: preserve Shell tab scroll position across periodic refresh

### DIFF
--- a/src/components/shell/view/Shell.tsx
+++ b/src/components/shell/view/Shell.tsx
@@ -160,7 +160,11 @@ export default function Shell({
     }
 
     const focusTerminal = () => {
-      terminalRef.current?.focus();
+      const term = terminalRef.current;
+      if (!term) return;
+      const savedViewport = term.buffer.active.viewportY;
+      term.focus();
+      term.scrollToLine(savedViewport);
     };
 
     const animationFrameId = window.requestAnimationFrame(focusTerminal);

--- a/src/components/shell/view/Shell.tsx
+++ b/src/components/shell/view/Shell.tsx
@@ -165,7 +165,11 @@ export default function Shell({
     }
 
     const focusTerminal = () => {
-      terminalRef.current?.focus();
+      const term = terminalRef.current;
+      if (!term) return;
+      const savedViewport = term.buffer.active.viewportY;
+      term.focus();
+      term.scrollToLine(savedViewport);
     };
 
     const animationFrameId = window.requestAnimationFrame(focusTerminal);


### PR DESCRIPTION
## Summary

- Preserve the Shell terminal viewport when the existing focus callback runs.
- Keep focus scheduling, connection handling, refresh behavior, and auto-connect unchanged.
- Move the downstream HolyClaude #35 vendored-bundle patch into source.

## Context

CoderLuii/HolyClaude#35 reported the Shell tab losing scroll position during the periodic browser refresh in the HolyClaude full image on Linux. The downstream reproduction was: open HolyClaude, go to the Shell tab, scroll inside a long shell session, wait for the periodic refresh, and the viewport jumps away from the line being read.

HolyClaude v1.2.1 fixed that downstream by patching the vendored CloudCLI bundle to preserve `buffer.active.viewportY` around the Shell `focus()` call. Current CloudCLI source still focuses the terminal without preserving the viewport, so this PR applies the same behavior in `src/components/shell/view/Shell.tsx`.

## Testing

- `git diff --check`
- `npm ci` completed; npm audit reported 39 existing advisories
- `npm run typecheck`
- `npm run build` passed with existing Browserslist/CSS/chunk-size warnings
- `npm run lint` passed with 0 errors and existing repo-wide warnings
- Built app smoke: login completed with a disposable local account, a test project opened, and the Shell tab mounted with xterm focused