### PR TITLE
fix: avoid Claude chat exit when bypass mode runs as root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ All notable changes to CloudCLI UI will be documented in this file.
 
 ### Bug Fixes
 
+* Claude chat now maps both skip-permissions and explicit `bypassPermissions` chat mode to `dontAsk` when CloudCLI runs as root, avoiding Claude SDK exit code 1 from forbidden bypass mode
+
 * iOS scrolling main chat area ([3969135](https://github.com/siteboon/claudecodeui/commit/3969135bd427fbf48f29bb3dbfedb47791ca78dc))
 * migrate PlanDisplay raw params from native details to Collapsible primitive ([fc3504e](https://github.com/siteboon/claudecodeui/commit/fc3504eaed8ca7ed9214838d148ea385b8352c31))
 * precise Claude SDK denial message detection in deriveToolStatus ([09dcea0](https://github.com/siteboon/claudecodeui/commit/09dcea05fbc8c208d931aa1f08618f0e8087392f))

--- a/README.md
+++ b/README.md
@@ -250,3 +250,9 @@ CloudCLI UI  - (https://cloudcli.ai).
 <div align="center">
   <strong>Made with care for the Claude Code, Cursor and Codex community.</strong>
 </div>
+
+## Root-Run Claude Chat
+
+When CloudCLI runs as `root`, Claude chat now maps both the chat mode button's `bypassPermissions` setting and the Claude-specific skip-permissions setting to `dontAsk`. Claude rejects bypass mode under `root`/`sudo`, which previously caused chat requests to exit immediately with code 1.
+
+Run `npm run test:claude-sdk-permissions` to rebuild the server bundle and verify the root permission-mode mapping.

--- a/features.md
+++ b/features.md
@@ -1,0 +1,4 @@
+# Features
+
+- Claude chat now uses `dontAsk` instead of `bypassPermissions` when CloudCLI is started as `root` and either skip-permissions or the chat mode button requests bypass mode, preventing Claude SDK chat exits with code 1.
+- Regression coverage is available via `npm run test:claude-sdk-permissions`, which rebuilds `dist-server` before running the permission-mode test.

--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
     "prepublishOnly": "npm run build",
     "postinstall": "node scripts/fix-node-pty.js",
     "prepare": "husky",
-    "update:platform": "./update-platform.sh"
+    "update:platform": "./update-platform.sh",
+    "test:claude-sdk-permissions": "npm run build:server && node --test server/modules/providers/tests/claude-sdk-permission-mode.test.mjs"
   },
   "keywords": [
     "claude code",

--- a/server/claude-sdk.js
+++ b/server/claude-sdk.js
@@ -42,6 +42,24 @@ function createRequestId() {
   return crypto.randomBytes(16).toString('hex');
 }
 
+function resolveSdkPermissionMode(permissionMode, toolsSettings = {}, options = {}) {
+  const isRoot = options.isRoot ?? (typeof process.getuid === 'function' && process.getuid() === 0);
+
+  if (permissionMode === 'bypassPermissions') {
+    return isRoot ? 'dontAsk' : 'bypassPermissions';
+  }
+
+  if (toolsSettings.skipPermissions && permissionMode !== 'plan') {
+    return isRoot ? 'dontAsk' : 'bypassPermissions';
+  }
+
+  if (permissionMode && permissionMode !== 'default') {
+    return permissionMode;
+  }
+
+  return undefined;
+}
+
 function waitForToolApproval(requestId, options = {}) {
   const { timeoutMs = TOOL_APPROVAL_TIMEOUT_MS, signal, onCancel, metadata } = options;
 
@@ -164,11 +182,6 @@ function mapCliOptionsToSDK(options = {}) {
     sdkOptions.cwd = cwd;
   }
 
-  // Map permission mode
-  if (permissionMode && permissionMode !== 'default') {
-    sdkOptions.permissionMode = permissionMode;
-  }
-
   // Map tool settings
   const settings = toolsSettings || {
     allowedTools: [],
@@ -176,10 +189,9 @@ function mapCliOptionsToSDK(options = {}) {
     skipPermissions: false
   };
 
-  // Handle tool permissions
-  if (settings.skipPermissions && permissionMode !== 'plan') {
-    // When skipping permissions, use bypassPermissions mode
-    sdkOptions.permissionMode = 'bypassPermissions';
+  const resolvedPermissionMode = resolveSdkPermissionMode(permissionMode, settings);
+  if (resolvedPermissionMode) {
+    sdkOptions.permissionMode = resolvedPermissionMode;
   }
 
   let allowedTools = [...(settings.allowedTools || [])];
@@ -828,5 +840,6 @@ export {
   getActiveClaudeSDKSessions,
   resolveToolApproval,
   getPendingApprovalsForSession,
-  reconnectSessionWriter
+  reconnectSessionWriter,
+  resolveSdkPermissionMode
 };

--- a/server/modules/providers/tests/claude-sdk-permission-mode.test.mjs
+++ b/server/modules/providers/tests/claude-sdk-permission-mode.test.mjs
@@ -1,0 +1,30 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { resolveSdkPermissionMode } from '../../../../dist-server/server/claude-sdk.js';
+
+// This test validates the compiled server artifact, so run it through
+// `npm run test:claude-sdk-permissions`, which rebuilds dist-server first.
+
+test('maps skipPermissions to dontAsk for root Claude SDK sessions', () => {
+  assert.equal(resolveSdkPermissionMode('default', { skipPermissions: true }, { isRoot: true }), 'dontAsk');
+});
+
+test('maps skipPermissions to bypassPermissions for non-root Claude SDK sessions', () => {
+  assert.equal(resolveSdkPermissionMode('default', { skipPermissions: true }, { isRoot: false }), 'bypassPermissions');
+});
+
+test('preserves plan mode when skipPermissions is enabled', () => {
+  assert.equal(resolveSdkPermissionMode('plan', { skipPermissions: true }, { isRoot: true }), 'plan');
+});
+
+test('preserves explicit non-default permission modes when skipPermissions is disabled', () => {
+  assert.equal(resolveSdkPermissionMode('acceptEdits', { skipPermissions: false }, { isRoot: true }), 'acceptEdits');
+});
+
+test('maps explicit bypassPermissions to dontAsk for root Claude SDK sessions', () => {
+  assert.equal(resolveSdkPermissionMode('bypassPermissions', { skipPermissions: false }, { isRoot: true }), 'dontAsk');
+});
+
+test('preserves explicit bypassPermissions for non-root Claude SDK sessions', () => {
+  assert.equal(resolveSdkPermissionMode('bypassPermissions', { skipPermissions: false }, { isRoot: false }), 'bypassPermissions');
+});


### PR DESCRIPTION
## Summary
- map Claude chat `bypassPermissions` to `dontAsk` when CloudCLI runs as `root`
- apply the same safeguard to the Claude-specific skip-permissions toggle
- add regression coverage for the root permission-mode mapping
- document the runtime behavior and test command

## Bug scenario
Claude chat fails immediately with `Claude Code process exited with code 1` when:
- CloudCLI runs as `root` (for example via `systemd` on a server)
- the user enables the chat mode button's `bypassPermissions` mode, or enables Claude skip-permissions
- the Claude provider is used through the chat UI (SDK path)

Shell mode does not show the same failure because it launches the interactive Claude CLI instead of the SDK stream-json path.

## Reproduction
1. Run CloudCLI as `root`
2. Open a Claude chat session
3. Switch the chat mode button to `bypassPermissions`, or enable Claude skip-permissions in settings
4. Send any message
5. Observe that the request fails immediately with `Claude Code process exited with code 1`

## Root cause
CloudCLI forwards Claude chat requests through `@anthropic-ai/claude-agent-sdk`, which launches Claude Code with stream-json arguments and `--permission-mode bypassPermissions`.

Claude rejects bypass mode when executed as `root`/`sudo`, returning:

`--dangerously-skip-permissions cannot be used with root/sudo privileges for security reasons`

That stderr is swallowed by the SDK and surfaces in CloudCLI only as a generic exit code 1.

## Suggested fix location
The safest place to fix this is the Claude SDK option mapping in:
- `server/claude-sdk.js`

Specifically, the permission-mode resolution should normalize both:
- explicit chat `permissionMode === 'bypassPermissions'`
- Claude skip-permissions settings

When CloudCLI is running as `root`, both should map to `dontAsk` instead of `bypassPermissions`.

## Validation
- `npm run test:claude-sdk-permissions`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed Claude chat failures when CloudCLI runs as root. Permission bypass requests now map to "do not ask" mode to prevent SDK errors.

* **Documentation**
  * Added clarification on permission mode behavior when running with root privileges.

* **Tests**
  * Added test coverage for permission-mode resolution in Claude chat.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->