### PR TITLE
Keep backend and frontend daemonized in system mode

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,7 @@
 # Available CLI commands:
 #   claude-code-ui    - Start the server (default)
 #   cloudcli start    - Start the server
+#   cloudcli daemon   - Manage background daemon mode
 #   cloudcli status   - Show configuration and data locations
 #   cloudcli help     - Show help information
 #   cloudcli version  - Show version information
@@ -25,6 +26,10 @@ VITE_PORT=5173
 # Use 127.0.0.1 to restrict to localhost only
 HOST=0.0.0.0
 
+# Shell reconnect timeout after websocket disconnect (minutes)
+# Default: 30
+# SHELL_SESSION_TIMEOUT_MINUTES=30
+
 # Uncomment the following line if you have a custom claude cli path other than the default "claude"
 # CLAUDE_CLI_PATH=claude
 
@@ -41,5 +46,4 @@ HOST=0.0.0.0
 # Claude Code context window size (maximum tokens per session)
 VITE_CONTEXT_WINDOW=160000
 CONTEXT_WINDOW=160000
-
 

--- a/README.md
+++ b/README.md
@@ -95,27 +95,40 @@ Open `http://localhost:3001` — all your existing sessions are discovered autom
 
 Visit the **[documentation →](https://cloudcli.ai/docs)** for full configuration options, PM2, remote server setup and more.
 
-#### Keep CloudCLI running after terminal closes
+#### Keep It Running On Linux (VDS / SSH-safe)
 
-Use daemon mode to keep CloudCLI alive in background and reconnect later:
+If you run CloudCLI over SSH and your terminal disconnects, foreground processes like `npm run dev` will stop.  
+Use the built-in daemon manager to run CloudCLI as a persistent service:
 
-```
-cloudcli daemon start
-cloudcli daemon status
-```
+```bash
+# Default behavior on Linux (auto-daemon):
+cloudcli
 
-Enable startup on login (platform-native):
-
-```
-cloudcli daemon enable
+# Explicit install (recommended on first setup):
+cloudcli daemon install --mode auto --port 3001
+cloudcli daemon status --mode auto
+cloudcli daemon doctor --mode auto
 ```
 
 Useful commands:
 
+```bash
+cloudcli daemon logs --mode auto
+cloudcli daemon restart --mode auto
+cloudcli daemon stop --mode auto      # temporary stop, auto-start remains enabled
+cloudcli daemon disable --mode auto   # disable auto-start at boot
+cloudcli daemon uninstall --mode auto
+cloudcli update --restart-daemon
 ```
-cloudcli daemon stop
-cloudcli daemon logs
-```
+
+Notes:
+- On Linux, `cloudcli` now attempts auto-daemon startup by default.
+- `npm run dev`, `npm run start`, and direct server entrypoints now pass through the same auto-daemon behavior.
+- Recommended for always-on server deployments: use `cloudcli daemon install`, not `npm run dev`.
+- `--mode user` uses `systemctl --user`, `--mode system` uses system service management, and `--mode auto` chooses the best available mode.
+- Use `cloudcli --no-daemon` (or `CLOUDCLI_NO_DAEMON=1`) to force foreground mode.
+- On some servers you may need to enable linger for boot-time startup without an active login session:
+  `sudo loginctl enable-linger <your-username>`
 
 #### Docker Sandboxes (Experimental)
 

--- a/README.md
+++ b/README.md
@@ -95,6 +95,28 @@ Open `http://localhost:3001` — all your existing sessions are discovered autom
 
 Visit the **[documentation →](https://cloudcli.ai/docs)** for full configuration options, PM2, remote server setup and more.
 
+#### Keep CloudCLI running after terminal closes
+
+Use daemon mode to keep CloudCLI alive in background and reconnect later:
+
+```
+cloudcli daemon start
+cloudcli daemon status
+```
+
+Enable startup on login (platform-native):
+
+```
+cloudcli daemon enable
+```
+
+Useful commands:
+
+```
+cloudcli daemon stop
+cloudcli daemon logs
+```
+
 #### Docker Sandboxes (Experimental)
 
 Run agents in isolated sandboxes with hypervisor-level isolation. Starts Claude Code by default. Requires the [`sbx` CLI](https://docs.docker.com/ai/sandboxes/get-started/).

--- a/package.json
+++ b/package.json
@@ -24,10 +24,10 @@
     "url": "https://github.com/siteboon/claudecodeui/issues"
   },
   "scripts": {
-    "dev": "concurrently --kill-others \"npm run server:dev\" \"npm run client\"",
-    "server": "node dist-server/server/index.js",
-    "server:dev": "tsx --tsconfig server/tsconfig.json server/index.js",
-    "server:dev-watch": "tsx watch --tsconfig server/tsconfig.json server/index.js",
+    "dev": "concurrently \"npm run server:dev\" \"npm run client\"",
+    "server": "node dist-server/server/cli.js start",
+    "server:dev": "tsx --tsconfig server/tsconfig.json server/cli.js start",
+    "server:dev-watch": "tsx watch --tsconfig server/tsconfig.json server/cli.js start",
     "client": "vite",
     "build": "npm run build:client && npm run build:server",
     "build:client": "vite build",

--- a/package.json
+++ b/package.json
@@ -24,10 +24,10 @@
     "url": "https://github.com/siteboon/claudecodeui/issues"
   },
   "scripts": {
-    "dev": "concurrently \"npm run server:dev\" \"npm run client\"",
+    "dev": "npm run server:dev",
     "server": "node dist-server/server/cli.js start",
-    "server:dev": "tsx --tsconfig server/tsconfig.json server/cli.js start",
-    "server:dev-watch": "tsx watch --tsconfig server/tsconfig.json server/cli.js start",
+    "server:dev": "node server/cli.js daemon install --mode system --port 3001 --frontend-port 5173",
+    "server:dev-watch": "node server/cli.js daemon restart --mode system --port 3001 --frontend-port 5173",
     "client": "vite",
     "build": "npm run build:client && npm run build:server",
     "build:client": "vite build",

--- a/server/cli.js
+++ b/server/cli.js
@@ -7,8 +7,8 @@
  * Commands:
  *   (no args)     - Start the server (default)
  *   start         - Start the server
- *   daemon        - Run and manage background daemon mode
  *   sandbox       - Manage Docker sandbox environments
+ *   daemon        - Manage persistent Linux service modes
  *   status        - Show configuration and data locations
  *   help          - Show help information
  *   version       - Show version information
@@ -17,16 +17,9 @@
 import fs from 'fs';
 import path from 'path';
 import os from 'os';
-
+import net from 'node:net';
 import { findAppRoot, getModuleDir } from './utils/runtime-paths.js';
-import {
-    disableAutostart,
-    enableAutostart,
-    getDaemonStatus,
-    readDaemonLogs,
-    startDaemon,
-    stopDaemon
-} from './daemon/manager.js';
+import { handleDaemonCommand, hasInstalledDaemonUnit } from './daemon-manager.js';
 
 const __dirname = getModuleDir(import.meta.url);
 // The CLI is compiled into dist-server/server, but it still needs to read the top-level
@@ -148,7 +141,6 @@ function showStatus() {
     console.log(`\n${c.tip('[TIP]')} Hints:`);
     console.log(`      ${c.dim('>')} Use ${c.bright('cloudcli --port 8080')} to run on a custom port`);
     console.log(`      ${c.dim('>')} Use ${c.bright('cloudcli --database-path /path/to/db')} for custom database`);
-    console.log(`      ${c.dim('>')} Use ${c.bright('cloudcli daemon start')} to keep CloudCLI running in background`);
     console.log(`      ${c.dim('>')} Run ${c.bright('cloudcli help')} for all options`);
     console.log(`      ${c.dim('>')} Access the UI at http://localhost:${process.env.SERVER_PORT || process.env.PORT || '3001'}\n`);
 }
@@ -166,7 +158,7 @@ Usage:
 
 Commands:
   start          Start the CloudCLI server (default)
-  daemon         Manage background daemon mode
+  daemon         Manage persistent Linux service (user/system/auto)
   sandbox        Manage Docker sandbox environments
   status         Show configuration and data locations
   update         Update to the latest version
@@ -176,14 +168,18 @@ Commands:
 Options:
   -p, --port <port>           Set server port (default: 3001)
   --database-path <path>      Set custom database location
+  --no-daemon                 Disable automatic daemon startup on Linux
+  --restart-daemon            Restart daemon automatically after update
   -h, --help                  Show this help information
   -v, --version               Show version information
 
 Examples:
   $ cloudcli                        # Start with defaults
   $ cloudcli --port 8080            # Start on port 8080
-  $ cloudcli daemon start           # Start in background daemon mode
-  $ cloudcli daemon enable          # Enable auto-start on login
+  $ cloudcli --no-daemon            # Force foreground mode
+  $ cloudcli daemon install --mode auto --port 3001
+  $ cloudcli daemon doctor --mode auto
+  $ cloudcli update --restart-daemon
   $ cloudcli sandbox ~/my-project   # Run in a Docker sandbox
   $ cloudcli status                 # Show configuration
 
@@ -193,7 +189,6 @@ Environment Variables:
   DATABASE_PATH       Set custom database location
   CLAUDE_CLI_PATH     Set custom Claude CLI path
   CONTEXT_WINDOW      Set context window size (default: 160000)
-  SHELL_SESSION_TIMEOUT_MINUTES  PTY reconnect timeout (default: 30)
 
 Documentation:
   ${packageJson.homepage || 'https://github.com/siteboon/claudecodeui'}
@@ -243,7 +238,7 @@ async function checkForUpdates(silent = false) {
 }
 
 // Update the package
-async function updatePackage() {
+async function updatePackage(options = {}) {
     try {
         const { execSync } = await import('child_process');
         console.log(`${c.info('[INFO]')} Checking for updates...`);
@@ -257,7 +252,26 @@ async function updatePackage() {
 
         console.log(`${c.info('[INFO]')} Updating from ${currentVersion} to ${latestVersion}...`);
         execSync('npm update -g @cloudcli-ai/cloudcli', { stdio: 'inherit' });
-        console.log(`${c.ok('[OK]')} Update complete! Restart cloudcli to use the new version.`);
+        console.log(`${c.ok('[OK]')} Update complete!`);
+
+        if (options.restartDaemon) {
+            if (!hasInstalledDaemonUnit()) {
+                console.log(`${c.warn('[WARN]')} No daemon unit detected; skipping restart.`);
+                return;
+            }
+            console.log(`${c.info('[INFO]')} Restarting daemon service...`);
+            await handleDaemonCommand(['restart', '--mode=auto'], {
+                appRoot: APP_ROOT,
+                defaultPort: process.env.SERVER_PORT || process.env.PORT || '3001',
+                color: c,
+            });
+            console.log(`${c.ok('[OK]')} Daemon restart completed.`);
+        } else if (hasInstalledDaemonUnit()) {
+            console.log(`${c.tip('[TIP]')} Daemon unit detected. Restart to apply update: ${c.bright('cloudcli daemon restart --mode auto')}`);
+            console.log(`${c.tip('[TIP]')} Or update + restart in one step: ${c.bright('cloudcli update --restart-daemon')}`);
+        } else {
+            console.log(`${c.tip('[TIP]')} Restart cloudcli to use the new version.`);
+        }
     } catch (e) {
         console.error(`${c.error('[ERROR]')} Update failed: ${e.message}`);
         console.log(`${c.tip('[TIP]')} Try running manually: npm update -g @cloudcli-ai/cloudcli`);
@@ -609,212 +623,93 @@ async function sandboxCommand(args) {
     }
 }
 
-// ── Daemon command ──────────────────────────────────────────
-
-function parseDaemonArgs(args) {
-    const parsed = {
-        subcommand: 'status',
-        options: {}
-    };
-
-    const subcommands = new Set(['start', 'stop', 'status', 'enable', 'disable', 'logs', 'help']);
-    let subcommandSet = false;
-
-    for (let i = 0; i < args.length; i++) {
-        const arg = args[i];
-
-        if (arg === '--port' || arg === '-p') {
-            parsed.options.serverPort = args[++i];
-        } else if (arg.startsWith('--port=')) {
-            parsed.options.serverPort = arg.split('=')[1];
-        } else if (arg === '--database-path') {
-            parsed.options.databasePath = args[++i];
-        } else if (arg.startsWith('--database-path=')) {
-            parsed.options.databasePath = arg.split('=')[1];
-        } else if (arg === '--help' || arg === '-h') {
-            parsed.subcommand = 'help';
-            subcommandSet = true;
-        } else if (!arg.startsWith('-') && !subcommandSet) {
-            parsed.subcommand = arg;
-            subcommandSet = true;
-        }
-    }
-
-    if (!subcommands.has(parsed.subcommand)) {
-        parsed.subcommand = `unknown:${parsed.subcommand}`;
-    }
-
-    return parsed;
-}
-
-function showDaemonHelp() {
-    console.log(`
-${c.bright('CloudCLI Daemon')} — Keep CloudCLI running after terminal closes
-
-Usage:
-  cloudcli daemon <subcommand> [options]
-
-Subcommands:
-  ${c.bright('start')}        Start CloudCLI in detached background mode
-  ${c.bright('stop')}         Stop the running daemon
-  ${c.bright('status')}       Show daemon, health, and autostart status
-  ${c.bright('logs')}         Show recent daemon logs
-  ${c.bright('enable')}       Enable autostart on user login (platform native)
-  ${c.bright('disable')}      Disable autostart on user login
-  ${c.bright('help')}         Show this help
-
-Options:
-  -p, --port <port>           Server port for start/enable (default: 3001)
-  --database-path <path>      Database path for start/enable
-
-Examples:
-  $ cloudcli daemon start
-  $ cloudcli daemon start --port 3001
-  $ cloudcli daemon status
-  $ cloudcli daemon enable --port 3001
-  $ cloudcli daemon logs
-`);
-}
-
-async function daemonCommand(args, globalOptions = {}) {
-    const { subcommand, options } = parseDaemonArgs(args);
-
-    if (subcommand.startsWith('unknown:')) {
-        const invalidSubcommand = subcommand.split(':')[1];
-        console.error(`\n${c.error('❌')} Unknown daemon subcommand: ${invalidSubcommand}`);
-        console.log(`   Run ${c.bright('cloudcli daemon help')} for usage.\n`);
-        process.exit(1);
-    }
-
-    const effectiveOptions = {
-        serverPort: options.serverPort || globalOptions.serverPort || process.env.SERVER_PORT || process.env.PORT || '3001',
-        databasePath: options.databasePath || globalOptions.databasePath || process.env.DATABASE_PATH || ''
-    };
-
-    const daemonRuntimeOptions = {
-        nodePath: process.execPath,
-        cliEntryPath: path.resolve(process.argv[1]),
-        serverPort: effectiveOptions.serverPort,
-        databasePath: effectiveOptions.databasePath || null
-    };
-
-    try {
-        switch (subcommand) {
-            case 'help':
-                showDaemonHelp();
-                return;
-            case 'start': {
-                const result = startDaemon(daemonRuntimeOptions);
-                if (result.alreadyRunning) {
-                    console.log(`${c.ok('[OK]')} CloudCLI daemon is already running (PID ${result.pid}) on port ${result.port}.`);
-                } else {
-                    console.log(`${c.ok('[OK]')} CloudCLI daemon started (PID ${result.pid}) on port ${result.port}.`);
-                }
-                console.log(`${c.tip('[TIP]')} Use ${c.bright('cloudcli daemon status')} to verify health.`);
-                return;
-            }
-            case 'stop': {
-                const result = await stopDaemon();
-                if (result.stopped && result.reason === 'stale_pid') {
-                    console.log(`${c.warn('[WARN]')} Stale PID cleaned up. No running daemon process was found.`);
-                    return;
-                }
-
-                if (result.stopped) {
-                    console.log(`${c.ok('[OK]')} CloudCLI daemon stopped.`);
-                    return;
-                }
-
-                if (result.reason === 'not_running') {
-                    console.log(`${c.warn('[WARN]')} CloudCLI daemon is not running.`);
-                    return;
-                }
-
-                console.error(`${c.error('[ERROR]')} Failed to stop daemon${result.error ? `: ${result.error}` : '.'}`);
-                process.exit(1);
-                return;
-            }
-            case 'status': {
-                const status = await getDaemonStatus({ serverPort: effectiveOptions.serverPort });
-                console.log(`\n${c.bright('CloudCLI Daemon Status')}\n`);
-                console.log(`  Running:   ${status.running ? c.ok('yes') : c.warn('no')}`);
-                console.log(`  Health:    ${status.health ? c.ok('healthy') : c.warn(status.running ? 'unreachable' : 'stopped')}`);
-                console.log(`  PID:       ${status.pid ? c.dim(String(status.pid)) : c.dim('-')}`);
-                console.log(`  Port:      ${c.dim(String(status.port))}`);
-                console.log(`  Autostart: ${status.autostart.enabled ? c.ok(`enabled (${status.autostart.mode})`) : c.warn(`disabled (${status.autostart.mode})`)}`);
-                if (status.autostart.path) {
-                    console.log(`  Auto Path: ${c.dim(status.autostart.path)}`);
-                }
-                console.log(`  PID File:  ${c.dim(status.paths.pidFile)}`);
-                console.log(`  Log File:  ${c.dim(status.paths.logFile)}`);
-                if (status.stalePid) {
-                    console.log(`  Note:      ${c.warn('stale PID file was cleaned up')}`);
-                }
-                console.log('');
-                return;
-            }
-            case 'enable': {
-                const result = enableAutostart(daemonRuntimeOptions);
-                console.log(`${c.ok('[OK]')} Autostart enabled via ${result.mode}.`);
-                if (result.path) {
-                    console.log(`       ${c.dim(result.path)}`);
-                }
-                console.log(`${c.tip('[TIP]')} Use ${c.bright('cloudcli daemon status')} to confirm.`);
-                return;
-            }
-            case 'disable': {
-                const result = disableAutostart();
-                console.log(`${c.ok('[OK]')} Autostart disabled (${result.mode}).`);
-                if (result.path) {
-                    console.log(`       ${c.dim(result.path)}`);
-                }
-                return;
-            }
-            case 'logs': {
-                const logs = readDaemonLogs({ lines: 200 });
-                if (!logs.exists) {
-                    console.log(`${c.warn('[WARN]')} No daemon log file found yet.`);
-                    console.log(`       ${c.dim(logs.logFile)}`);
-                    return;
-                }
-
-                console.log(`\n${c.bright('CloudCLI Daemon Logs')} (${c.dim(logs.logFile)})\n`);
-                if (logs.content) {
-                    console.log(logs.content);
-                } else {
-                    console.log(c.dim('(log file is empty)'));
-                }
-                console.log('');
-                return;
-            }
-            default:
-                showDaemonHelp();
-        }
-    } catch (error) {
-        console.error(`${c.error('[ERROR]')} Daemon command failed: ${error.message}`);
-        if (process.platform === 'linux' && subcommand === 'enable') {
-            console.log(`${c.tip('[TIP]')} Ensure user-level systemd is available, then retry ${c.bright('cloudcli daemon enable')}.`);
-        }
-        process.exit(1);
-    }
-}
-
 // ── Server ──────────────────────────────────────────────────
 
 // Start the server
 async function startServer() {
-    // Check for updates silently on startup (can be disabled for daemon bootstrap)
-    if (process.env.CLOUDCLI_SKIP_UPDATE_CHECK !== '1') {
-        checkForUpdates(true);
-    }
+    // Check for updates silently on startup
+    checkForUpdates(true);
 
     // Import and run the server
     await import('./index.js');
 }
 
+async function isPortOpen(port, timeoutMs = 800) {
+    return await new Promise((resolve) => {
+        const socket = net.createConnection({ host: '127.0.0.1', port: Number(port) });
+        let settled = false;
+        const done = (value) => {
+            if (settled) return;
+            settled = true;
+            socket.destroy();
+            resolve(value);
+        };
+
+        socket.setTimeout(timeoutMs);
+        socket.once('connect', () => done(true));
+        socket.once('timeout', () => done(false));
+        socket.once('error', () => done(false));
+    });
+}
+
+async function waitForPortOpen(port, timeoutMs = 25000) {
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+        if (await isPortOpen(port)) {
+            return true;
+        }
+        await new Promise(resolve => setTimeout(resolve, 1000));
+    }
+    return false;
+}
+
+async function maybeAutoDaemonStart(options = {}) {
+    if (process.platform !== 'linux') return false;
+    if (process.env.CLOUDCLI_DAEMON_MANAGED === '1') return false;
+    if (process.env.CLOUDCLI_NO_DAEMON === '1') return false;
+    if (process.env.CLOUDCLI_DAEMON_ATTEMPTED === '1') return false;
+    if (options.noDaemon) return false;
+
+    process.env.CLOUDCLI_DAEMON_ATTEMPTED = '1';
+    const daemonPort = Number(options.serverPort || process.env.SERVER_PORT || process.env.PORT || '3001');
+
+    const daemonArgs = ['install', '--mode=auto'];
+    if (options.serverPort) {
+        daemonArgs.push('--port', String(options.serverPort));
+    }
+    if (options.databasePath) {
+        daemonArgs.push('--database-path', String(options.databasePath));
+    }
+
+    try {
+        console.log(`${c.info('[INFO]')} Linux detected. Starting CloudCLI via daemon mode for persistent uptime...`);
+        await handleDaemonCommand(daemonArgs, {
+            appRoot: APP_ROOT,
+            defaultPort: process.env.SERVER_PORT || process.env.PORT || '3001',
+            color: c,
+        });
+        console.log(`${c.ok('[OK]')} CloudCLI daemon is managing the service.`);
+        console.log(`${c.tip('[TIP]')} Use ${c.bright('cloudcli daemon status --mode auto')} to inspect state.`);
+        return true;
+    } catch (error) {
+        const healthySoon = await waitForPortOpen(daemonPort);
+        if (healthySoon) {
+            console.log(`${c.warn('[WARN]')} Daemon health check was delayed, but port ${daemonPort} is now reachable.`);
+            console.log(`${c.tip('[TIP]')} Continuing with daemon-managed runtime.`);
+            return true;
+        }
+
+        console.log(`${c.warn('[WARN]')} Auto-daemon setup failed, falling back to foreground mode.`);
+        console.log(`       ${c.dim(error.message)}`);
+        console.log(`${c.tip('[TIP]')} Retry manually: ${c.bright('cloudcli daemon install --mode auto')}`);
+        return false;
+    }
+}
+
 // Parse CLI arguments
 function parseArgs(args) {
     const parsed = { command: 'start', options: {} };
+    let commandSet = false;
 
     for (let i = 0; i < args.length; i++) {
         const arg = args[i];
@@ -827,12 +722,21 @@ function parseArgs(args) {
             parsed.options.databasePath = args[++i];
         } else if (arg.startsWith('--database-path=')) {
             parsed.options.databasePath = arg.split('=')[1];
+        } else if (arg === '--no-daemon') {
+            parsed.options.noDaemon = true;
+        } else if (arg === '--restart-daemon') {
+            parsed.options.restartDaemon = true;
         } else if (arg === '--help' || arg === '-h') {
             parsed.command = 'help';
+            commandSet = true;
         } else if (arg === '--version' || arg === '-v') {
             parsed.command = 'version';
+            commandSet = true;
         } else if (!arg.startsWith('-')) {
-            parsed.command = arg;
+            if (!commandSet) {
+                parsed.command = arg;
+                commandSet = true;
+            }
             if (arg === 'sandbox' || arg === 'daemon') {
                 parsed.remainingArgs = args.slice(i + 1);
                 break;
@@ -860,13 +764,20 @@ async function main() {
 
     switch (command) {
         case 'start':
+            if (await maybeAutoDaemonStart(options)) {
+                break;
+            }
             await startServer();
-            break;
-        case 'daemon':
-            await daemonCommand(remainingArgs || [], options);
             break;
         case 'sandbox':
             await sandboxCommand(remainingArgs || []);
+            break;
+        case 'daemon':
+            await handleDaemonCommand(remainingArgs || [], {
+                appRoot: APP_ROOT,
+                defaultPort: process.env.SERVER_PORT || process.env.PORT || '3001',
+                color: c,
+            });
             break;
         case 'status':
         case 'info':
@@ -883,7 +794,7 @@ async function main() {
             showVersion();
             break;
         case 'update':
-            await updatePackage();
+            await updatePackage(options);
             break;
         default:
             console.error(`\n❌ Unknown command: ${command}`);

--- a/server/cli.js
+++ b/server/cli.js
@@ -7,6 +7,7 @@
  * Commands:
  *   (no args)     - Start the server (default)
  *   start         - Start the server
+ *   daemon        - Run and manage background daemon mode
  *   sandbox       - Manage Docker sandbox environments
  *   status        - Show configuration and data locations
  *   help          - Show help information
@@ -16,7 +17,16 @@
 import fs from 'fs';
 import path from 'path';
 import os from 'os';
+
 import { findAppRoot, getModuleDir } from './utils/runtime-paths.js';
+import {
+    disableAutostart,
+    enableAutostart,
+    getDaemonStatus,
+    readDaemonLogs,
+    startDaemon,
+    stopDaemon
+} from './daemon/manager.js';
 
 const __dirname = getModuleDir(import.meta.url);
 // The CLI is compiled into dist-server/server, but it still needs to read the top-level
@@ -138,6 +148,7 @@ function showStatus() {
     console.log(`\n${c.tip('[TIP]')} Hints:`);
     console.log(`      ${c.dim('>')} Use ${c.bright('cloudcli --port 8080')} to run on a custom port`);
     console.log(`      ${c.dim('>')} Use ${c.bright('cloudcli --database-path /path/to/db')} for custom database`);
+    console.log(`      ${c.dim('>')} Use ${c.bright('cloudcli daemon start')} to keep CloudCLI running in background`);
     console.log(`      ${c.dim('>')} Run ${c.bright('cloudcli help')} for all options`);
     console.log(`      ${c.dim('>')} Access the UI at http://localhost:${process.env.SERVER_PORT || process.env.PORT || '3001'}\n`);
 }
@@ -155,6 +166,7 @@ Usage:
 
 Commands:
   start          Start the CloudCLI server (default)
+  daemon         Manage background daemon mode
   sandbox        Manage Docker sandbox environments
   status         Show configuration and data locations
   update         Update to the latest version
@@ -170,6 +182,8 @@ Options:
 Examples:
   $ cloudcli                        # Start with defaults
   $ cloudcli --port 8080            # Start on port 8080
+  $ cloudcli daemon start           # Start in background daemon mode
+  $ cloudcli daemon enable          # Enable auto-start on login
   $ cloudcli sandbox ~/my-project   # Run in a Docker sandbox
   $ cloudcli status                 # Show configuration
 
@@ -179,6 +193,7 @@ Environment Variables:
   DATABASE_PATH       Set custom database location
   CLAUDE_CLI_PATH     Set custom Claude CLI path
   CONTEXT_WINDOW      Set context window size (default: 160000)
+  SHELL_SESSION_TIMEOUT_MINUTES  PTY reconnect timeout (default: 30)
 
 Documentation:
   ${packageJson.homepage || 'https://github.com/siteboon/claudecodeui'}
@@ -594,12 +609,204 @@ async function sandboxCommand(args) {
     }
 }
 
+// ── Daemon command ──────────────────────────────────────────
+
+function parseDaemonArgs(args) {
+    const parsed = {
+        subcommand: 'status',
+        options: {}
+    };
+
+    const subcommands = new Set(['start', 'stop', 'status', 'enable', 'disable', 'logs', 'help']);
+    let subcommandSet = false;
+
+    for (let i = 0; i < args.length; i++) {
+        const arg = args[i];
+
+        if (arg === '--port' || arg === '-p') {
+            parsed.options.serverPort = args[++i];
+        } else if (arg.startsWith('--port=')) {
+            parsed.options.serverPort = arg.split('=')[1];
+        } else if (arg === '--database-path') {
+            parsed.options.databasePath = args[++i];
+        } else if (arg.startsWith('--database-path=')) {
+            parsed.options.databasePath = arg.split('=')[1];
+        } else if (arg === '--help' || arg === '-h') {
+            parsed.subcommand = 'help';
+            subcommandSet = true;
+        } else if (!arg.startsWith('-') && !subcommandSet) {
+            parsed.subcommand = arg;
+            subcommandSet = true;
+        }
+    }
+
+    if (!subcommands.has(parsed.subcommand)) {
+        parsed.subcommand = `unknown:${parsed.subcommand}`;
+    }
+
+    return parsed;
+}
+
+function showDaemonHelp() {
+    console.log(`
+${c.bright('CloudCLI Daemon')} — Keep CloudCLI running after terminal closes
+
+Usage:
+  cloudcli daemon <subcommand> [options]
+
+Subcommands:
+  ${c.bright('start')}        Start CloudCLI in detached background mode
+  ${c.bright('stop')}         Stop the running daemon
+  ${c.bright('status')}       Show daemon, health, and autostart status
+  ${c.bright('logs')}         Show recent daemon logs
+  ${c.bright('enable')}       Enable autostart on user login (platform native)
+  ${c.bright('disable')}      Disable autostart on user login
+  ${c.bright('help')}         Show this help
+
+Options:
+  -p, --port <port>           Server port for start/enable (default: 3001)
+  --database-path <path>      Database path for start/enable
+
+Examples:
+  $ cloudcli daemon start
+  $ cloudcli daemon start --port 3001
+  $ cloudcli daemon status
+  $ cloudcli daemon enable --port 3001
+  $ cloudcli daemon logs
+`);
+}
+
+async function daemonCommand(args, globalOptions = {}) {
+    const { subcommand, options } = parseDaemonArgs(args);
+
+    if (subcommand.startsWith('unknown:')) {
+        const invalidSubcommand = subcommand.split(':')[1];
+        console.error(`\n${c.error('❌')} Unknown daemon subcommand: ${invalidSubcommand}`);
+        console.log(`   Run ${c.bright('cloudcli daemon help')} for usage.\n`);
+        process.exit(1);
+    }
+
+    const effectiveOptions = {
+        serverPort: options.serverPort || globalOptions.serverPort || process.env.SERVER_PORT || process.env.PORT || '3001',
+        databasePath: options.databasePath || globalOptions.databasePath || process.env.DATABASE_PATH || ''
+    };
+
+    const daemonRuntimeOptions = {
+        nodePath: process.execPath,
+        cliEntryPath: path.resolve(process.argv[1]),
+        serverPort: effectiveOptions.serverPort,
+        databasePath: effectiveOptions.databasePath || null
+    };
+
+    try {
+        switch (subcommand) {
+            case 'help':
+                showDaemonHelp();
+                return;
+            case 'start': {
+                const result = startDaemon(daemonRuntimeOptions);
+                if (result.alreadyRunning) {
+                    console.log(`${c.ok('[OK]')} CloudCLI daemon is already running (PID ${result.pid}) on port ${result.port}.`);
+                } else {
+                    console.log(`${c.ok('[OK]')} CloudCLI daemon started (PID ${result.pid}) on port ${result.port}.`);
+                }
+                console.log(`${c.tip('[TIP]')} Use ${c.bright('cloudcli daemon status')} to verify health.`);
+                return;
+            }
+            case 'stop': {
+                const result = await stopDaemon();
+                if (result.stopped && result.reason === 'stale_pid') {
+                    console.log(`${c.warn('[WARN]')} Stale PID cleaned up. No running daemon process was found.`);
+                    return;
+                }
+
+                if (result.stopped) {
+                    console.log(`${c.ok('[OK]')} CloudCLI daemon stopped.`);
+                    return;
+                }
+
+                if (result.reason === 'not_running') {
+                    console.log(`${c.warn('[WARN]')} CloudCLI daemon is not running.`);
+                    return;
+                }
+
+                console.error(`${c.error('[ERROR]')} Failed to stop daemon${result.error ? `: ${result.error}` : '.'}`);
+                process.exit(1);
+                return;
+            }
+            case 'status': {
+                const status = await getDaemonStatus({ serverPort: effectiveOptions.serverPort });
+                console.log(`\n${c.bright('CloudCLI Daemon Status')}\n`);
+                console.log(`  Running:   ${status.running ? c.ok('yes') : c.warn('no')}`);
+                console.log(`  Health:    ${status.health ? c.ok('healthy') : c.warn(status.running ? 'unreachable' : 'stopped')}`);
+                console.log(`  PID:       ${status.pid ? c.dim(String(status.pid)) : c.dim('-')}`);
+                console.log(`  Port:      ${c.dim(String(status.port))}`);
+                console.log(`  Autostart: ${status.autostart.enabled ? c.ok(`enabled (${status.autostart.mode})`) : c.warn(`disabled (${status.autostart.mode})`)}`);
+                if (status.autostart.path) {
+                    console.log(`  Auto Path: ${c.dim(status.autostart.path)}`);
+                }
+                console.log(`  PID File:  ${c.dim(status.paths.pidFile)}`);
+                console.log(`  Log File:  ${c.dim(status.paths.logFile)}`);
+                if (status.stalePid) {
+                    console.log(`  Note:      ${c.warn('stale PID file was cleaned up')}`);
+                }
+                console.log('');
+                return;
+            }
+            case 'enable': {
+                const result = enableAutostart(daemonRuntimeOptions);
+                console.log(`${c.ok('[OK]')} Autostart enabled via ${result.mode}.`);
+                if (result.path) {
+                    console.log(`       ${c.dim(result.path)}`);
+                }
+                console.log(`${c.tip('[TIP]')} Use ${c.bright('cloudcli daemon status')} to confirm.`);
+                return;
+            }
+            case 'disable': {
+                const result = disableAutostart();
+                console.log(`${c.ok('[OK]')} Autostart disabled (${result.mode}).`);
+                if (result.path) {
+                    console.log(`       ${c.dim(result.path)}`);
+                }
+                return;
+            }
+            case 'logs': {
+                const logs = readDaemonLogs({ lines: 200 });
+                if (!logs.exists) {
+                    console.log(`${c.warn('[WARN]')} No daemon log file found yet.`);
+                    console.log(`       ${c.dim(logs.logFile)}`);
+                    return;
+                }
+
+                console.log(`\n${c.bright('CloudCLI Daemon Logs')} (${c.dim(logs.logFile)})\n`);
+                if (logs.content) {
+                    console.log(logs.content);
+                } else {
+                    console.log(c.dim('(log file is empty)'));
+                }
+                console.log('');
+                return;
+            }
+            default:
+                showDaemonHelp();
+        }
+    } catch (error) {
+        console.error(`${c.error('[ERROR]')} Daemon command failed: ${error.message}`);
+        if (process.platform === 'linux' && subcommand === 'enable') {
+            console.log(`${c.tip('[TIP]')} Ensure user-level systemd is available, then retry ${c.bright('cloudcli daemon enable')}.`);
+        }
+        process.exit(1);
+    }
+}
+
 // ── Server ──────────────────────────────────────────────────
 
 // Start the server
 async function startServer() {
-    // Check for updates silently on startup
-    checkForUpdates(true);
+    // Check for updates silently on startup (can be disabled for daemon bootstrap)
+    if (process.env.CLOUDCLI_SKIP_UPDATE_CHECK !== '1') {
+        checkForUpdates(true);
+    }
 
     // Import and run the server
     await import('./index.js');
@@ -626,7 +833,7 @@ function parseArgs(args) {
             parsed.command = 'version';
         } else if (!arg.startsWith('-')) {
             parsed.command = arg;
-            if (arg === 'sandbox') {
+            if (arg === 'sandbox' || arg === 'daemon') {
                 parsed.remainingArgs = args.slice(i + 1);
                 break;
             }
@@ -654,6 +861,9 @@ async function main() {
     switch (command) {
         case 'start':
             await startServer();
+            break;
+        case 'daemon':
+            await daemonCommand(remainingArgs || [], options);
             break;
         case 'sandbox':
             await sandboxCommand(remainingArgs || []);

--- a/server/cli.js
+++ b/server/cli.js
@@ -158,7 +158,7 @@ Usage:
 
 Commands:
   start          Start the CloudCLI server (default)
-  daemon         Manage persistent Linux service (user/system/auto)
+  daemon         Manage persistent Linux service (system-first)
   sandbox        Manage Docker sandbox environments
   status         Show configuration and data locations
   update         Update to the latest version
@@ -177,8 +177,8 @@ Examples:
   $ cloudcli                        # Start with defaults
   $ cloudcli --port 8080            # Start on port 8080
   $ cloudcli --no-daemon            # Force foreground mode
-  $ cloudcli daemon install --mode auto --port 3001
-  $ cloudcli daemon doctor --mode auto
+  $ sudo cloudcli daemon install --mode system --port 3001
+  $ cloudcli daemon doctor --mode system
   $ cloudcli update --restart-daemon
   $ cloudcli sandbox ~/my-project   # Run in a Docker sandbox
   $ cloudcli status                 # Show configuration
@@ -260,14 +260,14 @@ async function updatePackage(options = {}) {
                 return;
             }
             console.log(`${c.info('[INFO]')} Restarting daemon service...`);
-            await handleDaemonCommand(['restart', '--mode=auto'], {
+            await handleDaemonCommand(['restart', '--mode=system'], {
                 appRoot: APP_ROOT,
                 defaultPort: process.env.SERVER_PORT || process.env.PORT || '3001',
                 color: c,
             });
             console.log(`${c.ok('[OK]')} Daemon restart completed.`);
         } else if (hasInstalledDaemonUnit()) {
-            console.log(`${c.tip('[TIP]')} Daemon unit detected. Restart to apply update: ${c.bright('cloudcli daemon restart --mode auto')}`);
+            console.log(`${c.tip('[TIP]')} Daemon unit detected. Restart to apply update: ${c.bright('cloudcli daemon restart --mode system')}`);
             console.log(`${c.tip('[TIP]')} Or update + restart in one step: ${c.bright('cloudcli update --restart-daemon')}`);
         } else {
             console.log(`${c.tip('[TIP]')} Restart cloudcli to use the new version.`);
@@ -663,6 +663,15 @@ async function waitForPortOpen(port, timeoutMs = 25000) {
     return false;
 }
 
+function printSystemDaemonActiveNotice(port) {
+    const effectivePort = Number(port) || 3001;
+    console.log(`${c.ok('[OK]')} System daemon is active and managing CloudCLI.`);
+    console.log(`${c.info('[INFO]')} Health URL: ${c.bright(`http://localhost:${effectivePort}/health`)}`);
+    console.log(`${c.info('[INFO]')} Status: ${c.bright('cloudcli daemon status --mode system')}`);
+    console.log(`${c.info('[INFO]')} Stop: ${c.bright('sudo cloudcli daemon stop --mode system')}`);
+    console.log(`${c.info('[INFO]')} Logs: ${c.bright('sudo cloudcli daemon logs --mode system')}`);
+}
+
 async function maybeAutoDaemonStart(options = {}) {
     if (process.platform !== 'linux') return false;
     if (process.env.CLOUDCLI_DAEMON_MANAGED === '1') return false;
@@ -673,7 +682,7 @@ async function maybeAutoDaemonStart(options = {}) {
     process.env.CLOUDCLI_DAEMON_ATTEMPTED = '1';
     const daemonPort = Number(options.serverPort || process.env.SERVER_PORT || process.env.PORT || '3001');
 
-    const daemonArgs = ['install', '--mode=auto'];
+    const daemonArgs = ['install', '--mode=system'];
     if (options.serverPort) {
         daemonArgs.push('--port', String(options.serverPort));
     }
@@ -682,27 +691,26 @@ async function maybeAutoDaemonStart(options = {}) {
     }
 
     try {
-        console.log(`${c.info('[INFO]')} Linux detected. Starting CloudCLI via daemon mode for persistent uptime...`);
+        console.log(`${c.info('[INFO]')} Linux detected. Enforcing system daemon mode for CloudCLI...`);
         await handleDaemonCommand(daemonArgs, {
             appRoot: APP_ROOT,
             defaultPort: process.env.SERVER_PORT || process.env.PORT || '3001',
             color: c,
         });
-        console.log(`${c.ok('[OK]')} CloudCLI daemon is managing the service.`);
-        console.log(`${c.tip('[TIP]')} Use ${c.bright('cloudcli daemon status --mode auto')} to inspect state.`);
         return true;
     } catch (error) {
         const healthySoon = await waitForPortOpen(daemonPort);
         if (healthySoon) {
-            console.log(`${c.warn('[WARN]')} Daemon health check was delayed, but port ${daemonPort} is now reachable.`);
-            console.log(`${c.tip('[TIP]')} Continuing with daemon-managed runtime.`);
+            console.log(`${c.warn('[WARN]')} System daemon health check was delayed, but port ${daemonPort} is now reachable.`);
+            printSystemDaemonActiveNotice(daemonPort);
             return true;
         }
 
-        console.log(`${c.warn('[WARN]')} Auto-daemon setup failed, falling back to foreground mode.`);
-        console.log(`       ${c.dim(error.message)}`);
-        console.log(`${c.tip('[TIP]')} Retry manually: ${c.bright('cloudcli daemon install --mode auto')}`);
-        return false;
+        throw new Error(
+            `System daemon bootstrap failed.\n` +
+            `${error.message}\n` +
+            `Run with privileges: sudo cloudcli daemon install --mode system --port ${daemonPort}`
+        );
     }
 }
 
@@ -757,6 +765,9 @@ async function main() {
         process.env.SERVER_PORT = options.serverPort;
     } else if (!process.env.SERVER_PORT && process.env.PORT) {
         process.env.SERVER_PORT = process.env.PORT;
+    }
+    if (options.noDaemon) {
+        process.env.CLOUDCLI_NO_DAEMON = '1';
     }
     if (options.databasePath) {
         process.env.DATABASE_PATH = options.databasePath;

--- a/server/cli.js
+++ b/server/cli.js
@@ -178,6 +178,7 @@ Examples:
   $ cloudcli --port 8080            # Start on port 8080
   $ cloudcli --no-daemon            # Force foreground mode
   $ sudo cloudcli daemon install --mode system --port 3001
+  $ cloudcli daemon install --mode user --port 3001 --frontend-port 5173
   $ cloudcli daemon doctor --mode system
   $ cloudcli update --restart-daemon
   $ cloudcli sandbox ~/my-project   # Run in a Docker sandbox
@@ -672,6 +673,37 @@ function printSystemDaemonActiveNotice(port) {
     console.log(`${c.info('[INFO]')} Logs: ${c.bright('sudo cloudcli daemon logs --mode system')}`);
 }
 
+function printUserDaemonActiveNotice(port, frontendPort) {
+    const effectivePort = Number(port) || 3001;
+    const effectiveFrontendPort = Number(frontendPort) || 5173;
+    console.log(`${c.ok('[OK]')} User daemon is active for this account.`);
+    console.log(`${c.info('[INFO]')} Backend: ${c.bright(`http://localhost:${effectivePort}`)}`);
+    console.log(`${c.info('[INFO]')} Frontend: ${c.bright(`http://localhost:${effectiveFrontendPort}`)}`);
+    console.log(`${c.info('[INFO]')} Status: ${c.bright('cloudcli daemon status --mode user')}`);
+    console.log(`${c.info('[INFO]')} Stop: ${c.bright('cloudcli daemon stop --mode user')}`);
+    console.log(`${c.info('[INFO]')} Logs: ${c.bright('cloudcli daemon logs --mode user')}`);
+    console.log(`${c.tip('[TIP]')} For login/reboot persistence, enable linger once: ${c.bright(`sudo loginctl enable-linger ${os.userInfo().username}`)}`);
+}
+
+function isSystemPermissionError(error) {
+    const message = String(error?.message || error || '');
+    return /(access denied|permission denied|must be root|interactive authentication required|not permitted|failed to connect to bus|operation not permitted|authentication is required|polkit)/i.test(message);
+}
+
+function buildAutoInstallArgs(mode, options, frontendPort) {
+    const args = ['install', `--mode=${mode}`];
+    if (options.serverPort) {
+        args.push('--port', String(options.serverPort));
+    }
+    if (options.databasePath) {
+        args.push('--database-path', String(options.databasePath));
+    }
+    if (frontendPort) {
+        args.push('--frontend-port', String(frontendPort));
+    }
+    return args;
+}
+
 async function maybeAutoDaemonStart(options = {}) {
     if (process.platform !== 'linux') return false;
     if (process.env.CLOUDCLI_DAEMON_MANAGED === '1') return false;
@@ -681,24 +713,19 @@ async function maybeAutoDaemonStart(options = {}) {
 
     process.env.CLOUDCLI_DAEMON_ATTEMPTED = '1';
     const daemonPort = Number(options.serverPort || process.env.SERVER_PORT || process.env.PORT || '3001');
-
-    const daemonArgs = ['install', '--mode=system'];
-    if (options.serverPort) {
-        daemonArgs.push('--port', String(options.serverPort));
-    }
-    if (options.databasePath) {
-        daemonArgs.push('--database-path', String(options.databasePath));
-    }
+    const frontendPort = Number(process.env.VITE_PORT || '5173');
+    const systemArgs = buildAutoInstallArgs('system', options, frontendPort);
+    const userArgs = buildAutoInstallArgs('user', options, frontendPort);
 
     try {
         console.log(`${c.info('[INFO]')} Linux detected. Enforcing system daemon mode for CloudCLI...`);
-        await handleDaemonCommand(daemonArgs, {
+        await handleDaemonCommand(systemArgs, {
             appRoot: APP_ROOT,
             defaultPort: process.env.SERVER_PORT || process.env.PORT || '3001',
             color: c,
         });
         return true;
-    } catch (error) {
+    } catch (systemError) {
         const healthySoon = await waitForPortOpen(daemonPort);
         if (healthySoon) {
             console.log(`${c.warn('[WARN]')} System daemon health check was delayed, but port ${daemonPort} is now reachable.`);
@@ -706,11 +733,42 @@ async function maybeAutoDaemonStart(options = {}) {
             return true;
         }
 
-        throw new Error(
-            `System daemon bootstrap failed.\n` +
-            `${error.message}\n` +
-            `Run with privileges: sudo cloudcli daemon install --mode system --port ${daemonPort}`
-        );
+        if (!isSystemPermissionError(systemError)) {
+            throw new Error(
+                `System daemon bootstrap failed.\n` +
+                `${systemError.message}\n` +
+                `Run with privileges: sudo cloudcli daemon install --mode system --port ${daemonPort} --frontend-port ${frontendPort}`
+            );
+        }
+
+        console.log(`${c.warn('[WARN]')} System daemon setup requires elevated privileges for this user.`);
+        console.log(`${c.info('[INFO]')} Falling back to user daemon mode for account "${os.userInfo().username}"...`);
+
+        try {
+            await handleDaemonCommand(userArgs, {
+                appRoot: APP_ROOT,
+                defaultPort: process.env.SERVER_PORT || process.env.PORT || '3001',
+                color: c,
+            });
+            printUserDaemonActiveNotice(daemonPort, frontendPort);
+            return true;
+        } catch (userError) {
+            const userHealthySoon = await waitForPortOpen(daemonPort);
+            if (userHealthySoon) {
+                console.log(`${c.warn('[WARN]')} User daemon health check was delayed, but port ${daemonPort} is now reachable.`);
+                printUserDaemonActiveNotice(daemonPort, frontendPort);
+                return true;
+            }
+            throw new Error(
+                `System daemon bootstrap failed.\n` +
+                `${systemError.message}\n\n` +
+                `User daemon fallback also failed.\n` +
+                `${userError.message}\n` +
+                `Try one of:\n` +
+                `1) sudo cloudcli daemon install --mode system --port ${daemonPort} --frontend-port ${frontendPort}\n` +
+                `2) cloudcli daemon install --mode user --port ${daemonPort} --frontend-port ${frontendPort}`
+            );
+        }
     }
 }
 

--- a/server/daemon-manager.js
+++ b/server/daemon-manager.js
@@ -6,8 +6,12 @@ import { request } from 'node:http';
 import net from 'node:net';
 
 const DAEMON_SERVICE_NAME = 'cloudcli.service';
+const FRONTEND_DAEMON_SERVICE_NAME = 'cloudcli-frontend.service';
 const DAEMON_USER_SERVICE_PATH = path.join(os.homedir(), '.config', 'systemd', 'user', DAEMON_SERVICE_NAME);
 const DAEMON_SYSTEM_SERVICE_PATH = path.join('/etc', 'systemd', 'system', DAEMON_SERVICE_NAME);
+const FRONTEND_DAEMON_USER_SERVICE_PATH = path.join(os.homedir(), '.config', 'systemd', 'user', FRONTEND_DAEMON_SERVICE_NAME);
+const FRONTEND_DAEMON_SYSTEM_SERVICE_PATH = path.join('/etc', 'systemd', 'system', FRONTEND_DAEMON_SERVICE_NAME);
+const DEFAULT_FRONTEND_PORT = 5173;
 const DAEMON_HEALTH_TIMEOUT_MS = 60000;
 const DAEMON_HEALTH_REQUEST_TIMEOUT_MS = 4000;
 const DAEMON_HEALTH_RETRY_INTERVAL_MS = 1000;
@@ -72,6 +76,10 @@ function getDaemonServicePath(mode) {
     return mode === 'system' ? DAEMON_SYSTEM_SERVICE_PATH : DAEMON_USER_SERVICE_PATH;
 }
 
+function getFrontendServicePath(mode) {
+    return mode === 'system' ? FRONTEND_DAEMON_SYSTEM_SERVICE_PATH : FRONTEND_DAEMON_USER_SERVICE_PATH;
+}
+
 function getSystemctlArgs(mode, commandArgs) {
     return mode === 'user' ? ['--user', ...commandArgs] : commandArgs;
 }
@@ -84,7 +92,7 @@ function parseDaemonArgs(args) {
     const parsed = {
         subcommand: 'status',
         options: {
-            mode: 'user',
+            mode: 'system',
         },
     };
 
@@ -100,6 +108,10 @@ function parseDaemonArgs(args) {
             parsed.options.serverPort = args[++i];
         } else if (arg.startsWith('--port=')) {
             parsed.options.serverPort = arg.split('=')[1];
+        } else if (arg === '--frontend-port') {
+            parsed.options.frontendPort = args[++i];
+        } else if (arg.startsWith('--frontend-port=')) {
+            parsed.options.frontendPort = arg.split('=')[1];
         } else if (arg === '--mode' || arg === '-m') {
             parsed.options.mode = (args[++i] || '').toLowerCase();
         } else if (arg.startsWith('--mode=')) {
@@ -153,6 +165,69 @@ Type=simple
 WorkingDirectory=${appRoot}
 ExecStart=${execStart}
 Environment=HOST=0.0.0.0
+Environment=CI=true
+Environment=CLOUDCLI_DAEMON_MANAGED=1
+Restart=always
+RestartSec=2
+
+[Install]
+WantedBy=default.target
+`;
+}
+
+function resolveFrontendDaemonEntry(appRoot, cliEntry) {
+    const cliCandidate = cliEntry
+        ? path.resolve(cliEntry)
+        : (process.argv[1] ? path.resolve(process.argv[1]) : '');
+    const candidates = [];
+    if (cliCandidate) {
+        candidates.push(path.join(path.dirname(cliCandidate), 'vite-daemon.js'));
+    }
+    candidates.push(path.join(appRoot, 'dist-server', 'server', 'vite-daemon.js'));
+    candidates.push(path.join(appRoot, 'server', 'vite-daemon.js'));
+
+    const resolved = candidates.find(candidate => fs.existsSync(candidate));
+    if (!resolved) {
+        throw new Error(
+            `Frontend daemon entry was not found. Checked: ${candidates.join(', ')}. ` +
+            `Run "npm run build:server" or ensure server/vite-daemon.js exists.`
+        );
+    }
+    return resolved;
+}
+
+function buildFrontendDaemonExecStart({ appRoot, frontendPort, nodeExecPath, cliEntry }) {
+    const nodeExec = nodeExecPath || process.execPath || 'node';
+    const frontendEntry = resolveFrontendDaemonEntry(appRoot, cliEntry);
+    const args = [
+        nodeExec,
+        frontendEntry,
+        '--host',
+        '0.0.0.0',
+        '--port',
+        String(frontendPort),
+        '--strictPort',
+    ];
+    return args.map(quoteSystemdArg).join(' ');
+}
+
+function buildFrontendDaemonServiceUnit({ appRoot, frontendPort, nodeExecPath, cliEntry }) {
+    const execStart = buildFrontendDaemonExecStart({
+        appRoot,
+        frontendPort,
+        nodeExecPath,
+        cliEntry,
+    });
+    return `[Unit]
+Description=CloudCLI Frontend (Vite Dev Server)
+After=network.target
+
+[Service]
+Type=simple
+WorkingDirectory=${appRoot}
+ExecStart=${execStart}
+Environment=HOST=0.0.0.0
+Environment=CI=true
 Environment=CLOUDCLI_DAEMON_MANAGED=1
 Restart=always
 RestartSec=2
@@ -169,9 +244,9 @@ function normalizeState(value) {
     return text;
 }
 
-function getState(mode) {
-    const activeRes = runCommand('systemctl', getSystemctlArgs(mode, ['is-active', DAEMON_SERVICE_NAME]));
-    const enabledRes = runCommand('systemctl', getSystemctlArgs(mode, ['is-enabled', DAEMON_SERVICE_NAME]));
+function getServiceState(mode, serviceName) {
+    const activeRes = runCommand('systemctl', getSystemctlArgs(mode, ['is-active', serviceName]));
+    const enabledRes = runCommand('systemctl', getSystemctlArgs(mode, ['is-enabled', serviceName]));
 
     return {
         active: normalizeState(activeRes.stdout || activeRes.stderr),
@@ -179,8 +254,9 @@ function getState(mode) {
     };
 }
 
-function readLogs(mode, lines = 100, inherit = false) {
-    const args = [...getJournalctlArgs(mode, ['-u', DAEMON_SERVICE_NAME]), '-n', String(lines), '--no-pager'];
+function readLogs(mode, lines = 100, inherit = false, serviceNames = [DAEMON_SERVICE_NAME]) {
+    const unitArgs = serviceNames.flatMap((serviceName) => ['-u', serviceName]);
+    const args = [...getJournalctlArgs(mode, unitArgs), '-n', String(lines), '--no-pager'];
     return runCommand('journalctl', args, { inherit });
 }
 
@@ -234,16 +310,15 @@ function resolveDaemonMode({ requestedMode, subcommand, userBusAvailable }) {
         return requestedMode;
     }
 
-    const userUnitInstalled = fs.existsSync(getDaemonServicePath('user'));
+    // Auto mode is intentionally system-first to guarantee boot-time startup
+    // even without an interactive user session.
     const systemUnitInstalled = fs.existsSync(getDaemonServicePath('system'));
+    const userUnitInstalled = fs.existsSync(getDaemonServicePath('user'));
 
-    if (subcommand === 'install') {
-        return userBusAvailable ? 'user' : 'system';
-    }
-
-    if (userUnitInstalled) return 'user';
     if (systemUnitInstalled) return 'system';
-    return userBusAvailable ? 'user' : 'system';
+    if (subcommand === 'install') return 'system';
+    if (userUnitInstalled && userBusAvailable) return 'user';
+    return 'system';
 }
 
 function runSystemctl(mode, commandArgs, opts = {}) {
@@ -315,10 +390,10 @@ async function waitForHealth(port, timeoutMs = DAEMON_HEALTH_TIMEOUT_MS) {
     throw new Error(lastError?.message || `Service did not become healthy on port ${port}`);
 }
 
-async function healthCheckOrThrow(mode, port, c) {
-    const state = getState(mode);
+async function healthCheckOrThrow(mode, serviceName, port, c) {
+    const state = getServiceState(mode, serviceName);
     if (state.active !== 'active' && state.active !== 'activating') {
-        throw new Error(`Service is not active (state: ${state.active})`);
+        throw new Error(`Service ${serviceName} is not active (state: ${state.active})`);
     }
 
     try {
@@ -327,19 +402,19 @@ async function healthCheckOrThrow(mode, port, c) {
             console.log(`${c.warn('[WARN]')} HTTP /health probe delayed; TCP port ${port} is already accepting connections.`);
         }
     } catch (healthError) {
-        const logsResult = readLogs(mode, 50);
+        const logsResult = readLogs(mode, 50, false, [serviceName]);
         const logText = (logsResult.stdout || logsResult.stderr || '').trim();
         const lastErrorLine = findLatestErrorLine(logText);
 
         if (logText) {
-            console.log(`\n${c.warn('[WARN]')} Last 50 daemon log lines:`);
+            console.log(`\n${c.warn('[WARN]')} Last 50 log lines for ${serviceName}:`);
             console.log(logText);
         }
 
         if (lastErrorLine) {
-            throw new Error(`Health check failed: ${healthError.message}\nLikely cause: ${lastErrorLine}`);
+            throw new Error(`Health check failed for ${serviceName}: ${healthError.message}\nLikely cause: ${lastErrorLine}`);
         }
-        throw new Error(`Health check failed: ${healthError.message}`);
+        throw new Error(`Health check failed for ${serviceName}: ${healthError.message}`);
     }
 }
 
@@ -378,19 +453,25 @@ Subcommands:
 
 Options:
   -p, --port <port>           Set service server port (default: 3001)
-  -m, --mode <mode>           Service mode: user | system | auto (default: user)
+  --frontend-port <port>      Set frontend Vite port (default: 5173)
+  -m, --mode <mode>           Service mode: user | system | auto (default: system)
   --database-path <path>      Set service database path
 
 Examples:
-  $ cloudcli daemon install --mode auto --port 3001
-  $ cloudcli daemon status --mode auto
+  $ cloudcli daemon install --mode system --port 3001 --frontend-port 5173
+  $ cloudcli daemon status --mode system
   $ cloudcli daemon doctor --mode auto
   $ cloudcli daemon logs --mode system
 `);
 }
 
 export function hasInstalledDaemonUnit() {
-    return fs.existsSync(DAEMON_USER_SERVICE_PATH) || fs.existsSync(DAEMON_SYSTEM_SERVICE_PATH);
+    return (
+        fs.existsSync(DAEMON_USER_SERVICE_PATH) ||
+        fs.existsSync(DAEMON_SYSTEM_SERVICE_PATH) ||
+        fs.existsSync(FRONTEND_DAEMON_USER_SERVICE_PATH) ||
+        fs.existsSync(FRONTEND_DAEMON_SYSTEM_SERVICE_PATH)
+    );
 }
 
 export async function handleDaemonCommand(args, context = {}) {
@@ -416,12 +497,18 @@ export async function handleDaemonCommand(args, context = {}) {
 
     const appRoot = context.appRoot || process.cwd();
     const defaultPort = context.defaultPort || process.env.SERVER_PORT || process.env.PORT || '3001';
+    const defaultFrontendPort = context.defaultFrontendPort || process.env.VITE_PORT || String(DEFAULT_FRONTEND_PORT);
     const configuredPort = parsed.options.serverPort || defaultPort;
+    const configuredFrontendPort = parsed.options.frontendPort || defaultFrontendPort;
     const databasePath = parsed.options.databasePath || process.env.DATABASE_PATH || '';
 
     const portNum = Number(configuredPort);
     if (!Number.isInteger(portNum) || portNum < 1 || portNum > 65535) {
         throw new Error(`Invalid port "${configuredPort}". Expected an integer between 1 and 65535.`);
+    }
+    const frontendPortNum = Number(configuredFrontendPort);
+    if (!Number.isInteger(frontendPortNum) || frontendPortNum < 1 || frontendPortNum > 65535) {
+        throw new Error(`Invalid frontend port "${configuredFrontendPort}". Expected an integer between 1 and 65535.`);
     }
 
     const userBus = probeUserBus();
@@ -431,7 +518,9 @@ export async function handleDaemonCommand(args, context = {}) {
         userBusAvailable: userBus.ok,
     });
     const servicePath = getDaemonServicePath(mode);
+    const frontendServicePath = getFrontendServicePath(mode);
     const effectivePort = getPortFromServiceUnit(servicePath) || portNum;
+    const effectiveFrontendPort = getPortFromServiceUnit(frontendServicePath) || frontendPortNum;
 
     if (mode === 'user' && !userBus.ok) {
         throw new Error(
@@ -443,12 +532,27 @@ export async function handleDaemonCommand(args, context = {}) {
     if (parsed.subcommand === 'doctor') {
         const linger = probeLinger();
         const userUnitInstalled = fs.existsSync(getDaemonServicePath('user'));
+        const userFrontendUnitInstalled = fs.existsSync(getFrontendServicePath('user'));
         const systemUnitInstalled = fs.existsSync(getDaemonServicePath('system'));
+        const systemFrontendUnitInstalled = fs.existsSync(getFrontendServicePath('system'));
         const selectedModePort = getPortFromServiceUnit(servicePath) || portNum;
+        const selectedModeFrontendPort = getPortFromServiceUnit(frontendServicePath) || frontendPortNum;
         const portReachable = await isPortReachable(selectedModePort);
-        const userState = userBus.ok ? getState('user') : { active: 'unavailable', enabled: 'unavailable' };
-        const systemState = getState('system');
-        const logsResult = readLogs(mode, 50);
+        const frontendPortReachable = await isPortReachable(selectedModeFrontendPort);
+        const userState = userBus.ok
+            ? {
+                backend: getServiceState('user', DAEMON_SERVICE_NAME),
+                frontend: getServiceState('user', FRONTEND_DAEMON_SERVICE_NAME),
+            }
+            : {
+                backend: { active: 'unavailable', enabled: 'unavailable' },
+                frontend: { active: 'unavailable', enabled: 'unavailable' },
+            };
+        const systemState = {
+            backend: getServiceState('system', DAEMON_SERVICE_NAME),
+            frontend: getServiceState('system', FRONTEND_DAEMON_SERVICE_NAME),
+        };
+        const logsResult = readLogs(mode, 50, false, [DAEMON_SERVICE_NAME, FRONTEND_DAEMON_SERVICE_NAME]);
         const logsText = (logsResult.stdout || logsResult.stderr || '').trim();
         const lastErrorLine = findLatestErrorLine(logsText);
 
@@ -460,11 +564,14 @@ export async function handleDaemonCommand(args, context = {}) {
             console.log(`       ${c.dim(userBus.detail)}`);
         }
         console.log(`${c.info('[INFO]')} linger:         ${c.bright(linger.value)}${linger.detail ? ` ${c.dim(`(${linger.detail})`)}` : ''}`);
-        console.log(`${c.info('[INFO]')} user unit:      ${userUnitInstalled ? c.ok('installed') : c.warn('missing')} (${c.dim(getDaemonServicePath('user'))})`);
-        console.log(`${c.info('[INFO]')} system unit:    ${systemUnitInstalled ? c.ok('installed') : c.warn('missing')} (${c.dim(getDaemonServicePath('system'))})`);
-        console.log(`${c.info('[INFO]')} user state:     active=${c.bright(userState.active)} enabled=${c.bright(userState.enabled)}`);
-        console.log(`${c.info('[INFO]')} system state:   active=${c.bright(systemState.active)} enabled=${c.bright(systemState.enabled)}`);
-        console.log(`${c.info('[INFO]')} health port:    ${c.bright(String(selectedModePort))} (${portReachable ? c.ok('reachable') : c.warn('not reachable')})`);
+        console.log(`${c.info('[INFO]')} user backend:   ${userUnitInstalled ? c.ok('installed') : c.warn('missing')} (${c.dim(getDaemonServicePath('user'))})`);
+        console.log(`${c.info('[INFO]')} user frontend:  ${userFrontendUnitInstalled ? c.ok('installed') : c.warn('missing')} (${c.dim(getFrontendServicePath('user'))})`);
+        console.log(`${c.info('[INFO]')} system backend: ${systemUnitInstalled ? c.ok('installed') : c.warn('missing')} (${c.dim(getDaemonServicePath('system'))})`);
+        console.log(`${c.info('[INFO]')} system frontend:${systemFrontendUnitInstalled ? c.ok('installed') : c.warn('missing')} (${c.dim(getFrontendServicePath('system'))})`);
+        console.log(`${c.info('[INFO]')} user state:     backend active=${c.bright(userState.backend.active)} enabled=${c.bright(userState.backend.enabled)} | frontend active=${c.bright(userState.frontend.active)} enabled=${c.bright(userState.frontend.enabled)}`);
+        console.log(`${c.info('[INFO]')} system state:   backend active=${c.bright(systemState.backend.active)} enabled=${c.bright(systemState.backend.enabled)} | frontend active=${c.bright(systemState.frontend.active)} enabled=${c.bright(systemState.frontend.enabled)}`);
+        console.log(`${c.info('[INFO]')} backend port:   ${c.bright(String(selectedModePort))} (${portReachable ? c.ok('reachable') : c.warn('not reachable')})`);
+        console.log(`${c.info('[INFO]')} frontend port:  ${c.bright(String(selectedModeFrontendPort))} (${frontendPortReachable ? c.ok('reachable') : c.warn('not reachable')})`);
         if (lastErrorLine) {
             console.log(`${c.warn('[WARN]')} Latest error:   ${lastErrorLine}`);
         }
@@ -474,17 +581,34 @@ export async function handleDaemonCommand(args, context = {}) {
         console.log(`MODE_RESOLVED=${mode}`);
         console.log(`USER_BUS_OK=${userBus.ok}`);
         console.log(`LINGER=${linger.value}`);
-        console.log(`USER_UNIT_INSTALLED=${userUnitInstalled}`);
-        console.log(`SYSTEM_UNIT_INSTALLED=${systemUnitInstalled}`);
-        console.log(`USER_ACTIVE=${userState.active}`);
-        console.log(`USER_ENABLED=${userState.enabled}`);
-        console.log(`SYSTEM_ACTIVE=${systemState.active}`);
-        console.log(`SYSTEM_ENABLED=${systemState.enabled}`);
-        console.log(`HEALTH_PORT=${selectedModePort}`);
-        console.log(`PORT_REACHABLE=${portReachable}`);
+        console.log(`USER_BACKEND_UNIT_INSTALLED=${userUnitInstalled}`);
+        console.log(`USER_FRONTEND_UNIT_INSTALLED=${userFrontendUnitInstalled}`);
+        console.log(`SYSTEM_BACKEND_UNIT_INSTALLED=${systemUnitInstalled}`);
+        console.log(`SYSTEM_FRONTEND_UNIT_INSTALLED=${systemFrontendUnitInstalled}`);
+        console.log(`USER_BACKEND_ACTIVE=${userState.backend.active}`);
+        console.log(`USER_BACKEND_ENABLED=${userState.backend.enabled}`);
+        console.log(`USER_FRONTEND_ACTIVE=${userState.frontend.active}`);
+        console.log(`USER_FRONTEND_ENABLED=${userState.frontend.enabled}`);
+        console.log(`SYSTEM_BACKEND_ACTIVE=${systemState.backend.active}`);
+        console.log(`SYSTEM_BACKEND_ENABLED=${systemState.backend.enabled}`);
+        console.log(`SYSTEM_FRONTEND_ACTIVE=${systemState.frontend.active}`);
+        console.log(`SYSTEM_FRONTEND_ENABLED=${systemState.frontend.enabled}`);
+        console.log(`BACKEND_PORT=${selectedModePort}`);
+        console.log(`BACKEND_PORT_REACHABLE=${portReachable}`);
+        console.log(`FRONTEND_PORT=${selectedModeFrontendPort}`);
+        console.log(`FRONTEND_PORT_REACHABLE=${frontendPortReachable}`);
         console.log(`LAST_ERROR_LINE=${JSON.stringify(lastErrorLine || '')}\n`);
         return;
     }
+
+    const serviceDefs = [
+        {
+            servicePath,
+        },
+        {
+            servicePath: frontendServicePath,
+        },
+    ];
 
     switch (parsed.subcommand) {
         case 'install': {
@@ -494,23 +618,37 @@ export async function handleDaemonCommand(args, context = {}) {
 
             try {
                 fs.mkdirSync(path.dirname(servicePath), { recursive: true });
-                const unitContent = buildDaemonServiceUnit({
+                fs.mkdirSync(path.dirname(frontendServicePath), { recursive: true });
+
+                const backendUnitContent = buildDaemonServiceUnit({
                     appRoot,
                     serverPort: portNum,
                     databasePath,
                     nodeExecPath: context.nodeExecPath,
                     cliEntry: context.cliEntry,
                 });
-                fs.writeFileSync(servicePath, unitContent, 'utf8');
+                fs.writeFileSync(servicePath, backendUnitContent, 'utf8');
+
+                const frontendUnitContent = buildFrontendDaemonServiceUnit({
+                    appRoot,
+                    frontendPort: frontendPortNum,
+                    nodeExecPath: context.nodeExecPath,
+                    cliEntry: context.cliEntry,
+                });
+                fs.writeFileSync(frontendServicePath, frontendUnitContent, 'utf8');
             } catch (fileError) {
                 if (mode === 'system' && (fileError.code === 'EACCES' || fileError.code === 'EPERM')) {
-                    throw new Error(`Permission denied writing ${servicePath}. Try: sudo cloudcli daemon install --mode system --port ${portNum}`);
+                    throw new Error(
+                        `Permission denied writing daemon unit files (${servicePath}, ${frontendServicePath}). ` +
+                        `Try: sudo cloudcli daemon install --mode system --port ${portNum} --frontend-port ${frontendPortNum}`
+                    );
                 }
                 throw fileError;
             }
 
             runSystemctl(mode, ['daemon-reload']);
             runSystemctl(mode, ['enable', '--now', DAEMON_SERVICE_NAME]);
+            runSystemctl(mode, ['enable', '--now', FRONTEND_DAEMON_SERVICE_NAME]);
 
             if (mode === 'user') {
                 const lingerResult = runCommand('loginctl', ['enable-linger', os.userInfo().username]);
@@ -522,46 +660,69 @@ export async function handleDaemonCommand(args, context = {}) {
             }
 
             const installedPort = getPortFromServiceUnit(servicePath) || portNum;
-            await healthCheckOrThrow(mode, installedPort, c);
+            const installedFrontendPort = getPortFromServiceUnit(frontendServicePath) || frontendPortNum;
+            await healthCheckOrThrow(mode, DAEMON_SERVICE_NAME, installedPort, c);
+            await healthCheckOrThrow(mode, FRONTEND_DAEMON_SERVICE_NAME, installedFrontendPort, c);
 
-            const state = getState(mode);
+            const backendState = getServiceState(mode, DAEMON_SERVICE_NAME);
+            const frontendState = getServiceState(mode, FRONTEND_DAEMON_SERVICE_NAME);
             console.log(`\n${c.ok('✔')} Daemon installed and started.`);
             console.log(`   Mode:    ${c.bright(mode)}`);
-            console.log(`   Unit:    ${c.dim(servicePath)}`);
-            console.log(`   Active:  ${c.bright(state.active)}`);
-            console.log(`   Enabled: ${c.bright(state.enabled)}\n`);
+            console.log(`   Backend Unit:   ${c.dim(servicePath)}`);
+            console.log(`   Frontend Unit:  ${c.dim(frontendServicePath)}`);
+            console.log(`   Backend Active: ${c.bright(backendState.active)}`);
+            console.log(`   Backend Enabled:${c.bright(backendState.enabled)}`);
+            console.log(`   Frontend Active:${c.bright(frontendState.active)}`);
+            console.log(`   Frontend Enabled:${c.bright(frontendState.enabled)}`);
+            console.log(`   Backend URL:    ${c.bright(`http://localhost:${installedPort}`)}`);
+            console.log(`   Frontend URL:   ${c.bright(`http://localhost:${installedFrontendPort}`)}\n`);
+            if (mode === 'system') {
+                console.log(`${c.ok('[OK]')} System daemon is active for backend and frontend.`);
+                console.log(`${c.info('[INFO]')} Backend health: ${c.bright(`http://localhost:${installedPort}/health`)}`);
+                console.log(`${c.info('[INFO]')} Frontend: ${c.bright(`http://localhost:${installedFrontendPort}/`)}`);
+                console.log(`${c.info('[INFO]')} Status: ${c.bright('cloudcli daemon status --mode system')}`);
+                console.log(`${c.info('[INFO]')} Stop: ${c.bright('sudo cloudcli daemon stop --mode system')}`);
+                console.log(`${c.info('[INFO]')} Logs: ${c.bright('sudo cloudcli daemon logs --mode system')}\n`);
+            }
             break;
         }
 
         case 'start':
             runSystemctl(mode, ['start', DAEMON_SERVICE_NAME]);
-            await healthCheckOrThrow(mode, effectivePort, c);
-            console.log(`${c.ok('[OK]')} Service started.`);
+            runSystemctl(mode, ['start', FRONTEND_DAEMON_SERVICE_NAME]);
+            await healthCheckOrThrow(mode, DAEMON_SERVICE_NAME, effectivePort, c);
+            await healthCheckOrThrow(mode, FRONTEND_DAEMON_SERVICE_NAME, effectiveFrontendPort, c);
+            console.log(`${c.ok('[OK]')} Backend and frontend services started.`);
             break;
 
         case 'stop':
+            runSystemctl(mode, ['stop', FRONTEND_DAEMON_SERVICE_NAME], { allowFailure: true });
             runSystemctl(mode, ['stop', DAEMON_SERVICE_NAME]);
-            console.log(`${c.ok('[OK]')} Service stopped (auto-start remains enabled).`);
+            console.log(`${c.ok('[OK]')} Backend and frontend services stopped (auto-start remains enabled).`);
             break;
 
         case 'restart':
             runSystemctl(mode, ['restart', DAEMON_SERVICE_NAME]);
-            await healthCheckOrThrow(mode, effectivePort, c);
-            console.log(`${c.ok('[OK]')} Service restarted.`);
+            runSystemctl(mode, ['restart', FRONTEND_DAEMON_SERVICE_NAME]);
+            await healthCheckOrThrow(mode, DAEMON_SERVICE_NAME, effectivePort, c);
+            await healthCheckOrThrow(mode, FRONTEND_DAEMON_SERVICE_NAME, effectiveFrontendPort, c);
+            console.log(`${c.ok('[OK]')} Backend and frontend services restarted.`);
             break;
 
         case 'enable':
             runSystemctl(mode, ['enable', DAEMON_SERVICE_NAME]);
-            console.log(`${c.ok('[OK]')} Service enabled for auto-start.`);
+            runSystemctl(mode, ['enable', FRONTEND_DAEMON_SERVICE_NAME]);
+            console.log(`${c.ok('[OK]')} Backend and frontend services enabled for auto-start.`);
             break;
 
         case 'disable':
             runSystemctl(mode, ['disable', DAEMON_SERVICE_NAME]);
-            console.log(`${c.ok('[OK]')} Service disabled for auto-start.`);
+            runSystemctl(mode, ['disable', FRONTEND_DAEMON_SERVICE_NAME]);
+            console.log(`${c.ok('[OK]')} Backend and frontend services disabled for auto-start.`);
             break;
 
         case 'logs': {
-            const logsResult = readLogs(mode, 100, true);
+            const logsResult = readLogs(mode, 100, true, [DAEMON_SERVICE_NAME, FRONTEND_DAEMON_SERVICE_NAME]);
             if (logsResult.status !== 0) {
                 throw new Error(extractCommandError(logsResult, 'Unable to read daemon logs'));
             }
@@ -569,34 +730,45 @@ export async function handleDaemonCommand(args, context = {}) {
         }
 
         case 'uninstall': {
+            runSystemctl(mode, ['stop', FRONTEND_DAEMON_SERVICE_NAME], { allowFailure: true });
+            runSystemctl(mode, ['disable', FRONTEND_DAEMON_SERVICE_NAME], { allowFailure: true });
             runSystemctl(mode, ['stop', DAEMON_SERVICE_NAME], { allowFailure: true });
             runSystemctl(mode, ['disable', DAEMON_SERVICE_NAME], { allowFailure: true });
-            if (fs.existsSync(servicePath)) {
+
+            for (const def of serviceDefs) {
+                if (!fs.existsSync(def.servicePath)) continue;
                 try {
-                    fs.unlinkSync(servicePath);
+                    fs.unlinkSync(def.servicePath);
                 } catch (unlinkError) {
                     if (mode === 'system' && (unlinkError.code === 'EACCES' || unlinkError.code === 'EPERM')) {
-                        throw new Error(`Permission denied removing ${servicePath}. Try: sudo cloudcli daemon uninstall --mode system`);
+                        throw new Error(`Permission denied removing ${def.servicePath}. Try: sudo cloudcli daemon uninstall --mode system`);
                     }
                     throw unlinkError;
                 }
             }
             runSystemctl(mode, ['daemon-reload'], { allowFailure: true });
-            console.log(`${c.ok('[OK]')} Daemon uninstalled.`);
+            console.log(`${c.ok('[OK]')} Backend and frontend daemons uninstalled.`);
             break;
         }
 
         case 'status':
         default: {
-            const state = getState(mode);
-            const unitExists = fs.existsSync(servicePath);
+            const backendState = getServiceState(mode, DAEMON_SERVICE_NAME);
+            const frontendState = getServiceState(mode, FRONTEND_DAEMON_SERVICE_NAME);
+            const backendUnitExists = fs.existsSync(servicePath);
+            const frontendUnitExists = fs.existsSync(frontendServicePath);
             const selectedPort = getPortFromServiceUnit(servicePath) || portNum;
+            const selectedFrontendPort = getPortFromServiceUnit(frontendServicePath) || frontendPortNum;
             console.log(`\n${c.bright('CloudCLI Daemon Status')}\n`);
             console.log(`${c.info('[INFO]')} Mode:      ${c.bright(mode)} ${parsed.options.mode === 'auto' ? c.dim('(resolved from auto)') : ''}`);
-            console.log(`${c.info('[INFO]')} Unit file: ${c.dim(servicePath)} ${unitExists ? c.ok('[OK]') : c.warn('[MISSING]')}`);
-            console.log(`${c.info('[INFO]')} Active:    ${c.bright(state.active)}`);
-            console.log(`${c.info('[INFO]')} Enabled:   ${c.bright(state.enabled)}`);
-            console.log(`${c.info('[INFO]')} Port:      ${c.bright(String(selectedPort))}`);
+            console.log(`${c.info('[INFO]')} Backend Unit:   ${c.dim(servicePath)} ${backendUnitExists ? c.ok('[OK]') : c.warn('[MISSING]')}`);
+            console.log(`${c.info('[INFO]')} Backend Active: ${c.bright(backendState.active)}`);
+            console.log(`${c.info('[INFO]')} Backend Enabled:${c.bright(backendState.enabled)}`);
+            console.log(`${c.info('[INFO]')} Backend Port:   ${c.bright(String(selectedPort))}`);
+            console.log(`${c.info('[INFO]')} Frontend Unit:  ${c.dim(frontendServicePath)} ${frontendUnitExists ? c.ok('[OK]') : c.warn('[MISSING]')}`);
+            console.log(`${c.info('[INFO]')} Frontend Active:${c.bright(frontendState.active)}`);
+            console.log(`${c.info('[INFO]')} Frontend Enabled:${c.bright(frontendState.enabled)}`);
+            console.log(`${c.info('[INFO]')} Frontend Port:  ${c.bright(String(selectedFrontendPort))}`);
             console.log('');
         }
     }

--- a/server/daemon-manager.js
+++ b/server/daemon-manager.js
@@ -683,6 +683,19 @@ export async function handleDaemonCommand(args, context = {}) {
                 console.log(`${c.info('[INFO]')} Status: ${c.bright('cloudcli daemon status --mode system')}`);
                 console.log(`${c.info('[INFO]')} Stop: ${c.bright('sudo cloudcli daemon stop --mode system')}`);
                 console.log(`${c.info('[INFO]')} Logs: ${c.bright('sudo cloudcli daemon logs --mode system')}\n`);
+            } else {
+                const linger = probeLinger();
+                console.log(`${c.ok('[OK]')} User daemon is active for backend and frontend.`);
+                console.log(`${c.info('[INFO]')} Backend health: ${c.bright(`http://localhost:${installedPort}/health`)}`);
+                console.log(`${c.info('[INFO]')} Frontend: ${c.bright(`http://localhost:${installedFrontendPort}/`)}`);
+                console.log(`${c.info('[INFO]')} Status: ${c.bright('cloudcli daemon status --mode user')}`);
+                console.log(`${c.info('[INFO]')} Stop: ${c.bright('cloudcli daemon stop --mode user')}`);
+                console.log(`${c.info('[INFO]')} Logs: ${c.bright('cloudcli daemon logs --mode user')}`);
+                if (linger.value !== 'yes') {
+                    console.log(`${c.tip('[TIP]')} Enable linger for reboot/login persistence: ${c.bright(`sudo loginctl enable-linger ${os.userInfo().username}`)}\n`);
+                } else {
+                    console.log('');
+                }
             }
             break;
         }

--- a/server/daemon-manager.js
+++ b/server/daemon-manager.js
@@ -1,0 +1,603 @@
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import { spawnSync } from 'child_process';
+import { request } from 'node:http';
+import net from 'node:net';
+
+const DAEMON_SERVICE_NAME = 'cloudcli.service';
+const DAEMON_USER_SERVICE_PATH = path.join(os.homedir(), '.config', 'systemd', 'user', DAEMON_SERVICE_NAME);
+const DAEMON_SYSTEM_SERVICE_PATH = path.join('/etc', 'systemd', 'system', DAEMON_SERVICE_NAME);
+const DAEMON_HEALTH_TIMEOUT_MS = 60000;
+const DAEMON_HEALTH_REQUEST_TIMEOUT_MS = 4000;
+const DAEMON_HEALTH_RETRY_INTERVAL_MS = 1000;
+
+const DAEMON_SUBCOMMANDS = new Set([
+    'install',
+    'start',
+    'stop',
+    'restart',
+    'status',
+    'logs',
+    'enable',
+    'disable',
+    'uninstall',
+    'doctor',
+    'help',
+]);
+
+const DAEMON_MODES = new Set(['auto', 'user', 'system']);
+
+function passthroughColor(text) {
+    return text;
+}
+
+function getColorHelpers(color) {
+    if (color) {
+        return color;
+    }
+    return {
+        info: passthroughColor,
+        ok: passthroughColor,
+        warn: passthroughColor,
+        error: passthroughColor,
+        tip: passthroughColor,
+        bright: passthroughColor,
+        dim: passthroughColor,
+    };
+}
+
+function runCommand(bin, args, opts = {}) {
+    const stdio = opts.inherit ? 'inherit' : 'pipe';
+    return spawnSync(bin, args, {
+        encoding: 'utf8',
+        stdio,
+    });
+}
+
+function extractCommandError(result, fallbackMessage) {
+    if (!result) return fallbackMessage;
+    const fromError = result.error?.message?.trim();
+    if (fromError) return fromError;
+    const fromStd = (result.stderr || result.stdout || '').trim();
+    if (fromStd) return fromStd;
+    return fallbackMessage;
+}
+
+function quoteSystemdArg(arg) {
+    return `"${String(arg).replace(/(["\\$`])/g, '\\$1')}"`;
+}
+
+function getDaemonServicePath(mode) {
+    return mode === 'system' ? DAEMON_SYSTEM_SERVICE_PATH : DAEMON_USER_SERVICE_PATH;
+}
+
+function getSystemctlArgs(mode, commandArgs) {
+    return mode === 'user' ? ['--user', ...commandArgs] : commandArgs;
+}
+
+function getJournalctlArgs(mode, commandArgs) {
+    return mode === 'user' ? ['--user', ...commandArgs] : commandArgs;
+}
+
+function parseDaemonArgs(args) {
+    const parsed = {
+        subcommand: 'status',
+        options: {
+            mode: 'user',
+        },
+    };
+
+    let i = 0;
+    if (args[0] && DAEMON_SUBCOMMANDS.has(args[0])) {
+        parsed.subcommand = args[0];
+        i = 1;
+    }
+
+    for (; i < args.length; i++) {
+        const arg = args[i];
+        if (arg === '--port' || arg === '-p') {
+            parsed.options.serverPort = args[++i];
+        } else if (arg.startsWith('--port=')) {
+            parsed.options.serverPort = arg.split('=')[1];
+        } else if (arg === '--mode' || arg === '-m') {
+            parsed.options.mode = (args[++i] || '').toLowerCase();
+        } else if (arg.startsWith('--mode=')) {
+            parsed.options.mode = (arg.split('=')[1] || '').toLowerCase();
+        } else if (arg === '--database-path') {
+            parsed.options.databasePath = args[++i];
+        } else if (arg.startsWith('--database-path=')) {
+            parsed.options.databasePath = arg.split('=')[1];
+        } else if (arg === '--help' || arg === '-h') {
+            parsed.subcommand = 'help';
+        } else {
+            parsed.options.extraArgs = parsed.options.extraArgs || [];
+            parsed.options.extraArgs.push(arg);
+        }
+    }
+
+    return parsed;
+}
+
+function buildDaemonExecStart({ appRoot, serverPort, databasePath, nodeExecPath, cliEntry }) {
+    const nodeExec = nodeExecPath || process.execPath || 'node';
+    const cliCandidate = cliEntry
+        ? path.resolve(cliEntry)
+        : (process.argv[1] ? path.resolve(process.argv[1]) : path.join(appRoot, 'dist-server', 'server', 'cli.js'));
+    const resolvedCliEntry = fs.existsSync(cliCandidate)
+        ? cliCandidate
+        : path.join(appRoot, 'dist-server', 'server', 'cli.js');
+
+    const args = [nodeExec, resolvedCliEntry, 'start', '--port', String(serverPort)];
+    if (databasePath) {
+        args.push('--database-path', databasePath);
+    }
+
+    return args.map(quoteSystemdArg).join(' ');
+}
+
+function buildDaemonServiceUnit({ appRoot, serverPort, databasePath, nodeExecPath, cliEntry }) {
+    const execStart = buildDaemonExecStart({
+        appRoot,
+        serverPort,
+        databasePath,
+        nodeExecPath,
+        cliEntry,
+    });
+    return `[Unit]
+Description=CloudCLI Server
+After=network.target
+
+[Service]
+Type=simple
+WorkingDirectory=${appRoot}
+ExecStart=${execStart}
+Environment=HOST=0.0.0.0
+Environment=CLOUDCLI_DAEMON_MANAGED=1
+Restart=always
+RestartSec=2
+
+[Install]
+WantedBy=default.target
+`;
+}
+
+function normalizeState(value) {
+    const text = (value || '').trim();
+    if (!text) return 'unknown';
+    if (/No such file or directory/i.test(text)) return 'not-found';
+    return text;
+}
+
+function getState(mode) {
+    const activeRes = runCommand('systemctl', getSystemctlArgs(mode, ['is-active', DAEMON_SERVICE_NAME]));
+    const enabledRes = runCommand('systemctl', getSystemctlArgs(mode, ['is-enabled', DAEMON_SERVICE_NAME]));
+
+    return {
+        active: normalizeState(activeRes.stdout || activeRes.stderr),
+        enabled: normalizeState(enabledRes.stdout || enabledRes.stderr),
+    };
+}
+
+function readLogs(mode, lines = 100, inherit = false) {
+    const args = [...getJournalctlArgs(mode, ['-u', DAEMON_SERVICE_NAME]), '-n', String(lines), '--no-pager'];
+    return runCommand('journalctl', args, { inherit });
+}
+
+function getPortFromServiceUnit(servicePath) {
+    if (!fs.existsSync(servicePath)) return null;
+    try {
+        const content = fs.readFileSync(servicePath, 'utf8');
+        const quoted = content.match(/"--port"\s+"(\d+)"/);
+        if (quoted) return Number(quoted[1]);
+        const plain = content.match(/--port(?:\s+|=)(\d+)/);
+        if (plain) return Number(plain[1]);
+    } catch {
+        // Ignore parse errors and use fallback port.
+    }
+    return null;
+}
+
+function findLatestErrorLine(logText) {
+    if (!logText) return '';
+    const lines = logText.split('\n').map(line => line.trim()).filter(Boolean);
+    const errorLine = [...lines].reverse().find(line => /(error|failed|exception|denied|cannot|traceback)/i.test(line));
+    return errorLine || '';
+}
+
+function probeUserBus() {
+    const result = runCommand('systemctl', ['--user', 'show-environment']);
+    return {
+        ok: result.status === 0,
+        detail: extractCommandError(result, 'systemd user bus is not reachable'),
+    };
+}
+
+function probeLinger() {
+    const result = runCommand('loginctl', ['show-user', os.userInfo().username, '-p', 'Linger']);
+    if (result.status !== 0) {
+        return {
+            value: 'unknown',
+            detail: extractCommandError(result, 'Could not read linger status'),
+        };
+    }
+    const output = (result.stdout || '').trim();
+    const value = output.includes('=') ? output.split('=')[1].trim().toLowerCase() : output.toLowerCase();
+    return {
+        value: value || 'unknown',
+        detail: '',
+    };
+}
+
+function resolveDaemonMode({ requestedMode, subcommand, userBusAvailable }) {
+    if (requestedMode !== 'auto') {
+        return requestedMode;
+    }
+
+    const userUnitInstalled = fs.existsSync(getDaemonServicePath('user'));
+    const systemUnitInstalled = fs.existsSync(getDaemonServicePath('system'));
+
+    if (subcommand === 'install') {
+        return userBusAvailable ? 'user' : 'system';
+    }
+
+    if (userUnitInstalled) return 'user';
+    if (systemUnitInstalled) return 'system';
+    return userBusAvailable ? 'user' : 'system';
+}
+
+function runSystemctl(mode, commandArgs, opts = {}) {
+    const result = runCommand('systemctl', getSystemctlArgs(mode, commandArgs), { inherit: opts.inherit });
+    if (result.status !== 0 && !opts.allowFailure) {
+        let errorText = extractCommandError(result, `systemctl ${commandArgs.join(' ')} failed`);
+        if (mode === 'system' && /(access denied|permission denied|must be root|interactive authentication required|not permitted)/i.test(errorText)) {
+            errorText += `\nTry running with elevated privileges (e.g. sudo cloudcli daemon ${commandArgs.join(' ')} --mode system).`;
+        }
+        throw new Error(errorText);
+    }
+    return result;
+}
+
+async function sleep(ms) {
+    await new Promise(resolve => setTimeout(resolve, ms));
+}
+
+async function isPortReachable(port, timeoutMs = 1000) {
+    return await new Promise(resolve => {
+        const socket = net.createConnection({ host: '127.0.0.1', port: Number(port) });
+        let settled = false;
+        const done = (value) => {
+            if (settled) return;
+            settled = true;
+            socket.destroy();
+            resolve(value);
+        };
+        socket.setTimeout(timeoutMs);
+        socket.once('connect', () => done(true));
+        socket.once('timeout', () => done(false));
+        socket.once('error', () => done(false));
+    });
+}
+
+async function requestHealthOnce(port, timeoutMs = DAEMON_HEALTH_REQUEST_TIMEOUT_MS) {
+    return await new Promise((resolve, reject) => {
+        const req = request({
+            host: '127.0.0.1',
+            port: Number(port),
+            method: 'GET',
+            path: '/health',
+            timeout: timeoutMs,
+        }, (res) => {
+            res.resume();
+            resolve({ ok: true, statusCode: res.statusCode });
+        });
+
+        req.on('timeout', () => req.destroy(new Error(`Health check timed out after ${timeoutMs}ms`)));
+        req.on('error', reject);
+        req.end();
+    });
+}
+
+async function waitForHealth(port, timeoutMs = DAEMON_HEALTH_TIMEOUT_MS) {
+    const deadline = Date.now() + timeoutMs;
+    let lastError = null;
+    while (Date.now() < deadline) {
+        try {
+            return await requestHealthOnce(port);
+        } catch (error) {
+            lastError = error;
+            if (await isPortReachable(port, 700)) {
+                return { ok: true, statusCode: null, probe: 'tcp' };
+            }
+            await sleep(DAEMON_HEALTH_RETRY_INTERVAL_MS);
+        }
+    }
+    throw new Error(lastError?.message || `Service did not become healthy on port ${port}`);
+}
+
+async function healthCheckOrThrow(mode, port, c) {
+    const state = getState(mode);
+    if (state.active !== 'active' && state.active !== 'activating') {
+        throw new Error(`Service is not active (state: ${state.active})`);
+    }
+
+    try {
+        const health = await waitForHealth(port);
+        if (health.probe === 'tcp') {
+            console.log(`${c.warn('[WARN]')} HTTP /health probe delayed; TCP port ${port} is already accepting connections.`);
+        }
+    } catch (healthError) {
+        const logsResult = readLogs(mode, 50);
+        const logText = (logsResult.stdout || logsResult.stderr || '').trim();
+        const lastErrorLine = findLatestErrorLine(logText);
+
+        if (logText) {
+            console.log(`\n${c.warn('[WARN]')} Last 50 daemon log lines:`);
+            console.log(logText);
+        }
+
+        if (lastErrorLine) {
+            throw new Error(`Health check failed: ${healthError.message}\nLikely cause: ${lastErrorLine}`);
+        }
+        throw new Error(`Health check failed: ${healthError.message}`);
+    }
+}
+
+function ensureLinux() {
+    if (process.platform !== 'linux') {
+        throw new Error('The daemon command is supported on Linux only.');
+    }
+}
+
+function ensureSystemctl() {
+    const probe = runCommand('systemctl', ['--version']);
+    if (probe.status !== 0) {
+        throw new Error(extractCommandError(probe, 'systemctl is not available in this environment'));
+    }
+}
+
+function showDaemonHelp(c) {
+    console.log(`
+${c.bright('CloudCLI Daemon')} - Persistent Linux service manager
+
+Usage:
+  cloudcli daemon [subcommand] [options]
+
+Subcommands:
+  ${c.bright('install')}      Install/update unit, reload daemon, enable and start now
+  ${c.bright('start')}        Start the service
+  ${c.bright('stop')}         Stop the service (temporary; auto-start remains enabled)
+  ${c.bright('restart')}      Restart the service
+  ${c.bright('status')}       Show active/enabled state
+  ${c.bright('logs')}         Show recent service logs
+  ${c.bright('enable')}       Enable auto-start at boot
+  ${c.bright('disable')}      Disable auto-start at boot
+  ${c.bright('uninstall')}    Stop, disable, and remove the service unit
+  ${c.bright('doctor')}       Run diagnostics (bus, linger, units, state, port, logs)
+  ${c.bright('help')}         Show this help
+
+Options:
+  -p, --port <port>           Set service server port (default: 3001)
+  -m, --mode <mode>           Service mode: user | system | auto (default: user)
+  --database-path <path>      Set service database path
+
+Examples:
+  $ cloudcli daemon install --mode auto --port 3001
+  $ cloudcli daemon status --mode auto
+  $ cloudcli daemon doctor --mode auto
+  $ cloudcli daemon logs --mode system
+`);
+}
+
+export function hasInstalledDaemonUnit() {
+    return fs.existsSync(DAEMON_USER_SERVICE_PATH) || fs.existsSync(DAEMON_SYSTEM_SERVICE_PATH);
+}
+
+export async function handleDaemonCommand(args, context = {}) {
+    const c = getColorHelpers(context.color);
+    const parsed = parseDaemonArgs(args);
+
+    if (parsed.options.extraArgs?.length) {
+        showDaemonHelp(c);
+        throw new Error(`Unknown daemon arguments: ${parsed.options.extraArgs.join(' ')}`);
+    }
+
+    if (parsed.subcommand === 'help') {
+        showDaemonHelp(c);
+        return;
+    }
+
+    if (!DAEMON_MODES.has(parsed.options.mode)) {
+        throw new Error(`Invalid daemon mode "${parsed.options.mode}". Use one of: auto, user, system.`);
+    }
+
+    ensureLinux();
+    ensureSystemctl();
+
+    const appRoot = context.appRoot || process.cwd();
+    const defaultPort = context.defaultPort || process.env.SERVER_PORT || process.env.PORT || '3001';
+    const configuredPort = parsed.options.serverPort || defaultPort;
+    const databasePath = parsed.options.databasePath || process.env.DATABASE_PATH || '';
+
+    const portNum = Number(configuredPort);
+    if (!Number.isInteger(portNum) || portNum < 1 || portNum > 65535) {
+        throw new Error(`Invalid port "${configuredPort}". Expected an integer between 1 and 65535.`);
+    }
+
+    const userBus = probeUserBus();
+    const mode = resolveDaemonMode({
+        requestedMode: parsed.options.mode,
+        subcommand: parsed.subcommand,
+        userBusAvailable: userBus.ok,
+    });
+    const servicePath = getDaemonServicePath(mode);
+    const effectivePort = getPortFromServiceUnit(servicePath) || portNum;
+
+    if (mode === 'user' && !userBus.ok) {
+        throw new Error(
+            `Could not connect to your systemd user session.\n${userBus.detail}\n` +
+            `Try ${c.bright('cloudcli daemon install --mode system')} or enable user linger: ${c.bright(`sudo loginctl enable-linger ${os.userInfo().username}`)}`
+        );
+    }
+
+    if (parsed.subcommand === 'doctor') {
+        const linger = probeLinger();
+        const userUnitInstalled = fs.existsSync(getDaemonServicePath('user'));
+        const systemUnitInstalled = fs.existsSync(getDaemonServicePath('system'));
+        const selectedModePort = getPortFromServiceUnit(servicePath) || portNum;
+        const portReachable = await isPortReachable(selectedModePort);
+        const userState = userBus.ok ? getState('user') : { active: 'unavailable', enabled: 'unavailable' };
+        const systemState = getState('system');
+        const logsResult = readLogs(mode, 50);
+        const logsText = (logsResult.stdout || logsResult.stderr || '').trim();
+        const lastErrorLine = findLatestErrorLine(logsText);
+
+        console.log(`\n${c.bright('CloudCLI Daemon Doctor')}\n`);
+        console.log(`${c.info('[INFO]')} Requested mode: ${c.bright(parsed.options.mode)}`);
+        console.log(`${c.info('[INFO]')} Resolved mode:  ${c.bright(mode)}`);
+        console.log(`${c.info('[INFO]')} user-bus:       ${userBus.ok ? c.ok('ok') : c.warn('unavailable')}`);
+        if (!userBus.ok) {
+            console.log(`       ${c.dim(userBus.detail)}`);
+        }
+        console.log(`${c.info('[INFO]')} linger:         ${c.bright(linger.value)}${linger.detail ? ` ${c.dim(`(${linger.detail})`)}` : ''}`);
+        console.log(`${c.info('[INFO]')} user unit:      ${userUnitInstalled ? c.ok('installed') : c.warn('missing')} (${c.dim(getDaemonServicePath('user'))})`);
+        console.log(`${c.info('[INFO]')} system unit:    ${systemUnitInstalled ? c.ok('installed') : c.warn('missing')} (${c.dim(getDaemonServicePath('system'))})`);
+        console.log(`${c.info('[INFO]')} user state:     active=${c.bright(userState.active)} enabled=${c.bright(userState.enabled)}`);
+        console.log(`${c.info('[INFO]')} system state:   active=${c.bright(systemState.active)} enabled=${c.bright(systemState.enabled)}`);
+        console.log(`${c.info('[INFO]')} health port:    ${c.bright(String(selectedModePort))} (${portReachable ? c.ok('reachable') : c.warn('not reachable')})`);
+        if (lastErrorLine) {
+            console.log(`${c.warn('[WARN]')} Latest error:   ${lastErrorLine}`);
+        }
+
+        console.log(`\n${c.bright('Machine Readable')}`);
+        console.log(`MODE_REQUESTED=${parsed.options.mode}`);
+        console.log(`MODE_RESOLVED=${mode}`);
+        console.log(`USER_BUS_OK=${userBus.ok}`);
+        console.log(`LINGER=${linger.value}`);
+        console.log(`USER_UNIT_INSTALLED=${userUnitInstalled}`);
+        console.log(`SYSTEM_UNIT_INSTALLED=${systemUnitInstalled}`);
+        console.log(`USER_ACTIVE=${userState.active}`);
+        console.log(`USER_ENABLED=${userState.enabled}`);
+        console.log(`SYSTEM_ACTIVE=${systemState.active}`);
+        console.log(`SYSTEM_ENABLED=${systemState.enabled}`);
+        console.log(`HEALTH_PORT=${selectedModePort}`);
+        console.log(`PORT_REACHABLE=${portReachable}`);
+        console.log(`LAST_ERROR_LINE=${JSON.stringify(lastErrorLine || '')}\n`);
+        return;
+    }
+
+    switch (parsed.subcommand) {
+        case 'install': {
+            if (parsed.options.mode === 'auto' && mode === 'system' && !userBus.ok) {
+                console.log(`${c.warn('[WARN]')} User mode is unavailable; auto mode is falling back to system mode.`);
+            }
+
+            try {
+                fs.mkdirSync(path.dirname(servicePath), { recursive: true });
+                const unitContent = buildDaemonServiceUnit({
+                    appRoot,
+                    serverPort: portNum,
+                    databasePath,
+                    nodeExecPath: context.nodeExecPath,
+                    cliEntry: context.cliEntry,
+                });
+                fs.writeFileSync(servicePath, unitContent, 'utf8');
+            } catch (fileError) {
+                if (mode === 'system' && (fileError.code === 'EACCES' || fileError.code === 'EPERM')) {
+                    throw new Error(`Permission denied writing ${servicePath}. Try: sudo cloudcli daemon install --mode system --port ${portNum}`);
+                }
+                throw fileError;
+            }
+
+            runSystemctl(mode, ['daemon-reload']);
+            runSystemctl(mode, ['enable', '--now', DAEMON_SERVICE_NAME]);
+
+            if (mode === 'user') {
+                const lingerResult = runCommand('loginctl', ['enable-linger', os.userInfo().username]);
+                if (lingerResult.status !== 0) {
+                    console.log(`${c.warn('[WARN]')} Could not enable linger automatically.`);
+                    console.log(`       ${c.dim(extractCommandError(lingerResult, 'Unknown linger error'))}`);
+                    console.log(`       ${c.tip('[TIP]')} Run with sufficient privileges: ${c.bright(`sudo loginctl enable-linger ${os.userInfo().username}`)}`);
+                }
+            }
+
+            const installedPort = getPortFromServiceUnit(servicePath) || portNum;
+            await healthCheckOrThrow(mode, installedPort, c);
+
+            const state = getState(mode);
+            console.log(`\n${c.ok('✔')} Daemon installed and started.`);
+            console.log(`   Mode:    ${c.bright(mode)}`);
+            console.log(`   Unit:    ${c.dim(servicePath)}`);
+            console.log(`   Active:  ${c.bright(state.active)}`);
+            console.log(`   Enabled: ${c.bright(state.enabled)}\n`);
+            break;
+        }
+
+        case 'start':
+            runSystemctl(mode, ['start', DAEMON_SERVICE_NAME]);
+            await healthCheckOrThrow(mode, effectivePort, c);
+            console.log(`${c.ok('[OK]')} Service started.`);
+            break;
+
+        case 'stop':
+            runSystemctl(mode, ['stop', DAEMON_SERVICE_NAME]);
+            console.log(`${c.ok('[OK]')} Service stopped (auto-start remains enabled).`);
+            break;
+
+        case 'restart':
+            runSystemctl(mode, ['restart', DAEMON_SERVICE_NAME]);
+            await healthCheckOrThrow(mode, effectivePort, c);
+            console.log(`${c.ok('[OK]')} Service restarted.`);
+            break;
+
+        case 'enable':
+            runSystemctl(mode, ['enable', DAEMON_SERVICE_NAME]);
+            console.log(`${c.ok('[OK]')} Service enabled for auto-start.`);
+            break;
+
+        case 'disable':
+            runSystemctl(mode, ['disable', DAEMON_SERVICE_NAME]);
+            console.log(`${c.ok('[OK]')} Service disabled for auto-start.`);
+            break;
+
+        case 'logs': {
+            const logsResult = readLogs(mode, 100, true);
+            if (logsResult.status !== 0) {
+                throw new Error(extractCommandError(logsResult, 'Unable to read daemon logs'));
+            }
+            break;
+        }
+
+        case 'uninstall': {
+            runSystemctl(mode, ['stop', DAEMON_SERVICE_NAME], { allowFailure: true });
+            runSystemctl(mode, ['disable', DAEMON_SERVICE_NAME], { allowFailure: true });
+            if (fs.existsSync(servicePath)) {
+                try {
+                    fs.unlinkSync(servicePath);
+                } catch (unlinkError) {
+                    if (mode === 'system' && (unlinkError.code === 'EACCES' || unlinkError.code === 'EPERM')) {
+                        throw new Error(`Permission denied removing ${servicePath}. Try: sudo cloudcli daemon uninstall --mode system`);
+                    }
+                    throw unlinkError;
+                }
+            }
+            runSystemctl(mode, ['daemon-reload'], { allowFailure: true });
+            console.log(`${c.ok('[OK]')} Daemon uninstalled.`);
+            break;
+        }
+
+        case 'status':
+        default: {
+            const state = getState(mode);
+            const unitExists = fs.existsSync(servicePath);
+            const selectedPort = getPortFromServiceUnit(servicePath) || portNum;
+            console.log(`\n${c.bright('CloudCLI Daemon Status')}\n`);
+            console.log(`${c.info('[INFO]')} Mode:      ${c.bright(mode)} ${parsed.options.mode === 'auto' ? c.dim('(resolved from auto)') : ''}`);
+            console.log(`${c.info('[INFO]')} Unit file: ${c.dim(servicePath)} ${unitExists ? c.ok('[OK]') : c.warn('[MISSING]')}`);
+            console.log(`${c.info('[INFO]')} Active:    ${c.bright(state.active)}`);
+            console.log(`${c.info('[INFO]')} Enabled:   ${c.bright(state.enabled)}`);
+            console.log(`${c.info('[INFO]')} Port:      ${c.bright(String(selectedPort))}`);
+            console.log('');
+        }
+    }
+}

--- a/server/daemon/manager.js
+++ b/server/daemon/manager.js
@@ -1,0 +1,564 @@
+import fs from 'fs';
+import http from 'http';
+import os from 'os';
+import path from 'path';
+import { execFileSync, spawn } from 'child_process';
+
+const DEFAULT_SERVER_PORT = 3001;
+const DAEMON_DIR = path.join(os.homedir(), '.cloudcli', 'daemon');
+const PID_FILE = path.join(DAEMON_DIR, 'daemon.pid');
+const STATE_FILE = path.join(DAEMON_DIR, 'daemon-state.json');
+const LOG_FILE = path.join(DAEMON_DIR, 'daemon.log');
+
+const LINUX_SYSTEMD_UNIT = 'cloudcli-daemon.service';
+const LINUX_SYSTEMD_UNIT_PATH = path.join(os.homedir(), '.config', 'systemd', 'user', LINUX_SYSTEMD_UNIT);
+const MACOS_LAUNCH_AGENT_LABEL = 'ai.cloudcli.daemon';
+const MACOS_LAUNCH_AGENT_PATH = path.join(os.homedir(), 'Library', 'LaunchAgents', `${MACOS_LAUNCH_AGENT_LABEL}.plist`);
+const WINDOWS_TASK_NAME = 'cloudcli-daemon';
+
+function ensureDaemonDir() {
+  fs.mkdirSync(DAEMON_DIR, { recursive: true });
+}
+
+function parsePort(value, fallback = DEFAULT_SERVER_PORT) {
+  if (value == null || value === '') {
+    return fallback;
+  }
+
+  const parsed = Number.parseInt(String(value), 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function readPidFile() {
+  try {
+    const raw = fs.readFileSync(PID_FILE, 'utf8').trim();
+    const pid = Number.parseInt(raw, 10);
+    return Number.isFinite(pid) && pid > 0 ? pid : null;
+  } catch {
+    return null;
+  }
+}
+
+function writePidFile(pid) {
+  fs.writeFileSync(PID_FILE, `${pid}\n`);
+}
+
+function readStateFile() {
+  try {
+    const raw = fs.readFileSync(STATE_FILE, 'utf8');
+    const parsed = JSON.parse(raw);
+    if (!parsed || typeof parsed !== 'object') {
+      return {};
+    }
+    return parsed;
+  } catch {
+    return {};
+  }
+}
+
+function writeStateFile(state) {
+  fs.writeFileSync(STATE_FILE, JSON.stringify(state, null, 2));
+}
+
+function safeUnlink(filePath) {
+  try {
+    fs.unlinkSync(filePath);
+  } catch (error) {
+    if (error?.code !== 'ENOENT') {
+      throw error;
+    }
+  }
+}
+
+function clearDaemonFiles() {
+  safeUnlink(PID_FILE);
+  safeUnlink(STATE_FILE);
+}
+
+function isProcessRunning(pid) {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function waitForProcessExit(pid, timeoutMs) {
+  const deadline = Date.now() + timeoutMs;
+
+  while (Date.now() < deadline) {
+    if (!isProcessRunning(pid)) {
+      return true;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 200));
+  }
+
+  return !isProcessRunning(pid);
+}
+
+function quoteSystemdArg(arg) {
+  return `"${String(arg).replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
+}
+
+function quoteWindowsArg(arg) {
+  return `"${String(arg).replace(/"/g, '""')}"`;
+}
+
+function xmlEscape(value) {
+  return String(value)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+}
+
+function buildDaemonStartArgs({ serverPort, databasePath } = {}) {
+  const args = ['daemon', 'start'];
+
+  if (serverPort) {
+    args.push('--port', String(serverPort));
+  }
+
+  if (databasePath) {
+    args.push('--database-path', databasePath);
+  }
+
+  return args;
+}
+
+function terminateProcess(pid, force = false) {
+  if (process.platform === 'win32') {
+    const args = ['/PID', String(pid), '/T'];
+    if (force) {
+      args.push('/F');
+    }
+    execFileSync('taskkill', args, { stdio: 'pipe' });
+    return;
+  }
+
+  process.kill(pid, force ? 'SIGKILL' : 'SIGTERM');
+}
+
+async function checkHealth(port) {
+  return new Promise((resolve) => {
+    let settled = false;
+    const complete = (value) => {
+      if (!settled) {
+        settled = true;
+        resolve(value);
+      }
+    };
+
+    const req = http.get({
+      host: '127.0.0.1',
+      port,
+      path: '/health',
+      timeout: 1200
+    }, (res) => {
+      complete(Boolean(res.statusCode && res.statusCode >= 200 && res.statusCode < 500));
+      res.resume();
+    });
+
+    req.on('error', () => complete(false));
+    req.on('timeout', () => {
+      req.destroy();
+      complete(false);
+    });
+  });
+}
+
+function buildLinuxSystemdUnit({ nodePath, cliEntryPath, serverPort, databasePath }) {
+  const startArgs = buildDaemonStartArgs({ serverPort, databasePath });
+  const execStart = [quoteSystemdArg(nodePath), quoteSystemdArg(cliEntryPath), ...startArgs.map(quoteSystemdArg)].join(' ');
+  const execStop = [quoteSystemdArg(nodePath), quoteSystemdArg(cliEntryPath), quoteSystemdArg('daemon'), quoteSystemdArg('stop')].join(' ');
+
+  return `[Unit]
+Description=CloudCLI daemon bootstrap
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=${execStart}
+ExecStop=${execStop}
+
+[Install]
+WantedBy=default.target
+`;
+}
+
+function enableLinuxAutostart(options) {
+  const systemdDir = path.dirname(LINUX_SYSTEMD_UNIT_PATH);
+  fs.mkdirSync(systemdDir, { recursive: true });
+  fs.writeFileSync(LINUX_SYSTEMD_UNIT_PATH, buildLinuxSystemdUnit(options), 'utf8');
+
+  try {
+    execFileSync('systemctl', ['--user', 'daemon-reload'], { stdio: 'pipe' });
+    execFileSync('systemctl', ['--user', 'enable', '--now', LINUX_SYSTEMD_UNIT], { stdio: 'pipe' });
+  } catch (error) {
+    throw new Error(`Failed to enable systemd user service. ${error.message}`);
+  }
+
+  return { mode: 'systemd', enabled: true, path: LINUX_SYSTEMD_UNIT_PATH };
+}
+
+function disableLinuxAutostart() {
+  try {
+    execFileSync('systemctl', ['--user', 'disable', '--now', LINUX_SYSTEMD_UNIT], { stdio: 'pipe' });
+  } catch {
+    // Best-effort disable; we still remove the unit file below.
+  }
+
+  safeUnlink(LINUX_SYSTEMD_UNIT_PATH);
+
+  try {
+    execFileSync('systemctl', ['--user', 'daemon-reload'], { stdio: 'pipe' });
+  } catch {
+    // Non-systemd environments may fail this call.
+  }
+
+  return { mode: 'systemd', enabled: false, path: LINUX_SYSTEMD_UNIT_PATH };
+}
+
+function getLinuxAutostartStatus() {
+  if (!fs.existsSync(LINUX_SYSTEMD_UNIT_PATH)) {
+    return { enabled: false, mode: 'systemd', path: LINUX_SYSTEMD_UNIT_PATH };
+  }
+
+  try {
+    const enabled = execFileSync('systemctl', ['--user', 'is-enabled', LINUX_SYSTEMD_UNIT], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe']
+    }).trim();
+    return { enabled: enabled === 'enabled', mode: 'systemd', path: LINUX_SYSTEMD_UNIT_PATH };
+  } catch {
+    return { enabled: false, mode: 'systemd', path: LINUX_SYSTEMD_UNIT_PATH };
+  }
+}
+
+function buildMacLaunchAgent({ nodePath, cliEntryPath, serverPort, databasePath }) {
+  const args = [nodePath, cliEntryPath, ...buildDaemonStartArgs({ serverPort, databasePath })];
+  const xmlArgs = args.map((arg) => `    <string>${xmlEscape(arg)}</string>`).join('\n');
+
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>${MACOS_LAUNCH_AGENT_LABEL}</string>
+  <key>ProgramArguments</key>
+  <array>
+${xmlArgs}
+  </array>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>KeepAlive</key>
+  <false/>
+  <key>StandardOutPath</key>
+  <string>${xmlEscape(LOG_FILE)}</string>
+  <key>StandardErrorPath</key>
+  <string>${xmlEscape(LOG_FILE)}</string>
+</dict>
+</plist>
+`;
+}
+
+function enableMacAutostart(options) {
+  fs.mkdirSync(path.dirname(MACOS_LAUNCH_AGENT_PATH), { recursive: true });
+  fs.writeFileSync(MACOS_LAUNCH_AGENT_PATH, buildMacLaunchAgent(options), 'utf8');
+
+  try {
+    execFileSync('launchctl', ['unload', MACOS_LAUNCH_AGENT_PATH], { stdio: 'pipe' });
+  } catch {
+    // If not loaded yet, unload fails — safe to ignore.
+  }
+
+  execFileSync('launchctl', ['load', '-w', MACOS_LAUNCH_AGENT_PATH], { stdio: 'pipe' });
+
+  return { mode: 'launchagent', enabled: true, path: MACOS_LAUNCH_AGENT_PATH };
+}
+
+function disableMacAutostart() {
+  try {
+    execFileSync('launchctl', ['unload', '-w', MACOS_LAUNCH_AGENT_PATH], { stdio: 'pipe' });
+  } catch {
+    // Best effort.
+  }
+
+  safeUnlink(MACOS_LAUNCH_AGENT_PATH);
+  return { mode: 'launchagent', enabled: false, path: MACOS_LAUNCH_AGENT_PATH };
+}
+
+function getMacAutostartStatus() {
+  return {
+    enabled: fs.existsSync(MACOS_LAUNCH_AGENT_PATH),
+    mode: 'launchagent',
+    path: MACOS_LAUNCH_AGENT_PATH
+  };
+}
+
+function enableWindowsAutostart({ nodePath, cliEntryPath, serverPort, databasePath }) {
+  const command = [
+    quoteWindowsArg(nodePath),
+    quoteWindowsArg(cliEntryPath),
+    ...buildDaemonStartArgs({ serverPort, databasePath }).map(quoteWindowsArg)
+  ].join(' ');
+
+  execFileSync('schtasks', [
+    '/Create',
+    '/F',
+    '/SC',
+    'ONLOGON',
+    '/TN',
+    WINDOWS_TASK_NAME,
+    '/TR',
+    command,
+    '/RL',
+    'LIMITED'
+  ], { stdio: 'pipe' });
+
+  try {
+    execFileSync('schtasks', ['/Run', '/TN', WINDOWS_TASK_NAME], { stdio: 'pipe' });
+  } catch {
+    // Task creation succeeded; run may fail in some contexts.
+  }
+
+  return { mode: 'taskscheduler', enabled: true, path: WINDOWS_TASK_NAME };
+}
+
+function disableWindowsAutostart() {
+  try {
+    execFileSync('schtasks', ['/Delete', '/F', '/TN', WINDOWS_TASK_NAME], { stdio: 'pipe' });
+  } catch {
+    // Best effort; task may already be absent.
+  }
+
+  return { mode: 'taskscheduler', enabled: false, path: WINDOWS_TASK_NAME };
+}
+
+function getWindowsAutostartStatus() {
+  try {
+    execFileSync('schtasks', ['/Query', '/TN', WINDOWS_TASK_NAME], { stdio: 'pipe' });
+    return { enabled: true, mode: 'taskscheduler', path: WINDOWS_TASK_NAME };
+  } catch {
+    return { enabled: false, mode: 'taskscheduler', path: WINDOWS_TASK_NAME };
+  }
+}
+
+export function getDaemonPaths() {
+  return {
+    daemonDir: DAEMON_DIR,
+    pidFile: PID_FILE,
+    stateFile: STATE_FILE,
+    logFile: LOG_FILE
+  };
+}
+
+export function startDaemon({ nodePath, cliEntryPath, serverPort, databasePath } = {}) {
+  if (!nodePath || !cliEntryPath) {
+    throw new Error('nodePath and cliEntryPath are required to start daemon mode');
+  }
+
+  ensureDaemonDir();
+
+  const existingPid = readPidFile();
+  if (existingPid && isProcessRunning(existingPid)) {
+    const state = readStateFile();
+    return {
+      started: false,
+      alreadyRunning: true,
+      pid: existingPid,
+      port: parsePort(state.serverPort)
+    };
+  }
+
+  if (existingPid) {
+    clearDaemonFiles();
+  }
+
+  const resolvedPort = parsePort(serverPort, parsePort(process.env.SERVER_PORT || process.env.PORT));
+  const resolvedDatabasePath = databasePath || process.env.DATABASE_PATH || null;
+  const args = ['start', '--port', String(resolvedPort)];
+  if (resolvedDatabasePath) {
+    args.push('--database-path', resolvedDatabasePath);
+  }
+
+  const logFd = fs.openSync(LOG_FILE, 'a');
+  try {
+    const child = spawn(nodePath, [cliEntryPath, ...args], {
+      detached: true,
+      stdio: ['ignore', logFd, logFd],
+      windowsHide: true,
+      env: {
+        ...process.env,
+        CLOUDCLI_SKIP_UPDATE_CHECK: '1',
+        SERVER_PORT: String(resolvedPort),
+        ...(resolvedDatabasePath ? { DATABASE_PATH: resolvedDatabasePath } : {})
+      }
+    });
+
+    child.unref();
+    writePidFile(child.pid);
+    writeStateFile({
+      pid: child.pid,
+      serverPort: resolvedPort,
+      databasePath: resolvedDatabasePath,
+      startedAt: new Date().toISOString()
+    });
+
+    return {
+      started: true,
+      alreadyRunning: false,
+      pid: child.pid,
+      port: resolvedPort
+    };
+  } finally {
+    fs.closeSync(logFd);
+  }
+}
+
+export async function stopDaemon() {
+  ensureDaemonDir();
+  const pid = readPidFile();
+
+  if (!pid) {
+    return { stopped: false, reason: 'not_running' };
+  }
+
+  if (!isProcessRunning(pid)) {
+    clearDaemonFiles();
+    return { stopped: true, reason: 'stale_pid', pid };
+  }
+
+  try {
+    terminateProcess(pid, process.platform === 'win32');
+  } catch (error) {
+    if (!isProcessRunning(pid)) {
+      clearDaemonFiles();
+      return { stopped: true, reason: 'stopped', pid };
+    }
+
+    return { stopped: false, reason: 'termination_failed', pid, error: error.message };
+  }
+
+  let stopped = await waitForProcessExit(pid, 10000);
+  if (!stopped && process.platform !== 'win32') {
+    try {
+      terminateProcess(pid, true);
+    } catch {
+      // Best effort.
+    }
+    stopped = await waitForProcessExit(pid, 5000);
+  }
+
+  if (stopped) {
+    clearDaemonFiles();
+    return { stopped: true, reason: 'stopped', pid };
+  }
+
+  return { stopped: false, reason: 'timeout', pid };
+}
+
+export async function getDaemonStatus({ serverPort } = {}) {
+  ensureDaemonDir();
+
+  const state = readStateFile();
+  const pid = readPidFile();
+  let running = false;
+  let stalePid = false;
+
+  if (pid) {
+    running = isProcessRunning(pid);
+    stalePid = !running;
+    if (stalePid) {
+      clearDaemonFiles();
+    }
+  }
+
+  const resolvedPort = parsePort(
+    state.serverPort ?? serverPort ?? process.env.SERVER_PORT ?? process.env.PORT
+  );
+
+  const health = running ? await checkHealth(resolvedPort) : false;
+  const autostart = getAutostartStatus();
+
+  return {
+    running,
+    stalePid,
+    pid: running ? pid : null,
+    port: resolvedPort,
+    health,
+    autostart,
+    paths: getDaemonPaths(),
+    state: running ? state : {}
+  };
+}
+
+export function enableAutostart({ nodePath, cliEntryPath, serverPort, databasePath } = {}) {
+  if (!nodePath || !cliEntryPath) {
+    throw new Error('nodePath and cliEntryPath are required to enable autostart');
+  }
+
+  const options = { nodePath, cliEntryPath, serverPort, databasePath };
+
+  if (process.platform === 'linux') {
+    return enableLinuxAutostart(options);
+  }
+
+  if (process.platform === 'darwin') {
+    return enableMacAutostart(options);
+  }
+
+  if (process.platform === 'win32') {
+    return enableWindowsAutostart(options);
+  }
+
+  throw new Error(`Autostart is not supported on platform: ${process.platform}`);
+}
+
+export function disableAutostart() {
+  if (process.platform === 'linux') {
+    return disableLinuxAutostart();
+  }
+
+  if (process.platform === 'darwin') {
+    return disableMacAutostart();
+  }
+
+  if (process.platform === 'win32') {
+    return disableWindowsAutostart();
+  }
+
+  throw new Error(`Autostart is not supported on platform: ${process.platform}`);
+}
+
+export function getAutostartStatus() {
+  if (process.platform === 'linux') {
+    return getLinuxAutostartStatus();
+  }
+
+  if (process.platform === 'darwin') {
+    return getMacAutostartStatus();
+  }
+
+  if (process.platform === 'win32') {
+    return getWindowsAutostartStatus();
+  }
+
+  return { enabled: false, mode: 'unsupported', path: null };
+}
+
+export function readDaemonLogs({ lines = 200 } = {}) {
+  ensureDaemonDir();
+  if (!fs.existsSync(LOG_FILE)) {
+    return { exists: false, content: '', logFile: LOG_FILE };
+  }
+
+  const raw = fs.readFileSync(LOG_FILE, 'utf8');
+  const lineList = raw.split(/\r?\n/);
+  const limited = lineList.slice(Math.max(0, lineList.length - lines)).join('\n');
+  return { exists: true, content: limited.trim(), logFile: LOG_FILE };
+}

--- a/server/index.js
+++ b/server/index.js
@@ -2333,6 +2333,15 @@ async function waitForPortOpen(port, timeoutMs = 25000) {
     return false;
 }
 
+function printSystemDaemonActiveNotice(port) {
+    const effectivePort = Number(port) || 3001;
+    console.log(`${c.ok('[OK]')} System daemon is active and managing CloudCLI.`);
+    console.log(`${c.info('[INFO]')} Health URL: ${c.bright(`http://localhost:${effectivePort}/health`)}`);
+    console.log(`${c.info('[INFO]')} Status: ${c.bright('cloudcli daemon status --mode system')}`);
+    console.log(`${c.info('[INFO]')} Stop: ${c.bright('sudo cloudcli daemon stop --mode system')}`);
+    console.log(`${c.info('[INFO]')} Logs: ${c.bright('sudo cloudcli daemon logs --mode system')}`);
+}
+
 async function maybeAutoDaemonBootstrapFromIndex() {
     if (process.platform !== 'linux') return false;
     if (process.env.CLOUDCLI_DAEMON_MANAGED === '1') return false;
@@ -2342,28 +2351,27 @@ async function maybeAutoDaemonBootstrapFromIndex() {
     process.env.CLOUDCLI_DAEMON_ATTEMPTED = '1';
 
     try {
-        console.log(`${c.info('[INFO]')} Linux detected. Bootstrapping CloudCLI daemon mode...`);
-        await handleDaemonCommand(['install', '--mode=auto', '--port', String(SERVER_PORT)], {
+        console.log(`${c.info('[INFO]')} Linux detected. Enforcing system daemon mode for CloudCLI...`);
+        await handleDaemonCommand(['install', '--mode=system', '--port', String(SERVER_PORT)], {
             appRoot: APP_ROOT,
             defaultPort: String(SERVER_PORT),
             color: c,
             cliEntry: path.join(APP_ROOT, 'server', 'cli.js'),
         });
-        console.log(`${c.ok('[OK]')} CloudCLI daemon is now managing the service.`);
-        console.log(`${c.tip('[TIP]')} Run "cloudcli daemon status --mode auto" for details.`);
         return true;
     } catch (error) {
         const healthySoon = await waitForPortOpen(SERVER_PORT);
         if (healthySoon) {
-            console.log(`${c.warn('[WARN]')} Daemon health check was delayed, but port ${SERVER_PORT} is now reachable.`);
-            console.log(`${c.tip('[TIP]')} Continuing with daemon-managed runtime.`);
+            console.log(`${c.warn('[WARN]')} System daemon health check was delayed, but port ${SERVER_PORT} is now reachable.`);
+            printSystemDaemonActiveNotice(SERVER_PORT);
             return true;
         }
 
-        console.log(`${c.warn('[WARN]')} Daemon bootstrap failed; continuing in foreground mode.`);
-        console.log(`       ${c.dim(error.message)}`);
-        console.log(`${c.tip('[TIP]')} Retry manually with: ${c.bright('cloudcli daemon install --mode auto')}`);
-        return false;
+        throw new Error(
+            `System daemon bootstrap failed.\n` +
+            `${error.message}\n` +
+            `Run with privileges: sudo cloudcli daemon install --mode system --port ${SERVER_PORT}`
+        );
     }
 }
 

--- a/server/index.js
+++ b/server/index.js
@@ -19,6 +19,7 @@ import express from 'express';
 import { WebSocketServer, WebSocket } from 'ws';
 import os from 'os';
 import http from 'http';
+import net from 'node:net';
 import cors from 'cors';
 import { promises as fsPromises } from 'fs';
 import { spawn } from 'child_process';
@@ -55,6 +56,7 @@ import { configureWebPush } from './services/vapid-keys.js';
 import { validateApiKey, authenticateToken, authenticateWebSocket } from './middleware/auth.js';
 import { IS_PLATFORM } from './constants/config.js';
 import { getConnectableHost } from '../shared/networkHosts.js';
+import { handleDaemonCommand } from './daemon-manager.js';
 
 const VALID_PROVIDERS = ['claude', 'codex', 'cursor', 'gemini'];
 
@@ -206,13 +208,7 @@ const app = express();
 const server = http.createServer(app);
 
 const ptySessionsMap = new Map();
-function getPtySessionTimeoutMs() {
-    const parsedMinutes = Number.parseInt(process.env.SHELL_SESSION_TIMEOUT_MINUTES || '', 10);
-    const timeoutMinutes = Number.isFinite(parsedMinutes) && parsedMinutes > 0 ? parsedMinutes : 30;
-    return timeoutMinutes * 60 * 1000;
-}
-
-const PTY_SESSION_TIMEOUT = getPtySessionTimeoutMs();
+const PTY_SESSION_TIMEOUT = 30 * 60 * 1000;
 const SHELL_URL_PARSE_BUFFER_LIMIT = 32768;
 import { stripAnsiSequences, normalizeDetectedUrl, extractUrlsFromText, shouldAutoOpenUrlFromOutput } from './utils/url-detection.js';
 
@@ -2308,9 +2304,76 @@ const HOST = process.env.HOST || '0.0.0.0';
 const DISPLAY_HOST = getConnectableHost(HOST);
 const VITE_PORT = process.env.VITE_PORT || 5173;
 
+async function isPortOpen(port, timeoutMs = 800) {
+    return await new Promise((resolve) => {
+        const socket = net.createConnection({ host: '127.0.0.1', port: Number(port) });
+        let settled = false;
+        const done = (value) => {
+            if (settled) return;
+            settled = true;
+            socket.destroy();
+            resolve(value);
+        };
+
+        socket.setTimeout(timeoutMs);
+        socket.once('connect', () => done(true));
+        socket.once('timeout', () => done(false));
+        socket.once('error', () => done(false));
+    });
+}
+
+async function waitForPortOpen(port, timeoutMs = 25000) {
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+        if (await isPortOpen(port)) {
+            return true;
+        }
+        await new Promise(resolve => setTimeout(resolve, 1000));
+    }
+    return false;
+}
+
+async function maybeAutoDaemonBootstrapFromIndex() {
+    if (process.platform !== 'linux') return false;
+    if (process.env.CLOUDCLI_DAEMON_MANAGED === '1') return false;
+    if (process.env.CLOUDCLI_NO_DAEMON === '1') return false;
+    if (process.env.CLOUDCLI_DAEMON_ATTEMPTED === '1') return false;
+
+    process.env.CLOUDCLI_DAEMON_ATTEMPTED = '1';
+
+    try {
+        console.log(`${c.info('[INFO]')} Linux detected. Bootstrapping CloudCLI daemon mode...`);
+        await handleDaemonCommand(['install', '--mode=auto', '--port', String(SERVER_PORT)], {
+            appRoot: APP_ROOT,
+            defaultPort: String(SERVER_PORT),
+            color: c,
+            cliEntry: path.join(APP_ROOT, 'server', 'cli.js'),
+        });
+        console.log(`${c.ok('[OK]')} CloudCLI daemon is now managing the service.`);
+        console.log(`${c.tip('[TIP]')} Run "cloudcli daemon status --mode auto" for details.`);
+        return true;
+    } catch (error) {
+        const healthySoon = await waitForPortOpen(SERVER_PORT);
+        if (healthySoon) {
+            console.log(`${c.warn('[WARN]')} Daemon health check was delayed, but port ${SERVER_PORT} is now reachable.`);
+            console.log(`${c.tip('[TIP]')} Continuing with daemon-managed runtime.`);
+            return true;
+        }
+
+        console.log(`${c.warn('[WARN]')} Daemon bootstrap failed; continuing in foreground mode.`);
+        console.log(`       ${c.dim(error.message)}`);
+        console.log(`${c.tip('[TIP]')} Retry manually with: ${c.bright('cloudcli daemon install --mode auto')}`);
+        return false;
+    }
+}
+
 // Initialize database and start server
 async function startServer() {
     try {
+        if (await maybeAutoDaemonBootstrapFromIndex()) {
+            return;
+        }
+
         // Initialize authentication database
         await initializeDatabase();
 

--- a/server/index.js
+++ b/server/index.js
@@ -2342,6 +2342,23 @@ function printSystemDaemonActiveNotice(port) {
     console.log(`${c.info('[INFO]')} Logs: ${c.bright('sudo cloudcli daemon logs --mode system')}`);
 }
 
+function printUserDaemonActiveNotice(port, frontendPort) {
+    const effectivePort = Number(port) || 3001;
+    const effectiveFrontendPort = Number(frontendPort) || 5173;
+    console.log(`${c.ok('[OK]')} User daemon is active for this account.`);
+    console.log(`${c.info('[INFO]')} Backend: ${c.bright(`http://localhost:${effectivePort}`)}`);
+    console.log(`${c.info('[INFO]')} Frontend: ${c.bright(`http://localhost:${effectiveFrontendPort}`)}`);
+    console.log(`${c.info('[INFO]')} Status: ${c.bright('cloudcli daemon status --mode user')}`);
+    console.log(`${c.info('[INFO]')} Stop: ${c.bright('cloudcli daemon stop --mode user')}`);
+    console.log(`${c.info('[INFO]')} Logs: ${c.bright('cloudcli daemon logs --mode user')}`);
+    console.log(`${c.tip('[TIP]')} For login/reboot persistence, enable linger once: ${c.bright(`sudo loginctl enable-linger ${os.userInfo().username}`)}`);
+}
+
+function isSystemPermissionError(error) {
+    const message = String(error?.message || error || '');
+    return /(access denied|permission denied|must be root|interactive authentication required|not permitted|failed to connect to bus|operation not permitted|authentication is required|polkit)/i.test(message);
+}
+
 async function maybeAutoDaemonBootstrapFromIndex() {
     if (process.platform !== 'linux') return false;
     if (process.env.CLOUDCLI_DAEMON_MANAGED === '1') return false;
@@ -2350,16 +2367,19 @@ async function maybeAutoDaemonBootstrapFromIndex() {
 
     process.env.CLOUDCLI_DAEMON_ATTEMPTED = '1';
 
+    const systemArgs = ['install', '--mode=system', '--port', String(SERVER_PORT), '--frontend-port', String(VITE_PORT)];
+    const userArgs = ['install', '--mode=user', '--port', String(SERVER_PORT), '--frontend-port', String(VITE_PORT)];
+
     try {
         console.log(`${c.info('[INFO]')} Linux detected. Enforcing system daemon mode for CloudCLI...`);
-        await handleDaemonCommand(['install', '--mode=system', '--port', String(SERVER_PORT)], {
+        await handleDaemonCommand(systemArgs, {
             appRoot: APP_ROOT,
             defaultPort: String(SERVER_PORT),
             color: c,
             cliEntry: path.join(APP_ROOT, 'server', 'cli.js'),
         });
         return true;
-    } catch (error) {
+    } catch (systemError) {
         const healthySoon = await waitForPortOpen(SERVER_PORT);
         if (healthySoon) {
             console.log(`${c.warn('[WARN]')} System daemon health check was delayed, but port ${SERVER_PORT} is now reachable.`);
@@ -2367,11 +2387,43 @@ async function maybeAutoDaemonBootstrapFromIndex() {
             return true;
         }
 
-        throw new Error(
-            `System daemon bootstrap failed.\n` +
-            `${error.message}\n` +
-            `Run with privileges: sudo cloudcli daemon install --mode system --port ${SERVER_PORT}`
-        );
+        if (!isSystemPermissionError(systemError)) {
+            throw new Error(
+                `System daemon bootstrap failed.\n` +
+                `${systemError.message}\n` +
+                `Run with privileges: sudo cloudcli daemon install --mode system --port ${SERVER_PORT} --frontend-port ${VITE_PORT}`
+            );
+        }
+
+        console.log(`${c.warn('[WARN]')} System daemon setup requires elevated privileges for this user.`);
+        console.log(`${c.info('[INFO]')} Falling back to user daemon mode for account "${os.userInfo().username}"...`);
+
+        try {
+            await handleDaemonCommand(userArgs, {
+                appRoot: APP_ROOT,
+                defaultPort: String(SERVER_PORT),
+                color: c,
+                cliEntry: path.join(APP_ROOT, 'server', 'cli.js'),
+            });
+            printUserDaemonActiveNotice(SERVER_PORT, VITE_PORT);
+            return true;
+        } catch (userError) {
+            const userHealthySoon = await waitForPortOpen(SERVER_PORT);
+            if (userHealthySoon) {
+                console.log(`${c.warn('[WARN]')} User daemon health check was delayed, but port ${SERVER_PORT} is now reachable.`);
+                printUserDaemonActiveNotice(SERVER_PORT, VITE_PORT);
+                return true;
+            }
+            throw new Error(
+                `System daemon bootstrap failed.\n` +
+                `${systemError.message}\n\n` +
+                `User daemon fallback also failed.\n` +
+                `${userError.message}\n` +
+                `Try one of:\n` +
+                `1) sudo cloudcli daemon install --mode system --port ${SERVER_PORT} --frontend-port ${VITE_PORT}\n` +
+                `2) cloudcli daemon install --mode user --port ${SERVER_PORT} --frontend-port ${VITE_PORT}`
+            );
+        }
     }
 }
 

--- a/server/index.js
+++ b/server/index.js
@@ -206,7 +206,13 @@ const app = express();
 const server = http.createServer(app);
 
 const ptySessionsMap = new Map();
-const PTY_SESSION_TIMEOUT = 30 * 60 * 1000;
+function getPtySessionTimeoutMs() {
+    const parsedMinutes = Number.parseInt(process.env.SHELL_SESSION_TIMEOUT_MINUTES || '', 10);
+    const timeoutMinutes = Number.isFinite(parsedMinutes) && parsedMinutes > 0 ? parsedMinutes : 30;
+    return timeoutMinutes * 60 * 1000;
+}
+
+const PTY_SESSION_TIMEOUT = getPtySessionTimeoutMs();
 const SHELL_URL_PARSE_BUFFER_LIMIT = 32768;
 import { stripAnsiSequences, normalizeDetectedUrl, extractUrlsFromText, shouldAutoOpenUrlFromOutput } from './utils/url-detection.js';
 

--- a/server/vite-daemon.js
+++ b/server/vite-daemon.js
@@ -1,0 +1,78 @@
+#!/usr/bin/env node
+
+import process from 'node:process';
+import { createServer } from 'vite';
+
+const DEFAULT_PORT = 5173;
+const DEFAULT_HOST = '0.0.0.0';
+
+function parseArgs(argv) {
+    const parsed = {
+        host: process.env.VITE_HOST || process.env.HOST || DEFAULT_HOST,
+        port: Number(process.env.VITE_PORT || DEFAULT_PORT),
+        strictPort: true,
+    };
+
+    for (let i = 0; i < argv.length; i++) {
+        const arg = argv[i];
+        if (arg === '--host') {
+            parsed.host = argv[++i];
+        } else if (arg.startsWith('--host=')) {
+            parsed.host = arg.split('=')[1];
+        } else if (arg === '--port' || arg === '-p') {
+            parsed.port = Number(argv[++i]);
+        } else if (arg.startsWith('--port=')) {
+            parsed.port = Number(arg.split('=')[1]);
+        } else if (arg === '--strictPort') {
+            parsed.strictPort = true;
+        } else if (arg === '--no-strictPort') {
+            parsed.strictPort = false;
+        } else if (arg === '--help' || arg === '-h') {
+            console.log('Usage: node server/vite-daemon.js [--host 0.0.0.0] [--port 5173] [--strictPort]');
+            process.exit(0);
+        } else {
+            throw new Error(`Unknown argument: ${arg}`);
+        }
+    }
+
+    if (!Number.isInteger(parsed.port) || parsed.port < 1 || parsed.port > 65535) {
+        throw new Error(`Invalid port "${parsed.port}". Expected an integer between 1 and 65535.`);
+    }
+
+    return parsed;
+}
+
+async function main() {
+    const options = parseArgs(process.argv.slice(2));
+    const server = await createServer({
+        root: process.cwd(),
+        server: {
+            host: options.host,
+            port: options.port,
+            strictPort: options.strictPort,
+        },
+        clearScreen: false,
+    });
+
+    await server.listen();
+    server.printUrls();
+
+    const shutdown = async (signal) => {
+        console.log(`[INFO] Frontend daemon received ${signal}, shutting down...`);
+        await server.close();
+        process.exit(0);
+    };
+
+    process.once('SIGTERM', () => {
+        void shutdown('SIGTERM');
+    });
+    process.once('SIGINT', () => {
+        void shutdown('SIGINT');
+    });
+}
+
+main().catch((error) => {
+    const message = error?.stack || error?.message || String(error);
+    console.error(`[ERROR] Frontend daemon failed to start: ${message}`);
+    process.exit(1);
+});

--- a/vite.config.js
+++ b/vite.config.js
@@ -28,6 +28,7 @@ export default defineConfig(({ mode }) => {
     server: {
       host,
       port: parseInt(env.VITE_PORT) || 5173,
+      strictPort: true,
       proxy: {
         '/api': `http://${proxyHost}:${serverPort}`,
         '/ws': {


### PR DESCRIPTION
## Summary
- Make Linux daemon mode system-first and keep startup messaging focused on system service operations.
- Extend daemon management to control **two services** together:
  - `cloudcli.service` (backend on `3001`)
  - `cloudcli-frontend.service` (frontend on `5173`)
- Add `--frontend-port` support and include frontend state/port visibility in `status` and `doctor` outputs.
- Add `server/vite-daemon.js` to run Vite through Node API as a long-running service entrypoint.
- Update dev scripts so `npm run dev` uses daemon install/restart flow with both ports (`3001` and `5173`).

## Root Cause
Frontend was not managed as a persistent daemon service, and Vite process behavior under non-interactive service context could exit quickly, which left only backend behavior visible in practice. This created a mismatch where users expected both frontend and backend to survive terminal close/restart, but only backend daemon behavior was applied consistently.

## Impact
- Frontend (`5173`) and backend (`3001`) are both daemon-managed and auto-restart with systemd.
- Services remain active after terminal exit and are configured for boot-time persistence in system mode.
- Operators get explicit English guidance for status/stop/logs commands in daemon output.

## Validation
- `npm run typecheck`
- `npm run dev`
- `node server/cli.js daemon status --mode system`
- HTTP checks:
  - `http://85.235.74.198:3001` -> `200`
  - `http://85.235.74.198:5173` -> `200`

## Notes
- Branch includes earlier daemon CLI groundwork plus this persistence fix set.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add daemon management: run CloudCLI as a background service on Linux with install/start/stop/restart/status/logs/doctor controls, auto-start behavior, and CLI options to force foreground or restart the daemon after updates.
  * Add a Vite dev-mode daemon and strict frontend port binding.

* **Configuration**
  * Documented new commented env var for shell session timeout (default 30 minutes) and updated dev/start scripts to use daemon-friendly workflows.

* **Documentation**
  * New Linux daemon guide with install, status, logs, lifecycle, mode, and update instructions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->