### PR TITLE
fix(claude): support Claude Desktop transcript format / 支持 Claude Desktop 转录格式

### DIFF
--- a/server/modules/providers/list/claude/claude-sessions.provider.ts
+++ b/server/modules/providers/list/claude/claude-sessions.provider.ts
@@ -53,7 +53,8 @@ async function parseAgentTools(filePath: string): Promise<AnyRecord[]> {
       try {
         const entry = JSON.parse(line) as AnyRecord;
 
-        if (entry.message?.role === 'assistant' && Array.isArray(entry.message?.content)) {
+        const isAssistantEntry = entry.message?.role === 'assistant' || entry.type === 'assistant';
+        if (isAssistantEntry && Array.isArray(entry.message?.content)) {
           for (const part of entry.message.content as AnyRecord[]) {
             if (part.type === 'tool_use') {
               tools.push({
@@ -348,7 +349,10 @@ export class ClaudeSessionsProvider implements IProviderSessions {
       return messages;
     }
 
-    if (raw.message?.role === 'assistant' && raw.message?.content) {
+    // Claude Desktop uses top-level `type: 'assistant'` instead of `message.role`,
+    // so check both to support CLI and Desktop transcript formats.
+    const isAssistant = raw.message?.role === 'assistant' || raw.type === 'assistant';
+    if (isAssistant && raw.message?.content) {
       if (Array.isArray(raw.message.content)) {
         let partIndex = 0;
         for (const part of raw.message.content) {


### PR DESCRIPTION
## Summary / 摘要

Claude Code Desktop 写入的 JSONL 条目使用顶层 `type: 'assistant'` 字段，而非 `message.role: 'assistant'`。之前的会话解析器只检查 `message.role`，导致 assistant 消息被静默跳过，用户看不到回复。

---

Claude Code Desktop writes JSONL entries with a top-level `type: 'assistant'` field instead of `message.role: 'assistant'`. The session parser only checked `message.role`, causing assistant messages to be silently skipped, so users see no replies in the chat UI.

## Fix / 修复方案

同时检查 `raw.message?.role === 'assistant'` 和 `raw.type === 'assistant'`，兼容 CLI 和 Desktop 两种转录格式。

---

Check both `raw.message?.role === 'assistant'` and `raw.type === 'assistant'` to support both CLI and Desktop transcript formats.

## Test plan / 测试计划

- [ ] 使用 Claude Code Desktop 会话，验证 assistant 消息正常显示
- [ ] 验证 CLI 会话（使用 `message.role`）仍然正常工作
- [ ] Verify Claude Code Desktop sessions display assistant messages correctly
- [ ] Verify CLI sessions (with `message.role`) still work as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)