### PR TITLE
Fix corrupted binary downloads from the Files tab

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -812,7 +812,7 @@ app.get('/api/projects/:projectName/file', authenticateToken, async (req, res) =
     }
 });
 
-// Serve binary file content endpoint (for images, etc.)
+// Serve raw file bytes for previews and downloads.
 app.get('/api/projects/:projectName/files/content', authenticateToken, async (req, res) => {
     try {
         const { projectName } = req.params;
@@ -829,7 +829,11 @@ app.get('/api/projects/:projectName/files/content', authenticateToken, async (re
             return res.status(404).json({ error: 'Project not found' });
         }
 
-        const resolved = path.resolve(filePath);
+        // Match the text reader endpoint so callers can pass either project-relative
+        // or absolute paths without changing how the bytes are served.
+        const resolved = path.isAbsolute(filePath)
+            ? path.resolve(filePath)
+            : path.resolve(projectRoot, filePath);
         const normalizedRoot = path.resolve(projectRoot) + path.sep;
         if (!resolved.startsWith(normalizedRoot)) {
             return res.status(403).json({ error: 'Path must be under project root' });

--- a/src/components/file-tree/hooks/useFileTreeOperations.ts
+++ b/src/components/file-tree/hooks/useFileTreeOperations.ts
@@ -248,6 +248,20 @@ export function useFileTreeOperations({
     showToast(t('fileTree.toast.pathCopied', 'Path copied to clipboard'), 'success');
   }, [showToast, t]);
 
+  const triggerBrowserDownload = useCallback((blob: Blob, fileName: string) => {
+    const url = URL.createObjectURL(blob);
+    const anchor = document.createElement('a');
+
+    anchor.href = url;
+    anchor.download = fileName;
+
+    document.body.appendChild(anchor);
+    anchor.click();
+    document.body.removeChild(anchor);
+
+    URL.revokeObjectURL(url);
+  }, []);
+
   // Download file or folder
   const handleDownload = useCallback(async (item: FileTreeNode) => {
     if (!selectedProject) return;
@@ -272,28 +286,16 @@ export function useFileTreeOperations({
   const downloadSingleFile = useCallback(async (item: FileTreeNode) => {
     if (!selectedProject) return;
 
-    const response = await api.readFile(selectedProject.name, item.path);
+    // Use the binary streaming endpoint so downloads preserve raw bytes.
+    const response = await api.readFileBlob(selectedProject.name, item.path);
 
     if (!response.ok) {
       throw new Error('Failed to download file');
     }
 
-    const data = await response.json();
-    const content = data.content;
-
-    const blob = new Blob([content], { type: 'text/plain' });
-    const url = URL.createObjectURL(blob);
-    const anchor = document.createElement('a');
-
-    anchor.href = url;
-    anchor.download = item.name;
-
-    document.body.appendChild(anchor);
-    anchor.click();
-    document.body.removeChild(anchor);
-
-    URL.revokeObjectURL(url);
-  }, [selectedProject]);
+    const blob = await response.blob();
+    triggerBrowserDownload(blob, item.name);
+  }, [selectedProject, triggerBrowserDownload]);
 
   // Download folder as ZIP
   const downloadFolderAsZip = useCallback(async (folder: FileTreeNode) => {
@@ -306,12 +308,14 @@ export function useFileTreeOperations({
       const fullPath = currentPath ? `${currentPath}/${node.name}` : node.name;
 
       if (node.type === 'file') {
-        // Fetch file content
-        const response = await api.readFile(selectedProject.name, node.path);
-        if (response.ok) {
-          const data = await response.json();
-          zip.file(fullPath, data.content);
+        const response = await api.readFileBlob(selectedProject.name, node.path);
+        if (!response.ok) {
+          throw new Error(`Failed to download "${node.name}" for ZIP export`);
         }
+
+        // Store raw bytes in the archive so binary files stay intact.
+        const fileBytes = await response.arrayBuffer();
+        zip.file(fullPath, fileBytes);
       } else if (node.type === 'directory' && node.children) {
         // Recursively process children
         for (const child of node.children) {
@@ -329,20 +333,10 @@ export function useFileTreeOperations({
 
     // Generate ZIP file
     const zipBlob = await zip.generateAsync({ type: 'blob' });
-    const url = URL.createObjectURL(zipBlob);
-    const anchor = document.createElement('a');
-
-    anchor.href = url;
-    anchor.download = `${folder.name}.zip`;
-
-    document.body.appendChild(anchor);
-    anchor.click();
-    document.body.removeChild(anchor);
-
-    URL.revokeObjectURL(url);
+    triggerBrowserDownload(zipBlob, `${folder.name}.zip`);
 
     showToast(t('fileTree.toast.folderDownloaded', 'Folder downloaded as ZIP'), 'success');
-  }, [selectedProject, showToast, t]);
+  }, [selectedProject, showToast, t, triggerBrowserDownload]);
 
   return {
     // Rename operations

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -111,6 +111,8 @@ export const api = {
     }),
   readFile: (projectName, filePath) =>
     authenticatedFetch(`/api/projects/${projectName}/file?filePath=${encodeURIComponent(filePath)}`),
+  readFileBlob: (projectName, filePath) =>
+    authenticatedFetch(`/api/projects/${projectName}/files/content?path=${encodeURIComponent(filePath)}`),
   saveFile: (projectName, filePath, content) =>
     authenticatedFetch(`/api/projects/${projectName}/file`, {
       method: 'PUT',


### PR DESCRIPTION
## Summary

This PR fixes a download corruption issue in the Files tab.

The root cause was that file downloads were going through the text reader path instead of the raw file content path. That meant binary files were being read as UTF-8 text, serialized into JSON, and then reconstructed in the browser as `text/plain`. That process changes the original byte stream and corrupts any non-text file format.

The issue was most visible with PDFs, but it also affected any binary asset downloaded directly from the Files tab. Folder ZIP exports had the same underlying problem because each file was being fetched through the same text-based flow before being added to the archive.

## Why this change is needed

The app already has two distinct file access patterns:

- `readFile` for loading editable text content into the editor
- `files/content` for serving raw bytes for previews and downloads

The bug came from using the text-oriented path for a download use case.

That distinction matters because text loading is expected to decode bytes into a string. Downloads must not do that. A download path needs to preserve the file exactly as it exists on disk.

Without this fix, the Files tab was effectively transforming binary data before download. The resulting file name looked correct, but the file contents were no longer valid.

## What changed

### Client-side download flow

In `src/utils/api.js`, this PR adds a dedicated `readFileBlob` helper for accessing the raw file content endpoint.

In `src/components/file-tree/hooks/useFileTreeOperations.ts`:

- Single-file downloads now use the raw file endpoint and download the returned `Blob` directly.
- Folder ZIP downloads now fetch each file as raw bytes (`ArrayBuffer`) and add those bytes to the ZIP archive.
- The browser download logic was consolidated into a small helper so both single-file and ZIP downloads use the same behavior.

### Server-side path handling

In `server/index.js`, the raw content endpoint was updated to resolve paths the same way as the text reader endpoint.

This keeps behavior consistent for both absolute and project-relative file paths, which reduces surprises between file preview and file download code paths.

## Resulting behavior

After this change:

- Binary files downloaded from the Files tab remain intact.
- PDFs downloaded from the UI open correctly instead of appearing corrupted.
- Folder ZIP downloads preserve binary files correctly as well.
- Text editing behavior remains unchanged because the text reader endpoint is still used where text decoding is actually required.

## Notes
This change is intentionally narrow. It does not alter how text files are loaded for editing. It only corrects the download/export path so raw file bytes are preserved end-to-end.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed file path resolution to correctly handle both absolute and relative file paths.

* **New Features**
  * Enhanced file and folder downloads to use binary data for improved reliability.
  * Added robust download functionality with better error handling for export operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->