### PR TITLE
feat: add configurable BASE_PATH for subpath deployments

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ BASE_PATH=/s/myproject npm run server
 ```
 
 **Reverse proxy example (Caddy):**
-```
+```caddyfile
 :443 {
     handle /s/myproject/* {
         uri strip_prefix /s/myproject

--- a/README.md
+++ b/README.md
@@ -105,6 +105,31 @@ npx @cloudcli-ai/cloudcli@latest sandbox ~/my-project
 
 Supports Claude Code, Codex, and Gemini CLI. See the [sandbox docs](docker/) for setup and advanced options.
 
+#### Subpath Deployment (BASE_PATH)
+
+Serve CloudCLI from a subpath (e.g. `/s/myproject/`) instead of the root `/`. This is useful when running multiple CloudCLI instances behind a single reverse proxy.
+
+**Build with relative asset paths:**
+```bash
+VITE_BASE_PATH=./ npm run build
+```
+
+**Start the server with a base path:**
+```bash
+BASE_PATH=/s/myproject npm run server
+```
+
+**Reverse proxy example (Caddy):**
+```caddyfile
+:443 {
+    handle /s/myproject/* {
+        uri strip_prefix /s/myproject
+        reverse_proxy 127.0.0.1:3001
+    }
+}
+```
+
+When `BASE_PATH` is not set, CloudCLI serves from `/` as usual — no changes needed for standard deployments.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -105,6 +105,31 @@ npx @cloudcli-ai/cloudcli@latest sandbox ~/my-project
 
 Supports Claude Code, Codex, and Gemini CLI. See the [sandbox docs](docker/) for setup and advanced options.
 
+#### Subpath Deployment (BASE_PATH)
+
+Serve CloudCLI from a subpath (e.g. `/s/myproject/`) instead of the root `/`. This is useful when running multiple CloudCLI instances behind a single reverse proxy.
+
+**Build with relative asset paths:**
+```bash
+VITE_BASE_PATH=./ npm run build
+```
+
+**Start the server with a base path:**
+```bash
+BASE_PATH=/s/myproject npm run server
+```
+
+**Reverse proxy example (Caddy):**
+```
+:443 {
+    handle /s/myproject/* {
+        uri strip_prefix /s/myproject
+        reverse_proxy 127.0.0.1:3001
+    }
+}
+```
+
+When `BASE_PATH` is not set, CloudCLI serves from `/` as usual — no changes needed for standard deployments.
 
 ---
 

--- a/index.html
+++ b/index.html
@@ -34,7 +34,7 @@
     <script>
       if ('serviceWorker' in navigator) {
         window.addEventListener('load', () => {
-          navigator.serviceWorker.register('/sw.js')
+          navigator.serviceWorker.register((window.__CLOUDCLI_BASE_PATH__ || '') + '/sw.js')
             .then(registration => {
               console.log('SW registered: ', registration);
             })

--- a/public/sw.js
+++ b/public/sw.js
@@ -2,8 +2,15 @@
 // Cache only manifest (needed for PWA install). HTML and JS are never pre-cached
 // so a rebuild + refresh always picks up the latest assets.
 const CACHE_NAME = 'claude-ui-v2';
+
+// Derive base path from service worker's own location.
+// If SW is at /s/mealstead/sw.js, BASE_PATH = '/s/mealstead'.
+// If SW is at /sw.js, BASE_PATH = ''.
+const SW_PATH = self.location.pathname;
+const BASE_PATH = SW_PATH.substring(0, SW_PATH.lastIndexOf('/')) || '';
+
 const urlsToCache = [
-  '/manifest.json'
+  `${BASE_PATH}/manifest.json`
 ];
 
 // Install event
@@ -20,14 +27,14 @@ self.addEventListener('fetch', event => {
   const url = event.request.url;
 
   // Never intercept API requests or WebSocket upgrades
-  if (url.includes('/api/') || url.includes('/ws')) {
+  if (url.includes(`${BASE_PATH}/api/`) || url.includes(`${BASE_PATH}/ws`)) {
     return;
   }
 
   // Navigation requests (HTML) — always go to network, no caching
   if (event.request.mode === 'navigate') {
     event.respondWith(
-      fetch(event.request).catch(() => caches.match('/manifest.json').then(() =>
+      fetch(event.request).catch(() => caches.match(`${BASE_PATH}/manifest.json`).then(() =>
         new Response('<h1>Offline</h1><p>Please check your connection.</p>', {
           headers: { 'Content-Type': 'text/html' }
         })
@@ -37,7 +44,7 @@ self.addEventListener('fetch', event => {
   }
 
   // Hashed assets (JS/CSS in /assets/) — cache-first since filenames change per build
-  if (url.includes('/assets/')) {
+  if (url.includes(`${BASE_PATH}/assets/`)) {
     event.respondWith(
       caches.match(event.request).then(cached => {
         if (cached) return cached;
@@ -84,8 +91,8 @@ self.addEventListener('push', event => {
 
   const options = {
     body: payload.body || '',
-    icon: '/logo-256.png',
-    badge: '/logo-128.png',
+    icon: `${BASE_PATH}/logo-256.png`,
+    badge: `${BASE_PATH}/logo-128.png`,
     data: payload.data || {},
     tag: payload.data?.tag || `${payload.data?.sessionId || 'global'}:${payload.data?.code || 'default'}`,
     renotify: true
@@ -102,7 +109,7 @@ self.addEventListener('notificationclick', event => {
 
   const sessionId = event.notification.data?.sessionId;
   const provider = event.notification.data?.provider || null;
-  const urlPath = sessionId ? `/session/${sessionId}` : '/';
+  const urlPath = sessionId ? `${BASE_PATH}/session/${sessionId}` : `${BASE_PATH}/`;
 
   event.waitUntil(
     self.clients.matchAll({ type: 'window', includeUncontrolled: true }).then(async clientList => {

--- a/public/sw.js
+++ b/public/sw.js
@@ -22,26 +22,12 @@ self.addEventListener('install', event => {
   self.skipWaiting();
 });
 
-// Fetch event — network-first for everything except hashed assets
+// Fetch event — only intercept assets and navigation, let everything else pass through
 self.addEventListener('fetch', event => {
   const url = event.request.url;
 
-  // Never intercept API requests or WebSocket upgrades
-  if (url.includes(`${BASE_PATH}/api/`) || url.includes(`${BASE_PATH}/ws`)) {
-    return;
-  }
-
-  // Navigation requests (HTML) — always go to network, no caching
-  if (event.request.mode === 'navigate') {
-    event.respondWith(
-      fetch(event.request).catch(() => caches.match(`${BASE_PATH}/manifest.json`).then(() =>
-        new Response('<h1>Offline</h1><p>Please check your connection.</p>', {
-          headers: { 'Content-Type': 'text/html' }
-        })
-      ))
-    );
-    return;
-  }
+  // Only intercept same-origin requests
+  if (!url.startsWith(self.location.origin)) return;
 
   // Hashed assets (JS/CSS in /assets/) — cache-first since filenames change per build
   if (url.includes(`${BASE_PATH}/assets/`)) {
@@ -58,10 +44,19 @@ self.addEventListener('fetch', event => {
     return;
   }
 
-  // Everything else — network-first
-  event.respondWith(
-    fetch(event.request).catch(() => caches.match(event.request))
-  );
+  // Navigation requests (HTML) — always go to network, offline fallback
+  if (event.request.mode === 'navigate') {
+    event.respondWith(
+      fetch(event.request).catch(() =>
+        new Response('<h1>Offline</h1><p>Please check your connection.</p>', {
+          headers: { 'Content-Type': 'text/html' }
+        })
+      )
+    );
+    return;
+  }
+
+  // Everything else (API, WS, session routes, etc.) — don't intercept
 });
 
 // Activate event — purge old caches

--- a/public/sw.js
+++ b/public/sw.js
@@ -2,8 +2,15 @@
 // Cache only manifest (needed for PWA install). HTML and JS are never pre-cached
 // so a rebuild + refresh always picks up the latest assets.
 const CACHE_NAME = 'claude-ui-v2';
+
+// Derive base path from service worker's own location.
+// If SW is at /s/mealstead/sw.js, BASE_PATH = '/s/mealstead'.
+// If SW is at /sw.js, BASE_PATH = ''.
+const SW_PATH = self.location.pathname;
+const BASE_PATH = SW_PATH.substring(0, SW_PATH.lastIndexOf('/')) || '';
+
 const urlsToCache = [
-  '/manifest.json'
+  `${BASE_PATH}/manifest.json`
 ];
 
 // Install event
@@ -15,29 +22,22 @@ self.addEventListener('install', event => {
   self.skipWaiting();
 });
 
-// Fetch event — network-first for everything except hashed assets
+// Fetch event — only intercept assets and navigation, let everything else pass through
 self.addEventListener('fetch', event => {
-  const url = event.request.url;
-
-  // Never intercept API requests or WebSocket upgrades
-  if (url.includes('/api/') || url.includes('/ws')) {
+  let requestUrl;
+  try {
+    requestUrl = new URL(event.request.url);
+  } catch {
     return;
   }
 
-  // Navigation requests (HTML) — always go to network, no caching
-  if (event.request.mode === 'navigate') {
-    event.respondWith(
-      fetch(event.request).catch(() => caches.match('/manifest.json').then(() =>
-        new Response('<h1>Offline</h1><p>Please check your connection.</p>', {
-          headers: { 'Content-Type': 'text/html' }
-        })
-      ))
-    );
-    return;
-  }
+  // Only intercept same-origin requests
+  if (requestUrl.origin !== self.location.origin) return;
+
+  const { pathname } = requestUrl;
 
   // Hashed assets (JS/CSS in /assets/) — cache-first since filenames change per build
-  if (url.includes('/assets/')) {
+  if (pathname.startsWith(`${BASE_PATH}/assets/`)) {
     event.respondWith(
       caches.match(event.request).then(cached => {
         if (cached) return cached;
@@ -51,10 +51,19 @@ self.addEventListener('fetch', event => {
     return;
   }
 
-  // Everything else — network-first
-  event.respondWith(
-    fetch(event.request).catch(() => caches.match(event.request))
-  );
+  // Navigation requests (HTML) — always go to network, offline fallback
+  if (event.request.mode === 'navigate') {
+    event.respondWith(
+      fetch(event.request).catch(() =>
+        new Response('<h1>Offline</h1><p>Please check your connection.</p>', {
+          headers: { 'Content-Type': 'text/html' }
+        })
+      )
+    );
+    return;
+  }
+
+  // Everything else (API, WS, session routes, etc.) — don't intercept
 });
 
 // Activate event — purge old caches
@@ -84,8 +93,8 @@ self.addEventListener('push', event => {
 
   const options = {
     body: payload.body || '',
-    icon: '/logo-256.png',
-    badge: '/logo-128.png',
+    icon: `${BASE_PATH}/logo-256.png`,
+    badge: `${BASE_PATH}/logo-128.png`,
     data: payload.data || {},
     tag: payload.data?.tag || `${payload.data?.sessionId || 'global'}:${payload.data?.code || 'default'}`,
     renotify: true
@@ -102,7 +111,7 @@ self.addEventListener('notificationclick', event => {
 
   const sessionId = event.notification.data?.sessionId;
   const provider = event.notification.data?.provider || null;
-  const urlPath = sessionId ? `/session/${sessionId}` : '/';
+  const urlPath = sessionId ? `${BASE_PATH}/session/${sessionId}` : `${BASE_PATH}/`;
 
   event.waitUntil(
     self.clients.matchAll({ type: 'window', includeUncontrolled: true }).then(async clientList => {

--- a/server/index.js
+++ b/server/index.js
@@ -13,8 +13,11 @@ const __dirname = getModuleDir(import.meta.url);
 // Resolving the app root once keeps every repo-level lookup below aligned across both layouts.
 const APP_ROOT = findAppRoot(__dirname);
 const installMode = fs.existsSync(path.join(APP_ROOT, '.git')) ? 'git' : 'npm';
-// BASE_PATH for subpath deployment (e.g. '/s/mealstead'). No trailing slash.
-const BASE_PATH = (process.env.BASE_PATH || '').replace(/\/+$/, '');
+// BASE_PATH for subpath deployment (e.g. '/s/mealstead'). Leading slash, no trailing slash.
+const BASE_PATH = (() => {
+    const trimmed = (process.env.BASE_PATH || '').trim().replace(/^\/+|\/+$/g, '');
+    return trimmed ? `/${trimmed}` : '';
+})();
 
 import { c } from './utils/colors.js';
 

--- a/server/index.js
+++ b/server/index.js
@@ -214,7 +214,7 @@ const server = http.createServer(app);
 // both behind a reverse proxy (which strips it) and with direct access.
 if (BASE_PATH) {
     app.use((req, res, next) => {
-        if (req.url === BASE_PATH || req.url.startsWith(`${BASE_PATH}/`)) {
+        if (req.url === BASE_PATH || req.url.startsWith(`${BASE_PATH}/`) || req.url.startsWith(`${BASE_PATH}?`)) {
             req.url = req.url.slice(BASE_PATH.length) || '/';
         }
         next();

--- a/server/index.js
+++ b/server/index.js
@@ -207,6 +207,17 @@ async function setupProjectsWatcher() {
 const app = express();
 const server = http.createServer(app);
 
+// Strip BASE_PATH prefix from incoming HTTP requests so routes work
+// both behind a reverse proxy (which strips it) and with direct access.
+if (BASE_PATH) {
+    app.use((req, res, next) => {
+        if (req.url === BASE_PATH || req.url.startsWith(`${BASE_PATH}/`)) {
+            req.url = req.url.slice(BASE_PATH.length) || '/';
+        }
+        next();
+    });
+}
+
 const ptySessionsMap = new Map();
 const PTY_SESSION_TIMEOUT = 30 * 60 * 1000;
 const SHELL_URL_PARSE_BUFFER_LIMIT = 32768;

--- a/server/index.js
+++ b/server/index.js
@@ -1369,7 +1369,7 @@ wss.on('connection', (ws, request) => {
     // Parse URL to get pathname without query parameters, stripping BASE_PATH
     const urlObj = new URL(url, 'http://localhost');
     let pathname = urlObj.pathname;
-    if (BASE_PATH && pathname.startsWith(BASE_PATH)) {
+    if (BASE_PATH && (pathname === BASE_PATH || pathname.startsWith(BASE_PATH + '/'))) {
         pathname = pathname.slice(BASE_PATH.length) || '/';
     }
 
@@ -2218,7 +2218,8 @@ app.get('*', (req, res) => {
         // Inject base path globals into index.html for subpath deployment
         let html = fs.readFileSync(indexPath, 'utf8');
         if (BASE_PATH) {
-            const injection = `<script>window.__CLOUDCLI_BASE_PATH__="${BASE_PATH}";window.__ROUTER_BASENAME__="${BASE_PATH}";</script>`;
+            const safeBase = JSON.stringify(BASE_PATH).replace(/</g, '\\u003c');
+            const injection = `<script>window.__CLOUDCLI_BASE_PATH__=${safeBase};window.__ROUTER_BASENAME__=${safeBase};</script>`;
             html = html.replace('<head>', `<head>${injection}`);
         }
         res.setHeader('Content-Type', 'text/html');

--- a/server/index.js
+++ b/server/index.js
@@ -13,6 +13,8 @@ const __dirname = getModuleDir(import.meta.url);
 // Resolving the app root once keeps every repo-level lookup below aligned across both layouts.
 const APP_ROOT = findAppRoot(__dirname);
 const installMode = fs.existsSync(path.join(APP_ROOT, '.git')) ? 'git' : 'npm';
+// BASE_PATH for subpath deployment (e.g. '/s/mealstead'). No trailing slash.
+const BASE_PATH = (process.env.BASE_PATH || '').replace(/\/+$/, '');
 
 import { c } from './utils/colors.js';
 
@@ -322,12 +324,37 @@ app.use('/api/providers', authenticateToken, providerRoutes);
 // Agent API Routes (uses API key authentication)
 app.use('/api/agent', agentRoutes);
 
+// Serve manifest.json dynamically with base-path-aware URLs
+app.get('/manifest.json', (req, res) => {
+    try {
+        const manifestPath = path.join(APP_ROOT, 'public', 'manifest.json');
+        const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+        if (BASE_PATH) {
+            manifest.start_url = BASE_PATH + '/';
+            manifest.scope = BASE_PATH + '/';
+            if (manifest.icons) {
+                manifest.icons = manifest.icons.map(icon => ({
+                    ...icon,
+                    src: BASE_PATH + icon.src,
+                }));
+            }
+        }
+        res.setHeader('Content-Type', 'application/manifest+json');
+        res.json(manifest);
+    } catch (error) {
+        res.status(500).json({ error: 'Failed to serve manifest' });
+    }
+});
+
 // Serve public files (like api-docs.html)
 app.use(express.static(path.join(APP_ROOT, 'public')));
 
 // Static files served after API routes
 // Add cache control: HTML files should not be cached, but assets can be cached
+// index: false prevents express.static from serving index.html for '/' —
+// the SPA catch-all handles it instead (with BASE_PATH injection).
 app.use(express.static(path.join(APP_ROOT, 'dist'), {
+    index: false,
     setHeaders: (res, filePath) => {
         if (filePath.endsWith('.html')) {
             // Prevent HTML caching to avoid service worker issues after builds
@@ -1339,9 +1366,12 @@ wss.on('connection', (ws, request) => {
     const url = request.url;
     console.log('[INFO] Client connected to:', url);
 
-    // Parse URL to get pathname without query parameters
+    // Parse URL to get pathname without query parameters, stripping BASE_PATH
     const urlObj = new URL(url, 'http://localhost');
-    const pathname = urlObj.pathname;
+    let pathname = urlObj.pathname;
+    if (BASE_PATH && pathname.startsWith(BASE_PATH)) {
+        pathname = pathname.slice(BASE_PATH.length) || '/';
+    }
 
     if (pathname === '/shell') {
         handleShellConnection(ws);
@@ -2185,7 +2215,14 @@ app.get('*', (req, res) => {
         res.setHeader('Cache-Control', 'no-cache, no-store, must-revalidate');
         res.setHeader('Pragma', 'no-cache');
         res.setHeader('Expires', '0');
-        res.sendFile(indexPath);
+        // Inject base path globals into index.html for subpath deployment
+        let html = fs.readFileSync(indexPath, 'utf8');
+        if (BASE_PATH) {
+            const injection = `<script>window.__CLOUDCLI_BASE_PATH__="${BASE_PATH}";window.__ROUTER_BASENAME__="${BASE_PATH}";</script>`;
+            html = html.replace('<head>', `<head>${injection}`);
+        }
+        res.setHeader('Content-Type', 'text/html');
+        res.send(html);
     } else {
         // In development, redirect to Vite dev server only if dist doesn't exist
         const redirectHost = getConnectableHost(req.hostname);

--- a/server/index.js
+++ b/server/index.js
@@ -84,6 +84,11 @@ const __dirname = getModuleDir(import.meta.url);
 // Resolving the app root once keeps every repo-level lookup below aligned across both layouts.
 const APP_ROOT = findAppRoot(__dirname);
 const installMode = fs.existsSync(path.join(APP_ROOT, '.git')) ? 'git' : 'npm';
+// BASE_PATH for subpath deployment (e.g. '/s/mealstead'). Leading slash, no trailing slash.
+const BASE_PATH = (() => {
+    const trimmed = (process.env.BASE_PATH || '').trim().replace(/^\/+|\/+$/g, '');
+    return trimmed ? `/${trimmed}` : '';
+})();
 
 console.log('SERVER_PORT from env:', process.env.SERVER_PORT);
 
@@ -133,6 +138,17 @@ const wss = createWebSocketServer(server, {
 
 // Make WebSocket server available to routes
 app.locals.wss = wss;
+
+// Strip BASE_PATH prefix from incoming HTTP requests so routes work
+// both behind a reverse proxy (which strips it) and with direct access.
+if (BASE_PATH) {
+    app.use((req, res, next) => {
+        if (req.url === BASE_PATH || req.url.startsWith(`${BASE_PATH}/`) || req.url.startsWith(`${BASE_PATH}?`)) {
+            req.url = req.url.slice(BASE_PATH.length) || '/';
+        }
+        next();
+    });
+}
 
 app.use(cors({ exposedHeaders: ['X-Refreshed-Token'] }));
 app.use(express.json({
@@ -199,12 +215,37 @@ app.use('/api/providers', authenticateToken, providerRoutes);
 // Agent API Routes (uses API key authentication)
 app.use('/api/agent', agentRoutes);
 
+// Serve manifest.json dynamically with base-path-aware URLs
+app.get('/manifest.json', (req, res) => {
+    try {
+        const manifestPath = path.join(APP_ROOT, 'public', 'manifest.json');
+        const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+        if (BASE_PATH) {
+            manifest.start_url = BASE_PATH + '/';
+            manifest.scope = BASE_PATH + '/';
+            if (manifest.icons) {
+                manifest.icons = manifest.icons.map(icon => ({
+                    ...icon,
+                    src: BASE_PATH + icon.src,
+                }));
+            }
+        }
+        res.setHeader('Content-Type', 'application/manifest+json');
+        res.json(manifest);
+    } catch (error) {
+        res.status(500).json({ error: 'Failed to serve manifest' });
+    }
+});
+
 // Serve public files (like api-docs.html)
 app.use(express.static(path.join(APP_ROOT, 'public')));
 
 // Static files served after API routes
 // Add cache control: HTML files should not be cached, but assets can be cached
+// index: false prevents express.static from serving index.html for '/' —
+// the SPA catch-all handles it instead (with BASE_PATH injection).
 app.use(express.static(path.join(APP_ROOT, 'dist'), {
+    index: false,
     setHeaders: (res, filePath) => {
         if (filePath.endsWith('.html')) {
             // Prevent HTML caching to avoid service worker issues after builds
@@ -1443,7 +1484,15 @@ app.get('*', (req, res) => {
         res.setHeader('Cache-Control', 'no-cache, no-store, must-revalidate');
         res.setHeader('Pragma', 'no-cache');
         res.setHeader('Expires', '0');
-        res.sendFile(indexPath);
+        // Inject base path globals into index.html for subpath deployment
+        let html = fs.readFileSync(indexPath, 'utf8');
+        if (BASE_PATH) {
+            const safeBase = JSON.stringify(BASE_PATH).replace(/</g, '\\u003c');
+            const injection = `<script>window.__CLOUDCLI_BASE_PATH__=${safeBase};window.__ROUTER_BASENAME__=${safeBase};</script>`;
+            html = html.replace('<head>', `<head>${injection}`);
+        }
+        res.setHeader('Content-Type', 'text/html');
+        res.send(html);
     } else {
         // In development, redirect to Vite dev server only if dist doesn't exist
         const redirectHost = getConnectableHost(req.hostname);

--- a/server/modules/websocket/services/websocket-server.service.ts
+++ b/server/modules/websocket/services/websocket-server.service.ts
@@ -15,6 +15,12 @@ type WebSocketServerDependencies = {
   getPluginPort: Parameters<typeof handlePluginWsProxy>[2];
 };
 
+// BASE_PATH for subpath deployment (e.g. '/s/mealstead'). Leading slash, no trailing slash.
+const BASE_PATH = (() => {
+  const trimmed = (process.env.BASE_PATH || '').trim().replace(/^\/+|\/+$/g, '');
+  return trimmed ? `/${trimmed}` : '';
+})();
+
 /**
  * Creates and wires the server-wide websocket gateway used for chat, shell, and
  * plugin proxy routes.
@@ -33,7 +39,13 @@ export function createWebSocketServer(
   wss.on('connection', (ws, request) => {
     const incomingRequest = request as AuthenticatedWebSocketRequest;
     const url = incomingRequest.url ?? '/';
-    const pathname = new URL(url, 'http://localhost').pathname;
+    let pathname = new URL(url, 'http://localhost').pathname;
+
+    // Strip BASE_PATH prefix on segment boundary so subpath deployments
+    // route the same as direct ones. Avoid greedy prefix matching.
+    if (BASE_PATH && (pathname === BASE_PATH || pathname.startsWith(`${BASE_PATH}/`))) {
+      pathname = pathname.slice(BASE_PATH.length) || '/';
+    }
 
     if (pathname === '/shell') {
       handleShellConnection(ws, dependencies.shell);

--- a/src/components/auth/view/SetupForm.tsx
+++ b/src/components/auth/view/SetupForm.tsx
@@ -4,6 +4,7 @@ import { useAuth } from '../context/AuthContext';
 import AuthErrorAlert from './AuthErrorAlert';
 import AuthInputField from './AuthInputField';
 import AuthScreenLayout from './AuthScreenLayout';
+import { assetUrl } from '../../../utils/basePath';
 
 type SetupFormState = {
   username: string;
@@ -85,7 +86,7 @@ export default function SetupForm() {
       title="Welcome to CloudCLI"
       description="Set up your account to get started"
       footerText="This is a single-user system. Only one account can be created."
-      logo={<img src="/logo.svg" alt="CloudCLI" className="h-16 w-16" />}
+      logo={<img src={assetUrl('/logo.svg')} alt="CloudCLI" className="h-16 w-16" />}
     >
       <form onSubmit={handleSubmit} className="space-y-4">
         <AuthInputField

--- a/src/components/llm-logo-provider/ClaudeLogo.tsx
+++ b/src/components/llm-logo-provider/ClaudeLogo.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { assetUrl } from '../../utils/basePath';
 
 type ClaudeLogoProps = {
   className?: string;
@@ -6,7 +7,7 @@ type ClaudeLogoProps = {
 
 const ClaudeLogo = ({ className = 'w-5 h-5' }: ClaudeLogoProps) => {
   return (
-    <img src="/icons/claude-ai-icon.svg" alt="Claude" className={className} />
+    <img src={assetUrl('/icons/claude-ai-icon.svg')} alt="Claude" className={className} />
   );
 };
 

--- a/src/components/llm-logo-provider/CodexLogo.tsx
+++ b/src/components/llm-logo-provider/CodexLogo.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { useTheme } from '../../contexts/ThemeContext';
+import { assetUrl } from '../../utils/basePath';
 
 type CodexLogoProps = {
   className?: string;
@@ -10,7 +11,7 @@ const CodexLogo = ({ className = 'w-5 h-5' }: CodexLogoProps) => {
 
   return (
     <img
-      src={isDarkMode ? "/icons/codex-white.svg" : "/icons/codex.svg"}
+      src={isDarkMode ? assetUrl("/icons/codex-white.svg") : assetUrl("/icons/codex.svg")}
       alt="Codex"
       className={className}
     />

--- a/src/components/llm-logo-provider/CursorLogo.tsx
+++ b/src/components/llm-logo-provider/CursorLogo.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { useTheme } from '../../contexts/ThemeContext';
+import { assetUrl } from '../../utils/basePath';
 
 type CursorLogoProps = {
   className?: string;
@@ -10,7 +11,7 @@ const CursorLogo = ({ className = 'w-5 h-5' }: CursorLogoProps) => {
 
   return (
     <img
-      src={isDarkMode ? "/icons/cursor-white.svg" : "/icons/cursor.svg"}
+      src={isDarkMode ? assetUrl("/icons/cursor-white.svg") : assetUrl("/icons/cursor.svg")}
       alt="Cursor"
       className={className}
     />

--- a/src/components/llm-logo-provider/GeminiLogo.tsx
+++ b/src/components/llm-logo-provider/GeminiLogo.tsx
@@ -1,6 +1,8 @@
+import { assetUrl } from '../../utils/basePath';
+
 const GeminiLogo = ({className = 'w-5 h-5'}) => {
   return (
-    <img src="/icons/gemini-ai-icon.svg" alt="Gemini" className={className} />
+    <img src={assetUrl('/icons/gemini-ai-icon.svg')} alt="Gemini" className={className} />
   );
 };
 

--- a/src/components/project-creation-wizard/data/workspaceApi.ts
+++ b/src/components/project-creation-wizard/data/workspaceApi.ts
@@ -1,4 +1,5 @@
 import { api } from '../../../utils/api';
+import { BASE_PATH } from '../../../utils/basePath';
 import type {
   BrowseFilesystemResponse,
   CloneProgressEvent,
@@ -110,7 +111,7 @@ export const cloneWorkspaceWithProgress = (
 ) =>
   new Promise<Record<string, unknown> | undefined>((resolve, reject) => {
     const query = buildCloneProgressQuery(params);
-    const eventSource = new EventSource(`/api/projects/clone-progress?${query}`);
+    const eventSource = new EventSource(`${BASE_PATH}/api/projects/clone-progress?${query}`);
     let settled = false;
 
     const settle = (callback: () => void) => {

--- a/src/components/project-creation-wizard/data/workspaceApi.ts
+++ b/src/components/project-creation-wizard/data/workspaceApi.ts
@@ -1,4 +1,5 @@
 import { api } from '../../../utils/api';
+import { BASE_PATH } from '../../../utils/basePath';
 import type {
   BrowseFilesystemResponse,
   CloneProgressEvent,
@@ -146,7 +147,7 @@ export const cloneWorkspaceWithProgress = (
 ) =>
   new Promise<Record<string, unknown> | undefined>((resolve, reject) => {
     const query = buildCloneProgressQuery(params);
-    const eventSource = new EventSource(`/api/projects/clone-progress?${query}`);
+    const eventSource = new EventSource(`${BASE_PATH}/api/projects/clone-progress?${query}`);
     let settled = false;
 
     const settle = (callback: () => void) => {

--- a/src/components/settings/view/tabs/api-settings/sections/ApiKeysSection.tsx
+++ b/src/components/settings/view/tabs/api-settings/sections/ApiKeysSection.tsx
@@ -1,6 +1,7 @@
 import { ExternalLink, Key, Plus, Trash2 } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { Button, Input } from '../../../../../../shared/view/ui';
+import { assetUrl } from '../../../../../../utils/basePath';
 import type { ApiKeyItem } from '../types';
 
 type ApiKeysSectionProps = {
@@ -44,7 +45,7 @@ export default function ApiKeysSection({
       <div className="mb-4">
         <p className="mb-2 text-sm text-muted-foreground">{t('apiKeys.description')}</p>
         <a
-          href="/api-docs.html"
+          href={assetUrl('/api-docs.html')}
           target="_blank"
           rel="noopener noreferrer"
           className="inline-flex items-center gap-1 text-sm text-primary hover:underline"

--- a/src/components/shell/utils/socket.ts
+++ b/src/components/shell/utils/socket.ts
@@ -1,11 +1,12 @@
 import { IS_PLATFORM } from '../../../constants/config';
+import { BASE_PATH } from '../../../utils/basePath';
 import type { ShellIncomingMessage, ShellOutgoingMessage } from '../types/types';
 
 export function getShellWebSocketUrl(): string | null {
   const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
 
   if (IS_PLATFORM) {
-    return `${protocol}//${window.location.host}/shell`;
+    return `${protocol}//${window.location.host}${BASE_PATH}/shell`;
   }
 
   const token = localStorage.getItem('auth-token');
@@ -14,7 +15,7 @@ export function getShellWebSocketUrl(): string | null {
     return null;
   }
 
-  return `${protocol}//${window.location.host}/shell?token=${encodeURIComponent(token)}`;
+  return `${protocol}//${window.location.host}${BASE_PATH}/shell?token=${encodeURIComponent(token)}`;
 }
 
 export function parseShellMessage(payload: string): ShellIncomingMessage | null {

--- a/src/contexts/WebSocketContext.tsx
+++ b/src/contexts/WebSocketContext.tsx
@@ -1,6 +1,7 @@
 import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
 import { useAuth } from '../components/auth/context/AuthContext';
 import { IS_PLATFORM } from '../constants/config';
+import { BASE_PATH } from '../utils/basePath';
 
 type WebSocketContextType = {
   ws: WebSocket | null;
@@ -21,9 +22,9 @@ export const useWebSocket = () => {
 
 const buildWebSocketUrl = (token: string | null) => {
   const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
-  if (IS_PLATFORM) return `${protocol}//${window.location.host}/ws`; // Platform mode: Use same domain as the page (goes through proxy)
+  if (IS_PLATFORM) return `${protocol}//${window.location.host}${BASE_PATH}/ws`; // Platform mode: Use same domain as the page (goes through proxy)
   if (!token) return null;
-  return `${protocol}//${window.location.host}/ws?token=${encodeURIComponent(token)}`; // OSS mode: Use same host:port that served the page
+  return `${protocol}//${window.location.host}${BASE_PATH}/ws?token=${encodeURIComponent(token)}`; // OSS mode: Use same host:port that served the page
 };
 
 const useWebSocketProviderState = (): WebSocketContextType => {

--- a/src/hooks/useVersionCheck.ts
+++ b/src/hooks/useVersionCheck.ts
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react';
 import { version } from '../../package.json';
 import { ReleaseInfo } from '../types/sharedTypes';
+import { BASE_PATH } from '../utils/basePath';
 
 /**
  * Compare two semantic version strings
@@ -32,7 +33,7 @@ export const useVersionCheck = (owner: string, repo: string) => {
   useEffect(() => {
     const fetchInstallMode = async () => {
       try {
-        const response = await fetch('/health');
+        const response = await fetch(`${BASE_PATH}/health`);
         const data = await response.json();
         if (data.installMode === 'npm' || data.installMode === 'git') {
           setInstallMode(data.installMode);

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -9,7 +9,7 @@ import './i18n/config.js'
 
 // Register service worker for PWA + Web Push support
 if ('serviceWorker' in navigator) {
-  navigator.serviceWorker.register('/sw.js').catch(err => {
+  navigator.serviceWorker.register((window.__CLOUDCLI_BASE_PATH__ || '') + '/sw.js').catch(err => {
     console.warn('Service worker registration failed:', err);
   });
 }

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -4,7 +4,7 @@ import { BASE_PATH } from "./basePath";
 // Utility function for authenticated API calls
 export const authenticatedFetch = (rawUrl, options = {}) => {
   // Auto-prepend BASE_PATH for root-relative URLs (e.g. '/api/...')
-  const url = rawUrl.startsWith('/') ? `${BASE_PATH}${rawUrl}` : rawUrl;
+  const url = (typeof rawUrl === 'string' && rawUrl.startsWith('/')) ? `${BASE_PATH}${rawUrl}` : rawUrl;
   const token = localStorage.getItem('auth-token');
 
   const defaultHeaders = {};

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -1,7 +1,10 @@
 import { IS_PLATFORM } from "../constants/config";
+import { BASE_PATH } from "./basePath";
 
 // Utility function for authenticated API calls
-export const authenticatedFetch = (url, options = {}) => {
+export const authenticatedFetch = (rawUrl, options = {}) => {
+  // Auto-prepend BASE_PATH for root-relative URLs (e.g. '/api/...')
+  const url = rawUrl.startsWith('/') ? `${BASE_PATH}${rawUrl}` : rawUrl;
   const token = localStorage.getItem('auth-token');
 
   const defaultHeaders = {};
@@ -34,24 +37,24 @@ export const authenticatedFetch = (url, options = {}) => {
 export const api = {
   // Auth endpoints (no token required)
   auth: {
-    status: () => fetch('/api/auth/status'),
-    login: (username, password) => fetch('/api/auth/login', {
+    status: () => fetch(`${BASE_PATH}/api/auth/status`),
+    login: (username, password) => fetch(`${BASE_PATH}/api/auth/login`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ username, password }),
     }),
-    register: (username, password) => fetch('/api/auth/register', {
+    register: (username, password) => fetch(`${BASE_PATH}/api/auth/register`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ username, password }),
     }),
-    user: () => authenticatedFetch('/api/auth/user'),
-    logout: () => authenticatedFetch('/api/auth/logout', { method: 'POST' }),
+    user: () => authenticatedFetch(`/api/auth/user`),
+    logout: () => authenticatedFetch(`/api/auth/logout`, { method: 'POST' }),
   },
 
   // Protected endpoints
   // config endpoint removed - no longer needed (frontend uses window.location)
-  projects: () => authenticatedFetch('/api/projects'),
+  projects: () => authenticatedFetch(`/api/projects`),
   sessions: (projectName, limit = 5, offset = 0) =>
     authenticatedFetch(`/api/projects/${projectName}/sessions?limit=${limit}&offset=${offset}`),
   // Unified endpoint — all providers through one URL
@@ -102,10 +105,10 @@ export const api = {
     const token = localStorage.getItem('auth-token');
     const params = new URLSearchParams({ q: query, limit: String(limit) });
     if (token) params.set('token', token);
-    return `/api/search/conversations?${params.toString()}`;
+    return `${BASE_PATH}/api/search/conversations?${params.toString()}`;
   },
   createWorkspace: (workspaceData) =>
-    authenticatedFetch('/api/projects/create-workspace', {
+    authenticatedFetch(`/api/projects/create-workspace`, {
       method: 'POST',
       body: JSON.stringify(workspaceData),
     }),
@@ -171,7 +174,7 @@ export const api = {
 
     // Get available PRD templates
     getTemplates: () =>
-      authenticatedFetch('/api/taskmaster/prd-templates'),
+      authenticatedFetch(`/api/taskmaster/prd-templates`),
 
     // Apply a PRD template
     applyTemplate: (projectName, { templateId, fileName, customizations }) =>
@@ -197,22 +200,22 @@ export const api = {
   },
 
   createFolder: (folderPath) =>
-    authenticatedFetch('/api/create-folder', {
+    authenticatedFetch(`/api/create-folder`, {
       method: 'POST',
       body: JSON.stringify({ path: folderPath }),
     }),
 
   // User endpoints
   user: {
-    gitConfig: () => authenticatedFetch('/api/user/git-config'),
+    gitConfig: () => authenticatedFetch(`/api/user/git-config`),
     updateGitConfig: (gitName, gitEmail) =>
-      authenticatedFetch('/api/user/git-config', {
+      authenticatedFetch(`/api/user/git-config`, {
         method: 'POST',
         body: JSON.stringify({ gitName, gitEmail }),
       }),
-    onboardingStatus: () => authenticatedFetch('/api/user/onboarding-status'),
+    onboardingStatus: () => authenticatedFetch(`/api/user/onboarding-status`),
     completeOnboarding: () =>
-      authenticatedFetch('/api/user/complete-onboarding', {
+      authenticatedFetch(`/api/user/complete-onboarding`, {
         method: 'POST',
       }),
   },

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -1,7 +1,10 @@
 import { IS_PLATFORM } from "../constants/config";
+import { BASE_PATH } from "./basePath";
 
 // Utility function for authenticated API calls
-export const authenticatedFetch = (url, options = {}) => {
+export const authenticatedFetch = (rawUrl, options = {}) => {
+  // Auto-prepend BASE_PATH for root-relative URLs (e.g. '/api/...')
+  const url = (typeof rawUrl === 'string' && rawUrl.startsWith('/')) ? `${BASE_PATH}${rawUrl}` : rawUrl;
   const token = localStorage.getItem('auth-token');
 
   const defaultHeaders = {};
@@ -34,19 +37,19 @@ export const authenticatedFetch = (url, options = {}) => {
 export const api = {
   // Auth endpoints (no token required)
   auth: {
-    status: () => fetch('/api/auth/status'),
-    login: (username, password) => fetch('/api/auth/login', {
+    status: () => fetch(`${BASE_PATH}/api/auth/status`),
+    login: (username, password) => fetch(`${BASE_PATH}/api/auth/login`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ username, password }),
     }),
-    register: (username, password) => fetch('/api/auth/register', {
+    register: (username, password) => fetch(`${BASE_PATH}/api/auth/register`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ username, password }),
     }),
-    user: () => authenticatedFetch('/api/auth/user'),
-    logout: () => authenticatedFetch('/api/auth/logout', { method: 'POST' }),
+    user: () => authenticatedFetch(`/api/auth/user`),
+    logout: () => authenticatedFetch(`/api/auth/logout`, { method: 'POST' }),
   },
 
   // Protected endpoints
@@ -120,7 +123,7 @@ export const api = {
     const token = localStorage.getItem('auth-token');
     const params = new URLSearchParams({ q: query, limit: String(limit) });
     if (token) params.set('token', token);
-    return `/api/providers/search/sessions?${params.toString()}`;
+    return `${BASE_PATH}/api/providers/search/sessions?${params.toString()}`;
   },
   createProject: (projectData) =>
     authenticatedFetch('/api/projects/create-project', {
@@ -198,7 +201,7 @@ export const api = {
 
     // Get available PRD templates
     getTemplates: () =>
-      authenticatedFetch('/api/taskmaster/prd-templates'),
+      authenticatedFetch(`/api/taskmaster/prd-templates`),
 
     // Apply a PRD template
     applyTemplate: (projectId, { templateId, fileName, customizations }) =>
@@ -224,22 +227,22 @@ export const api = {
   },
 
   createFolder: (folderPath) =>
-    authenticatedFetch('/api/create-folder', {
+    authenticatedFetch(`/api/create-folder`, {
       method: 'POST',
       body: JSON.stringify({ path: folderPath }),
     }),
 
   // User endpoints
   user: {
-    gitConfig: () => authenticatedFetch('/api/user/git-config'),
+    gitConfig: () => authenticatedFetch(`/api/user/git-config`),
     updateGitConfig: (gitName, gitEmail) =>
-      authenticatedFetch('/api/user/git-config', {
+      authenticatedFetch(`/api/user/git-config`, {
         method: 'POST',
         body: JSON.stringify({ gitName, gitEmail }),
       }),
-    onboardingStatus: () => authenticatedFetch('/api/user/onboarding-status'),
+    onboardingStatus: () => authenticatedFetch(`/api/user/onboarding-status`),
     completeOnboarding: () =>
-      authenticatedFetch('/api/user/complete-onboarding', {
+      authenticatedFetch(`/api/user/complete-onboarding`, {
         method: 'POST',
       }),
   },

--- a/src/utils/basePath.ts
+++ b/src/utils/basePath.ts
@@ -1,0 +1,16 @@
+/**
+ * Shared base path helper for subpath deployment support.
+ * When CloudCLI is served from a subpath (e.g. /s/mealstead/),
+ * the server injects window.__CLOUDCLI_BASE_PATH__ at runtime.
+ */
+
+declare global {
+  interface Window {
+    __CLOUDCLI_BASE_PATH__?: string;
+    __ROUTER_BASENAME__?: string;
+  }
+}
+
+export const BASE_PATH = window.__CLOUDCLI_BASE_PATH__ || '';
+
+export const assetUrl = (path: string): string => `${BASE_PATH}${path}`;

--- a/vite.config.js
+++ b/vite.config.js
@@ -19,6 +19,7 @@ export default defineConfig(({ mode }) => {
   const serverPort = env.SERVER_PORT || env.PORT || 3001
 
   return {
+    base: env.VITE_BASE_PATH || '/',
     plugins: [react()],
     resolve: {
       alias: {


### PR DESCRIPTION
## Summary

Adds support for serving CloudCLI from a configurable subpath (e.g. `/s/myproject/`) via the `BASE_PATH` environment variable, using **runtime injection** so a single build works at any mount point.

When `BASE_PATH` is unset, behavior is identical to current — **zero impact on root deployments**.

> **Relationship to #815:** That PR fixes runtime *router basename detection* when the HTML already contains prefixed asset URLs. This PR provides the rest of the stack — server middleware, fetch/WS URL prefixing, dynamic manifest, service worker, HTML injection — so the prefix actually makes it through every part of the request chain (especially `fetch('/api/…')` calls that React Router's basename doesn't cover). The two are complementary.

## What's in this PR

**Frontend**
- `src/utils/basePath.ts` — exports `BASE_PATH` (from `window.__CLOUDCLI_BASE_PATH__`) and an `assetUrl()` helper
- `authenticatedFetch` auto-prepends `BASE_PATH` for root-relative URLs (covers ~50 callers across 20+ files without touching each one)
- Bare `fetch()` auth endpoints, `EventSource` URLs, health check, and WebSocket URLs include `BASE_PATH`
- All component image `src` attributes use `assetUrl()`
- The existing `window.__ROUTER_BASENAME__` reading in App.tsx now has an authoritative server-injected value (still falls back to #815's URL sniffing if unset)

**Server**
- `server/index.js`: normalized `BASE_PATH` constant (leading slash, no trailing slash), early middleware to strip the prefix from `req.url` (supports direct subpath access without a smart reverse proxy), dynamic `/manifest.json` with prefixed `start_url`/`scope`/icons, `index: false` on `express.static` so SPA catch-all handles `index.html`, and XSS-safe HTML injection of `window.__CLOUDCLI_BASE_PATH__` + `window.__ROUTER_BASENAME__`
- `server/modules/websocket/services/websocket-server.service.ts`: strips `BASE_PATH` from `pathname` on a segment boundary before routing to `/ws`, `/shell`, `/plugin-ws/*`

**Service worker (`public/sw.js`)**
- Derives `BASE_PATH` from its own script location at runtime
- Whitelist-style fetch handler (parses request URL, checks `origin` + `pathname.startsWith(...)` rather than substring matching)
- Cached URLs, navigation responses, and push-notification icon paths all use the derived prefix

**Build (`vite.config.js`)**
- `base` reads from `VITE_BASE_PATH` (default `/`), so root deployments build identically to before; subpath deployments build with `VITE_BASE_PATH=/s/myproject` (or `./` for relative)

## Usage

```bash
# Root deployment (unchanged)
npm run build && npm run server

# Subpath deployment behind a reverse proxy
VITE_BASE_PATH=/s/myproject npm run build
BASE_PATH=/s/myproject npm run server
```

Reverse-proxy example (Caddy):

```caddyfile
:443 {
    handle /s/myproject/* {
        uri strip_prefix /s/myproject
        reverse_proxy 127.0.0.1:3001
    }
}
```

The server middleware also strips the prefix if your proxy doesn't, so a simpler proxy that just forwards `/s/myproject/*` without stripping also works.

## Test plan

- [x] Without `BASE_PATH`: app works at `http://localhost:3001/` — regression-clean
- [x] With `BASE_PATH=/s/test` behind Caddy: full UI loads at `/s/test/`
- [x] Registration, login, onboarding flow works through proxy
- [x] WebSocket connections (chat + shell + plugin-ws) connect at `/s/test/ws`, `/s/test/shell`, `/s/test/plugin-ws/<name>`
- [x] Logo icons (Claude, Cursor, Codex, Gemini) render
- [x] `manifest.json` returns prefixed paths
- [x] Service worker registers at the correct path
- [x] API calls route through `/s/test/api/...`
- [x] `npm run typecheck` + `npm run build` pass
- [x] CodeRabbit's prior review comments addressed: XSS-safe runtime-config injection, segment-boundary BASE_PATH stripping, parsed-URL pathname checks in sw.js, query-string handling on bare `BASE_PATH`, leading-slash normalization, `typeof rawUrl === 'string'` guard in `authenticatedFetch`

## Notes for reviewers

- Rebased onto current `main` (post-#815). All CodeRabbit feedback from the original review round folded into the squashed commit.
- The WebSocket BASE_PATH stripping ported from the old inline handler into the new `createWebSocketServer` module introduced by #715.
- No new dependencies.
