### PR TITLE
fix(claude-sdk): emit token-by-token streaming to the client

### DIFF
--- a/server/claude-sdk.js
+++ b/server/claude-sdk.js
@@ -218,10 +218,6 @@ function mapCliOptionsToSDK(options = {}) {
   // This loads CLAUDE.md from project, user (~/.config/claude/CLAUDE.md), and local directories
   sdkOptions.settingSources = ['project', 'user', 'local'];
 
-  // Emit token-by-token deltas so the UI can render streaming output instead of
-  // receiving each assistant message as a single completed block.
-  sdkOptions.includePartialMessages = true;
-
   // Map resume session
   if (sessionId) {
     sdkOptions.resume = sessionId;
@@ -495,9 +491,18 @@ async function queryClaudeSDK(command, options = {}, ws) {
     });
   };
 
+  // Only writers that finalize streaming on the client side (WebSocket UI, SSE
+  // endpoints) can consume the partial-message events; other callers
+  // (commit-message generator, ResponseCollector) just collect the consolidated
+  // assistant message, so we leave streaming off for them.
+  const writerStreams = Boolean(ws?.isWebSocketWriter || ws?.isSSEStreamWriter);
+
   try {
     // Map CLI options to SDK format
     const sdkOptions = mapCliOptionsToSDK(options);
+    if (writerStreams) {
+      sdkOptions.includePartialMessages = true;
+    }
 
     // Load MCP configuration
     const mcpServers = await loadMcpConfig(options.cwd);
@@ -677,7 +682,10 @@ async function queryClaudeSDK(command, options = {}, ws) {
       // Strip text parts from the consolidated assistant message when text was
       // already streamed for this turn — otherwise the client renders both the
       // streamed buffer (finalized by stream_end) and a duplicate text message.
+      // Only applies to streaming writers; non-streaming consumers need the
+      // consolidated text payload to remain intact.
       if (
+        writerStreams &&
         textWasStreamed &&
         message.type === 'assistant' &&
         Array.isArray(message.message?.content)

--- a/server/claude-sdk.js
+++ b/server/claude-sdk.js
@@ -218,6 +218,10 @@ function mapCliOptionsToSDK(options = {}) {
   // This loads CLAUDE.md from project, user (~/.config/claude/CLAUDE.md), and local directories
   sdkOptions.settingSources = ['project', 'user', 'local'];
 
+  // Emit token-by-token deltas so the UI can render streaming output instead of
+  // receiving each assistant message as a single completed block.
+  sdkOptions.includePartialMessages = true;
+
   // Map resume session
   if (sessionId) {
     sdkOptions.resume = sessionId;
@@ -634,6 +638,7 @@ async function queryClaudeSDK(command, options = {}, ws) {
 
     // Process streaming messages
     console.log('Starting async generator loop for session:', capturedSessionId || 'NEW');
+    let textWasStreamed = false;
     for await (const message of queryInstance) {
       // Capture session ID from first message
       if (message.session_id && !capturedSessionId) {
@@ -655,9 +660,35 @@ async function queryClaudeSDK(command, options = {}, ws) {
         // session_id already captured
       }
 
+      // Track text deltas streamed via includePartialMessages so we can avoid
+      // re-emitting the same text from the consolidated assistant message below.
+      if (
+        message.type === 'stream_event' &&
+        message.event?.type === 'content_block_delta' &&
+        message.event?.delta?.type === 'text_delta'
+      ) {
+        textWasStreamed = true;
+      }
+
       // Transform and normalize message via adapter
-      const transformedMessage = transformMessage(message);
+      let transformedMessage = transformMessage(message);
       const sid = capturedSessionId || sessionId || null;
+
+      // Strip text parts from the consolidated assistant message when text was
+      // already streamed for this turn — otherwise the client renders both the
+      // streamed buffer (finalized by stream_end) and a duplicate text message.
+      if (
+        textWasStreamed &&
+        message.type === 'assistant' &&
+        Array.isArray(message.message?.content)
+      ) {
+        const filtered = message.message.content.filter((part) => part.type !== 'text');
+        transformedMessage = {
+          ...transformedMessage,
+          message: { ...message.message, content: filtered },
+        };
+        textWasStreamed = false;
+      }
 
       // Use adapter to normalize SDK events into NormalizedMessage[]
       const normalized = sessionsService.normalizeMessage('claude', transformedMessage, sid);

--- a/server/modules/providers/list/claude/claude-sessions.provider.ts
+++ b/server/modules/providers/list/claude/claude-sessions.provider.ts
@@ -66,10 +66,14 @@ export class ClaudeSessionsProvider implements IProviderSessions {
 
     // Live SDK stream events (emitted when includePartialMessages is enabled) wrap
     // the Anthropic streaming event under a `stream_event` envelope.
-    if (raw.type === 'stream_event' && raw.event && typeof raw.event === 'object') {
-      const ev = raw.event as { type?: string; delta?: { type?: string; text?: string } };
-      if (ev.type === 'content_block_delta' && ev.delta?.type === 'text_delta' && ev.delta.text) {
-        return [createNormalizedMessage({ kind: 'stream_delta', content: ev.delta.text, sessionId, provider: PROVIDER })];
+    if (raw.type === 'stream_event') {
+      const ev = readObjectRecord(raw.event);
+      if (!ev) {
+        return [];
+      }
+      const delta = readObjectRecord(ev.delta);
+      if (ev.type === 'content_block_delta' && delta?.type === 'text_delta' && typeof delta.text === 'string' && delta.text) {
+        return [createNormalizedMessage({ kind: 'stream_delta', content: delta.text, sessionId, provider: PROVIDER })];
       }
       if (ev.type === 'content_block_stop') {
         return [createNormalizedMessage({ kind: 'stream_end', sessionId, provider: PROVIDER })];

--- a/server/modules/providers/list/claude/claude-sessions.provider.ts
+++ b/server/modules/providers/list/claude/claude-sessions.provider.ts
@@ -64,6 +64,19 @@ export class ClaudeSessionsProvider implements IProviderSessions {
       return [createNormalizedMessage({ kind: 'stream_end', sessionId, provider: PROVIDER })];
     }
 
+    // Live SDK stream events (emitted when includePartialMessages is enabled) wrap
+    // the Anthropic streaming event under a `stream_event` envelope.
+    if (raw.type === 'stream_event' && raw.event && typeof raw.event === 'object') {
+      const ev = raw.event as { type?: string; delta?: { type?: string; text?: string } };
+      if (ev.type === 'content_block_delta' && ev.delta?.type === 'text_delta' && ev.delta.text) {
+        return [createNormalizedMessage({ kind: 'stream_delta', content: ev.delta.text, sessionId, provider: PROVIDER })];
+      }
+      if (ev.type === 'content_block_stop') {
+        return [createNormalizedMessage({ kind: 'stream_end', sessionId, provider: PROVIDER })];
+      }
+      return [];
+    }
+
     const messages: NormalizedMessage[] = [];
     const ts = raw.timestamp || new Date().toISOString();
     const baseId = raw.uuid || generateMessageId('claude');


### PR DESCRIPTION
## Summary

Assistant responses arrive as a single block instead of streaming token by token. Three coordinated changes are needed to make streaming actually flow through the existing `stream_delta` / `stream_end` pipeline:

1. **`server/claude-sdk.js`** — set `sdkOptions.includePartialMessages = true` so the Claude Agent SDK emits `SDKPartialAssistantMessage` events during a turn. Without this flag the SDK only emits the final consolidated assistant message.
2. **`server/modules/providers/list/claude/claude-sessions.provider.ts`** — unwrap the `{ type: 'stream_event', event: { ... } }` envelope into the existing `stream_delta` / `stream_end` normalized kinds. The previous flat-event branch (`raw.type === 'content_block_delta'`) never matched the real SDK shape and was effectively dead code.
3. **`server/claude-sdk.js`** — once text was streamed for a turn, strip `text` parts from the consolidated `SDKAssistantMessage` so the client does not render both the streamed buffer (finalized by `stream_end`) and a duplicate text message. `tool_use` and `thinking` blocks pass through unchanged so tool grouping and thinking rendering still work.

Splitting these into separate PRs would leave intermediate states broken (flag-only would emit unhandled stream events; provider-only would have no stream events to unwrap; either without the dedup would double-render the response).

## Test plan

- [ ] Send a long prompt — text appears token by token in the UI rather than as a single block at the end
- [ ] Final rendered message contains the full response (no truncation, no duplication)
- [ ] Tool use still appears (e.g. `Read`, `Bash`) and is grouped under its parent assistant message
- [ ] Thinking blocks still render when the model emits them
- [ ] Token-budget event still arrives at end-of-turn (`message.type === 'result'` path unchanged)
- [ ] Cursor / Gemini provider streaming behavior unchanged (only Claude provider touched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enabled partial/token streaming for WebSocket/SSE writer connections for faster response delivery.

* **Bug Fixes**
  * Prevented duplicate text from appearing when streamed content and consolidated messages arrive.
  * Improved handling of live-stream events so incremental text and stream end signals normalize correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->