### PR TITLE
Fix: index Cursor sessions from agent-transcripts/, support nested depths

### DIFF
--- a/server/modules/providers/list/cursor/cursor-session-synchronizer.provider.ts
+++ b/server/modules/providers/list/cursor/cursor-session-synchronizer.provider.ts
@@ -1,4 +1,3 @@
-import crypto from 'node:crypto';
 import fs from 'node:fs';
 import fsp from 'node:fs/promises';
 import os from 'node:os';
@@ -35,13 +34,20 @@ async function listDirectoryEntriesSafe(
 
 /**
  * Session indexer for Cursor transcript artifacts.
+ *
+ * Recent cursor-agent versions write JSONL transcripts under
+ *   ~/.cursor/projects/<project-dir>/agent-transcripts/<chatId>/<chatId>.jsonl
+ * (sometimes nested one level deeper). The legacy
+ *   ~/.cursor/chats/<projectHash>/
+ * directory still exists but now holds SQLite `store.db` files used by the
+ * loader (cursor-sessions.provider.ts), not JSONL the indexer can parse.
  */
 export class CursorSessionSynchronizer implements IProviderSessionSynchronizer {
   private readonly provider = 'cursor' as const;
   private readonly cursorHome = path.join(os.homedir(), '.cursor');
 
   /**
-   * Scans Cursor chats and upserts discovered sessions into DB.
+   * Scans Cursor transcripts and upserts discovered sessions into DB.
    */
   async synchronize(since?: Date): Promise<number> {
     const projectsDir = path.join(this.cursorHome, 'projects');
@@ -54,19 +60,19 @@ export class CursorSessionSynchronizer implements IProviderSessionSynchronizer {
         continue;
       }
 
-      const workerLogPath = path.join(projectsDir, entry.name, 'worker.log');
+      const projectDir = path.join(projectsDir, entry.name);
+      const workerLogPath = path.join(projectDir, 'worker.log');
       const projectPath = await this.extractProjectPathFromWorkerLog(workerLogPath);
       if (!projectPath || seenProjectPaths.has(projectPath)) {
         continue;
       }
-
       seenProjectPaths.add(projectPath);
-      const projectHash = this.md5(projectPath);
-      const chatsDir = path.join(this.cursorHome, 'chats', projectHash);
-      const files = await findFilesRecursivelyCreatedAfter(chatsDir, '.jsonl', since ?? null);
+
+      const transcriptsDir = path.join(projectDir, 'agent-transcripts');
+      const files = await findFilesRecursivelyCreatedAfter(transcriptsDir, '.jsonl', since ?? null);
 
       for (const filePath of files) {
-        const parsed = await this.processSessionFile(filePath);
+        const parsed = await this.processSessionFile(filePath, projectPath);
         if (!parsed) {
           continue;
         }
@@ -89,7 +95,7 @@ export class CursorSessionSynchronizer implements IProviderSessionSynchronizer {
   }
 
   /**
-   * Parses and upserts one Cursor session JSONL file.
+   * Parses and upserts one Cursor session JSONL file (called by the file watcher).
    */
   async synchronizeFile(filePath: string): Promise<string | null> {
     if (!filePath.endsWith('.jsonl')) {
@@ -114,10 +120,30 @@ export class CursorSessionSynchronizer implements IProviderSessionSynchronizer {
   }
 
   /**
-   * Produces the same project hash Cursor uses in chat directory names.
+   * Walks up from a transcript file looking for the project's worker.log.
+   *
+   * Cursor has nested transcripts at varying depths over time
+   * (`agent-transcripts/<chatId>/<file>.jsonl` and
+   *  `agent-transcripts/<chatId>/<sub>/<file>.jsonl` both occur in the wild),
+   * so a fixed `dirname()` count silently skipped the deeper variant.
    */
-  private md5(input: string): string {
-    return crypto.createHash('md5').update(input).digest('hex');
+  private async findProjectDirForTranscript(filePath: string): Promise<string | null> {
+    const projectsRoot = path.join(this.cursorHome, 'projects');
+    let current = path.dirname(filePath);
+    while (current.startsWith(projectsRoot + path.sep) && current !== projectsRoot) {
+      try {
+        await fsp.access(path.join(current, 'worker.log'));
+        return current;
+      } catch {
+        // keep walking up
+      }
+      const parent = path.dirname(current);
+      if (parent === current) {
+        break;
+      }
+      current = parent;
+    }
+    return null;
   }
 
   /**
@@ -147,16 +173,25 @@ export class CursorSessionSynchronizer implements IProviderSessionSynchronizer {
   /**
    * Extracts session metadata from one Cursor JSONL session file.
    */
-  private async processSessionFile(filePath: string): Promise<ParsedSession | null> {
+  private async processSessionFile(
+    filePath: string,
+    projectPathHint?: string
+  ): Promise<ParsedSession | null> {
     const sessionId = path.basename(filePath, '.jsonl');
-    const grandparentDir = path.dirname(path.dirname(filePath));
-    const workerLogPath = path.join(grandparentDir, 'worker.log');
-    const projectPath = await this.extractProjectPathFromWorkerLog(workerLogPath);
 
+    let projectPath = projectPathHint ?? null;
     if (!projectPath) {
-      return null;
+      const projectDir = await this.findProjectDirForTranscript(filePath);
+      if (!projectDir) {
+        return null;
+      }
+      projectPath = await this.extractProjectPathFromWorkerLog(path.join(projectDir, 'worker.log'));
+      if (!projectPath) {
+        return null;
+      }
     }
 
+    const resolvedProjectPath = projectPath;
     return extractFirstValidJsonlData(filePath, (rawData) => {
       const data = rawData as Record<string, any>;
       if (data.role !== 'user') {
@@ -168,7 +203,7 @@ export class CursorSessionSynchronizer implements IProviderSessionSynchronizer {
 
       return {
         sessionId,
-        projectPath,
+        projectPath: resolvedProjectPath,
         sessionName: normalizeSessionName(firstLine, 'Untitled Cursor Session'),
       };
     });

--- a/server/modules/providers/tests/cursor-session-synchronizer.test.ts
+++ b/server/modules/providers/tests/cursor-session-synchronizer.test.ts
@@ -1,0 +1,120 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+
+const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'cursor-sync-'));
+process.env.DATABASE_PATH = path.join(tempRoot, 'auth.db');
+
+const { initializeDatabase, sessionsDb, scanStateDb } = await import(
+  '@/modules/database/index.js'
+);
+const { CursorSessionSynchronizer } = await import(
+  '@/modules/providers/list/cursor/cursor-session-synchronizer.provider.js'
+);
+const { closeConnection } = await import('@/modules/database/connection.js');
+
+const patchHomeDir = (nextHomeDir: string) => {
+  const original = os.homedir;
+  (os as any).homedir = () => nextHomeDir;
+  return () => {
+    (os as any).homedir = original;
+  };
+};
+
+const writeJsonl = async (filePath: string, rows: unknown[]) => {
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  await fs.writeFile(filePath, rows.map((r) => JSON.stringify(r)).join('\n') + '\n');
+};
+
+const userQueryRow = (text: string) => ({
+  role: 'user',
+  message: { content: [{ type: 'text', text: `<user_query>\n${text}\n</user_query>` }] },
+});
+
+/**
+ * Cursor's transcript layout has shifted over time:
+ *   - jsonl at agent-transcripts/<chatId>/<chatId>.jsonl              (current)
+ *   - jsonl at agent-transcripts/<chatId>/<sub>/<chatId>.jsonl        (older)
+ * Both must be picked up. The legacy ~/.cursor/chats/<projectHash>/
+ * directory now holds only SQLite store.db files used by the loader.
+ */
+test('CursorSessionSynchronizer indexes transcripts at both nested depths', { concurrency: false }, async () => {
+  const restoreHomeDir = patchHomeDir(tempRoot);
+  try {
+    await initializeDatabase();
+
+    const cursorHome = path.join(tempRoot, '.cursor');
+    const projectsDir = path.join(cursorHome, 'projects');
+    const projectDir = path.join(projectsDir, 'home-coder-cc-backend');
+    const transcriptsDir = path.join(projectDir, 'agent-transcripts');
+
+    await fs.mkdir(projectDir, { recursive: true });
+    await fs.writeFile(
+      path.join(projectDir, 'worker.log'),
+      [
+        '[info] starting worker',
+        '[info] Getting tree structure for workspacePath=/home/coder/cc-backend',
+      ].join('\n')
+    );
+
+    const shallowChatId = '11111111-2222-3333-4444-555555555555';
+    const shallowJsonl = path.join(transcriptsDir, shallowChatId, `${shallowChatId}.jsonl`);
+    await writeJsonl(shallowJsonl, [userQueryRow('refactor the watchtower analytics route')]);
+
+    const deepChatId = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
+    const deepJsonl = path.join(transcriptsDir, deepChatId, 'turn-001', `${deepChatId}.jsonl`);
+    await writeJsonl(deepJsonl, [userQueryRow('add a parity test for the bun build')]);
+
+    // Project that lacks worker.log — must be ignored, not crash the scan.
+    await fs.mkdir(path.join(projectsDir, 'tmp-orphan'), { recursive: true });
+    await writeJsonl(
+      path.join(projectsDir, 'tmp-orphan', 'agent-transcripts', 'orphan', 'orphan.jsonl'),
+      [userQueryRow('orphan')]
+    );
+
+    // Legacy ~/.cursor/chats SQLite presence must NOT cause indexer to claim sessions.
+    await fs.mkdir(path.join(cursorHome, 'chats', 'deadbeef'), { recursive: true });
+    await fs.writeFile(path.join(cursorHome, 'chats', 'deadbeef', 'store.db'), '');
+
+    const sync = new CursorSessionSynchronizer();
+    const processed = await sync.synchronize();
+    assert.equal(processed, 2, 'should index both shallow and deep transcripts');
+
+    const shallow = sessionsDb.getSessionById(shallowChatId);
+    assert.ok(shallow, 'shallow session indexed');
+    assert.equal(shallow!.provider, 'cursor');
+    assert.equal(shallow!.project_path, '/home/coder/cc-backend');
+    assert.match(shallow!.custom_name ?? '', /watchtower analytics/);
+
+    const deep = sessionsDb.getSessionById(deepChatId);
+    assert.ok(deep, 'deep session indexed');
+    assert.equal(deep!.project_path, '/home/coder/cc-backend');
+    assert.match(deep!.custom_name ?? '', /parity test/);
+
+    // Per-file path used by the watcher must also resolve project_path
+    // for transcripts at both depths without a hint.
+    const ad = path.join(transcriptsDir, 'cccccccc-cccc-cccc-cccc-cccccccccccc');
+    const adHocJsonl = path.join(ad, 'cccccccc-cccc-cccc-cccc-cccccccccccc.jsonl');
+    await writeJsonl(adHocJsonl, [userQueryRow('hot-added by watcher')]);
+    const indexedId = await sync.synchronizeFile(adHocJsonl);
+    assert.equal(indexedId, 'cccccccc-cccc-cccc-cccc-cccccccccccc');
+    const adHoc = sessionsDb.getSessionById('cccccccc-cccc-cccc-cccc-cccccccccccc');
+    assert.equal(adHoc!.project_path, '/home/coder/cc-backend');
+
+    // Transcripts outside ~/.cursor/projects must be rejected.
+    const outsideJsonl = path.join(tempRoot, 'random', 'dddddddd.jsonl');
+    await writeJsonl(outsideJsonl, [userQueryRow('outside cursor home')]);
+    assert.equal(await sync.synchronizeFile(outsideJsonl), null);
+
+    // Incremental rescan with `since` set to now finds nothing new.
+    scanStateDb.updateLastScannedAt(new Date(Date.now() + 60_000));
+    const reprocessed = await sync.synchronize(scanStateDb.getLastScannedAt() ?? undefined);
+    assert.equal(reprocessed, 0, 'incremental scan should skip files older than `since`');
+  } finally {
+    closeConnection();
+    restoreHomeDir();
+    await fs.rm(tempRoot, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Why

Recent cursor-agent versions write JSONL transcripts under `~/.cursor/projects/<project-dir>/agent-transcripts/<chatId>/...`. The legacy `~/.cursor/chats/<projectHash>/` directory still exists but now holds only SQLite `store.db` files, used by the loader (`cursor-sessions.provider.ts`), not JSONL the indexer can parse. Result: on `main`, `CursorSessionSynchronizer` finds zero transcripts for any current Cursor user — every initial scan returns 0, advances `scan_state.last_scanned_at`, and from then on the file watcher only catches whatever brand-new chats happen after startup.

The transcript layout itself isn't fixed either — the same install can have chats at both `agent-transcripts/<chatId>/<chatId>.jsonl` and `agent-transcripts/<chatId>/<sub>/<chatId>.jsonl`, so the hard-coded `path.dirname(path.dirname(filePath))` silently skipped the deeper variant.

## Changes
- Switch the cursor synchronizer to scan `~/.cursor/projects/<name>/agent-transcripts/` for transcripts; the legacy hashed `chats/` dir is left to the loader, which already has its own md5 hashing.
- Locate `worker.log` by walking up from the transcript file, bounded to `~/.cursor/projects`, so both nested depths work and a transcript outside the cursor home returns null instead of asserting on path arithmetic.
- Pass the already-resolved `projectPath` from the project loop into `processSessionFile` to avoid redundant per-file resolution; the watcher entry point still resolves it via the walk-up helper.
- Drop the now-dead `md5` helper and `crypto` import from the synchronizer.
- Add `server/modules/providers/tests/cursor-session-synchronizer.test.ts` covering: transcripts at both depths, a project missing `worker.log`, the legacy `chats/<hash>/store.db` presence (must not be claimed by the indexer), watcher-added transcripts, transcripts outside `~/.cursor/projects`, and the incremental `since` filter.

## Testing
1. \`TSX_TSCONFIG_PATH=server/tsconfig.json node --import tsx --test server/modules/providers/tests/cursor-session-synchronizer.test.ts\` → 1/1 pass.
2. Existing \`server/modules/providers/tests/mcp.test.ts\` → 4/4 still pass.
3. \`tsc --noEmit -p server/tsconfig.json\` → clean.
4. Smoke-tested against a real \`~/.cursor\` with 109 jsonls across two projects: pre-fix indexed 1 (the one chat that was modified after CloudCLI started, picked up by the watcher); post-fix initial scan indexes 62 — every transcript whose project has a parseable \`worker.log\`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated transcript discovery mechanism to use location-aware detection instead of hash-based lookup, improving reliability across varying project structures and directory layouts.

* **Tests**
  * Added comprehensive test coverage for transcript indexing behavior, including edge cases and multiple directory structure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->