### PR TITLE
fix(sessions): filter sidechain (sub-agent) JSONL files from sidebar

### DIFF
--- a/server/projects.js
+++ b/server/projects.js
@@ -640,28 +640,78 @@ async function getProjects(progressCallback = null) {
   return projects;
 }
 
+/**
+ * Returns true iff the given Claude JSONL file represents an interactive
+ * top-level session (i.e. a `claude --resume`-able conversation).
+ *
+ * Files written by sub-agents — both Task-tool transcripts and MCP-spawned
+ * Agent SDK sub-conversations (e.g. Taskmaster `expand`, `update_subtask`) —
+ * carry `isSidechain: true` on every record. The `agent-*.jsonl` filename
+ * filter catches the Task-tool case cheaply; this content-based check is
+ * the authoritative one and covers MCP sub-agents that get UUID filenames
+ * indistinguishable from real sessions.
+ *
+ * Streams the file and returns as soon as a `user` or `assistant` entry is
+ * found. Files without any user/assistant entry are treated as
+ * non-interactive.
+ */
+async function isInteractiveClaudeSessionFile(filePath) {
+  try {
+    const fileStream = fsSync.createReadStream(filePath);
+    const rl = readline.createInterface({ input: fileStream, crlfDelay: Infinity });
+    try {
+      for await (const line of rl) {
+        if (!line.trim()) continue;
+        let entry;
+        try { entry = JSON.parse(line); } catch { continue; }
+        if (entry.type === 'user' || entry.type === 'assistant') {
+          return entry.isSidechain !== true;
+        }
+      }
+      return false;
+    } finally {
+      rl.close();
+      fileStream.destroy();
+    }
+  } catch {
+    return false;
+  }
+}
+
 async function getSessions(projectName, limit = 5, offset = 0) {
   const projectDir = path.join(os.homedir(), '.claude', 'projects', projectName);
 
   try {
     const files = await fs.readdir(projectDir);
-    // agent-*.jsonl files contain session start data at this point. This needs to be revisited
-    // periodically to make sure only accurate data is there and no new functionality is added there
+    // agent-*.jsonl files are Task-tool sub-agent transcripts (cheap fast-path).
+    // The authoritative sub-agent filter is the isSidechain content check below,
+    // which also catches MCP-spawned (Agent SDK) sub-conversations that get
+    // UUID-named files.
     const jsonlFiles = files.filter(file => file.endsWith('.jsonl') && !file.startsWith('agent-'));
 
     if (jsonlFiles.length === 0) {
       return { sessions: [], hasMore: false, total: 0 };
     }
 
-    // Sort files by modification time (newest first)
-    const filesWithStats = await Promise.all(
+    // Stat each file and drop sidechain files (sub-agent transcripts with
+    // UUID filenames — see isInteractiveClaudeSessionFile).
+    const enriched = await Promise.all(
       jsonlFiles.map(async (file) => {
         const filePath = path.join(projectDir, file);
-        const stats = await fs.stat(filePath);
-        return { file, mtime: stats.mtime };
+        const [stats, interactive] = await Promise.all([
+          fs.stat(filePath),
+          isInteractiveClaudeSessionFile(filePath),
+        ]);
+        return { file, mtime: stats.mtime, interactive };
       })
     );
-    filesWithStats.sort((a, b) => b.mtime - a.mtime);
+    const filesWithStats = enriched
+      .filter(f => f.interactive)
+      .sort((a, b) => b.mtime - a.mtime);
+
+    if (filesWithStats.length === 0) {
+      return { sessions: [], hasMore: false, total: 0 };
+    }
 
     const allSessions = new Map();
     const allEntries = [];
@@ -784,6 +834,12 @@ async function parseJsonlSessions(filePath) {
       if (line.trim()) {
         try {
           const entry = JSON.parse(line);
+          // Defensive: skip sub-agent records that may appear in mixed-content
+          // files. The file-level filter in getSessions() is the primary gate;
+          // this prevents a stray sidechain entry from materialising a session.
+          if (entry.isSidechain === true) {
+            continue;
+          }
           entries.push(entry);
 
           // Handle summary entries that don't have sessionId yet


### PR DESCRIPTION
# fix(sessions): filter sidechain (sub-agent) JSONL files from sidebar

## Summary

The session sidebar surfaces every `*.jsonl` file in
`~/.claude/projects/<project-dir>/` as a resumable session. That includes
MCP-spawned sub-agent transcripts which the Agent SDK writes with normal UUID filenames —
indistinguishable from real sessions by name. Each one becomes a phantom
"tab" in the sidebar and resuming it does nothing useful, since each is a
finished non-interactive sub-conversation.

The existing `agent-*.jsonl` filename filter only catches Task-tool
transcripts; it doesn't catch MCP sub-agents.

## Fix

Adds a content-based predicate `isInteractiveClaudeSessionFile()` next to
the existing filename filter in `server/projects.js`. It streams each
candidate file, finds the first `user`/`assistant` entry, and returns
`entry.isSidechain !== true`. Files with no user/assistant entry (e.g.
files that contain only `file-history-snapshot` records) are treated as
non-interactive.

Why `isSidechain` and not a heuristic:

- It's Claude Code's own canonical field for "this record is part of a
  sub-conversation".
- Every sub-agent path — Task tool, Agent SDK, future MCP servers — goes
  through the same SDK code that sets it, so the predicate is forward-
  compatible.
- It's structural, not prompt-based.

The filename `agent-*` filter is kept as a cheap fast-path so we don't
have to open those files at all.

A small defensive change in `parseJsonlSessions()` also skips individual
entries with `isSidechain === true`. The file-level filter is the primary
gate; this prevents a stray sidechain entry inside a mixed-content file
from materialising a phantom session.

## Files changed

- `server/projects.js`
  - new helper: `isInteractiveClaudeSessionFile(filePath)`
  - `getSessions()`: applies the predicate after the `agent-*` filename
    filter, before iterating into `parseJsonlSessions()`
  - `parseJsonlSessions()`: per-entry defensive skip when
    `entry.isSidechain === true`

## Verification

- `node --check server/projects.js` passes.
- Tested against local projects: every previously-listed interactive
  session is preserved; sidechain UUID files (when present) are dropped;
  `file-history-snapshot`-only stub files (no `sessionId`, didn't render
  before either) are also dropped — no behavioural change for those, just
  cleaner up-front filtering.
- Sidebar smoke test: lightly-used projects show identical session lists;
  Taskmaster-heavy projects no longer show competing-tab phantoms.

## Out of scope (follow-up)

`isSidechain` is Claude-specific. Other providers will hit the same UX
bug class as they grow MCP-style sub-agents. The architectural home for
that is a per-provider `provider.isInteractiveSession(records)` predicate
dispatched by a shared sidebar filter, which fits naturally into the
DB-driven session refactor in #715. Not changing the provider adapter
shape here to keep this fix small and back-portable.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Session list now accurately displays only interactive Claude sessions, filtering out non-interactive files based on content analysis.
  * Sidechain entries within mixed-content session files are now properly excluded from session listings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->