### PR TITLE
fix(gemini): native session IDs and process lifecycle reliability

### DIFF
--- a/server/gemini-cli.js
+++ b/server/gemini-cli.js
@@ -48,10 +48,13 @@ async function spawnGemini(command, options = {}, ws) {
     // If we have a sessionId, we want to resume
     if (sessionId) {
         const session = sessionManager.getSession(sessionId);
-        if (session && session.cliSessionId) {
-            args.push('--resume', session.cliSessionId);
-        } else if (session) {
-            console.warn(`[Gemini] Session ${sessionId} found but missing cliSessionId. Resuming without --resume.`);
+        if (session) {
+            // Use native ID for resumption: 
+            // 1. If it's a legacy session, it has a cliSessionId field.
+            // 2. In the new unified architecture, the session ID itself is the native ID.
+            const resumeId = session.cliSessionId || session.id || sessionId;
+            args.push('--resume', resumeId);
+            console.log(`[Gemini] Resuming native session: ${resumeId}`);
         } else {
             console.warn(`[Gemini] Session ${sessionId} not found in sessionManager. Resuming without --resume.`);
         }
@@ -290,12 +293,40 @@ async function spawnGemini(command, options = {}, ws) {
                     }
                 },
                 onInit: (event) => {
-                    if (capturedSessionId) {
-                        const sess = sessionManager.getSession(capturedSessionId);
-                        if (sess && !sess.cliSessionId) {
-                            sess.cliSessionId = event.session_id;
-                            sessionManager.saveSession(capturedSessionId);
+                    // Match Claude's implementation: wait for the native session_id before creating the UI session
+                    if (event.session_id && !capturedSessionId) {
+                        capturedSessionId = event.session_id;
+                        sessionCreatedSent = true;
+
+                        // Create session in session manager using the native native ID
+                        sessionManager.createSession(capturedSessionId, cwd || process.cwd());
+
+                        // Save the user message now that we have the native session ID
+                        if (command) {
+                            sessionManager.addMessage(capturedSessionId, 'user', command);
                         }
+
+                        // Re-key the active process map to use the native native ID
+                        if (processKey !== capturedSessionId) {
+                            activeGeminiProcesses.delete(processKey);
+                            activeGeminiProcesses.set(capturedSessionId, geminiProcess);
+                            geminiProcess.sessionId = capturedSessionId;
+                        }
+
+                        // Inform the writer and client about the newly established native ID
+                        if (ws) {
+                            if (typeof ws.setSessionId === 'function') {
+                                ws.setSessionId(capturedSessionId);
+                            }
+                            ws.send(createNormalizedMessage({ 
+                                kind: 'session_created', 
+                                newSessionId: capturedSessionId, 
+                                sessionId: capturedSessionId, 
+                                provider: 'gemini' 
+                            }));
+                        }
+                        
+                        console.log(`[Gemini] Native session established: ${capturedSessionId}`);
                     }
                 }
             });
@@ -306,34 +337,43 @@ async function spawnGemini(command, options = {}, ws) {
             const rawOutput = data.toString();
             startTimeout(); // Re-arm the timeout
 
-            // For new sessions, create a session ID FIRST
-            if (!sessionId && !sessionCreatedSent && !capturedSessionId) {
-                capturedSessionId = `gemini_${Date.now()}`;
-                sessionCreatedSent = true;
-
-                // Create session in session manager
-                sessionManager.createSession(capturedSessionId, cwd || process.cwd());
-
-                // Save the user message now that we have a session ID
-                if (command) {
-                    sessionManager.addMessage(capturedSessionId, 'user', command);
-                }
-
-                // Update process key with captured session ID
-                if (processKey !== capturedSessionId) {
-                    activeGeminiProcesses.delete(processKey);
-                    activeGeminiProcesses.set(capturedSessionId, geminiProcess);
-                }
-
-                ws.setSessionId && typeof ws.setSessionId === 'function' && ws.setSessionId(capturedSessionId);
-
-                ws.send(createNormalizedMessage({ kind: 'session_created', newSessionId: capturedSessionId, sessionId: capturedSessionId, provider: 'gemini' }));
-            }
-
             if (responseHandler) {
                 responseHandler.processData(rawOutput);
             } else if (rawOutput) {
-                // Fallback to direct sending for raw CLI mode without WS
+                // Fallback for raw CLI mode without structured JSON streaming
+                if (!sessionId && !sessionCreatedSent && !capturedSessionId) {
+                    capturedSessionId = `gemini_${Date.now()}`;
+                    sessionCreatedSent = true;
+
+                    // Create session in session manager
+                    sessionManager.createSession(capturedSessionId, cwd || process.cwd());
+
+                    // Save the user message now that we have a fallback session ID
+                    if (command) {
+                        sessionManager.addMessage(capturedSessionId, 'user', command);
+                    }
+
+                    // Update process key
+                    if (processKey !== capturedSessionId) {
+                        activeGeminiProcesses.delete(processKey);
+                        activeGeminiProcesses.set(capturedSessionId, geminiProcess);
+                        geminiProcess.sessionId = capturedSessionId;
+                    }
+
+                    if (ws) {
+                        if (typeof ws.setSessionId === 'function') {
+                            ws.setSessionId(capturedSessionId);
+                        }
+                        ws.send(createNormalizedMessage({ 
+                            kind: 'session_created', 
+                            newSessionId: capturedSessionId, 
+                            sessionId: capturedSessionId, 
+                            provider: 'gemini' 
+                        }));
+                    }
+                }
+
+                // Fallback direct streaming
                 if (assistantBlocks.length > 0 && assistantBlocks[assistantBlocks.length - 1].type === 'text') {
                     assistantBlocks[assistantBlocks.length - 1].text += rawOutput;
                 } else {

--- a/server/gemini-cli.js
+++ b/server/gemini-cli.js
@@ -186,6 +186,15 @@ async function spawnGemini(command, options = {}, ws) {
     }
 
     return new Promise((resolve, reject) => {
+        let settled = false;
+
+        const settleOnce = (callback) => {
+            if (settled) return;
+            settled = true;
+            if (timeout) clearTimeout(timeout);
+            callback();
+        };
+
         const geminiProcess = spawnFunction(spawnCmd, spawnArgs, {
             cwd: workingDir,
             stdio: ['pipe', 'pipe', 'pipe'],
@@ -244,11 +253,12 @@ async function spawnGemini(command, options = {}, ws) {
             if (timeout) clearTimeout(timeout);
             timeout = setTimeout(() => {
                 const socketSessionId = typeof ws.getSessionId === 'function' ? ws.getSessionId() : (capturedSessionId || sessionId || processKey);
-                terminalFailureReason = `Gemini CLI timeout - no response received for ${timeoutMs / 1000} seconds`;
+                terminalFailureReason = 'Gemini CLI process timed out';
                 ws.send(createNormalizedMessage({ kind: 'error', content: terminalFailureReason, sessionId: socketSessionId, provider: 'gemini' }));
                 try {
                     geminiProcess.kill('SIGTERM');
                 } catch (e) { }
+                settleOnce(() => reject(new Error(terminalFailureReason)));
             }, timeoutMs);
         };
 
@@ -433,7 +443,7 @@ async function spawnGemini(command, options = {}, ws) {
 
             if (code === 0) {
                 notifyTerminalState({ code });
-                resolve();
+                settleOnce(() => resolve());
             } else {
                 // code 127 = shell "command not found" — check installation
                 if (code === 127) {
@@ -448,7 +458,7 @@ async function spawnGemini(command, options = {}, ws) {
                     code,
                     error: code === null ? 'Gemini CLI process was terminated or timed out' : null
                 });
-                reject(new Error(code === null ? 'Gemini CLI process was terminated or timed out' : `Gemini CLI exited with code ${code}`));
+                settleOnce(() => reject(new Error(code === null ? 'Gemini CLI process was terminated or timed out' : `Gemini CLI exited with code ${code}`))));
             }
         });
 
@@ -468,7 +478,7 @@ async function spawnGemini(command, options = {}, ws) {
             ws.send(createNormalizedMessage({ kind: 'error', content: errorContent, sessionId: errorSessionId, provider: 'gemini' }));
             notifyTerminalState({ error });
 
-            reject(error);
+            settleOnce(() => reject(error));
         });
 
     });

--- a/server/gemini-cli.js
+++ b/server/gemini-cli.js
@@ -16,6 +16,16 @@ let activeGeminiProcesses = new Map(); // Track active processes by session ID
 
 async function spawnGemini(command, options = {}, ws) {
     const { sessionId, projectPath, cwd, toolsSettings, permissionMode, images, sessionSummary } = options;
+    
+    // Ensure session store is loaded (Issue #3)
+    await sessionManager.ready;
+
+    // Abort existing process for this session to prevent orphans (Issue #1)
+    if (sessionId && activeGeminiProcesses.has(sessionId)) {
+        console.log(`[Gemini] Aborting existing process for session ${sessionId} before starting new one`);
+        abortGeminiSession(sessionId);
+    }
+
     let capturedSessionId = sessionId; // Track session ID throughout the process
     let sessionCreatedSent = false; // Track if we've already sent session-created event
     let assistantBlocks = []; // Accumulate the full response blocks including tools
@@ -40,6 +50,10 @@ async function spawnGemini(command, options = {}, ws) {
         const session = sessionManager.getSession(sessionId);
         if (session && session.cliSessionId) {
             args.push('--resume', session.cliSessionId);
+        } else if (session) {
+            console.warn(`[Gemini] Session ${sessionId} found but missing cliSessionId. Resuming without --resume.`);
+        } else {
+            console.warn(`[Gemini] Session ${sessionId} not found in sessionManager. Resuming without --resume.`);
         }
     }
 
@@ -437,10 +451,21 @@ function abortGeminiSession(sessionId) {
     if (geminiProc) {
         try {
             geminiProc.kill('SIGTERM');
+            const targetProc = geminiProc; // Capture for closure
             setTimeout(() => {
-                if (activeGeminiProcesses.has(processKey)) {
+                // Check if the exact same process is still in the map (by value, not just by key)
+                // This ensures we don't SIGKILL a NEW process that might have taken the same key
+                let isStillActive = false;
+                for (const proc of activeGeminiProcesses.values()) {
+                    if (proc === targetProc) {
+                        isStillActive = true;
+                        break;
+                    }
+                }
+
+                if (isStillActive) {
                     try {
-                        geminiProc.kill('SIGKILL');
+                        targetProc.kill('SIGKILL');
                     } catch (e) { }
                 }
             }, 2000); // Wait 2 seconds before force kill

--- a/server/index.js
+++ b/server/index.js
@@ -2312,6 +2312,9 @@ async function startServer() {
         // Initialize authentication database
         await initializeDatabase();
 
+        // Ensure Gemini session store is loaded from disk before accepting requests
+        await sessionManager.ready;
+
         // Configure Web Push (VAPID keys)
         configureWebPush();
 

--- a/server/modules/providers/list/gemini/gemini-sessions.provider.ts
+++ b/server/modules/providers/list/gemini/gemini-sessions.provider.ts
@@ -122,7 +122,9 @@ export class GeminiSessionsProvider implements IProviderSessions {
       rawMessages = sessionManager.getSessionMessages(sessionId) as AnyRecord[];
 
       if (rawMessages.length === 0) {
-        rawMessages = await getGeminiCliSessionMessages(sessionId) as AnyRecord[];
+        const session = sessionManager.getSession(sessionId);
+        const cliSessionId = (session as any)?.cliSessionId || sessionId;
+        rawMessages = await getGeminiCliSessionMessages(cliSessionId) as AnyRecord[];
       }
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);


### PR DESCRIPTION
## Summary
This Pull Request significantly improves the Gemini provider by adopting the native session ID architecture and fixing several process management bugs.

### Key Changes
1. **Native ID Refactor:** Postpones session creation until the Gemini CLI emits its native `session_id` (e.g., `chat_...`). This aligns Gemini with the Claude SDK implementation and natively resolves the "duplicate sessions in sidebar" issue.
2. **Orphan Prevention:** `spawnGemini` now proactively checks for and aborts any existing process for a session before starting a new one, preventing background resource leaks.
3. **Reliable Resumption:** Updated the resumption logic to correctly handle native IDs, ensuring the `--resume` flag is always passed for existing conversations.
4. **Double-Fire Protection:** Implemented a `settleOnce` pattern to ensure the process promise only resolves/rejects once, preventing duplicate error messages to the client.
5. **Improved SIGKILL Logic:** Fixed the force-kill timeout to track the specific process object, ensuring orphaned processes are reliably terminated even if session keys have changed.

### Impact
- Eliminates duplicate Gemini sessions in the UI.
- Improves overall provider stability during rapid message exchanges.
- Reduces server resource usage by cleaning up orphaned CLI processes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed orphaned Gemini processes by terminating existing sessions before starting new ones
  * Improved session lifecycle management to prevent process leaks

* **Improvements**
  * Server startup now ensures session store is fully loaded before accepting requests
  * Enhanced session resumption and initialization for greater reliability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->