### PR TITLE
feat: add daemon management commands and docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,7 @@
 # Available CLI commands:
 #   claude-code-ui    - Start the server (default)
 #   cloudcli start    - Start the server
+#   cloudcli daemon   - Manage background daemon mode
 #   cloudcli status   - Show configuration and data locations
 #   cloudcli help     - Show help information
 #   cloudcli version  - Show version information
@@ -25,6 +26,10 @@ VITE_PORT=5173
 # Use 127.0.0.1 to restrict to localhost only
 HOST=0.0.0.0
 
+# Shell reconnect timeout after websocket disconnect (minutes)
+# Default: 30
+# SHELL_SESSION_TIMEOUT_MINUTES=30
+
 # Uncomment the following line if you have a custom claude cli path other than the default "claude"
 # CLAUDE_CLI_PATH=claude
 
@@ -41,5 +46,4 @@ HOST=0.0.0.0
 # Claude Code context window size (maximum tokens per session)
 VITE_CONTEXT_WINDOW=160000
 CONTEXT_WINDOW=160000
-
 

--- a/README.md
+++ b/README.md
@@ -95,6 +95,28 @@ Open `http://localhost:3001` — all your existing sessions are discovered autom
 
 Visit the **[documentation →](https://cloudcli.ai/docs)** for full configuration options, PM2, remote server setup and more.
 
+#### Keep CloudCLI running after terminal closes
+
+Use daemon mode to keep CloudCLI alive in background and reconnect later:
+
+```
+cloudcli daemon start
+cloudcli daemon status
+```
+
+Enable startup on login (platform-native):
+
+```
+cloudcli daemon enable
+```
+
+Useful commands:
+
+```
+cloudcli daemon stop
+cloudcli daemon logs
+```
+
 #### Docker Sandboxes (Experimental)
 
 Run agents in isolated sandboxes with hypervisor-level isolation. Starts Claude Code by default. Requires the [`sbx` CLI](https://docs.docker.com/ai/sandboxes/get-started/).

--- a/server/cli.js
+++ b/server/cli.js
@@ -7,6 +7,7 @@
  * Commands:
  *   (no args)     - Start the server (default)
  *   start         - Start the server
+ *   daemon        - Run and manage background daemon mode
  *   sandbox       - Manage Docker sandbox environments
  *   status        - Show configuration and data locations
  *   help          - Show help information
@@ -16,7 +17,16 @@
 import fs from 'fs';
 import path from 'path';
 import os from 'os';
+
 import { findAppRoot, getModuleDir } from './utils/runtime-paths.js';
+import {
+    disableAutostart,
+    enableAutostart,
+    getDaemonStatus,
+    readDaemonLogs,
+    startDaemon,
+    stopDaemon
+} from './daemon/manager.js';
 
 const __dirname = getModuleDir(import.meta.url);
 // The CLI is compiled into dist-server/server, but it still needs to read the top-level
@@ -138,6 +148,7 @@ function showStatus() {
     console.log(`\n${c.tip('[TIP]')} Hints:`);
     console.log(`      ${c.dim('>')} Use ${c.bright('cloudcli --port 8080')} to run on a custom port`);
     console.log(`      ${c.dim('>')} Use ${c.bright('cloudcli --database-path /path/to/db')} for custom database`);
+    console.log(`      ${c.dim('>')} Use ${c.bright('cloudcli daemon start')} to keep CloudCLI running in background`);
     console.log(`      ${c.dim('>')} Run ${c.bright('cloudcli help')} for all options`);
     console.log(`      ${c.dim('>')} Access the UI at http://localhost:${process.env.SERVER_PORT || process.env.PORT || '3001'}\n`);
 }
@@ -155,6 +166,7 @@ Usage:
 
 Commands:
   start          Start the CloudCLI server (default)
+  daemon         Manage background daemon mode
   sandbox        Manage Docker sandbox environments
   status         Show configuration and data locations
   update         Update to the latest version
@@ -170,6 +182,8 @@ Options:
 Examples:
   $ cloudcli                        # Start with defaults
   $ cloudcli --port 8080            # Start on port 8080
+  $ cloudcli daemon start           # Start in background daemon mode
+  $ cloudcli daemon enable          # Enable auto-start on login
   $ cloudcli sandbox ~/my-project   # Run in a Docker sandbox
   $ cloudcli status                 # Show configuration
 
@@ -179,6 +193,7 @@ Environment Variables:
   DATABASE_PATH       Set custom database location
   CLAUDE_CLI_PATH     Set custom Claude CLI path
   CONTEXT_WINDOW      Set context window size (default: 160000)
+  SHELL_SESSION_TIMEOUT_MINUTES  PTY reconnect timeout (default: 30)
 
 Documentation:
   ${packageJson.homepage || 'https://github.com/siteboon/claudecodeui'}
@@ -594,12 +609,204 @@ async function sandboxCommand(args) {
     }
 }
 
+// ── Daemon command ──────────────────────────────────────────
+
+function parseDaemonArgs(args) {
+    const parsed = {
+        subcommand: 'status',
+        options: {}
+    };
+
+    const subcommands = new Set(['start', 'stop', 'status', 'enable', 'disable', 'logs', 'help']);
+    let subcommandSet = false;
+
+    for (let i = 0; i < args.length; i++) {
+        const arg = args[i];
+
+        if (arg === '--port' || arg === '-p') {
+            parsed.options.serverPort = args[++i];
+        } else if (arg.startsWith('--port=')) {
+            parsed.options.serverPort = arg.split('=')[1];
+        } else if (arg === '--database-path') {
+            parsed.options.databasePath = args[++i];
+        } else if (arg.startsWith('--database-path=')) {
+            parsed.options.databasePath = arg.split('=')[1];
+        } else if (arg === '--help' || arg === '-h') {
+            parsed.subcommand = 'help';
+            subcommandSet = true;
+        } else if (!arg.startsWith('-') && !subcommandSet) {
+            parsed.subcommand = arg;
+            subcommandSet = true;
+        }
+    }
+
+    if (!subcommands.has(parsed.subcommand)) {
+        parsed.subcommand = `unknown:${parsed.subcommand}`;
+    }
+
+    return parsed;
+}
+
+function showDaemonHelp() {
+    console.log(`
+${c.bright('CloudCLI Daemon')} — Keep CloudCLI running after terminal closes
+
+Usage:
+  cloudcli daemon <subcommand> [options]
+
+Subcommands:
+  ${c.bright('start')}        Start CloudCLI in detached background mode
+  ${c.bright('stop')}         Stop the running daemon
+  ${c.bright('status')}       Show daemon, health, and autostart status
+  ${c.bright('logs')}         Show recent daemon logs
+  ${c.bright('enable')}       Enable autostart on user login (platform native)
+  ${c.bright('disable')}      Disable autostart on user login
+  ${c.bright('help')}         Show this help
+
+Options:
+  -p, --port <port>           Server port for start/enable (default: 3001)
+  --database-path <path>      Database path for start/enable
+
+Examples:
+  $ cloudcli daemon start
+  $ cloudcli daemon start --port 3001
+  $ cloudcli daemon status
+  $ cloudcli daemon enable --port 3001
+  $ cloudcli daemon logs
+`);
+}
+
+async function daemonCommand(args, globalOptions = {}) {
+    const { subcommand, options } = parseDaemonArgs(args);
+
+    if (subcommand.startsWith('unknown:')) {
+        const invalidSubcommand = subcommand.split(':')[1];
+        console.error(`\n${c.error('❌')} Unknown daemon subcommand: ${invalidSubcommand}`);
+        console.log(`   Run ${c.bright('cloudcli daemon help')} for usage.\n`);
+        process.exit(1);
+    }
+
+    const effectiveOptions = {
+        serverPort: options.serverPort || globalOptions.serverPort || process.env.SERVER_PORT || process.env.PORT || '3001',
+        databasePath: options.databasePath || globalOptions.databasePath || process.env.DATABASE_PATH || ''
+    };
+
+    const daemonRuntimeOptions = {
+        nodePath: process.execPath,
+        cliEntryPath: path.resolve(process.argv[1]),
+        serverPort: effectiveOptions.serverPort,
+        databasePath: effectiveOptions.databasePath || null
+    };
+
+    try {
+        switch (subcommand) {
+            case 'help':
+                showDaemonHelp();
+                return;
+            case 'start': {
+                const result = startDaemon(daemonRuntimeOptions);
+                if (result.alreadyRunning) {
+                    console.log(`${c.ok('[OK]')} CloudCLI daemon is already running (PID ${result.pid}) on port ${result.port}.`);
+                } else {
+                    console.log(`${c.ok('[OK]')} CloudCLI daemon started (PID ${result.pid}) on port ${result.port}.`);
+                }
+                console.log(`${c.tip('[TIP]')} Use ${c.bright('cloudcli daemon status')} to verify health.`);
+                return;
+            }
+            case 'stop': {
+                const result = await stopDaemon();
+                if (result.stopped && result.reason === 'stale_pid') {
+                    console.log(`${c.warn('[WARN]')} Stale PID cleaned up. No running daemon process was found.`);
+                    return;
+                }
+
+                if (result.stopped) {
+                    console.log(`${c.ok('[OK]')} CloudCLI daemon stopped.`);
+                    return;
+                }
+
+                if (result.reason === 'not_running') {
+                    console.log(`${c.warn('[WARN]')} CloudCLI daemon is not running.`);
+                    return;
+                }
+
+                console.error(`${c.error('[ERROR]')} Failed to stop daemon${result.error ? `: ${result.error}` : '.'}`);
+                process.exit(1);
+                return;
+            }
+            case 'status': {
+                const status = await getDaemonStatus({ serverPort: effectiveOptions.serverPort });
+                console.log(`\n${c.bright('CloudCLI Daemon Status')}\n`);
+                console.log(`  Running:   ${status.running ? c.ok('yes') : c.warn('no')}`);
+                console.log(`  Health:    ${status.health ? c.ok('healthy') : c.warn(status.running ? 'unreachable' : 'stopped')}`);
+                console.log(`  PID:       ${status.pid ? c.dim(String(status.pid)) : c.dim('-')}`);
+                console.log(`  Port:      ${c.dim(String(status.port))}`);
+                console.log(`  Autostart: ${status.autostart.enabled ? c.ok(`enabled (${status.autostart.mode})`) : c.warn(`disabled (${status.autostart.mode})`)}`);
+                if (status.autostart.path) {
+                    console.log(`  Auto Path: ${c.dim(status.autostart.path)}`);
+                }
+                console.log(`  PID File:  ${c.dim(status.paths.pidFile)}`);
+                console.log(`  Log File:  ${c.dim(status.paths.logFile)}`);
+                if (status.stalePid) {
+                    console.log(`  Note:      ${c.warn('stale PID file was cleaned up')}`);
+                }
+                console.log('');
+                return;
+            }
+            case 'enable': {
+                const result = enableAutostart(daemonRuntimeOptions);
+                console.log(`${c.ok('[OK]')} Autostart enabled via ${result.mode}.`);
+                if (result.path) {
+                    console.log(`       ${c.dim(result.path)}`);
+                }
+                console.log(`${c.tip('[TIP]')} Use ${c.bright('cloudcli daemon status')} to confirm.`);
+                return;
+            }
+            case 'disable': {
+                const result = disableAutostart();
+                console.log(`${c.ok('[OK]')} Autostart disabled (${result.mode}).`);
+                if (result.path) {
+                    console.log(`       ${c.dim(result.path)}`);
+                }
+                return;
+            }
+            case 'logs': {
+                const logs = readDaemonLogs({ lines: 200 });
+                if (!logs.exists) {
+                    console.log(`${c.warn('[WARN]')} No daemon log file found yet.`);
+                    console.log(`       ${c.dim(logs.logFile)}`);
+                    return;
+                }
+
+                console.log(`\n${c.bright('CloudCLI Daemon Logs')} (${c.dim(logs.logFile)})\n`);
+                if (logs.content) {
+                    console.log(logs.content);
+                } else {
+                    console.log(c.dim('(log file is empty)'));
+                }
+                console.log('');
+                return;
+            }
+            default:
+                showDaemonHelp();
+        }
+    } catch (error) {
+        console.error(`${c.error('[ERROR]')} Daemon command failed: ${error.message}`);
+        if (process.platform === 'linux' && subcommand === 'enable') {
+            console.log(`${c.tip('[TIP]')} Ensure user-level systemd is available, then retry ${c.bright('cloudcli daemon enable')}.`);
+        }
+        process.exit(1);
+    }
+}
+
 // ── Server ──────────────────────────────────────────────────
 
 // Start the server
 async function startServer() {
-    // Check for updates silently on startup
-    checkForUpdates(true);
+    // Check for updates silently on startup (can be disabled for daemon bootstrap)
+    if (process.env.CLOUDCLI_SKIP_UPDATE_CHECK !== '1') {
+        checkForUpdates(true);
+    }
 
     // Import and run the server
     await import('./index.js');
@@ -626,7 +833,7 @@ function parseArgs(args) {
             parsed.command = 'version';
         } else if (!arg.startsWith('-')) {
             parsed.command = arg;
-            if (arg === 'sandbox') {
+            if (arg === 'sandbox' || arg === 'daemon') {
                 parsed.remainingArgs = args.slice(i + 1);
                 break;
             }
@@ -654,6 +861,9 @@ async function main() {
     switch (command) {
         case 'start':
             await startServer();
+            break;
+        case 'daemon':
+            await daemonCommand(remainingArgs || [], options);
             break;
         case 'sandbox':
             await sandboxCommand(remainingArgs || []);

--- a/server/daemon/manager.js
+++ b/server/daemon/manager.js
@@ -1,0 +1,564 @@
+import fs from 'fs';
+import http from 'http';
+import os from 'os';
+import path from 'path';
+import { execFileSync, spawn } from 'child_process';
+
+const DEFAULT_SERVER_PORT = 3001;
+const DAEMON_DIR = path.join(os.homedir(), '.cloudcli', 'daemon');
+const PID_FILE = path.join(DAEMON_DIR, 'daemon.pid');
+const STATE_FILE = path.join(DAEMON_DIR, 'daemon-state.json');
+const LOG_FILE = path.join(DAEMON_DIR, 'daemon.log');
+
+const LINUX_SYSTEMD_UNIT = 'cloudcli-daemon.service';
+const LINUX_SYSTEMD_UNIT_PATH = path.join(os.homedir(), '.config', 'systemd', 'user', LINUX_SYSTEMD_UNIT);
+const MACOS_LAUNCH_AGENT_LABEL = 'ai.cloudcli.daemon';
+const MACOS_LAUNCH_AGENT_PATH = path.join(os.homedir(), 'Library', 'LaunchAgents', `${MACOS_LAUNCH_AGENT_LABEL}.plist`);
+const WINDOWS_TASK_NAME = 'cloudcli-daemon';
+
+function ensureDaemonDir() {
+  fs.mkdirSync(DAEMON_DIR, { recursive: true });
+}
+
+function parsePort(value, fallback = DEFAULT_SERVER_PORT) {
+  if (value == null || value === '') {
+    return fallback;
+  }
+
+  const parsed = Number.parseInt(String(value), 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function readPidFile() {
+  try {
+    const raw = fs.readFileSync(PID_FILE, 'utf8').trim();
+    const pid = Number.parseInt(raw, 10);
+    return Number.isFinite(pid) && pid > 0 ? pid : null;
+  } catch {
+    return null;
+  }
+}
+
+function writePidFile(pid) {
+  fs.writeFileSync(PID_FILE, `${pid}\n`);
+}
+
+function readStateFile() {
+  try {
+    const raw = fs.readFileSync(STATE_FILE, 'utf8');
+    const parsed = JSON.parse(raw);
+    if (!parsed || typeof parsed !== 'object') {
+      return {};
+    }
+    return parsed;
+  } catch {
+    return {};
+  }
+}
+
+function writeStateFile(state) {
+  fs.writeFileSync(STATE_FILE, JSON.stringify(state, null, 2));
+}
+
+function safeUnlink(filePath) {
+  try {
+    fs.unlinkSync(filePath);
+  } catch (error) {
+    if (error?.code !== 'ENOENT') {
+      throw error;
+    }
+  }
+}
+
+function clearDaemonFiles() {
+  safeUnlink(PID_FILE);
+  safeUnlink(STATE_FILE);
+}
+
+function isProcessRunning(pid) {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function waitForProcessExit(pid, timeoutMs) {
+  const deadline = Date.now() + timeoutMs;
+
+  while (Date.now() < deadline) {
+    if (!isProcessRunning(pid)) {
+      return true;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 200));
+  }
+
+  return !isProcessRunning(pid);
+}
+
+function quoteSystemdArg(arg) {
+  return `"${String(arg).replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
+}
+
+function quoteWindowsArg(arg) {
+  return `"${String(arg).replace(/"/g, '""')}"`;
+}
+
+function xmlEscape(value) {
+  return String(value)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+}
+
+function buildDaemonStartArgs({ serverPort, databasePath } = {}) {
+  const args = ['daemon', 'start'];
+
+  if (serverPort) {
+    args.push('--port', String(serverPort));
+  }
+
+  if (databasePath) {
+    args.push('--database-path', databasePath);
+  }
+
+  return args;
+}
+
+function terminateProcess(pid, force = false) {
+  if (process.platform === 'win32') {
+    const args = ['/PID', String(pid), '/T'];
+    if (force) {
+      args.push('/F');
+    }
+    execFileSync('taskkill', args, { stdio: 'pipe' });
+    return;
+  }
+
+  process.kill(pid, force ? 'SIGKILL' : 'SIGTERM');
+}
+
+async function checkHealth(port) {
+  return new Promise((resolve) => {
+    let settled = false;
+    const complete = (value) => {
+      if (!settled) {
+        settled = true;
+        resolve(value);
+      }
+    };
+
+    const req = http.get({
+      host: '127.0.0.1',
+      port,
+      path: '/health',
+      timeout: 1200
+    }, (res) => {
+      complete(Boolean(res.statusCode && res.statusCode >= 200 && res.statusCode < 500));
+      res.resume();
+    });
+
+    req.on('error', () => complete(false));
+    req.on('timeout', () => {
+      req.destroy();
+      complete(false);
+    });
+  });
+}
+
+function buildLinuxSystemdUnit({ nodePath, cliEntryPath, serverPort, databasePath }) {
+  const startArgs = buildDaemonStartArgs({ serverPort, databasePath });
+  const execStart = [quoteSystemdArg(nodePath), quoteSystemdArg(cliEntryPath), ...startArgs.map(quoteSystemdArg)].join(' ');
+  const execStop = [quoteSystemdArg(nodePath), quoteSystemdArg(cliEntryPath), quoteSystemdArg('daemon'), quoteSystemdArg('stop')].join(' ');
+
+  return `[Unit]
+Description=CloudCLI daemon bootstrap
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=${execStart}
+ExecStop=${execStop}
+
+[Install]
+WantedBy=default.target
+`;
+}
+
+function enableLinuxAutostart(options) {
+  const systemdDir = path.dirname(LINUX_SYSTEMD_UNIT_PATH);
+  fs.mkdirSync(systemdDir, { recursive: true });
+  fs.writeFileSync(LINUX_SYSTEMD_UNIT_PATH, buildLinuxSystemdUnit(options), 'utf8');
+
+  try {
+    execFileSync('systemctl', ['--user', 'daemon-reload'], { stdio: 'pipe' });
+    execFileSync('systemctl', ['--user', 'enable', '--now', LINUX_SYSTEMD_UNIT], { stdio: 'pipe' });
+  } catch (error) {
+    throw new Error(`Failed to enable systemd user service. ${error.message}`);
+  }
+
+  return { mode: 'systemd', enabled: true, path: LINUX_SYSTEMD_UNIT_PATH };
+}
+
+function disableLinuxAutostart() {
+  try {
+    execFileSync('systemctl', ['--user', 'disable', '--now', LINUX_SYSTEMD_UNIT], { stdio: 'pipe' });
+  } catch {
+    // Best-effort disable; we still remove the unit file below.
+  }
+
+  safeUnlink(LINUX_SYSTEMD_UNIT_PATH);
+
+  try {
+    execFileSync('systemctl', ['--user', 'daemon-reload'], { stdio: 'pipe' });
+  } catch {
+    // Non-systemd environments may fail this call.
+  }
+
+  return { mode: 'systemd', enabled: false, path: LINUX_SYSTEMD_UNIT_PATH };
+}
+
+function getLinuxAutostartStatus() {
+  if (!fs.existsSync(LINUX_SYSTEMD_UNIT_PATH)) {
+    return { enabled: false, mode: 'systemd', path: LINUX_SYSTEMD_UNIT_PATH };
+  }
+
+  try {
+    const enabled = execFileSync('systemctl', ['--user', 'is-enabled', LINUX_SYSTEMD_UNIT], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe']
+    }).trim();
+    return { enabled: enabled === 'enabled', mode: 'systemd', path: LINUX_SYSTEMD_UNIT_PATH };
+  } catch {
+    return { enabled: false, mode: 'systemd', path: LINUX_SYSTEMD_UNIT_PATH };
+  }
+}
+
+function buildMacLaunchAgent({ nodePath, cliEntryPath, serverPort, databasePath }) {
+  const args = [nodePath, cliEntryPath, ...buildDaemonStartArgs({ serverPort, databasePath })];
+  const xmlArgs = args.map((arg) => `    <string>${xmlEscape(arg)}</string>`).join('\n');
+
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>${MACOS_LAUNCH_AGENT_LABEL}</string>
+  <key>ProgramArguments</key>
+  <array>
+${xmlArgs}
+  </array>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>KeepAlive</key>
+  <false/>
+  <key>StandardOutPath</key>
+  <string>${xmlEscape(LOG_FILE)}</string>
+  <key>StandardErrorPath</key>
+  <string>${xmlEscape(LOG_FILE)}</string>
+</dict>
+</plist>
+`;
+}
+
+function enableMacAutostart(options) {
+  fs.mkdirSync(path.dirname(MACOS_LAUNCH_AGENT_PATH), { recursive: true });
+  fs.writeFileSync(MACOS_LAUNCH_AGENT_PATH, buildMacLaunchAgent(options), 'utf8');
+
+  try {
+    execFileSync('launchctl', ['unload', MACOS_LAUNCH_AGENT_PATH], { stdio: 'pipe' });
+  } catch {
+    // If not loaded yet, unload fails — safe to ignore.
+  }
+
+  execFileSync('launchctl', ['load', '-w', MACOS_LAUNCH_AGENT_PATH], { stdio: 'pipe' });
+
+  return { mode: 'launchagent', enabled: true, path: MACOS_LAUNCH_AGENT_PATH };
+}
+
+function disableMacAutostart() {
+  try {
+    execFileSync('launchctl', ['unload', '-w', MACOS_LAUNCH_AGENT_PATH], { stdio: 'pipe' });
+  } catch {
+    // Best effort.
+  }
+
+  safeUnlink(MACOS_LAUNCH_AGENT_PATH);
+  return { mode: 'launchagent', enabled: false, path: MACOS_LAUNCH_AGENT_PATH };
+}
+
+function getMacAutostartStatus() {
+  return {
+    enabled: fs.existsSync(MACOS_LAUNCH_AGENT_PATH),
+    mode: 'launchagent',
+    path: MACOS_LAUNCH_AGENT_PATH
+  };
+}
+
+function enableWindowsAutostart({ nodePath, cliEntryPath, serverPort, databasePath }) {
+  const command = [
+    quoteWindowsArg(nodePath),
+    quoteWindowsArg(cliEntryPath),
+    ...buildDaemonStartArgs({ serverPort, databasePath }).map(quoteWindowsArg)
+  ].join(' ');
+
+  execFileSync('schtasks', [
+    '/Create',
+    '/F',
+    '/SC',
+    'ONLOGON',
+    '/TN',
+    WINDOWS_TASK_NAME,
+    '/TR',
+    command,
+    '/RL',
+    'LIMITED'
+  ], { stdio: 'pipe' });
+
+  try {
+    execFileSync('schtasks', ['/Run', '/TN', WINDOWS_TASK_NAME], { stdio: 'pipe' });
+  } catch {
+    // Task creation succeeded; run may fail in some contexts.
+  }
+
+  return { mode: 'taskscheduler', enabled: true, path: WINDOWS_TASK_NAME };
+}
+
+function disableWindowsAutostart() {
+  try {
+    execFileSync('schtasks', ['/Delete', '/F', '/TN', WINDOWS_TASK_NAME], { stdio: 'pipe' });
+  } catch {
+    // Best effort; task may already be absent.
+  }
+
+  return { mode: 'taskscheduler', enabled: false, path: WINDOWS_TASK_NAME };
+}
+
+function getWindowsAutostartStatus() {
+  try {
+    execFileSync('schtasks', ['/Query', '/TN', WINDOWS_TASK_NAME], { stdio: 'pipe' });
+    return { enabled: true, mode: 'taskscheduler', path: WINDOWS_TASK_NAME };
+  } catch {
+    return { enabled: false, mode: 'taskscheduler', path: WINDOWS_TASK_NAME };
+  }
+}
+
+export function getDaemonPaths() {
+  return {
+    daemonDir: DAEMON_DIR,
+    pidFile: PID_FILE,
+    stateFile: STATE_FILE,
+    logFile: LOG_FILE
+  };
+}
+
+export function startDaemon({ nodePath, cliEntryPath, serverPort, databasePath } = {}) {
+  if (!nodePath || !cliEntryPath) {
+    throw new Error('nodePath and cliEntryPath are required to start daemon mode');
+  }
+
+  ensureDaemonDir();
+
+  const existingPid = readPidFile();
+  if (existingPid && isProcessRunning(existingPid)) {
+    const state = readStateFile();
+    return {
+      started: false,
+      alreadyRunning: true,
+      pid: existingPid,
+      port: parsePort(state.serverPort)
+    };
+  }
+
+  if (existingPid) {
+    clearDaemonFiles();
+  }
+
+  const resolvedPort = parsePort(serverPort, parsePort(process.env.SERVER_PORT || process.env.PORT));
+  const resolvedDatabasePath = databasePath || process.env.DATABASE_PATH || null;
+  const args = ['start', '--port', String(resolvedPort)];
+  if (resolvedDatabasePath) {
+    args.push('--database-path', resolvedDatabasePath);
+  }
+
+  const logFd = fs.openSync(LOG_FILE, 'a');
+  try {
+    const child = spawn(nodePath, [cliEntryPath, ...args], {
+      detached: true,
+      stdio: ['ignore', logFd, logFd],
+      windowsHide: true,
+      env: {
+        ...process.env,
+        CLOUDCLI_SKIP_UPDATE_CHECK: '1',
+        SERVER_PORT: String(resolvedPort),
+        ...(resolvedDatabasePath ? { DATABASE_PATH: resolvedDatabasePath } : {})
+      }
+    });
+
+    child.unref();
+    writePidFile(child.pid);
+    writeStateFile({
+      pid: child.pid,
+      serverPort: resolvedPort,
+      databasePath: resolvedDatabasePath,
+      startedAt: new Date().toISOString()
+    });
+
+    return {
+      started: true,
+      alreadyRunning: false,
+      pid: child.pid,
+      port: resolvedPort
+    };
+  } finally {
+    fs.closeSync(logFd);
+  }
+}
+
+export async function stopDaemon() {
+  ensureDaemonDir();
+  const pid = readPidFile();
+
+  if (!pid) {
+    return { stopped: false, reason: 'not_running' };
+  }
+
+  if (!isProcessRunning(pid)) {
+    clearDaemonFiles();
+    return { stopped: true, reason: 'stale_pid', pid };
+  }
+
+  try {
+    terminateProcess(pid, process.platform === 'win32');
+  } catch (error) {
+    if (!isProcessRunning(pid)) {
+      clearDaemonFiles();
+      return { stopped: true, reason: 'stopped', pid };
+    }
+
+    return { stopped: false, reason: 'termination_failed', pid, error: error.message };
+  }
+
+  let stopped = await waitForProcessExit(pid, 10000);
+  if (!stopped && process.platform !== 'win32') {
+    try {
+      terminateProcess(pid, true);
+    } catch {
+      // Best effort.
+    }
+    stopped = await waitForProcessExit(pid, 5000);
+  }
+
+  if (stopped) {
+    clearDaemonFiles();
+    return { stopped: true, reason: 'stopped', pid };
+  }
+
+  return { stopped: false, reason: 'timeout', pid };
+}
+
+export async function getDaemonStatus({ serverPort } = {}) {
+  ensureDaemonDir();
+
+  const state = readStateFile();
+  const pid = readPidFile();
+  let running = false;
+  let stalePid = false;
+
+  if (pid) {
+    running = isProcessRunning(pid);
+    stalePid = !running;
+    if (stalePid) {
+      clearDaemonFiles();
+    }
+  }
+
+  const resolvedPort = parsePort(
+    state.serverPort ?? serverPort ?? process.env.SERVER_PORT ?? process.env.PORT
+  );
+
+  const health = running ? await checkHealth(resolvedPort) : false;
+  const autostart = getAutostartStatus();
+
+  return {
+    running,
+    stalePid,
+    pid: running ? pid : null,
+    port: resolvedPort,
+    health,
+    autostart,
+    paths: getDaemonPaths(),
+    state: running ? state : {}
+  };
+}
+
+export function enableAutostart({ nodePath, cliEntryPath, serverPort, databasePath } = {}) {
+  if (!nodePath || !cliEntryPath) {
+    throw new Error('nodePath and cliEntryPath are required to enable autostart');
+  }
+
+  const options = { nodePath, cliEntryPath, serverPort, databasePath };
+
+  if (process.platform === 'linux') {
+    return enableLinuxAutostart(options);
+  }
+
+  if (process.platform === 'darwin') {
+    return enableMacAutostart(options);
+  }
+
+  if (process.platform === 'win32') {
+    return enableWindowsAutostart(options);
+  }
+
+  throw new Error(`Autostart is not supported on platform: ${process.platform}`);
+}
+
+export function disableAutostart() {
+  if (process.platform === 'linux') {
+    return disableLinuxAutostart();
+  }
+
+  if (process.platform === 'darwin') {
+    return disableMacAutostart();
+  }
+
+  if (process.platform === 'win32') {
+    return disableWindowsAutostart();
+  }
+
+  throw new Error(`Autostart is not supported on platform: ${process.platform}`);
+}
+
+export function getAutostartStatus() {
+  if (process.platform === 'linux') {
+    return getLinuxAutostartStatus();
+  }
+
+  if (process.platform === 'darwin') {
+    return getMacAutostartStatus();
+  }
+
+  if (process.platform === 'win32') {
+    return getWindowsAutostartStatus();
+  }
+
+  return { enabled: false, mode: 'unsupported', path: null };
+}
+
+export function readDaemonLogs({ lines = 200 } = {}) {
+  ensureDaemonDir();
+  if (!fs.existsSync(LOG_FILE)) {
+    return { exists: false, content: '', logFile: LOG_FILE };
+  }
+
+  const raw = fs.readFileSync(LOG_FILE, 'utf8');
+  const lineList = raw.split(/\r?\n/);
+  const limited = lineList.slice(Math.max(0, lineList.length - lines)).join('\n');
+  return { exists: true, content: limited.trim(), logFile: LOG_FILE };
+}

--- a/server/index.js
+++ b/server/index.js
@@ -206,7 +206,13 @@ const app = express();
 const server = http.createServer(app);
 
 const ptySessionsMap = new Map();
-const PTY_SESSION_TIMEOUT = 30 * 60 * 1000;
+function getPtySessionTimeoutMs() {
+    const parsedMinutes = Number.parseInt(process.env.SHELL_SESSION_TIMEOUT_MINUTES || '', 10);
+    const timeoutMinutes = Number.isFinite(parsedMinutes) && parsedMinutes > 0 ? parsedMinutes : 30;
+    return timeoutMinutes * 60 * 1000;
+}
+
+const PTY_SESSION_TIMEOUT = getPtySessionTimeoutMs();
 const SHELL_URL_PARSE_BUFFER_LIMIT = 32768;
 import { stripAnsiSequences, normalizeDetectedUrl, extractUrlsFromText, shouldAutoOpenUrlFromOutput } from './utils/url-detection.js';
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added daemon mode to keep CloudCLI running in the background after terminal closes.
  * Introduced daemon subcommands: start, stop, status, enable (autostart), disable, logs.
  * Configurable shell session timeout (default 30 minutes).

* **Documentation**
  * Updated setup guide with daemon mode instructions and usage examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->