### PR TITLE
feat: group linked git worktrees under their main repo in sidebar

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -624,6 +624,12 @@ app.post('/api/projects/:projectName/worktrees', authenticateToken, async (req, 
         const safeSuffix = branch.replace(/[/\\]/g, '-');
         const worktreePath = path.join(path.dirname(mainRepoPath), `${repoName}-${safeSuffix}`);
 
+        // Validate the resolved path is inside the allowed workspace boundary
+        const workspaceValidation = await validateWorkspacePath(worktreePath);
+        if (!workspaceValidation.isValid) {
+            return res.status(400).json({ error: 'Worktree path is outside the allowed workspace area' });
+        }
+
         // Check if the worktree path already exists
         try {
             await fsPromises.access(worktreePath);
@@ -637,7 +643,6 @@ app.post('/api/projects/:projectName/worktrees', authenticateToken, async (req, 
         try {
             await new Promise((resolve, reject) => {
                 const check = spawn('git', ['rev-parse', '--verify', branch], { cwd: mainRepoPath });
-                check.on('error', reject);
                 check.on('close', code => code === 0 ? resolve() : reject());
             });
             branchExists = true;
@@ -652,7 +657,6 @@ app.post('/api/projects/:projectName/worktrees', authenticateToken, async (req, 
         await new Promise((resolve, reject) => {
             const proc = spawn('git', worktreeArgs, { cwd: mainRepoPath });
             let stderr = '';
-            proc.on('error', reject);
             proc.stderr.on('data', d => { stderr += d.toString(); });
             proc.on('close', code => {
                 if (code === 0) resolve();
@@ -666,7 +670,7 @@ app.post('/api/projects/:projectName/worktrees', authenticateToken, async (req, 
         res.json({ success: true, worktreePath, project });
     } catch (error) {
         console.error('Error creating worktree:', error);
-        res.status(500).json({ error: error.message });
+        res.status(500).json({ error: 'Failed to create worktree' });
     }
 });
 

--- a/server/index.js
+++ b/server/index.js
@@ -595,6 +595,79 @@ app.post('/api/projects/create', authenticateToken, async (req, res) => {
     }
 });
 
+// Create a new git worktree for a project and register it
+app.post('/api/projects/:projectName/worktrees', authenticateToken, async (req, res) => {
+    try {
+        const { projectName } = req.params;
+        const { branchName } = req.body;
+
+        if (!branchName || !branchName.trim()) {
+            return res.status(400).json({ error: 'branchName is required' });
+        }
+
+        // Validate branch name — only allow safe git branch characters
+        const safeBranchPattern = /^[a-zA-Z0-9._/\-]+$/;
+        if (!safeBranchPattern.test(branchName.trim())) {
+            return res.status(400).json({ error: 'Invalid branch name' });
+        }
+
+        const branch = branchName.trim();
+        const mainRepoPath = await extractProjectDirectory(projectName);
+
+        if (!mainRepoPath) {
+            return res.status(404).json({ error: 'Project not found' });
+        }
+
+        // Determine worktree path: sibling directory named <repo>-<branch>
+        // e.g. /home/user/myrepo + feature/foo → /home/user/myrepo-feature-foo
+        const repoName = path.basename(mainRepoPath);
+        const safeSuffix = branch.replace(/[/\\]/g, '-');
+        const worktreePath = path.join(path.dirname(mainRepoPath), `${repoName}-${safeSuffix}`);
+
+        // Check if the worktree path already exists
+        try {
+            await fsPromises.access(worktreePath);
+            return res.status(409).json({ error: `Path already exists: ${worktreePath}` });
+        } catch {
+            // Good — path does not exist
+        }
+
+        // Determine whether the branch already exists in the repo
+        let branchExists = false;
+        try {
+            await new Promise((resolve, reject) => {
+                const check = spawn('git', ['rev-parse', '--verify', branch], { cwd: mainRepoPath });
+                check.on('close', code => code === 0 ? resolve() : reject());
+            });
+            branchExists = true;
+        } catch {
+            branchExists = false;
+        }
+
+        const worktreeArgs = branchExists
+            ? ['worktree', 'add', worktreePath, branch]
+            : ['worktree', 'add', '-b', branch, worktreePath];
+
+        await new Promise((resolve, reject) => {
+            const proc = spawn('git', worktreeArgs, { cwd: mainRepoPath });
+            let stderr = '';
+            proc.stderr.on('data', d => { stderr += d.toString(); });
+            proc.on('close', code => {
+                if (code === 0) resolve();
+                else reject(new Error(stderr.trim() || `git worktree add exited with code ${code}`));
+            });
+        });
+
+        // Register the new worktree as a project so it appears in the sidebar
+        const project = await addProjectManually(worktreePath);
+
+        res.json({ success: true, worktreePath, project });
+    } catch (error) {
+        console.error('Error creating worktree:', error);
+        res.status(500).json({ error: error.message });
+    }
+});
+
 // Search conversations content (SSE streaming)
 app.get('/api/search/conversations', authenticateToken, async (req, res) => {
     const query = typeof req.query.q === 'string' ? req.query.q.trim() : '';

--- a/server/index.js
+++ b/server/index.js
@@ -637,6 +637,7 @@ app.post('/api/projects/:projectName/worktrees', authenticateToken, async (req, 
         try {
             await new Promise((resolve, reject) => {
                 const check = spawn('git', ['rev-parse', '--verify', branch], { cwd: mainRepoPath });
+                check.on('error', reject);
                 check.on('close', code => code === 0 ? resolve() : reject());
             });
             branchExists = true;
@@ -651,6 +652,7 @@ app.post('/api/projects/:projectName/worktrees', authenticateToken, async (req, 
         await new Promise((resolve, reject) => {
             const proc = spawn('git', worktreeArgs, { cwd: mainRepoPath });
             let stderr = '';
+            proc.on('error', reject);
             proc.stderr.on('data', d => { stderr += d.toString(); });
             proc.on('close', code => {
                 if (code === 0) resolve();

--- a/server/projects.js
+++ b/server/projects.js
@@ -65,8 +65,12 @@ import crypto from 'crypto';
 import sqlite3 from 'sqlite3';
 import { open } from 'sqlite';
 import os from 'os';
+import { execFile } from 'child_process';
+import { promisify } from 'util';
 import sessionManager from './sessionManager.js';
 import { applyCustomSessionNames } from './database/db.js';
+
+const execFileAsync = promisify(execFile);
 
 // Import TaskMaster detection functions
 async function detectTaskMasterFolder(projectPath) {
@@ -381,6 +385,52 @@ async function extractProjectDirectory(projectName) {
   }
 }
 
+/**
+ * Detect if a given path is a git linked worktree and return metadata.
+ * Uses `git worktree list --porcelain` which lists all worktrees from any
+ * worktree path (the first entry is always the main worktree).
+ *
+ * Returns null if not in a git repo or if the git command fails.
+ * Returns { isWorktree: false } for the main worktree.
+ * Returns { isWorktree: true, mainRepoPath, worktreeBranch } for linked worktrees.
+ */
+async function resolveWorktreeInfo(projectPath) {
+  try {
+    const { stdout } = await execFileAsync('git', ['-C', projectPath, 'worktree', 'list', '--porcelain']);
+    // Each worktree block is separated by a blank line
+    const blocks = stdout.trim().split(/\n\n+/);
+    const worktrees = blocks.map(block => {
+      const result = {};
+      for (const line of block.trim().split('\n')) {
+        if (line.startsWith('worktree ')) result.path = line.slice(9).trim();
+        else if (line.startsWith('branch ')) result.branch = line.slice(7).trim().replace('refs/heads/', '');
+        else if (line === 'detached') result.branch = 'HEAD (detached)';
+      }
+      return result;
+    }).filter(w => w.path);
+
+    if (worktrees.length === 0) return null;
+
+    const mainWorktree = worktrees[0];
+    const resolvedPath = path.resolve(projectPath);
+
+    if (path.resolve(mainWorktree.path) === resolvedPath) {
+      return { isWorktree: false };
+    }
+
+    const linked = worktrees.find(w => path.resolve(w.path) === resolvedPath);
+    if (!linked) return null;
+
+    return {
+      isWorktree: true,
+      mainRepoPath: mainWorktree.path,
+      worktreeBranch: linked.branch || 'HEAD (detached)',
+    };
+  } catch {
+    return null;
+  }
+}
+
 async function getProjects(progressCallback = null) {
   const claudeDir = path.join(os.homedir(), '.claude', 'projects');
   const config = await loadProjectConfig();
@@ -513,6 +563,18 @@ async function getProjects(progressCallback = null) {
         };
       }
 
+      // Detect git worktree membership
+      try {
+        const worktreeInfo = await resolveWorktreeInfo(actualProjectDir);
+        if (worktreeInfo) {
+          project.isWorktree = worktreeInfo.isWorktree;
+          project.mainRepoPath = worktreeInfo.mainRepoPath || null;
+          project.worktreeBranch = worktreeInfo.worktreeBranch || null;
+        }
+      } catch (e) {
+        // Non-fatal: worktree detection failure should not break project listing
+      }
+
       projects.push(project);
     }
   } catch (error) {
@@ -623,6 +685,18 @@ async function getProjects(progressCallback = null) {
           hasEssentialFiles: false,
           error: error.message
         };
+      }
+
+      // Detect git worktree membership for manual projects
+      try {
+        const worktreeInfo = await resolveWorktreeInfo(actualProjectDir);
+        if (worktreeInfo) {
+          project.isWorktree = worktreeInfo.isWorktree;
+          project.mainRepoPath = worktreeInfo.mainRepoPath || null;
+          project.worktreeBranch = worktreeInfo.worktreeBranch || null;
+        }
+      } catch (e) {
+        // Non-fatal
       }
 
       projects.push(project);

--- a/server/projects.js
+++ b/server/projects.js
@@ -423,7 +423,7 @@ async function resolveWorktreeInfo(projectPath) {
 
     return {
       isWorktree: true,
-      mainRepoPath: mainWorktree.path,
+      mainRepoPath: path.resolve(mainWorktree.path),
       worktreeBranch: linked.branch || 'HEAD (detached)',
     };
   } catch {

--- a/src/components/app/AppContent.tsx
+++ b/src/components/app/AppContent.tsx
@@ -27,6 +27,7 @@ export default function AppContent() {
   } = useSessionProtection();
 
   const {
+    projects,
     selectedProject,
     selectedSession,
     activeTab,
@@ -39,6 +40,7 @@ export default function AppContent() {
     setShowSettings,
     openSettings,
     refreshProjectsSilently,
+    handleProjectSelect,
     sidebarSharedProps,
   } = useProjectsState({
     sessionId,
@@ -159,8 +161,10 @@ export default function AppContent() {
 
       <div className="flex min-w-0 flex-1 flex-col">
         <MainContent
+          projects={projects}
           selectedProject={selectedProject}
           selectedSession={selectedSession}
+          onProjectSelect={handleProjectSelect}
           activeTab={activeTab}
           setActiveTab={setActiveTab}
           ws={ws}

--- a/src/components/chat/types/types.ts
+++ b/src/components/chat/types/types.ts
@@ -92,8 +92,10 @@ export interface Question {
 }
 
 export interface ChatInterfaceProps {
+  projects?: Project[];
   selectedProject: Project | null;
   selectedSession: ProjectSession | null;
+  onProjectSelect?: (project: Project) => void;
   ws: WebSocket | null;
   sendMessage: (message: unknown) => void;
   latestMessage: any;

--- a/src/components/chat/view/ChatInterface.tsx
+++ b/src/components/chat/view/ChatInterface.tsx
@@ -19,8 +19,10 @@ type PendingViewSession = {
 };
 
 function ChatInterface({
+  projects = [],
   selectedProject,
   selectedSession,
+  onProjectSelect,
   ws,
   sendMessage,
   latestMessage,
@@ -317,6 +319,8 @@ function ChatInterface({
           isTaskMasterInstalled={isTaskMasterInstalled}
           onShowAllTasks={onShowAllTasks}
           setInput={setInput}
+          linkedWorktrees={projects.filter(p => p.isWorktree && p.mainRepoPath === selectedProject.fullPath)}
+          onWorktreeSelect={onProjectSelect}
           isLoadingMoreMessages={isLoadingMoreMessages}
           hasMoreMessages={hasMoreMessages}
           totalMessages={totalMessages}

--- a/src/components/chat/view/subcomponents/ChatMessagesPane.tsx
+++ b/src/components/chat/view/subcomponents/ChatMessagesPane.tsx
@@ -30,6 +30,8 @@ interface ChatMessagesPaneProps {
   isTaskMasterInstalled: boolean | null;
   onShowAllTasks?: (() => void) | null;
   setInput: Dispatch<SetStateAction<string>>;
+  linkedWorktrees?: Project[];
+  onWorktreeSelect?: (project: Project) => void;
   isLoadingMoreMessages: boolean;
   hasMoreMessages: boolean;
   totalMessages: number;
@@ -75,6 +77,8 @@ export default function ChatMessagesPane({
   isTaskMasterInstalled,
   onShowAllTasks,
   setInput,
+  linkedWorktrees,
+  onWorktreeSelect,
   isLoadingMoreMessages,
   hasMoreMessages,
   totalMessages,
@@ -158,6 +162,8 @@ export default function ChatMessagesPane({
           isTaskMasterInstalled={isTaskMasterInstalled}
           onShowAllTasks={onShowAllTasks}
           setInput={setInput}
+          linkedWorktrees={linkedWorktrees}
+          onWorktreeSelect={onWorktreeSelect}
         />
       ) : (
         <>

--- a/src/components/chat/view/subcomponents/ProviderSelectionEmptyState.tsx
+++ b/src/components/chat/view/subcomponents/ProviderSelectionEmptyState.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Check, ChevronDown } from "lucide-react";
+import { Check, ChevronDown, GitBranch } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import SessionProviderLogo from "../../../llm-logo-provider/SessionProviderLogo";
 import {
@@ -8,7 +8,7 @@ import {
   CODEX_MODELS,
   GEMINI_MODELS,
 } from "../../../../../shared/modelConstants";
-import type { ProjectSession, SessionProvider } from "../../../../types/app";
+import type { Project, ProjectSession, SessionProvider } from "../../../../types/app";
 import { NextTaskBanner } from "../../../task-master";
 
 type ProviderSelectionEmptyStateProps = {
@@ -29,6 +29,8 @@ type ProviderSelectionEmptyStateProps = {
   isTaskMasterInstalled: boolean | null;
   onShowAllTasks?: (() => void) | null;
   setInput: React.Dispatch<React.SetStateAction<string>>;
+  linkedWorktrees?: Project[];
+  onWorktreeSelect?: (project: Project) => void;
 };
 
 type ProviderDef = {
@@ -113,6 +115,8 @@ export default function ProviderSelectionEmptyState({
   isTaskMasterInstalled,
   onShowAllTasks,
   setInput,
+  linkedWorktrees = [],
+  onWorktreeSelect,
 }: ProviderSelectionEmptyStateProps) {
   const { t } = useTranslation("chat");
   const nextTaskPrompt = t("tasks.nextTaskPrompt", {
@@ -155,6 +159,26 @@ export default function ProviderSelectionEmptyState({
     return (
       <div className="flex h-full items-center justify-center px-4">
         <div className="w-full max-w-md">
+          {/* Linked-worktree workspace switcher */}
+          {linkedWorktrees.length > 0 && onWorktreeSelect && (
+            <div className="mb-6 flex flex-wrap items-center justify-center gap-2">
+              <span className="flex items-center gap-1 text-[12px] text-muted-foreground">
+                <GitBranch className="h-3 w-3" />
+                Switch workspace:
+              </span>
+              {linkedWorktrees.map((wt) => (
+                <button
+                  key={wt.name}
+                  onClick={() => onWorktreeSelect(wt)}
+                  className="flex items-center gap-1 rounded-full border border-emerald-200 bg-emerald-50 px-2.5 py-0.5 text-[11px] font-medium text-emerald-700 transition-colors hover:bg-emerald-100 dark:border-emerald-800 dark:bg-emerald-900/20 dark:text-emerald-400 dark:hover:bg-emerald-900/40"
+                >
+                  <GitBranch className="h-2.5 w-2.5" />
+                  {wt.worktreeBranch ?? wt.displayName}
+                </button>
+              ))}
+            </div>
+          )}
+
           {/* Heading */}
           <div className="mb-8 text-center">
             <h2 className="text-lg font-semibold tracking-tight text-foreground sm:text-xl">

--- a/src/components/main-content/types/types.ts
+++ b/src/components/main-content/types/types.ts
@@ -33,6 +33,7 @@ export type PrdFile = {
 };
 
 export type MainContentProps = {
+  projects: Project[];
   selectedProject: Project | null;
   selectedSession: ProjectSession | null;
   activeTab: AppTab;
@@ -52,6 +53,7 @@ export type MainContentProps = {
   onReplaceTemporarySession: SessionLifecycleHandler;
   onNavigateToSession: (targetSessionId: string) => void;
   onShowSettings: () => void;
+  onProjectSelect: (project: Project) => void;
   externalMessageUpdate: number;
 };
 

--- a/src/components/main-content/view/MainContent.tsx
+++ b/src/components/main-content/view/MainContent.tsx
@@ -28,6 +28,7 @@ type TasksSettingsContextValue = {
 };
 
 function MainContent({
+  projects,
   selectedProject,
   selectedSession,
   activeTab,
@@ -47,6 +48,7 @@ function MainContent({
   onReplaceTemporarySession,
   onNavigateToSession,
   onShowSettings,
+  onProjectSelect,
   externalMessageUpdate,
 }: MainContentProps) {
   const { preferences } = useUiPreferences();
@@ -112,6 +114,7 @@ function MainContent({
           <div className={`h-full ${activeTab === 'chat' ? 'block' : 'hidden'}`}>
             <ErrorBoundary showDetails>
               <ChatInterface
+                projects={projects}
                 selectedProject={selectedProject}
                 selectedSession={selectedSession}
                 ws={ws}
@@ -127,6 +130,7 @@ function MainContent({
                 onReplaceTemporarySession={onReplaceTemporarySession}
                 onNavigateToSession={onNavigateToSession}
                 onShowSettings={onShowSettings}
+                onProjectSelect={onProjectSelect}
                 autoExpandTools={autoExpandTools}
                 showRawParameters={showRawParameters}
                 showThinking={showThinking}

--- a/src/components/sidebar/view/Sidebar.tsx
+++ b/src/components/sidebar/view/Sidebar.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useDeviceSettings } from '../../../hooks/useDeviceSettings';
 import { useVersionCheck } from '../../../hooks/useVersionCheck';
@@ -11,6 +11,7 @@ import type { MCPServerStatus, SidebarProps } from '../types/types';
 import SidebarCollapsed from './subcomponents/SidebarCollapsed';
 import SidebarContent from './subcomponents/SidebarContent';
 import SidebarModals from './subcomponents/SidebarModals';
+import NewWorktreeDialog from './subcomponents/NewWorktreeDialog';
 import type { SidebarProjectListProps } from './subcomponents/SidebarProjectList';
 
 type TaskMasterSidebarContext = {
@@ -123,6 +124,24 @@ function Sidebar({
     document.body.classList.toggle('pwa-mode', isPWA);
   }, [isPWA]);
 
+  const [newWorktreeProject, setNewWorktreeProject] = useState<Project | null>(null);
+
+  const handleWorktreeCreated = (worktreePath: string) => {
+    setNewWorktreeProject(null);
+    if (window.refreshProjects) {
+      void window.refreshProjects().then(() => {
+        // After refresh, find the new worktree project and open a new session
+        const wt = projects.find(p => p.fullPath === worktreePath);
+        if (wt) {
+          handleProjectSelect(wt);
+          onNewSession(wt);
+        }
+      });
+    } else {
+      window.location.reload();
+    }
+  };
+
   const handleProjectCreated = () => {
     if (window.refreshProjects) {
       void window.refreshProjects();
@@ -168,6 +187,7 @@ function Sidebar({
       void loadMoreSessions(project);
     },
     onNewSession,
+    onNewWorktree: (project: Project) => setNewWorktreeProject(project),
     onEditingSessionNameChange: setEditingSessionName,
     onStartEditingSession: (sessionId, initialName) => {
       setEditingSession(sessionId);
@@ -185,6 +205,14 @@ function Sidebar({
 
   return (
     <>
+      {newWorktreeProject && (
+        <NewWorktreeDialog
+          project={newWorktreeProject}
+          onClose={() => setNewWorktreeProject(null)}
+          onCreated={handleWorktreeCreated}
+          t={t}
+        />
+      )}
       <SidebarModals
         projects={projects}
         showSettings={showSettings}

--- a/src/components/sidebar/view/Sidebar.tsx
+++ b/src/components/sidebar/view/Sidebar.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useDeviceSettings } from '../../../hooks/useDeviceSettings';
 import { useVersionCheck } from '../../../hooks/useVersionCheck';
@@ -125,21 +125,24 @@ function Sidebar({
   }, [isPWA]);
 
   const [newWorktreeProject, setNewWorktreeProject] = useState<Project | null>(null);
-  // Keep a ref to latest projects so the post-refresh callback isn't a stale closure
-  const projectsRef = useRef(projects);
-  useEffect(() => { projectsRef.current = projects; }, [projects]);
+  const [pendingWorktreePath, setPendingWorktreePath] = useState<string | null>(null);
+
+  // When projects list updates after worktree creation, navigate to the new project
+  useEffect(() => {
+    if (!pendingWorktreePath) return;
+    const wt = projects.find(p => p.fullPath === pendingWorktreePath);
+    if (wt) {
+      setPendingWorktreePath(null);
+      handleProjectSelect(wt);
+      onNewSession(wt);
+    }
+  }, [projects, pendingWorktreePath, handleProjectSelect, onNewSession]);
 
   const handleWorktreeCreated = (worktreePath: string) => {
     setNewWorktreeProject(null);
     if (window.refreshProjects) {
-      void window.refreshProjects().then(() => {
-        // After refresh, projectsRef.current has the updated list
-        const wt = projectsRef.current.find(p => p.fullPath === worktreePath);
-        if (wt) {
-          handleProjectSelect(wt);
-          onNewSession(wt);
-        }
-      });
+      setPendingWorktreePath(worktreePath);
+      void window.refreshProjects();
     } else {
       window.location.reload();
     }

--- a/src/components/sidebar/view/Sidebar.tsx
+++ b/src/components/sidebar/view/Sidebar.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useDeviceSettings } from '../../../hooks/useDeviceSettings';
 import { useVersionCheck } from '../../../hooks/useVersionCheck';
@@ -125,13 +125,16 @@ function Sidebar({
   }, [isPWA]);
 
   const [newWorktreeProject, setNewWorktreeProject] = useState<Project | null>(null);
+  // Keep a ref to latest projects so the post-refresh callback isn't a stale closure
+  const projectsRef = useRef(projects);
+  useEffect(() => { projectsRef.current = projects; }, [projects]);
 
   const handleWorktreeCreated = (worktreePath: string) => {
     setNewWorktreeProject(null);
     if (window.refreshProjects) {
       void window.refreshProjects().then(() => {
-        // After refresh, find the new worktree project and open a new session
-        const wt = projects.find(p => p.fullPath === worktreePath);
+        // After refresh, projectsRef.current has the updated list
+        const wt = projectsRef.current.find(p => p.fullPath === worktreePath);
         if (wt) {
           handleProjectSelect(wt);
           onNewSession(wt);

--- a/src/components/sidebar/view/subcomponents/NewWorktreeDialog.tsx
+++ b/src/components/sidebar/view/subcomponents/NewWorktreeDialog.tsx
@@ -1,0 +1,144 @@
+/**
+ * NewWorktreeDialog
+ *
+ * A modal dialog that lets the user create a new git linked worktree for the
+ * currently selected project and immediately open a new session in it.
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import ReactDOM from 'react-dom';
+import { GitBranch, X } from 'lucide-react';
+import type { TFunction } from 'i18next';
+import { Button } from '../../../../shared/view/ui';
+import { api } from '../../../../utils/api';
+import type { Project } from '../../../../types/app';
+
+type NewWorktreeDialogProps = {
+  project: Project;
+  onClose: () => void;
+  onCreated: (worktreePath: string) => void;
+  t: TFunction;
+};
+
+export default function NewWorktreeDialog({ project, onClose, onCreated, t }: NewWorktreeDialogProps) {
+  const [branchName, setBranchName] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [isCreating, setIsCreating] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    inputRef.current?.focus();
+  }, []);
+
+  // Close on Escape
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => { if (e.key === 'Escape') onClose(); };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [onClose]);
+
+  const handleSubmit = useCallback(async () => {
+    const branch = branchName.trim();
+    if (!branch) { setError('Branch name is required'); return; }
+
+    setIsCreating(true);
+    setError(null);
+
+    try {
+      const response = await api.createWorktree(project.name, branch);
+      const data = await response.json();
+      if (!response.ok) throw new Error(data.error || 'Failed to create worktree');
+      onCreated(data.worktreePath as string);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+      setIsCreating(false);
+    }
+  }, [branchName, project.name, onCreated]);
+
+  const modal = (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
+      onClick={(e) => { if (e.target === e.currentTarget) onClose(); }}
+    >
+      <div className="w-full max-w-md rounded-xl border border-border bg-background shadow-2xl">
+        {/* Header */}
+        <div className="flex items-center justify-between border-b border-border px-5 py-4">
+          <div className="flex items-center gap-2">
+            <GitBranch className="h-4 w-4 text-emerald-500" />
+            <h2 className="text-sm font-semibold text-foreground">
+              New worktree — {project.displayName}
+            </h2>
+          </div>
+          <button
+            className="flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+            onClick={onClose}
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+
+        {/* Body */}
+        <div className="px-5 py-4 space-y-3">
+          <p className="text-xs text-muted-foreground">
+            Creates a new git worktree as a sibling directory so you can work on a separate
+            branch in parallel. A new session will open in the worktree automatically.
+          </p>
+
+          <div className="space-y-1">
+            <label className="text-xs font-medium text-foreground" htmlFor="worktree-branch">
+              Branch name
+            </label>
+            <input
+              id="worktree-branch"
+              ref={inputRef}
+              type="text"
+              value={branchName}
+              onChange={(e) => { setBranchName(e.target.value); setError(null); }}
+              onKeyDown={(e) => { if (e.key === 'Enter' && !isCreating) handleSubmit(); }}
+              placeholder="feature/my-feature"
+              className="w-full rounded-lg border border-border bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
+              autoComplete="off"
+              spellCheck={false}
+            />
+            <p className="text-[10px] text-muted-foreground">
+              If the branch already exists it will be checked out; otherwise a new branch is created.
+            </p>
+          </div>
+
+          {error && (
+            <p className="rounded-md border border-red-200 bg-red-50 px-3 py-2 text-xs text-red-700 dark:border-red-800 dark:bg-red-900/20 dark:text-red-400">
+              {error}
+            </p>
+          )}
+        </div>
+
+        {/* Footer */}
+        <div className="flex justify-end gap-2 border-t border-border px-5 py-3">
+          <Button variant="outline" size="sm" onClick={onClose} disabled={isCreating}>
+            Cancel
+          </Button>
+          <Button
+            size="sm"
+            onClick={handleSubmit}
+            disabled={isCreating || !branchName.trim()}
+            className="gap-1.5"
+          >
+            {isCreating ? (
+              <>
+                <span className="h-3 w-3 animate-spin rounded-full border-2 border-current border-t-transparent" />
+                Creating…
+              </>
+            ) : (
+              <>
+                <GitBranch className="h-3.5 w-3.5" />
+                Create worktree
+              </>
+            )}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+
+  return ReactDOM.createPortal(modal, document.body);
+}

--- a/src/components/sidebar/view/subcomponents/SidebarProjectItem.tsx
+++ b/src/components/sidebar/view/subcomponents/SidebarProjectItem.tsx
@@ -1,4 +1,4 @@
-import { Check, ChevronDown, ChevronRight, Edit3, Folder, FolderOpen, Star, Trash2, X } from 'lucide-react';
+import { Check, ChevronDown, ChevronRight, Edit3, Folder, FolderOpen, GitBranch, Star, Trash2, X } from 'lucide-react';
 import type { TFunction } from 'i18next';
 import { Button } from '../../../../shared/view/ui';
 import { cn } from '../../../../lib/utils';
@@ -42,6 +42,7 @@ type SidebarProjectItemProps = {
   ) => void;
   onLoadMoreSessions: (project: Project) => void;
   onNewSession: (project: Project) => void;
+  onNewWorktree?: (project: Project) => void;
   onEditingSessionNameChange: (value: string) => void;
   onStartEditingSession: (sessionId: string, initialName: string) => void;
   onCancelEditingSession: () => void;
@@ -87,6 +88,7 @@ export default function SidebarProjectItem({
   onDeleteSession,
   onLoadMoreSessions,
   onNewSession,
+  onNewWorktree,
   onEditingSessionNameChange,
   onStartEditingSession,
   onCancelEditingSession,
@@ -235,6 +237,18 @@ export default function SidebarProjectItem({
                       />
                     </button>
 
+                    {!project.isWorktree && onNewWorktree && (
+                      <button
+                        className="flex h-8 w-8 items-center justify-center rounded-lg border border-emerald-200 bg-emerald-500/10 active:scale-90 dark:border-emerald-800 dark:bg-emerald-900/30"
+                        onClick={(event) => {
+                          event.stopPropagation();
+                          onNewWorktree(project);
+                        }}
+                        title="New worktree"
+                      >
+                        <GitBranch className="h-4 w-4 text-emerald-600 dark:text-emerald-400" />
+                      </button>
+                    )}
                     <button
                       className="flex h-8 w-8 items-center justify-center rounded-lg border border-red-200 bg-red-500/10 active:scale-90 dark:border-red-800 dark:bg-red-900/30"
                       onClick={(event) => {
@@ -382,6 +396,18 @@ export default function SidebarProjectItem({
                 >
                   <Edit3 className="h-3 w-3" />
                 </div>
+                {!project.isWorktree && onNewWorktree && (
+                  <div
+                    className="touch:opacity-100 flex h-6 w-6 cursor-pointer items-center justify-center rounded opacity-0 transition-all duration-200 hover:bg-emerald-50 group-hover:opacity-100 dark:hover:bg-emerald-900/20"
+                    onClick={(event) => {
+                      event.stopPropagation();
+                      onNewWorktree(project);
+                    }}
+                    title="New worktree"
+                  >
+                    <GitBranch className="h-3 w-3 text-emerald-600 dark:text-emerald-400" />
+                  </div>
+                )}
                 <div
                   className="touch:opacity-100 flex h-6 w-6 cursor-pointer items-center justify-center rounded opacity-0 transition-all duration-200 hover:bg-red-50 group-hover:opacity-100 dark:hover:bg-red-900/20"
                   onClick={(event) => {

--- a/src/components/sidebar/view/subcomponents/SidebarProjectList.tsx
+++ b/src/components/sidebar/view/subcomponents/SidebarProjectList.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useMemo } from 'react';
 import type { TFunction } from 'i18next';
 import type { LoadingProgress, Project, ProjectSession, SessionProvider } from '../../../../types/app';
 import type {
@@ -8,6 +8,7 @@ import type {
 } from '../../types/types';
 import SidebarProjectItem from './SidebarProjectItem';
 import SidebarProjectsState from './SidebarProjectsState';
+import SidebarWorktreeItem from './SidebarWorktreeItem';
 
 export type SidebarProjectListProps = {
   projects: Project[];
@@ -112,47 +113,96 @@ export default function SidebarProjectList({
 
   const showProjects = !isLoading && projects.length > 0 && filteredProjects.length > 0;
 
+  /**
+   * Group worktree projects under their main repo.
+   * Each entry is either:
+   *   - A plain project (non-worktree, or worktree whose main repo isn't in the list)
+   *   - A main-repo project that has linked worktrees attached
+   */
+  const groupedProjects = useMemo(() => {
+    // Build a fast lookup: fullPath -> project
+    const byPath = new Map<string, Project>(
+      filteredProjects.map(p => [p.fullPath, p])
+    );
+
+    const worktreesByMain = new Map<string, Project[]>();
+    const linked = new Set<string>();
+
+    for (const p of filteredProjects) {
+      if (p.isWorktree && p.mainRepoPath) {
+        const mainProject = byPath.get(p.mainRepoPath);
+        if (mainProject) {
+          const bucket = worktreesByMain.get(mainProject.name) ?? [];
+          bucket.push(p);
+          worktreesByMain.set(mainProject.name, bucket);
+          linked.add(p.name);
+        }
+      }
+    }
+
+    return filteredProjects
+      .filter(p => !linked.has(p.name))
+      .map(p => ({ project: p, worktrees: worktreesByMain.get(p.name) ?? [] }));
+  }, [filteredProjects]);
+
+  const sharedItemProps = {
+    selectedProject,
+    selectedSession,
+    editingProject,
+    editingName,
+    currentTime,
+    editingSession,
+    editingSessionName,
+    tasksEnabled,
+    mcpServerStatus,
+    onEditingNameChange,
+    onToggleProject,
+    onProjectSelect,
+    onToggleStarProject,
+    onStartEditingProject,
+    onCancelEditingProject,
+    onSaveProjectName,
+    onDeleteProject,
+    onSessionSelect,
+    onDeleteSession,
+    onLoadMoreSessions,
+    onNewSession,
+    onEditingSessionNameChange,
+    onStartEditingSession,
+    onCancelEditingSession,
+    onSaveEditingSession,
+    t,
+  };
+
   return (
     <div className="pb-safe-area-inset-bottom md:space-y-1">
       {!showProjects
         ? state
-        : filteredProjects.map((project) => (
-            <SidebarProjectItem
-              key={project.name}
-              project={project}
-              selectedProject={selectedProject}
-              selectedSession={selectedSession}
-              isExpanded={expandedProjects.has(project.name)}
-              isDeleting={deletingProjects.has(project.name)}
-              isStarred={isProjectStarred(project.name)}
-              editingProject={editingProject}
-              editingName={editingName}
-              sessions={getProjectSessions(project)}
-              initialSessionsLoaded={initialSessionsLoaded.has(project.name)}
-              isLoadingSessions={Boolean(loadingSessions[project.name])}
-              currentTime={currentTime}
-              editingSession={editingSession}
-              editingSessionName={editingSessionName}
-              tasksEnabled={tasksEnabled}
-              mcpServerStatus={mcpServerStatus}
-              onEditingNameChange={onEditingNameChange}
-              onToggleProject={onToggleProject}
-              onProjectSelect={onProjectSelect}
-              onToggleStarProject={onToggleStarProject}
-              onStartEditingProject={onStartEditingProject}
-              onCancelEditingProject={onCancelEditingProject}
-              onSaveProjectName={onSaveProjectName}
-              onDeleteProject={onDeleteProject}
-              onSessionSelect={onSessionSelect}
-              onDeleteSession={onDeleteSession}
-              onLoadMoreSessions={onLoadMoreSessions}
-              onNewSession={onNewSession}
-              onEditingSessionNameChange={onEditingSessionNameChange}
-              onStartEditingSession={onStartEditingSession}
-              onCancelEditingSession={onCancelEditingSession}
-              onSaveEditingSession={onSaveEditingSession}
-              t={t}
-            />
+        : groupedProjects.map(({ project, worktrees }) => (
+            <div key={project.name}>
+              <SidebarProjectItem
+                project={project}
+                isExpanded={expandedProjects.has(project.name)}
+                isDeleting={deletingProjects.has(project.name)}
+                isStarred={isProjectStarred(project.name)}
+                sessions={getProjectSessions(project)}
+                initialSessionsLoaded={initialSessionsLoaded.has(project.name)}
+                isLoadingSessions={Boolean(loadingSessions[project.name])}
+                {...sharedItemProps}
+              />
+              {worktrees.map(wt => (
+                <SidebarWorktreeItem
+                  key={wt.name}
+                  project={wt}
+                  isExpanded={expandedProjects.has(wt.name)}
+                  isDeleting={deletingProjects.has(wt.name)}
+                  sessions={getProjectSessions(wt)}
+                  initialSessionsLoaded={initialSessionsLoaded.has(wt.name)}
+                  isLoadingSessions={Boolean(loadingSessions[wt.name])}
+                  {...sharedItemProps}
+                />
+              ))}
+            </div>
           ))}
     </div>
   );

--- a/src/components/sidebar/view/subcomponents/SidebarProjectList.tsx
+++ b/src/components/sidebar/view/subcomponents/SidebarProjectList.tsx
@@ -47,6 +47,7 @@ export type SidebarProjectListProps = {
   ) => void;
   onLoadMoreSessions: (project: Project) => void;
   onNewSession: (project: Project) => void;
+  onNewWorktree?: (project: Project) => void;
   onEditingSessionNameChange: (value: string) => void;
   onStartEditingSession: (sessionId: string, initialName: string) => void;
   onCancelEditingSession: () => void;
@@ -86,6 +87,7 @@ export default function SidebarProjectList({
   onDeleteSession,
   onLoadMoreSessions,
   onNewSession,
+  onNewWorktree,
   onEditingSessionNameChange,
   onStartEditingSession,
   onCancelEditingSession,
@@ -167,6 +169,7 @@ export default function SidebarProjectList({
     onDeleteSession,
     onLoadMoreSessions,
     onNewSession,
+    onNewWorktree,
     onEditingSessionNameChange,
     onStartEditingSession,
     onCancelEditingSession,

--- a/src/components/sidebar/view/subcomponents/SidebarWorktreeItem.tsx
+++ b/src/components/sidebar/view/subcomponents/SidebarWorktreeItem.tsx
@@ -1,0 +1,218 @@
+/**
+ * SidebarWorktreeItem
+ *
+ * Renders a git linked-worktree project as an indented sub-item beneath its
+ * main repo entry in the sidebar.  The appearance intentionally mirrors
+ * SidebarProjectItem but adds:
+ *   - Left indentation + a subtle connector line
+ *   - A GitBranch icon + branch name badge instead of a folder icon
+ *   - No star / rename controls (worktree identity is managed by git, not by
+ *     the user via the UI)
+ */
+
+import { ChevronDown, ChevronRight, GitBranch, Trash2 } from 'lucide-react';
+import type { TFunction } from 'i18next';
+import { cn } from '../../../../lib/utils';
+import type { Project, ProjectSession, SessionProvider } from '../../../../types/app';
+import type { MCPServerStatus, SessionWithProvider } from '../../types/types';
+import SidebarProjectSessions from './SidebarProjectSessions';
+
+type SidebarWorktreeItemProps = {
+  project: Project;
+  selectedProject: Project | null;
+  selectedSession: ProjectSession | null;
+  isExpanded: boolean;
+  isDeleting: boolean;
+  sessions: SessionWithProvider[];
+  initialSessionsLoaded: boolean;
+  isLoadingSessions: boolean;
+  currentTime: Date;
+  editingSession: string | null;
+  editingSessionName: string;
+  mcpServerStatus: MCPServerStatus;
+  // Unused but forwarded from sharedItemProps — kept so the spread works cleanly
+  editingProject: string | null;
+  editingName: string;
+  tasksEnabled: boolean;
+  isStarred?: boolean;
+  onEditingNameChange: (name: string) => void;
+  onToggleProject: (projectName: string) => void;
+  onProjectSelect: (project: Project) => void;
+  onToggleStarProject: (projectName: string) => void;
+  onStartEditingProject: (project: Project) => void;
+  onCancelEditingProject: () => void;
+  onSaveProjectName: (projectName: string) => void;
+  onDeleteProject: (project: Project) => void;
+  onSessionSelect: (session: SessionWithProvider, projectName: string) => void;
+  onDeleteSession: (
+    projectName: string,
+    sessionId: string,
+    sessionTitle: string,
+    provider: SessionProvider,
+  ) => void;
+  onLoadMoreSessions: (project: Project) => void;
+  onNewSession: (project: Project) => void;
+  onEditingSessionNameChange: (value: string) => void;
+  onStartEditingSession: (sessionId: string, initialName: string) => void;
+  onCancelEditingSession: () => void;
+  onSaveEditingSession: (
+    projectName: string,
+    sessionId: string,
+    summary: string,
+    provider: SessionProvider,
+  ) => void;
+  t: TFunction;
+};
+
+export default function SidebarWorktreeItem({
+  project,
+  selectedProject,
+  selectedSession,
+  isExpanded,
+  isDeleting,
+  sessions,
+  initialSessionsLoaded,
+  isLoadingSessions,
+  currentTime,
+  editingSession,
+  editingSessionName,
+  onToggleProject,
+  onProjectSelect,
+  onDeleteProject,
+  onSessionSelect,
+  onDeleteSession,
+  onLoadMoreSessions,
+  onNewSession,
+  onEditingSessionNameChange,
+  onStartEditingSession,
+  onCancelEditingSession,
+  onSaveEditingSession,
+  t,
+}: SidebarWorktreeItemProps) {
+  const isSelected = selectedProject?.name === project.name;
+  const branch = project.worktreeBranch ?? 'worktree';
+  const hasMoreSessions = project.sessionMeta?.hasMore === true;
+  const sessionCount = sessions.length;
+  const sessionCountDisplay = hasMoreSessions && sessionCount >= 5 ? `${sessionCount}+` : `${sessionCount}`;
+  const sessionCountLabel = `${sessionCountDisplay} session${sessionCount === 1 ? '' : 's'}`;
+
+  const toggle = () => onToggleProject(project.name);
+  const selectAndToggle = () => {
+    if (selectedProject?.name !== project.name) {
+      onProjectSelect(project);
+    }
+    toggle();
+  };
+
+  return (
+    <div className={cn('md:space-y-1', isDeleting && 'opacity-50 pointer-events-none')}>
+      {/* ── Desktop ─────────────────────────────────────────────────── */}
+      <div className="hidden md:block">
+        <div className="relative pl-6">
+          {/* Vertical connector line */}
+          <span
+            className="absolute left-3 top-0 h-full w-px bg-border/50"
+            aria-hidden
+          />
+          {/* Horizontal connector nub */}
+          <span
+            className="absolute left-3 top-1/2 h-px w-3 bg-border/50"
+            aria-hidden
+          />
+
+          <div
+            className={cn(
+              'flex cursor-pointer items-center justify-between rounded-lg px-2 py-1.5 transition-colors hover:bg-accent/50',
+              isSelected && 'bg-primary/5',
+            )}
+            onClick={selectAndToggle}
+          >
+            <div className="flex min-w-0 flex-1 items-center gap-2">
+              {/* Expand/collapse chevron */}
+              {isExpanded ? (
+                <ChevronDown className="h-3 w-3 shrink-0 text-muted-foreground" />
+              ) : (
+                <ChevronRight className="h-3 w-3 shrink-0 text-muted-foreground" />
+              )}
+
+              {/* Branch icon */}
+              <GitBranch className="h-3.5 w-3.5 shrink-0 text-emerald-500 dark:text-emerald-400" />
+
+              <div className="min-w-0 flex-1">
+                <div className="flex min-w-0 items-center gap-1.5">
+                  <span
+                    className="truncate text-xs font-medium text-foreground"
+                    title={branch}
+                  >
+                    {branch}
+                  </span>
+                </div>
+                <p className="text-[10px] leading-none text-muted-foreground mt-0.5">{sessionCountLabel}</p>
+              </div>
+            </div>
+
+            {/* Delete button — visible on hover */}
+            <div className="hidden shrink-0 items-center gap-1 group-hover:flex">
+              <button
+                className="flex h-6 w-6 items-center justify-center rounded border border-red-200 bg-red-500/10 opacity-0 transition-opacity group-hover:opacity-100 dark:border-red-800 dark:bg-red-900/30"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onDeleteProject(project);
+                }}
+                title={t('tooltips.deleteProject')}
+              >
+                <Trash2 className="h-3 w-3 text-red-600 dark:text-red-400" />
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* ── Mobile ──────────────────────────────────────────────────── */}
+      <div className="md:hidden">
+        <div className="pl-4">
+          <div
+            className={cn(
+              'flex items-center gap-2 rounded-lg border border-border/50 bg-card px-3 py-2 mx-3 my-1 active:scale-[0.98] transition-all duration-150',
+              isSelected && 'border-primary/20 bg-primary/5',
+            )}
+            onClick={toggle}
+          >
+            <GitBranch className="h-4 w-4 shrink-0 text-emerald-500 dark:text-emerald-400" />
+            <div className="min-w-0 flex-1">
+              <p className="truncate text-sm font-medium text-foreground">{branch}</p>
+              <p className="text-xs text-muted-foreground">{sessionCountLabel}</p>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* ── Sessions (shared for desktop + mobile) ──────────────────── */}
+      {isExpanded && (
+        <div className="pl-6">
+          <SidebarProjectSessions
+            project={project}
+            isExpanded={isExpanded}
+            sessions={sessions}
+            selectedSession={selectedSession}
+            initialSessionsLoaded={initialSessionsLoaded}
+            isLoadingSessions={isLoadingSessions}
+            currentTime={currentTime}
+            editingSession={editingSession}
+            editingSessionName={editingSessionName}
+            onProjectSelect={onProjectSelect}
+            onSessionSelect={onSessionSelect}
+            onDeleteSession={onDeleteSession}
+            onLoadMoreSessions={onLoadMoreSessions}
+            onNewSession={onNewSession}
+            onEditingSessionNameChange={onEditingSessionNameChange}
+            onStartEditingSession={onStartEditingSession}
+            onCancelEditingSession={onCancelEditingSession}
+            onSaveEditingSession={onSaveEditingSession}
+            t={t}
+          />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/sidebar/view/subcomponents/SidebarWorktreeItem.tsx
+++ b/src/components/sidebar/view/subcomponents/SidebarWorktreeItem.tsx
@@ -122,7 +122,7 @@ export default function SidebarWorktreeItem({
 
           <div
             className={cn(
-              'flex cursor-pointer items-center justify-between rounded-lg px-2 py-1.5 transition-colors hover:bg-accent/50',
+              'group flex cursor-pointer items-center justify-between rounded-lg px-2 py-1.5 transition-colors hover:bg-accent/50',
               isSelected && 'bg-primary/5',
             )}
             onClick={selectAndToggle}
@@ -176,7 +176,7 @@ export default function SidebarWorktreeItem({
               'flex items-center gap-2 rounded-lg border border-border/50 bg-card px-3 py-2 mx-3 my-1 active:scale-[0.98] transition-all duration-150',
               isSelected && 'border-primary/20 bg-primary/5',
             )}
-            onClick={toggle}
+            onClick={selectAndToggle}
           >
             <GitBranch className="h-4 w-4 shrink-0 text-emerald-500 dark:text-emerald-400" />
             <div className="min-w-0 flex-1">

--- a/src/types/app.ts
+++ b/src/types/app.ts
@@ -41,6 +41,12 @@ export interface Project {
   geminiSessions?: ProjectSession[];
   sessionMeta?: ProjectSessionMeta;
   taskmaster?: ProjectTaskmasterInfo;
+  /** True if this project lives in a linked git worktree (not the main worktree). */
+  isWorktree?: boolean;
+  /** Absolute path to the main worktree root. Populated only when isWorktree is true. */
+  mainRepoPath?: string;
+  /** Branch checked out in this worktree. Populated only when isWorktree is true. */
+  worktreeBranch?: string;
   [key: string]: unknown;
 }
 

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -104,6 +104,11 @@ export const api = {
       method: 'POST',
       body: JSON.stringify({ path }),
     }),
+  createWorktree: (projectName, branchName) =>
+    authenticatedFetch(`/api/projects/${projectName}/worktrees`, {
+      method: 'POST',
+      body: JSON.stringify({ branchName }),
+    }),
   createWorkspace: (workspaceData) =>
     authenticatedFetch('/api/projects/create-workspace', {
       method: 'POST',


### PR DESCRIPTION
## Problem

When Claude Code (or any other agent) runs inside a git linked worktree, the session is stored under a different path in `~/.claude/projects/`, so cloudcli treats it as a completely unrelated project. Users who rely on `claude mcp` / `EnterWorktree` for parallel workstreams end up with a fragmented sidebar.

## Solution

Detect worktrees on the server and surface grouping metadata to the frontend, which then renders linked worktrees as indented sub-items beneath their main repo.

### Backend (`server/projects.js`)

- Add `resolveWorktreeInfo(projectPath)`: runs `git -C <path> worktree list --porcelain` (fast, no network) and returns `{ isWorktree, mainRepoPath, worktreeBranch }` for each project path. Falls back silently for non-git directories.
- Call it for every discovered project (both auto-discovered and manually added), attaching the three optional fields to the project object.

### Frontend

- **`src/types/app.ts`**: add `isWorktree?`, `mainRepoPath?`, `worktreeBranch?` to `Project`.
- **`SidebarProjectList`**: `useMemo`-group `filteredProjects` by `mainRepoPath`. Worktrees whose main repo is present in the list are promoted to sub-items; orphan worktrees (main repo not loaded) continue to appear as standalone entries.
- **`SidebarWorktreeItem`** *(new)*: renders a linked worktree as an indented sub-item with:
  - A left connector line visually attaching it to the parent
  - A `GitBranch` icon + branch name badge
  - Its own expand/collapse and session list (reuses `SidebarProjectSessions`)
  - A delete button on hover

### Terminal & Git diff — no changes needed

Both features already use the actual worktree `projectPath` as `cwd`:
- **Terminal** (`server/index.js` line ~1824): `pty.spawn(shell, ..., { cwd: resolvedProjectPath })` — spawns in the worktree dir, so the shell opens on the right branch.
- **Git explorer** (`server/routes/git.js`): calls `git rev-parse --show-toplevel` with the worktree path, which returns the worktree root. All diff/status/stage/commit operations run scoped to that worktree's branch.

## Screenshots

_Worktrees now appear indented under their main repo with a branch badge:_

```
📁 my-repo          (main branch sessions)
  └─ 🌿 feature-x  (worktree sessions)
  └─ 🌿 hotfix-123 (worktree sessions)
```

## Testing

1. Create a worktree: `git worktree add ../my-repo-feature feature-branch`
2. Start a Claude session in that worktree directory
3. Open cloudcli — the worktree should appear indented under `my-repo`
4. Click the worktree → sessions load correctly
5. Open Terminal tab → shell opens in the worktree directory
6. Open Git tab → shows diffs for `feature-branch`, not `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Detect and display linked Git worktrees for projects (branch + main-repo info).
  * Group linked worktrees under their main repository in the sidebar.
  * Add a "New worktree" flow: sidebar dialog, server-side creation API with validation, and UI affordance to create worktrees.
  * Compact worktree sidebar entries (desktop & mobile) show branch and session counts; newly created worktrees are auto-selected and start a new session.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->