### PR TITLE
feat: add Opus [1M] model with correct 1M context window reporting

### DIFF
--- a/server/claude-sdk.js
+++ b/server/claude-sdk.js
@@ -279,7 +279,7 @@ function transformMessage(sdkMessage) {
  * @param {Object} resultMessage - SDK result message
  * @returns {Object|null} Token budget object or null
  */
-function extractTokenBudget(resultMessage) {
+function extractTokenBudget(resultMessage, selectedModel) {
   if (resultMessage.type !== 'result' || !resultMessage.modelUsage) {
     return null;
   }
@@ -302,9 +302,17 @@ function extractTokenBudget(resultMessage) {
   // Total used = input + output + cache tokens
   const totalUsed = inputTokens + outputTokens + cacheReadTokens + cacheCreationTokens;
 
-  // Use configured context window budget from environment (default 160000)
-  // This is the user's budget limit, not the model's context window
-  const contextWindow = parseInt(process.env.CONTEXT_WINDOW) || 160000;
+  // Determine context window: env override > model usage data > selected model > default
+  let contextWindow = parseInt(process.env.CONTEXT_WINDOW) || 0;
+  if (!contextWindow) {
+    if (modelData.contextWindow && modelData.contextWindow > 0) {
+      contextWindow = modelData.contextWindow;
+    } else if (selectedModel && selectedModel.toLowerCase().includes('1m')) {
+      contextWindow = 1000000;
+    } else {
+      contextWindow = 200000;
+    }
+  }
 
   // Token calc logged via token-budget WS event
 
@@ -664,7 +672,7 @@ async function queryClaudeSDK(command, options = {}, ws) {
         if (models.length > 0) {
           // Model info available in result message
         }
-        const tokenBudgetData = extractTokenBudget(message);
+        const tokenBudgetData = extractTokenBudget(message, sdkOptions.model);
         if (tokenBudgetData) {
           ws.send(createNormalizedMessage({ kind: 'status', text: 'token_budget', tokenBudget: tokenBudgetData, sessionId: capturedSessionId || sessionId || null, provider: 'claude' }));
         }

--- a/shared/modelConstants.js
+++ b/shared/modelConstants.js
@@ -18,6 +18,7 @@ export const CLAUDE_MODELS = {
     { value: "haiku", label: "Haiku" },
     { value: "opusplan", label: "Opus Plan" },
     { value: "sonnet[1m]", label: "Sonnet [1M]" },
+    { value: "opus[1m]", label: "Opus [1M]" },
   ],
 
   DEFAULT: "sonnet",

--- a/src/components/chat/hooks/useChatSessionState.ts
+++ b/src/components/chat/hooks/useChatSessionState.ts
@@ -548,13 +548,21 @@ export function useChatSessionState({
     const sessionProvider = selectedSession.__provider || 'claude';
     if (sessionProvider !== 'claude') return;
 
+    // Fetch initial token usage but don't overwrite a higher value from WebSocket
+    let cancelled = false;
     const fetchInitialTokenUsage = async () => {
       try {
         const url = `/api/projects/${selectedProject.name}/sessions/${selectedSession.id}/token-usage`;
         const response = await authenticatedFetch(url);
-        if (response.ok) {
-          setTokenBudget(await response.json());
-        } else {
+        if (response.ok && !cancelled) {
+          const data = await response.json();
+          setTokenBudget((prev: Record<string, unknown> | null) => {
+            if (prev && typeof prev.total === 'number' && prev.total > (data.total || 0)) {
+              return prev;
+            }
+            return data;
+          });
+        } else if (!cancelled) {
           setTokenBudget(null);
         }
       } catch (error) {
@@ -562,6 +570,7 @@ export function useChatSessionState({
       }
     };
     fetchInitialTokenUsage();
+    return () => { cancelled = true; };
   }, [selectedProject, selectedSession?.id, selectedSession?.__provider]);
 
   const visibleMessages = useMemo(() => {

--- a/src/components/chat/view/ChatInterface.tsx
+++ b/src/components/chat/view/ChatInterface.tsx
@@ -352,6 +352,7 @@ function ChatInterface({
           thinkingMode={thinkingMode}
           setThinkingMode={setThinkingMode}
           tokenBudget={tokenBudget}
+          selectedModel={claudeModel}
           slashCommandsCount={slashCommandsCount}
           onToggleCommandMenu={handleToggleCommandMenu}
           hasInput={Boolean(input.trim())}

--- a/src/components/chat/view/subcomponents/ChatComposer.tsx
+++ b/src/components/chat/view/subcomponents/ChatComposer.tsx
@@ -49,6 +49,7 @@ interface ChatComposerProps {
   thinkingMode: string;
   setThinkingMode: Dispatch<SetStateAction<string>>;
   tokenBudget: { used?: number; total?: number } | null;
+  selectedModel?: string;
   slashCommandsCount: number;
   onToggleCommandMenu: () => void;
   hasInput: boolean;
@@ -105,6 +106,7 @@ export default function ChatComposer({
   thinkingMode,
   setThinkingMode,
   tokenBudget,
+  selectedModel,
   slashCommandsCount,
   onToggleCommandMenu,
   hasInput,
@@ -192,6 +194,7 @@ export default function ChatComposer({
           thinkingMode={thinkingMode}
           setThinkingMode={setThinkingMode}
           tokenBudget={tokenBudget}
+          selectedModel={selectedModel}
           slashCommandsCount={slashCommandsCount}
           onToggleCommandMenu={onToggleCommandMenu}
           hasInput={hasInput}

--- a/src/components/chat/view/subcomponents/ChatInputControls.tsx
+++ b/src/components/chat/view/subcomponents/ChatInputControls.tsx
@@ -11,6 +11,7 @@ interface ChatInputControlsProps {
   thinkingMode: string;
   setThinkingMode: React.Dispatch<React.SetStateAction<string>>;
   tokenBudget: { used?: number; total?: number } | null;
+  selectedModel?: string;
   slashCommandsCount: number;
   onToggleCommandMenu: () => void;
   hasInput: boolean;
@@ -27,6 +28,7 @@ export default function ChatInputControls({
   thinkingMode,
   setThinkingMode,
   tokenBudget,
+  selectedModel,
   slashCommandsCount,
   onToggleCommandMenu,
   hasInput,
@@ -78,7 +80,7 @@ export default function ChatInputControls({
         <ThinkingModeSelector selectedMode={thinkingMode} onModeChange={setThinkingMode} onClose={() => {}} className="" />
       )}
 
-      <TokenUsagePie used={tokenBudget?.used || 0} total={tokenBudget?.total || parseInt(import.meta.env.VITE_CONTEXT_WINDOW) || 160000} />
+      <TokenUsagePie used={tokenBudget?.used || 0} total={tokenBudget?.total || (selectedModel && selectedModel.includes('1m') ? 1000000 : 200000)} />
 
       <button
         type="button"


### PR DESCRIPTION
## Summary

Closes #579

Adds `opus[1m]` to the Claude model picker and fixes context window reporting so 1M-context models display the correct token budget instead of showing 160K/200K.

## Problem

When using Opus with 1M context (`claude-opus-4-6[1m]`), the token usage pie chart incorrectly showed 160K or 200K as the total context window, making it appear 100% full even with plenty of room remaining.

## Root Cause

The fix required addressing four layers:

1. **Model list** — `opus[1m]` was missing from `CLAUDE_MODELS.OPTIONS`
2. **Server-side token budget** — `extractTokenBudget()` hardcoded `160000` instead of reading `contextWindow` from the SDK's `modelUsage` result (which already reports `1000000` for 1M models)
3. **Frontend fallback** — `TokenUsagePie` used `160000` as fallback before the first server response. Now checks the selected model name for `1m` suffix
4. **Frontend state race** — After the WebSocket correctly sets `total: 1000000`, the HTTP `token-usage` endpoint re-fires and overwrites it with `200000`. Fixed by preventing HTTP from overwriting a higher WebSocket value

## Changes

- `shared/modelConstants.js` — Add `opus[1m]` option
- `server/claude-sdk.js` — Read `contextWindow` from SDK result's `modelUsage` data; pass `selectedModel` for fallback detection
- `src/.../ChatInputControls.tsx` — Accept `selectedModel` prop, use model-aware context window fallback
- `src/.../ChatComposer.tsx` — Thread `selectedModel` prop
- `src/.../ChatInterface.tsx` — Pass `claudeModel` to composer
- `src/.../useChatSessionState.ts` — Prevent HTTP token-usage fetch from overwriting WebSocket value

## Testing

Tested with Claude Code CLI 2.1.92 + `@anthropic-ai/claude-agent-sdk` 0.2.104.

- New session with `opus[1m]` → pie shows 1,000,000 immediately ✓
- After Claude responds → pie stays at 1,000,000 (not reverted to 200K) ✓
- Sessions with `sonnet` → pie correctly shows 200,000 ✓
- Sessions with `sonnet[1m]` → pie correctly shows 1,000,000 ✓

## Note

The SDK (0.2.104) already reports `contextWindow: 1000000` in the `modelUsage` result for 1M models. This PR makes CloudCLI read that value instead of ignoring it. Users on older SDK versions may need to upgrade for the server-side detection to work; the frontend fallback handles the case where the SDK doesn't report `contextWindow`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Claude Opus [1M] model to available options, providing access to an expanded 1M token context window.

* **Improvements**
  * Enhanced token budget detection with intelligent model-aware fallback logic.
  * Improved token usage state management with cancellation tracking and state preservation across model selections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->