### PR TITLE
feat: update Claude models list, default, and context window detection

### DIFF
--- a/server/claude-sdk.js
+++ b/server/claude-sdk.js
@@ -282,9 +282,10 @@ function transformMessage(sdkMessage) {
 /**
  * Extracts token usage from SDK result messages
  * @param {Object} resultMessage - SDK result message
+ * @param {string} [selectedModel] - The user-selected model identifier (preserves [1m] suffix)
  * @returns {Object|null} Token budget object or null
  */
-function extractTokenBudget(resultMessage) {
+function extractTokenBudget(resultMessage, selectedModel) {
   if (resultMessage.type !== 'result' || !resultMessage.modelUsage) {
     return null;
   }
@@ -308,10 +309,15 @@ function extractTokenBudget(resultMessage) {
   const totalUsed = inputTokens + outputTokens + cacheReadTokens + cacheCreationTokens;
 
   // Determine the context window from the model that produced this usage.
+  // Prefer `selectedModel` (user input) since `modelKey` from the SDK returns
+  // the resolved API id (e.g. `claude-opus-4-6`) and loses the `[1m]` suffix.
   // Falls back to CONTEXT_WINDOW env var only when the model is unknown.
-  const contextWindow = modelKey
-    ? getClaudeContextWindow(modelKey)
-    : parseInt(process.env.CONTEXT_WINDOW) || CLAUDE_DEFAULT_CONTEXT_WINDOW;
+  const modelForContext = selectedModel || modelKey;
+  const fallbackContextWindow =
+    Number.parseInt(process.env.CONTEXT_WINDOW || '', 10) || CLAUDE_DEFAULT_CONTEXT_WINDOW;
+  const contextWindow = modelForContext
+    ? getClaudeContextWindow(modelForContext)
+    : fallbackContextWindow;
 
   // Token calc logged via token-budget WS event
 
@@ -671,7 +677,7 @@ async function queryClaudeSDK(command, options = {}, ws) {
         if (models.length > 0) {
           // Model info available in result message
         }
-        const tokenBudgetData = extractTokenBudget(message);
+        const tokenBudgetData = extractTokenBudget(message, sdkOptions.model);
         if (tokenBudgetData) {
           ws.send(createNormalizedMessage({ kind: 'status', text: 'token_budget', tokenBudget: tokenBudgetData, sessionId: capturedSessionId || sessionId || null, provider: 'claude' }));
         }

--- a/server/claude-sdk.js
+++ b/server/claude-sdk.js
@@ -17,7 +17,7 @@ import crypto from 'crypto';
 import { promises as fs } from 'fs';
 import path from 'path';
 import os from 'os';
-import { CLAUDE_MODELS } from '../shared/modelConstants.js';
+import { CLAUDE_MODELS, CLAUDE_DEFAULT_CONTEXT_WINDOW, getClaudeContextWindow } from '../shared/modelConstants.js';
 import {
   createNotificationEvent,
   notifyRunFailed,
@@ -307,9 +307,11 @@ function extractTokenBudget(resultMessage) {
   // Total used = input + output + cache tokens
   const totalUsed = inputTokens + outputTokens + cacheReadTokens + cacheCreationTokens;
 
-  // Use configured context window budget from environment (default 160000)
-  // This is the user's budget limit, not the model's context window
-  const contextWindow = parseInt(process.env.CONTEXT_WINDOW) || 160000;
+  // Determine the context window from the model that produced this usage.
+  // Falls back to CONTEXT_WINDOW env var only when the model is unknown.
+  const contextWindow = modelKey
+    ? getClaudeContextWindow(modelKey)
+    : parseInt(process.env.CONTEXT_WINDOW) || CLAUDE_DEFAULT_CONTEXT_WINDOW;
 
   // Token calc logged via token-budget WS event
 

--- a/shared/modelConstants.js
+++ b/shared/modelConstants.js
@@ -13,18 +13,16 @@
 export const CLAUDE_MODELS = {
   // Models in SDK format (what the actual SDK accepts)
   OPTIONS: [
+    { value: "sonnet", label: "Sonnet" },
+    { value: "opus", label: "Opus" },
     { value: "claude-opus-4-7", label: "Opus 4.7" },
-    { value: "claude-opus-4-6", label: "Opus 4.6" },
-    { value: "opus[1m]", label: "Opus 4.6 (1M context)" },
-    { value: "claude-sonnet-4-6", label: "Sonnet 4.6" },
-    { value: "sonnet[1m]", label: "Sonnet 4.6 (1M context)" },
-    { value: "claude-opus-4-5-20251101", label: "Opus 4.5" },
-    { value: "claude-sonnet-4-5-20250929", label: "Sonnet 4.5" },
-    { value: "claude-haiku-4-5-20251001", label: "Haiku 4.5" },
-    { value: "opusplan", label: "Opus Plan (Opus + Sonnet)" },
+    { value: "haiku", label: "Haiku" },
+    { value: "opusplan", label: "Opus Plan" },
+    { value: "sonnet[1m]", label: "Sonnet [1M]" },
+    { value: "opus[1m]", label: "Opus [1M]" },
   ],
 
-  DEFAULT: "claude-sonnet-4-6",
+  DEFAULT: "sonnet",
 };
 
 /**

--- a/shared/modelConstants.js
+++ b/shared/modelConstants.js
@@ -13,15 +13,48 @@
 export const CLAUDE_MODELS = {
   // Models in SDK format (what the actual SDK accepts)
   OPTIONS: [
-    { value: "sonnet", label: "Sonnet" },
-    { value: "opus", label: "Opus" },
-    { value: "haiku", label: "Haiku" },
-    { value: "opusplan", label: "Opus Plan" },
-    { value: "sonnet[1m]", label: "Sonnet [1M]" },
-    { value: "opus[1m]", label: "Opus [1M]" },
+    { value: "claude-opus-4-7", label: "Opus 4.7" },
+    { value: "claude-opus-4-6", label: "Opus 4.6" },
+    { value: "opus[1m]", label: "Opus 4.6 (1M context)" },
+    { value: "claude-sonnet-4-6", label: "Sonnet 4.6" },
+    { value: "sonnet[1m]", label: "Sonnet 4.6 (1M context)" },
+    { value: "claude-opus-4-5-20251101", label: "Opus 4.5" },
+    { value: "claude-sonnet-4-5-20250929", label: "Sonnet 4.5" },
+    { value: "claude-haiku-4-5-20251001", label: "Haiku 4.5" },
+    { value: "opusplan", label: "Opus Plan (Opus + Sonnet)" },
   ],
 
-  DEFAULT: "opus",
+  DEFAULT: "claude-sonnet-4-6",
+};
+
+/**
+ * Claude Model Context Windows (in tokens)
+ *
+ * Standard Claude 4.x models have a 200k context window.
+ * The [1m] variants enable the 1M-token context window.
+ */
+export const CLAUDE_DEFAULT_CONTEXT_WINDOW = 200000;
+export const CLAUDE_1M_CONTEXT_WINDOW = 1000000;
+
+/**
+ * Returns the context window (in tokens) for a given Claude model identifier.
+ *
+ * Accepts both the SDK short aliases (e.g. "sonnet", "opus[1m]", "opusplan")
+ * and the full API model IDs (e.g. "claude-opus-4-7", "claude-sonnet-4-6").
+ * Unknown models fall back to the standard 200k context window.
+ *
+ * @param {string} model - Model identifier
+ * @returns {number} Context window size in tokens
+ */
+export const getClaudeContextWindow = (model) => {
+  if (!model || typeof model !== 'string') {
+    return CLAUDE_DEFAULT_CONTEXT_WINDOW;
+  }
+  const normalized = model.toLowerCase();
+  if (normalized.includes('[1m]') || normalized.includes('-1m')) {
+    return CLAUDE_1M_CONTEXT_WINDOW;
+  }
+  return CLAUDE_DEFAULT_CONTEXT_WINDOW;
 };
 
 /**

--- a/src/components/chat/view/ChatInterface.tsx
+++ b/src/components/chat/view/ChatInterface.tsx
@@ -360,6 +360,7 @@ function ChatInterface({
           thinkingMode={thinkingMode}
           setThinkingMode={setThinkingMode}
           tokenBudget={tokenBudget}
+          selectedModel={provider === 'claude' ? claudeModel : undefined}
           slashCommandsCount={slashCommandsCount}
           onToggleCommandMenu={handleToggleCommandMenu}
           hasInput={Boolean(input.trim())}

--- a/src/components/chat/view/subcomponents/ChatComposer.tsx
+++ b/src/components/chat/view/subcomponents/ChatComposer.tsx
@@ -359,7 +359,15 @@ export default function ChatComposer({
               <ThinkingModeSelector selectedMode={thinkingMode} onModeChange={setThinkingMode} onClose={() => {}} className="" />
             )}
 
-            <TokenUsagePie used={tokenBudget?.used || 0} total={tokenBudget?.total || getClaudeContextWindow(selectedModel)} />
+            <TokenUsagePie
+              used={tokenBudget?.used || 0}
+              total={
+                tokenBudget?.total ||
+                (provider === 'claude'
+                  ? getClaudeContextWindow(selectedModel)
+                  : parseInt(import.meta.env.VITE_CONTEXT_WINDOW) || 160000)
+              }
+            />
 
             <PromptInputButton
               tooltip={{ content: t('input.showAllCommands') }}

--- a/src/components/chat/view/subcomponents/ChatComposer.tsx
+++ b/src/components/chat/view/subcomponents/ChatComposer.tsx
@@ -19,6 +19,7 @@ import ImageAttachment from './ImageAttachment';
 import PermissionRequestsBanner from './PermissionRequestsBanner';
 import ThinkingModeSelector from './ThinkingModeSelector';
 import TokenUsagePie from './TokenUsagePie';
+import { getClaudeContextWindow } from '../../../../../shared/modelConstants';
 import {
   PromptInput,
   PromptInputHeader,
@@ -61,6 +62,7 @@ interface ChatComposerProps {
   thinkingMode: string;
   setThinkingMode: Dispatch<SetStateAction<string>>;
   tokenBudget: { used?: number; total?: number } | null;
+  selectedModel?: string;
   slashCommandsCount: number;
   onToggleCommandMenu: () => void;
   hasInput: boolean;
@@ -116,6 +118,7 @@ export default function ChatComposer({
   thinkingMode,
   setThinkingMode,
   tokenBudget,
+  selectedModel,
   slashCommandsCount,
   onToggleCommandMenu,
   hasInput,
@@ -356,7 +359,7 @@ export default function ChatComposer({
               <ThinkingModeSelector selectedMode={thinkingMode} onModeChange={setThinkingMode} onClose={() => {}} className="" />
             )}
 
-            <TokenUsagePie used={tokenBudget?.used || 0} total={tokenBudget?.total || parseInt(import.meta.env.VITE_CONTEXT_WINDOW) || 160000} />
+            <TokenUsagePie used={tokenBudget?.used || 0} total={tokenBudget?.total || getClaudeContextWindow(selectedModel)} />
 
             <PromptInputButton
               tooltip={{ content: t('input.showAllCommands') }}


### PR DESCRIPTION
## Summary
- Add all officially supported Claude models with full API IDs
  (Opus 4.7, Opus 4.6, Sonnet 4.6, Opus 4.5, Sonnet 4.5, Haiku 4.5)
- Remove redundant "Claude" prefix from labels (provider name already shown)
- Change default model to Sonnet 4.6 (matches Claude Code CLI default)
- Add `getClaudeContextWindow()` to resolve context window per model
  (200k standard, 1M for [1m] variants)
- TokenUsagePie now shows accurate context window based on selected model
  instead of hardcoded 160k

## Screenshots
<img width="1118" height="960" alt="image" src="https://github.com/user-attachments/assets/00aaa5d3-0907-44dd-b0c1-bd4f2bce4b3f" />
<img width="941" height="947" alt="image" src="https://github.com/user-attachments/assets/483db521-9432-4908-bc91-020dc838c612" />

## Test plan
- [ ] Verify model selector shows all models with clean labels
- [ ] Switch between models and verify the token pie updates to 200k or 1M
- [ ] Verify `CONTEXT_WINDOW` env var still works as fallback


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * More Claude model choices added (including Opus 4.7) and explicit support for 1M-context models.

* **Bug Fixes**
  * Token budget and context calculations now use the selected Claude model when available, improving accuracy for usage tracking.

* **Changes**
  * Default Claude model changed to Sonnet (user-facing default selection updated).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->