### PR TITLE
fix: enhance regex to correctly parse wrapper file paths for claude.exe

### DIFF
--- a/server/shared/claude-cli-path.test.ts
+++ b/server/shared/claude-cli-path.test.ts
@@ -33,6 +33,20 @@ test('resolveClaudeCodeExecutablePath keeps an explicit JavaScript launcher path
   assert.equal(resolved, scriptPath);
 });
 
+test('resolveClaudeCodeExecutablePath can parse a wrapper file path containing letters r and n before claude.exe', () => {
+  const wrapperPath = 'C:\\tools\\claude';
+  const nativePath = 'C:\\tools\\custom\\bin\\node_modules\\@anthropic-ai\\claude-code\\bin\\claude.exe';
+  const readFileSync = (() => `exec "$basedir/custom/bin/node_modules/@anthropic-ai/claude-code/bin/claude.exe" "$@"`) as unknown as ResolveClaudeCodeExecutablePathDependencies['readFileSync'];
+
+  const resolved = resolveClaudeCodeExecutablePath(wrapperPath, {
+    platform: 'win32',
+    existsSync: (candidate) => candidate === nativePath,
+    readFileSync,
+  });
+
+  assert.equal(resolved, nativePath);
+});
+
 test('resolveClaudeCodeExecutablePath falls back to the configured command when PATH lookup fails', () => {
   const execFileSync = (() => {
     throw new Error('not found');

--- a/server/shared/claude-cli-path.ts
+++ b/server/shared/claude-cli-path.ts
@@ -50,7 +50,7 @@ function resolveClaudeWrapperBinary(
     return null;
   }
 
-  const matches = content.matchAll(/["']([^"'\\r\\n]*claude\.exe)["']/gi);
+  const matches = content.matchAll(/["']([^"'\\\r\n]*claude\.exe)["']/gi);
   for (const match of matches) {
     const rawTarget = match[1]
       .replace(/^\$basedir[\\/]/i, '')


### PR DESCRIPTION
Fix for https://github.com/siteboon/claudecodeui/pull/738/files/e6be3528cc7500ab06ae9f41d09df860d60af421#diff-d7cffbaee29f72585cc82e94ac0ffecffdc6c05f012b92e465ea4953d064ca50

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection and resolution of Windows command-line interface wrapper script paths to correctly handle edge cases with special character sequences.

* **Tests**
  * Added test coverage validating proper parsing and resolution of Windows wrapper paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->