### PR TITLE
fix(chat): prevent double send on mobile by removing redundant submit handlers

### DIFF
--- a/src/components/chat/view/subcomponents/ChatComposer.tsx
+++ b/src/components/chat/view/subcomponents/ChatComposer.tsx
@@ -396,14 +396,6 @@ export default function ChatComposer({
             <PromptInputSubmit
               disabled={!input.trim() || isLoading}
               className="h-10 w-10 sm:h-10 sm:w-10"
-              onMouseDown={(event) => {
-                event.preventDefault();
-                onSubmit(event as unknown as MouseEvent<HTMLButtonElement>);
-              }}
-              onTouchStart={(event) => {
-                event.preventDefault();
-                onSubmit(event as unknown as TouchEvent<HTMLButtonElement>);
-              }}
             />
           </div>
         </PromptInputFooter>


### PR DESCRIPTION
## Summary

`PromptInputSubmit` is rendered as `type=\"submit\"` inside a `<form>` whose `onSubmit` already invokes `handleSubmit`. The component additionally wired `onMouseDown` and `onTouchStart` to call `onSubmit` directly, creating three submit paths.

On iOS Safari a single tap fires `touchstart` and a synthetic `mousedown` before React state propagates `isLoading=true`, so the `disabled={!input.trim() || isLoading}` guard does not catch the second invocation. Result: two user messages, two image-upload roundtrips per tap (visible as duplicate `.tmp/images/<timestamp>` folders).

This PR removes the redundant `onMouseDown` / `onTouchStart` handlers; the form's `onSubmit` is the single, browser-debounced submit path.

## Test plan

- [ ] Desktop click on the send button sends exactly once
- [ ] Desktop Enter in the textarea sends exactly once
- [ ] iOS Safari tap (with attached image) sends exactly once — single bubble, single `.tmp/images/<ts>` folder
- [ ] Send-button `disabled` state still gates submission while `isLoading`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified event handling in the chat composer's submit control by removing redundant pointer/touch event interception, relying instead on standard form submission mechanics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->