### PR TITLE
feat: add GLM models to Claude provider options

### DIFF
--- a/shared/modelConstants.js
+++ b/shared/modelConstants.js
@@ -20,6 +20,10 @@ export const CLAUDE_MODELS = {
     { value: "opusplan", label: "Opus Plan" },
     { value: "sonnet[1m]", label: "Sonnet [1M]" },
     { value: "opus[1m]", label: "Opus [1M]" },
+    { value: "glm-4.7", label: "GLM-4.7 (智谱AI)" },
+    { value: "glm-4-flash", label: "GLM-4 Flash" },
+    { value: "glm-4-plus", label: "GLM-4 Plus" },
+    { value: "glm-4-air", label: "GLM-4 Air" },
   ],
 
   DEFAULT: "opus",


### PR DESCRIPTION
- Add glm-4.7, glm-4-flash, glm-4-plus, glm-4-air to CLAUDE_MODELS
- These models work with Anthropic-compatible APIs like ZhipuAI (https://open.bigmodel.cn/api/anthropic)
- Users can configure via ANTHROPIC_BASE_URL and ANTHROPIC_AUTH_TOKEN environment variables

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for four new Claude-family models: GLM-4.7, GLM-4 Flash, GLM-4 Plus, and GLM-4 Air — these appear in model selection lists for users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->