### PR TITLE
fix: prevent permission mode button text from wrapping

### DIFF
--- a/src/components/chat/view/subcomponents/ChatComposer.tsx
+++ b/src/components/chat/view/subcomponents/ChatComposer.tsx
@@ -343,7 +343,7 @@ export default function ChatComposer({
                           : 'bg-primary'
                   }`}
                 />
-                <span className="hidden sm:inline">
+                <span className="hidden whitespace-nowrap sm:inline">
                   {permissionMode === 'default' && t('codex.modes.default')}
                   {permissionMode === 'acceptEdits' && t('codex.modes.acceptEdits')}
                   {permissionMode === 'bypassPermissions' && t('codex.modes.bypassPermissions')}


### PR DESCRIPTION
## Summary
- Add `whitespace-nowrap` to the permission mode label in the chat
  composer toolbar so longer translations (e.g. Italian "Modalità
  predefinita") stay on a single line

## Screenshots
<img width="459" height="228" alt="image" src="https://github.com/user-attachments/assets/15e9deb3-b154-4a43-9275-1b21de70a7f6" />

<img width="509" height="294" alt="image" src="https://github.com/user-attachments/assets/e98e8038-ca0c-42e4-9b31-fed97ba9da14" />

## Test plan
- [ ] Verify the permission mode button stays on one line with all languages
- [ ] Test on narrow viewport widths

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Fixed text wrapping behavior in the chat composer's mode label.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->