### PR TITLE
fix(claude-sync): skip subagent JSONL files to prevent main session corruption

### DIFF
--- a/server/modules/providers/list/claude/claude-session-synchronizer.provider.ts
+++ b/server/modules/providers/list/claude/claude-session-synchronizer.provider.ts
@@ -37,6 +37,14 @@ export class ClaudeSessionSynchronizer implements IProviderSessionSynchronizer {
 
     let processed = 0;
     for (const filePath of files) {
+      // PATCH (kamioj): subagent .jsonl 文件共享父 session 的 sessionId，
+      // 会被当成主 session 写入 DB → 污染主会话记录。直接跳过。
+      if (
+        filePath.includes(`${path.sep}subagents${path.sep}`) ||
+        filePath.replace(/\\/g, '/').includes('/subagents/')
+      ) {
+        continue;
+      }
       const parsed = await this.processSessionFile(filePath, nameMap);
       if (!parsed) {
         continue;
@@ -63,6 +71,13 @@ export class ClaudeSessionSynchronizer implements IProviderSessionSynchronizer {
    */
   async synchronizeFile(filePath: string): Promise<string | null> {
     if (!filePath.endsWith('.jsonl')) {
+      return null;
+    }
+    // PATCH (kamioj): 同 synchronize()，单文件路径走 watcher 进来时也要排除 subagents/
+    if (
+      filePath.includes(`${path.sep}subagents${path.sep}`) ||
+      filePath.replace(/\\/g, '/').includes('/subagents/')
+    ) {
       return null;
     }
 


### PR DESCRIPTION
## Summary

`ClaudeSessionSynchronizer` walks `~/.claude/projects/<project>/` for
`.jsonl` files and indexes each one as a session row. Claude Code writes
subagent transcripts under a `subagents/` subdirectory but **shares the
parent session's `sessionId`** in those files. The current scan picks them
up and upserts them into the sessions DB with the same `sessionId`, which
overwrites the parent row and breaks session resume / history listing.

## Reproduction

1. Run a Claude Code session that spawns at least one subagent (Task tool, `/agent`, etc.).
2. Layout becomes:
   ```
   ~/.claude/projects/<encoded-cwd>/<sid>.jsonl                  ← parent
   ~/.claude/projects/<encoded-cwd>/subagents/<sid>-<n>.jsonl    ← subagent (same sid)
   ```
3. Trigger session sync (initial scan or filesystem watcher).
4. The `sessions` row for `<sid>` now reflects the subagent file's metadata; opening the session in the UI shows the subagent transcript instead of the parent.

## Fix

Skip any path containing `/subagents/` (or `\subagents\` on Windows) in:
- `synchronize()` — the bulk scan loop
- `synchronizeFile()` — the watcher-driven entry point

Both code paths use the same cross-platform separator-aware guard.

## Notes

- +15 / -0, single file
- No behavior change for setups without subagents
- No new dependencies / no schema migration

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session synchronization to properly exclude subagent transcript files from being stored, ensuring cleaner data management and preventing redundant session artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->