### PR TITLE
fix: correct token budget gauge and populate session message count badge

### DIFF
--- a/server/claude-sdk.js
+++ b/server/claude-sdk.js
@@ -302,19 +302,15 @@ function extractTokenBudget(resultMessage) {
     return null;
   }
 
-  // Use cumulative tokens if available (tracks total for the session)
-  // Otherwise fall back to per-request tokens
-  const inputTokens = modelData.cumulativeInputTokens || modelData.inputTokens || 0;
-  const outputTokens = modelData.cumulativeOutputTokens || modelData.outputTokens || 0;
-  const cacheReadTokens = modelData.cumulativeCacheReadInputTokens || modelData.cacheReadInputTokens || 0;
-  const cacheCreationTokens = modelData.cumulativeCacheCreationInputTokens || modelData.cacheCreationInputTokens || 0;
+  // Only input tokens consume the context window; output tokens do not.
+  // Use the current-turn input token count (not cumulative) to reflect
+  // the actual context window pressure for this message.
+  const totalUsed = modelData.inputTokens || 0;
 
-  // Total used = input + output + cache tokens
-  const totalUsed = inputTokens + outputTokens + cacheReadTokens + cacheCreationTokens;
-
-  // Use configured context window budget from environment (default 160000)
-  // This is the user's budget limit, not the model's context window
-  const contextWindow = parseInt(process.env.CONTEXT_WINDOW) || 160000;
+  // Use the model's actual context window size (default 200000 for claude-3.x/4.x).
+  // Previously this used a hardcoded 160000 "budget" which caused the gauge to
+  // read incorrectly — 160K is not the context window for current models.
+  const contextWindow = modelData.contextWindow || 200000;
 
   // Token calc logged via token-budget WS event
 

--- a/server/modules/projects/services/projects-with-sessions-fetch.service.ts
+++ b/server/modules/projects/services/projects-with-sessions-fetch.service.ts
@@ -148,8 +148,9 @@ function countUserMessagesInJsonl(jsonlPath: string): number {
           const content = message?.content;
           const isToolResult =
             Array.isArray(content) &&
-            content.length > 0 &&
-            (content[0] as Record<string, unknown>)?.type === 'tool_result';
+            content.some(
+              (item) => (item as Record<string, unknown>)?.type === 'tool_result',
+            );
           if (!isToolResult) {
             count += 1;
           }

--- a/server/modules/projects/services/projects-with-sessions-fetch.service.ts
+++ b/server/modules/projects/services/projects-with-sessions-fetch.service.ts
@@ -1,4 +1,5 @@
 import fs from 'node:fs/promises';
+import fsSync from 'node:fs';
 import path from 'node:path';
 
 import { projectsDb, sessionsDb } from '@/modules/database/index.js';
@@ -22,6 +23,7 @@ type SessionRepositoryRow = {
   custom_name?: string | null;
   updated_at?: string | null;
   created_at?: string | null;
+  jsonl_path?: string | null;
 };
 
 export type ProjectListItem = {
@@ -124,11 +126,50 @@ function normalizeSessionPagination(options: SessionPaginationOptions = {}): { l
   };
 }
 
+/**
+ * Counts human ("user" role) messages in a Claude JSONL session file.
+ * Each line is a JSON object; we count lines where `role === "user"` and
+ * the content is not a tool result (i.e. actual user prompts, not tool outputs).
+ * Returns 0 if the file is missing or unreadable.
+ */
+function countUserMessagesInJsonl(jsonlPath: string): number {
+  try {
+    const content = fsSync.readFileSync(jsonlPath, 'utf8');
+    const lines = content.split(/\r?\n/);
+    let count = 0;
+    for (const line of lines) {
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+      try {
+        const data = JSON.parse(trimmed) as Record<string, unknown>;
+        if (data.type === 'user') {
+          // Only count genuine user prompts, not tool_result messages
+          const message = data.message as Record<string, unknown> | undefined;
+          const content = message?.content;
+          const isToolResult =
+            Array.isArray(content) &&
+            content.length > 0 &&
+            (content[0] as Record<string, unknown>)?.type === 'tool_result';
+          if (!isToolResult) {
+            count += 1;
+          }
+        }
+      } catch {
+        // Skip malformed lines
+      }
+    }
+    return count;
+  } catch {
+    return 0;
+  }
+}
+
 function mapSessionRowToSummary(row: SessionRepositoryRow): SessionSummary {
+  const messageCount = row.jsonl_path ? countUserMessagesInJsonl(row.jsonl_path) : 0;
   return {
     id: row.session_id,
     summary: row.custom_name || '',
-    messageCount: 0,
+    messageCount,
     lastActivity: row.updated_at ?? row.created_at ?? new Date().toISOString(),
   };
 }


### PR DESCRIPTION
Token budget (server/claude-sdk.js): The context window gauge was double-counting tokens — it summed cumulative input + output + cache tokens against a hardcoded 160K limit. Output tokens don't consume the context window. Replace with current-turn inputTokens only and derive the ceiling from modelData.contextWindow (defaulting to 200000 for current Claude models) instead of the 160K env-var budget. 
`Fixes #588`

Message count badge (projects-with-sessions-fetch.service.ts): mapSessionRowToSummary was hardcoding messageCount: 0, causing the sidebar badge to never render. Count user-turn messages on-the-fly from the stored JSONL path using synchronous readFileSync (no DB migration required). Tool-result messages are excluded so only genuine human prompts are counted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Session summaries now show per-session message counts derived from available session transcripts.

* **Improvements**
  * Token usage reporting for conversation turns is more accurate.
  * Message counts exclude automated/tool-result entries; missing or unreadable transcripts default to zero.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->