### PR TITLE
fix(gemini): await sessionManager.ready before server starts accepting requests

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -2312,6 +2312,9 @@ async function startServer() {
         // Initialize authentication database
         await initializeDatabase();
 
+        // Ensure Gemini session store is loaded from disk before accepting requests
+        await sessionManager.ready;
+
         // Configure Web Push (VAPID keys)
         configureWebPush();
 


### PR DESCRIPTION
SessionManager loads all persisted Gemini sessions from ~/.gemini/sessions/*.json asynchronously in its constructor via `this.ready = this.init()`. Previously, `sessionManager.ready` was never awaited anywhere, so the server would start accepting WebSocket connections before loadSessions() had completed.

This created a race condition on the very first request after a server restart: if a client tried to resume an existing Gemini session, `sessionManager.getSession(sessionId)` would return undefined (the session hadn't been loaded from disk yet), causing the `--resume <cliSessionId>` flag to be silently omitted when spawning the Gemini CLI process. The CLI would then start a blank new session instead of continuing the prior conversation, with no error or indication to the user.

The fix adds `await sessionManager.ready` in startServer() immediately after `await initializeDatabase()`, following the same pattern already established for database initialization. This guarantees the session store is fully populated before any request handler can call getSession(), createSession(), or addMessage().

No other providers are affected: Claude, Cursor, and Codex session providers are stateless per-request (they read from disk or SQLite on demand) and have no equivalent eager-loading singleton.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced server startup reliability by ensuring session data is fully loaded before the application begins accepting requests, preventing potential session-related errors and improving overall stability.

* **Chores**
  * Optimized server initialization sequence with improved asynchronous loading handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->