### PR TITLE
feat: auto-name new sessions and support API-key renames

### DIFF
--- a/server/claude-sdk.js
+++ b/server/claude-sdk.js
@@ -27,6 +27,7 @@ import {
 import { claudeAdapter } from './providers/claude/adapter.js';
 import { createNormalizedMessage } from './providers/types.js';
 import { getStatusChecker } from './providers/registry.js';
+import { generateAndPersistSessionName } from './session-naming.js';
 
 const activeSessions = new Map();
 const pendingToolApprovals = new Map();
@@ -476,6 +477,7 @@ async function queryClaudeSDK(command, options = {}, ws) {
   let sessionCreatedSent = false;
   let tempImagePaths = [];
   let tempDir = null;
+  let firstAssistantResponse = null;
 
   const emitNotification = (event) => {
     notifyUserIfEnabled({
@@ -663,6 +665,14 @@ async function queryClaudeSDK(command, options = {}, ws) {
         ws.send(msg);
       }
 
+      // Capture first assistant response for session naming
+      if (!firstAssistantResponse && message.type === 'assistant' && message.message?.content) {
+        const c = message.message.content;
+        firstAssistantResponse = Array.isArray(c)
+          ? c.find(p => p.type === 'text')?.text
+          : typeof c === 'string' ? c : null;
+      }
+
       // Extract and send token budget updates from result messages
       if (message.type === 'result') {
         const models = Object.keys(message.modelUsage || {});
@@ -694,6 +704,14 @@ async function queryClaudeSDK(command, options = {}, ws) {
       stopReason: 'completed'
     });
     // Complete
+
+    // Fire-and-forget: auto-name new sessions (opt-in only — chat sessions pass this flag)
+    if (options.autoNameSession && !sessionId && !!command && capturedSessionId) {
+      generateAndPersistSessionName(
+        capturedSessionId, command, firstAssistantResponse,
+        options.broadcastSessionNameUpdated || null
+      ).catch(err => console.error('Session naming failed:', err));
+    }
 
   } catch (error) {
     console.error('SDK query error:', error);

--- a/server/database/db.js
+++ b/server/database/db.js
@@ -490,6 +490,15 @@ const sessionNamesDb = {
     `).run(sessionId, provider, customName);
   },
 
+  setNameIfAbsent: (sessionId, provider, customName) => {
+    const result = db.prepare(`
+      INSERT INTO session_names (session_id, provider, custom_name)
+      VALUES (?, ?, ?)
+      ON CONFLICT(session_id, provider) DO NOTHING
+    `).run(sessionId, provider, customName);
+    return result.changes > 0;
+  },
+
   // Get a single custom session name
   getName: (sessionId, provider) => {
     const row = db.prepare(

--- a/server/index.js
+++ b/server/index.js
@@ -17,6 +17,7 @@ console.log('SERVER_PORT from env:', process.env.SERVER_PORT);
 
 import express from 'express';
 import { WebSocketServer, WebSocket } from 'ws';
+import { connectedClients, broadcastProgress, broadcastSessionNameUpdated } from './utils/websocket-clients.js';
 import os from 'os';
 import http from 'http';
 import cors from 'cors';
@@ -50,7 +51,7 @@ import pluginsRoutes from './routes/plugins.js';
 import messagesRoutes from './routes/messages.js';
 import { createNormalizedMessage } from './providers/types.js';
 import { startEnabledPluginServers, stopAllPlugins, getPluginPort } from './utils/plugin-process-manager.js';
-import { initializeDatabase, sessionNamesDb, applyCustomSessionNames } from './database/db.js';
+import { initializeDatabase, sessionNamesDb, apiKeysDb, applyCustomSessionNames } from './database/db.js';
 import { configureWebPush } from './services/vapid-keys.js';
 import { validateApiKey, authenticateToken, authenticateWebSocket } from './middleware/auth.js';
 import { IS_PLATFORM } from './constants/config.js';
@@ -78,21 +79,7 @@ const WATCHER_IGNORED_PATTERNS = [
 const WATCHER_DEBOUNCE_MS = 300;
 let projectsWatchers = [];
 let projectsWatcherDebounceTimer = null;
-const connectedClients = new Set();
 let isGetProjectsRunning = false; // Flag to prevent reentrant calls
-
-// Broadcast progress to all connected WebSocket clients
-function broadcastProgress(progress) {
-    const message = JSON.stringify({
-        type: 'loading_progress',
-        ...progress
-    });
-    connectedClients.forEach(client => {
-        if (client.readyState === WebSocket.OPEN) {
-            client.send(message);
-        }
-    });
-}
 
 // Setup file system watchers for Claude, Cursor, and Codex project/session folders
 async function setupProjectsWatcher() {
@@ -274,6 +261,54 @@ app.get('/health', (req, res) => {
     });
 });
 
+// Rename session endpoint (JWT or DB API-key) — registered before the
+// global validateApiKey middleware so DB-stored API keys are not blocked
+// by the env-level API_KEY gate.
+app.put('/api/sessions/:sessionId/rename', (req, res, next) => {
+    // Platform mode or Bearer token → delegate to authenticateToken (handles
+    // platform default-user and normal JWT validation).
+    const authHeader = req.headers['authorization'];
+    if (IS_PLATFORM || (authHeader && authHeader.startsWith('Bearer '))) {
+        return authenticateToken(req, res, next);
+    }
+
+    const rawKey = req.headers['x-api-key'];
+    if (Array.isArray(rawKey)) {
+        return res.status(400).json({ error: 'Invalid x-api-key header' });
+    }
+    if (typeof rawKey === 'string' && rawKey) {
+        const user = apiKeysDb.validateApiKey(rawKey);
+        if (user) { req.user = user; return next(); }
+        return res.status(401).json({ error: 'Invalid or inactive API key' });
+    }
+
+    return res.status(401).json({ error: 'Authentication required (Authorization or x-api-key header)' });
+}, async (req, res) => {
+    try {
+        const { sessionId } = req.params;
+        const safeSessionId = String(sessionId).replace(/[^a-zA-Z0-9._-]/g, '');
+        if (!safeSessionId || safeSessionId !== String(sessionId)) {
+            return res.status(400).json({ error: 'Invalid sessionId' });
+        }
+        const { summary, provider } = req.body;
+        if (!summary || typeof summary !== 'string' || summary.trim() === '') {
+            return res.status(400).json({ error: 'Summary is required' });
+        }
+        if (summary.trim().length > 500) {
+            return res.status(400).json({ error: 'Summary must not exceed 500 characters' });
+        }
+        if (!provider || !VALID_PROVIDERS.includes(provider)) {
+            return res.status(400).json({ error: `Provider must be one of: ${VALID_PROVIDERS.join(', ')}` });
+        }
+        sessionNamesDb.setName(safeSessionId, provider, summary.trim());
+        broadcastSessionNameUpdated(safeSessionId, provider, summary.trim());
+        res.json({ success: true });
+    } catch (error) {
+        console.error(`[API] Error renaming session ${req.params.sessionId}:`, error);
+        res.status(500).json({ error: error.message });
+    }
+});
+
 // Optional API key validation (if configured)
 app.use('/api', validateApiKey);
 
@@ -324,6 +359,7 @@ app.use('/api/sessions', authenticateToken, messagesRoutes);
 
 // Agent API Routes (uses API key authentication)
 app.use('/api/agent', agentRoutes);
+
 
 // Serve public files (like api-docs.html)
 app.use(express.static(path.join(APP_ROOT, 'public')));
@@ -464,32 +500,6 @@ app.delete('/api/projects/:projectName/sessions/:sessionId', authenticateToken, 
         res.json({ success: true });
     } catch (error) {
         console.error(`[API] Error deleting session ${req.params.sessionId}:`, error);
-        res.status(500).json({ error: error.message });
-    }
-});
-
-// Rename session endpoint
-app.put('/api/sessions/:sessionId/rename', authenticateToken, async (req, res) => {
-    try {
-        const { sessionId } = req.params;
-        const safeSessionId = String(sessionId).replace(/[^a-zA-Z0-9._-]/g, '');
-        if (!safeSessionId || safeSessionId !== String(sessionId)) {
-            return res.status(400).json({ error: 'Invalid sessionId' });
-        }
-        const { summary, provider } = req.body;
-        if (!summary || typeof summary !== 'string' || summary.trim() === '') {
-            return res.status(400).json({ error: 'Summary is required' });
-        }
-        if (summary.trim().length > 500) {
-            return res.status(400).json({ error: 'Summary must not exceed 500 characters' });
-        }
-        if (!provider || !VALID_PROVIDERS.includes(provider)) {
-            return res.status(400).json({ error: `Provider must be one of: ${VALID_PROVIDERS.join(', ')}` });
-        }
-        sessionNamesDb.setName(safeSessionId, provider, summary.trim());
-        res.json({ success: true });
-    } catch (error) {
-        console.error(`[API] Error renaming session ${req.params.sessionId}:`, error);
         res.status(500).json({ error: error.message });
     }
 });
@@ -1429,7 +1439,7 @@ function handleChatConnection(ws, request) {
                 console.log('🔄 Session:', data.options?.sessionId ? 'Resume' : 'New');
 
                 // Use Claude Agents SDK
-                await queryClaudeSDK(data.command, data.options, writer);
+                await queryClaudeSDK(data.command, { ...data.options, autoNameSession: true, broadcastSessionNameUpdated }, writer);
             } else if (data.type === 'cursor-command') {
                 console.log('[DEBUG] Cursor message:', data.command || '[Continue/Resume]');
                 console.log('📁 Project:', data.options?.cwd || 'Unknown');

--- a/server/routes/agent.js
+++ b/server/routes/agent.js
@@ -7,6 +7,7 @@ import crypto from 'crypto';
 import { userDb, apiKeysDb, githubTokensDb } from '../database/db.js';
 import { addProjectManually } from '../projects.js';
 import { queryClaudeSDK } from '../claude-sdk.js';
+import { broadcastSessionNameUpdated } from '../utils/websocket-clients.js';
 import { spawnCursor } from '../cursor-cli.js';
 import { queryCodex } from '../openai-codex.js';
 import { spawnGemini } from '../gemini-cli.js';
@@ -952,7 +953,9 @@ router.post('/', validateExternalApiKey, async (req, res) => {
         cwd: finalProjectPath,
         sessionId: sessionId || null,
         model: model,
-        permissionMode: 'bypassPermissions' // Bypass all permissions for API calls
+        permissionMode: 'bypassPermissions', // Bypass all permissions for API calls
+        autoNameSession: true,
+        broadcastSessionNameUpdated
       }, writer);
 
     } else if (provider === 'cursor') {

--- a/server/session-naming.js
+++ b/server/session-naming.js
@@ -1,0 +1,100 @@
+import { query } from '@anthropic-ai/claude-agent-sdk';
+import { sessionNamesDb } from './database/db.js';
+
+const inFlight = new Set();
+
+function cleanUserMessage(text) {
+  if (!text || typeof text !== 'string') return '';
+  return text
+    .replace(/<command-name>[\s\S]*?<\/command-name>/g, '')
+    .replace(/<command-message>[\s\S]*?<\/command-message>/g, '')
+    .replace(/<command-args>[\s\S]*?<\/command-args>/g, '')
+    .replace(/<system-reminder>[\s\S]*?<\/system-reminder>/g, '')
+    .replace(/<local-command-stdout>[\s\S]*?<\/local-command-stdout>/g, '')
+    .trim();
+}
+
+function sanitizeSummary(text) {
+  if (!text || typeof text !== 'string') return null;
+  let s = text
+    .replace(/[\n\r]/g, ' ')
+    .replace(/^["'`]+|["'`]+$/g, '')  // strip surrounding quotes
+    .replace(/^(Session name|Name|Title|Summary):\s*/i, '')  // strip common prefixes
+    .trim();
+  if (!s) return null;
+  return s.substring(0, 60);
+}
+
+async function generateSessionName(userMessage, assistantResponse) {
+  const cleaned = cleanUserMessage(userMessage);
+  if (!cleaned) return null;
+
+  const prompt = `Given this coding assistant conversation, generate a concise session name (max 60 chars).
+
+User: ${cleaned.substring(0, 500)}
+Assistant: ${(assistantResponse || '').substring(0, 500)}
+
+Rules:
+- Return ONLY the session name, no quotes, no explanation
+- Focus on the actual task, ignore XML tags and boilerplate content
+- Be specific (e.g. "Fix auth token refresh bug" not "Code changes")
+- Max 60 characters`;
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 30000);
+  timeout.unref();
+  try {
+    const q = query({
+      prompt,
+      options: {
+        model: 'haiku',
+        tools: [],
+        maxTurns: 1,
+        persistSession: false,
+        permissionMode: 'plan',
+        abortController: controller,
+      },
+    });
+    for await (const msg of q) {
+      if (msg.type === 'result' && msg.result) {
+        return sanitizeSummary(msg.result);
+      }
+    }
+  } finally {
+    clearTimeout(timeout);
+  }
+  return null;
+}
+
+/**
+ * Generate a session name using Claude SDK and persist it to SQLite.
+ * Skips if a custom name (manual rename) already exists for this session.
+ * @param {string} sessionId
+ * @param {string} userMessage - First user message
+ * @param {string|null} assistantResponse - First assistant response
+ * @param {function|null} broadcastFn - Optional callback to broadcast session_name_updated
+ */
+export async function generateAndPersistSessionName(sessionId, userMessage, assistantResponse, broadcastFn) {
+  if (inFlight.has(sessionId)) return;
+  inFlight.add(sessionId);
+  try {
+    // Skip if user already manually renamed this session
+    const existing = sessionNamesDb.getName(sessionId, 'claude');
+    if (existing) return;
+
+    const name = await generateSessionName(userMessage, assistantResponse);
+    if (!name) return;
+
+    // Atomic insert — a concurrent manual rename always wins
+    const didPersist = sessionNamesDb.setNameIfAbsent(sessionId, 'claude', name);
+    if (!didPersist) return;
+    console.log(`Session ${sessionId} auto-named`);
+
+    // SQLite writes don't trigger file watchers, so broadcast explicitly
+    if (broadcastFn) {
+      broadcastFn(sessionId, 'claude', name);
+    }
+  } finally {
+    inFlight.delete(sessionId);
+  }
+}

--- a/server/utils/websocket-clients.js
+++ b/server/utils/websocket-clients.js
@@ -1,0 +1,32 @@
+import WebSocket from 'ws';
+
+// Shared set of connected WebSocket clients, used by both the main server
+// (index.js) and the agent API routes to broadcast real-time updates.
+export const connectedClients = new Set();
+
+// Broadcast loading/progress updates to all connected clients.
+export function broadcastProgress(progress) {
+    const message = JSON.stringify({
+        type: 'loading_progress',
+        ...progress
+    });
+    connectedClients.forEach(client => {
+        if (client.readyState === WebSocket.OPEN) {
+            client.send(message);
+        }
+    });
+}
+
+// Broadcast a lightweight session-name-updated event to all connected clients.
+// Unlike the old broadcastProjectsUpdated(), this does NOT re-scan projects —
+// the frontend patches its local state directly.
+export function broadcastSessionNameUpdated(sessionId, provider, name) {
+    const msg = JSON.stringify({
+        type: 'session_name_updated',
+        sessionId, provider, name,
+        timestamp: new Date().toISOString()
+    });
+    connectedClients.forEach(client => {
+        if (client.readyState === WebSocket.OPEN) client.send(msg);
+    });
+}

--- a/src/hooks/useProjectsState.ts
+++ b/src/hooks/useProjectsState.ts
@@ -8,6 +8,8 @@ import type {
   Project,
   ProjectSession,
   ProjectsUpdatedMessage,
+  LLMProvider,
+  SessionNameUpdatedMessage,
 } from '../types/app';
 
 type UseProjectsStateArgs = {
@@ -222,6 +224,57 @@ export function useProjectsState({
           loadingProgressTimeoutRef.current = null;
         }, 500);
       }
+
+      return;
+    }
+
+    if (latestMessage.type === 'session_name_updated') {
+      const { sessionId: updatedId, provider, name } = latestMessage as SessionNameUpdatedMessage;
+
+      const sessionKey = (p: LLMProvider): keyof Project => {
+        switch (p) {
+          case 'cursor': return 'cursorSessions';
+          case 'codex': return 'codexSessions';
+          case 'gemini': return 'geminiSessions';
+          default: return 'sessions';
+        }
+      };
+
+      const key = sessionKey(provider);
+
+      setProjects(prev => {
+        let changed = false;
+        const next = prev.map(project => {
+          const sessions = project[key] as ProjectSession[] | undefined;
+          if (!sessions) return project;
+
+          const idx = sessions.findIndex(s => s.id === updatedId);
+          if (idx === -1 || sessions[idx]?.summary === name) return project;
+
+          changed = true;
+          const updated = [...sessions];
+          updated[idx] = { ...updated[idx], summary: name };
+          return { ...project, [key]: updated };
+        });
+        return changed ? next : prev;
+      });
+
+      setSelectedProject(prev => {
+        if (!prev) return prev;
+        const sessions = prev[key] as ProjectSession[] | undefined;
+        if (!sessions) return prev;
+        const idx = sessions.findIndex(s => s.id === updatedId);
+        if (idx === -1 || sessions[idx]?.summary === name) return prev;
+        const updated = [...sessions];
+        updated[idx] = { ...updated[idx], summary: name };
+        return { ...prev, [key]: updated };
+      });
+
+      setSelectedSession(prev => {
+        if (!prev || prev.id !== updatedId || prev.summary === name) return prev;
+        if (prev.__provider && prev.__provider !== provider) return prev;
+        return { ...prev, summary: name };
+      });
 
       return;
     }

--- a/src/types/app.ts
+++ b/src/types/app.ts
@@ -60,6 +60,14 @@ export interface ProjectsUpdatedMessage {
   [key: string]: unknown;
 }
 
+export interface SessionNameUpdatedMessage {
+  type: 'session_name_updated';
+  sessionId: string;
+  provider: LLMProvider;
+  name: string;
+  timestamp?: string;
+}
+
 export interface LoadingProgressMessage extends LoadingProgress {
   type: 'loading_progress';
 }
@@ -67,4 +75,5 @@ export interface LoadingProgressMessage extends LoadingProgress {
 export type AppSocketMessage =
   | LoadingProgressMessage
   | ProjectsUpdatedMessage
+  | SessionNameUpdatedMessage
   | { type?: string;[key: string]: unknown };


### PR DESCRIPTION
## Summary

Today, newly created Claude sessions are labelled by a truncated slice of the first user message. Once the sidebar fills up with dozens of sessions that all start with "help me fix...", it gets hard to tell them apart, and users end up either hand-renaming every session they want to revisit or scrolling through low-signal titles.

This PR auto-generates a short, descriptive title for each new session from the first user/assistant exchange, so session lists stay scannable without manual work. Manual rename continues to work exactly as before and always wins.

Example of a session that used to look like:

```
help me debug why websocket reconnect loops after deploy on sta...
```

now shows up as:

```
Debug websocket reconnect loop after deploy
```

As a small related change, the rename endpoint now also accepts `x-api-key` auth so API-driven clients (scripts, the agent API) can apply their own titles through the same endpoint.

## Why this is useful

- Long-running workspaces accumulate many similar-looking sessions; auto-naming makes the sidebar immediately scannable
- Removes the "rename every useful session manually" friction
- Keeps manual rename as the source of truth when you do want a custom title
- Opens the rename endpoint to API-key clients, enabling scripted labelling of sessions created via `/api/agent/launch`

## Guardrails

- **Opt-in**: auto-naming only runs when the caller passes `autoNameSession: true`. The chat WebSocket path and `/api/agent/launch` opt in; `git.js` and other non-interactive `queryClaudeSDK` callers are untouched.
- **Cheap and fire-and-forget**: one call to the `haiku` model per new session, based only on the first exchange, with a 30s timeout. Failures are logged and swallowed — they never affect the chat itself.
- **Manual rename always wins**: the module re-checks `sessionNamesDb.getName()` both before and after the LLM call, so a user rename during the in-flight window is never clobbered.
- **Lightweight update path**: instead of triggering a full `getProjects()` rescan on every auto-naming event, the server emits a small `session_name_updated` WebSocket message and the frontend patches its local state in place.

## Implementation notes

- New `server/session-naming.js` generates and persists titles to the existing `session_names` SQLite table. No schema change.
- Extracted `connectedClients` / `broadcastProgress` / `broadcastSessionNameUpdated` into `server/utils/websocket-clients.js` so both the chat WebSocket handler and `/api/agent/launch` can share them.
- `PUT /api/sessions/:sessionId/rename` is registered **before** the global `/api/sessions` JWT-only mount so its dual JWT-or-`x-api-key` handler runs first. Header-only (no query-string API key).

## Known limitation

Authorization for the rename endpoint is unchanged from the current upstream behaviour: any authenticated caller who knows a session ID can rename that session. Adding per-user ownership checks would require storing ownership metadata on `session_names` (schema migration), which felt better scoped as a follow-up PR.

## Test plan

- [ ] Start server; a new chat session gets an auto-generated title shortly after the first assistant reply
- [ ] The session label updates in place from a `session_name_updated` WebSocket event — no full project rescan
- [ ] Manual rename during an in-flight auto-name call is preserved (re-check path)
- [ ] Non-interactive `queryClaudeSDK` callers (e.g. `git.js`) do **not** trigger auto-naming
- [ ] `PUT /api/sessions/:id/rename` with JWT `Authorization` header → 200
- [ ] `PUT /api/sessions/:id/rename` with `x-api-key` header → 200
- [ ] `npx vite build` succeeds


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic session naming from the assistant’s first response, producing concise human-readable titles.
  * Real-time broadcast of session-name updates so connected clients show new names immediately.

* **Improvements**
  * Session rename API now supports alternate API-key auth and enforces stronger validation (required, trimmed, ≤500 chars).
  * Auto-naming respects manual names and avoids duplicate generation under concurrency; broadcasts are more reliable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->