### PR TITLE
feat: lazy-loading file tree with on-demand directory expansion

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -587,7 +587,8 @@ app.get('/api/projects/:projectId/files', authenticateToken, async (req, res) =>
             return res.status(404).json({ error: `Project path not found: ${actualPath}` });
         }
 
-        const files = await getFileTree(actualPath, 1, 0, true);
+        const depth = Math.min(parseInt(req.query.depth) || 1, 10);
+        const files = await getFileTree(actualPath, depth, 0, true);
         res.json(files);
     } catch (error) {
         console.error('[ERROR] File tree error:', error.message);

--- a/server/index.js
+++ b/server/index.js
@@ -587,10 +587,46 @@ app.get('/api/projects/:projectId/files', authenticateToken, async (req, res) =>
             return res.status(404).json({ error: `Project path not found: ${actualPath}` });
         }
 
-        const files = await getFileTree(actualPath, 10, 0, true);
+        const files = await getFileTree(actualPath, 1, 0, true);
         res.json(files);
     } catch (error) {
         console.error('[ERROR] File tree error:', error.message);
+        res.status(500).json({ error: error.message });
+    }
+});
+
+// Lazy-load directory children for on-demand expansion
+app.get('/api/projects/:projectId/files/children', authenticateToken, async (req, res) => {
+    try {
+        const { dirPath } = req.query;
+        if (!dirPath || typeof dirPath !== 'string') {
+            return res.status(400).json({ error: 'dirPath query parameter is required' });
+        }
+
+        const projectPath = await projectsDb.getProjectPathById(req.params.projectId);
+        if (!projectPath) {
+            return res.status(404).json({ error: 'Project not found' });
+        }
+
+        // Security: ensure resolved path is within project directory
+        const resolvedDir = path.resolve(dirPath);
+        if (!resolvedDir.startsWith(projectPath)) {
+            return res.status(403).json({ error: 'Path is outside project directory' });
+        }
+
+        try {
+            const stats = await fsPromises.stat(resolvedDir);
+            if (!stats.isDirectory()) {
+                return res.status(400).json({ error: 'Path is not a directory' });
+            }
+        } catch (e) {
+            return res.status(404).json({ error: 'Directory not found' });
+        }
+
+        const children = await getFileTree(resolvedDir, 1, 0, true);
+        res.json(children);
+    } catch (error) {
+        console.error('[ERROR] File tree children error:', error.message);
         res.status(500).json({ error: error.message });
     }
 });

--- a/src/components/command-palette/sources/useFilesSource.ts
+++ b/src/components/command-palette/sources/useFilesSource.ts
@@ -31,7 +31,7 @@ export function useFilesSource(projectId: string | undefined, enabled: boolean) 
   return useApiSource<FileResult, unknown>({
     enabled: enabled && !!projectId,
     deps: [projectId],
-    fetcher: (signal) => api.getFiles(projectId!, { signal }),
+    fetcher: (signal) => api.getFilesDeep(projectId!, 5, { signal }),
     parse: (data) => {
       const tree: FileNode[] = Array.isArray(data) ? (data as FileNode[]) : [];
       const flat: FileResult[] = [];

--- a/src/components/file-tree/hooks/useFileTreeData.ts
+++ b/src/components/file-tree/hooks/useFileTreeData.ts
@@ -6,12 +6,30 @@ import type { FileTreeNode } from '../types/types';
 type UseFileTreeDataResult = {
   files: FileTreeNode[];
   loading: boolean;
+  loadingDirs: Set<string>;
   refreshFiles: () => void;
+  loadDirectoryChildren: (dirPath: string) => Promise<void>;
 };
+
+function insertChildren(tree: FileTreeNode[], dirPath: string, children: FileTreeNode[]): boolean {
+  for (const node of tree) {
+    if (node.path === dirPath) {
+      node.children = children;
+      return true;
+    }
+    if (node.children) {
+      if (insertChildren(node.children, dirPath, children)) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
 
 export function useFileTreeData(selectedProject: Project | null): UseFileTreeDataResult {
   const [files, setFiles] = useState<FileTreeNode[]>([]);
   const [loading, setLoading] = useState(false);
+  const [loadingDirs, setLoadingDirs] = useState<Set<string>>(() => new Set());
   const [refreshKey, setRefreshKey] = useState(0);
   const abortControllerRef = useRef<AbortController | null>(null);
 
@@ -20,8 +38,6 @@ export function useFileTreeData(selectedProject: Project | null): UseFileTreeDat
   }, []);
 
   useEffect(() => {
-    // File-tree requests use the DB projectId; the backend resolves it to the
-    // project's absolute path through the projects table.
     const projectId = selectedProject?.projectId;
 
     if (!projectId) {
@@ -30,13 +46,11 @@ export function useFileTreeData(selectedProject: Project | null): UseFileTreeDat
       return;
     }
 
-    // Abort previous request
     if (abortControllerRef.current) {
       abortControllerRef.current.abort();
     }
     abortControllerRef.current = new AbortController();
 
-    // Track mount state so aborted or late responses do not enqueue stale state updates.
     let isActive = true;
 
     const fetchFiles = async () => {
@@ -83,9 +97,38 @@ export function useFileTreeData(selectedProject: Project | null): UseFileTreeDat
     };
   }, [selectedProject?.projectId, refreshKey]);
 
+  const loadDirectoryChildren = useCallback(async (dirPath: string) => {
+    const projectId = selectedProject?.projectId;
+    if (!projectId) return;
+
+    setLoadingDirs((prev) => new Set(prev).add(dirPath));
+
+    try {
+      const response = await api.getFileChildren(projectId, dirPath);
+      if (!response.ok) return;
+
+      const children = (await response.json()) as FileTreeNode[];
+      setFiles((prevFiles) => {
+        const newTree = JSON.parse(JSON.stringify(prevFiles)) as FileTreeNode[];
+        insertChildren(newTree, dirPath, children);
+        return newTree;
+      });
+    } catch (error) {
+      console.error('Error loading directory children:', error);
+    } finally {
+      setLoadingDirs((prev) => {
+        const next = new Set(prev);
+        next.delete(dirPath);
+        return next;
+      });
+    }
+  }, [selectedProject?.projectId]);
+
   return {
     files,
     loading,
+    loadingDirs,
     refreshFiles,
+    loadDirectoryChildren,
   };
 }

--- a/src/components/file-tree/hooks/useFileTreeData.ts
+++ b/src/components/file-tree/hooks/useFileTreeData.ts
@@ -8,6 +8,7 @@ type UseFileTreeDataResult = {
   loading: boolean;
   loadingDirs: Set<string>;
   refreshFiles: () => void;
+  refreshDirectory: (dirPath: string) => Promise<void>;
   loadDirectoryChildren: (dirPath: string) => Promise<void>;
 };
 
@@ -124,11 +125,31 @@ export function useFileTreeData(selectedProject: Project | null): UseFileTreeDat
     }
   }, [selectedProject?.projectId]);
 
+  const refreshDirectory = useCallback(async (dirPath: string) => {
+    const projectId = selectedProject?.projectId;
+    if (!projectId) return;
+
+    try {
+      const response = await api.getFileChildren(projectId, dirPath);
+      if (!response.ok) return;
+
+      const children = (await response.json()) as FileTreeNode[];
+      setFiles((prevFiles) => {
+        const newTree = JSON.parse(JSON.stringify(prevFiles)) as FileTreeNode[];
+        insertChildren(newTree, dirPath, children);
+        return newTree;
+      });
+    } catch (error) {
+      console.error('Error refreshing directory:', error);
+    }
+  }, [selectedProject?.projectId]);
+
   return {
     files,
     loading,
     loadingDirs,
     refreshFiles,
+    refreshDirectory,
     loadDirectoryChildren,
   };
 }

--- a/src/components/file-tree/hooks/useFileTreeOperations.ts
+++ b/src/components/file-tree/hooks/useFileTreeOperations.ts
@@ -21,7 +21,7 @@ export type DeleteConfirmation = {
 
 export type UseFileTreeOperationsOptions = {
   selectedProject: Project | null;
-  onRefresh: () => void;
+  onRefresh: (dirPath?: string) => void;
   showToast: (message: string, type: 'success' | 'error') => void;
 };
 
@@ -137,7 +137,7 @@ export function useFileTreeOperations({
       }
 
       showToast(t('fileTree.toast.renamed', 'Renamed successfully'), 'success');
-      onRefresh();
+      onRefresh(renamingItem.path.substring(0, renamingItem.path.lastIndexOf('/')));
       handleCancelRename();
     } catch (err) {
       showToast((err as Error).message, 'error');
@@ -177,7 +177,7 @@ export function useFileTreeOperations({
           : t('fileTree.toast.fileDeleted', 'File deleted'),
         'success'
       );
-      onRefresh();
+      onRefresh(item.path.substring(0, item.path.lastIndexOf('/')));
       handleCancelDelete();
     } catch (err) {
       showToast((err as Error).message, 'error');
@@ -229,7 +229,7 @@ export function useFileTreeOperations({
           : t('fileTree.toast.folderCreated', 'Folder created successfully'),
         'success'
       );
-      onRefresh();
+      onRefresh(newItemParent || selectedProject?.path);
       handleCancelCreate();
     } catch (err) {
       showToast((err as Error).message, 'error');

--- a/src/components/file-tree/view/FileTree.tsx
+++ b/src/components/file-tree/view/FileTree.tsx
@@ -45,7 +45,7 @@ export default function FileTree({ selectedProject, onFileOpen }: FileTreeProps)
     }
   }, [toast]);
 
-  const { files, loading, refreshFiles } = useFileTreeData(selectedProject);
+  const { files, loading, loadingDirs, refreshFiles, loadDirectoryChildren } = useFileTreeData(selectedProject);
   const { viewMode, changeViewMode } = useFileTreeViewMode();
   const { expandedDirs, toggleDirectory, expandDirectories, collapseAll } = useExpandedDirectories();
   const { searchQuery, setSearchQuery, filteredFiles } = useFileTreeSearch({
@@ -93,6 +93,9 @@ export default function FileTree({ selectedProject, onFileOpen }: FileTreeProps)
     (item: FileTreeNode) => {
       if (item.type === 'directory') {
         toggleDirectory(item.path);
+        if (item.children === undefined || item.children === null) {
+          loadDirectoryChildren(item.path);
+        }
         return;
       }
 
@@ -110,7 +113,7 @@ export default function FileTree({ selectedProject, onFileOpen }: FileTreeProps)
 
       onFileOpen?.(item.path);
     },
-    [onFileOpen, selectedProject, toggleDirectory],
+    [onFileOpen, selectedProject, toggleDirectory, loadDirectoryChildren],
   );
 
   const formatRelativeTimeLabel = useCallback(
@@ -195,6 +198,7 @@ export default function FileTree({ selectedProject, onFileOpen }: FileTreeProps)
           searchQuery={searchQuery}
           viewMode={viewMode}
           expandedDirs={expandedDirs}
+          loadingDirs={loadingDirs}
           onItemClick={handleItemClick}
           renderFileIcon={renderFileIcon}
           formatFileSize={formatFileSize}

--- a/src/components/file-tree/view/FileTree.tsx
+++ b/src/components/file-tree/view/FileTree.tsx
@@ -45,7 +45,7 @@ export default function FileTree({ selectedProject, onFileOpen }: FileTreeProps)
     }
   }, [toast]);
 
-  const { files, loading, loadingDirs, refreshFiles, loadDirectoryChildren } = useFileTreeData(selectedProject);
+  const { files, loading, loadingDirs, refreshFiles, refreshDirectory, loadDirectoryChildren } = useFileTreeData(selectedProject);
   const { viewMode, changeViewMode } = useFileTreeViewMode();
   const { expandedDirs, toggleDirectory, expandDirectories, collapseAll } = useExpandedDirectories();
   const { searchQuery, setSearchQuery, filteredFiles } = useFileTreeSearch({
@@ -54,9 +54,17 @@ export default function FileTree({ selectedProject, onFileOpen }: FileTreeProps)
   });
 
   // File operations
+  const handleRefresh = useCallback((dirPath?: string) => {
+    if (dirPath) {
+      refreshDirectory(dirPath);
+    } else {
+      refreshFiles();
+    }
+  }, [refreshDirectory, refreshFiles]);
+
   const operations = useFileTreeOperations({
     selectedProject,
-    onRefresh: refreshFiles,
+    onRefresh: handleRefresh,
     showToast,
   });
 

--- a/src/components/file-tree/view/FileTreeBody.tsx
+++ b/src/components/file-tree/view/FileTreeBody.tsx
@@ -11,6 +11,7 @@ type FileTreeBodyProps = {
   searchQuery: string;
   viewMode: FileTreeViewMode;
   expandedDirs: Set<string>;
+  loadingDirs: Set<string>;
   onItemClick: (item: FileTreeNode) => void;
   renderFileIcon: (filename: string) => ReactNode;
   formatFileSize: (bytes?: number) => string;
@@ -38,6 +39,7 @@ export default function FileTreeBody({
   searchQuery,
   viewMode,
   expandedDirs,
+  loadingDirs,
   onItemClick,
   renderFileIcon,
   formatFileSize,
@@ -78,6 +80,7 @@ export default function FileTreeBody({
           items={filteredFiles}
           viewMode={viewMode}
           expandedDirs={expandedDirs}
+          loadingDirs={loadingDirs}
           onItemClick={onItemClick}
           renderFileIcon={renderFileIcon}
           formatFileSize={formatFileSize}

--- a/src/components/file-tree/view/FileTreeList.tsx
+++ b/src/components/file-tree/view/FileTreeList.tsx
@@ -6,6 +6,7 @@ type FileTreeListProps = {
   items: FileTreeNodeType[];
   viewMode: FileTreeViewMode;
   expandedDirs: Set<string>;
+  loadingDirs: Set<string>;
   onItemClick: (item: FileTreeNodeType) => void;
   renderFileIcon: (filename: string) => ReactNode;
   formatFileSize: (bytes?: number) => string;
@@ -31,6 +32,7 @@ export default function FileTreeList({
   items,
   viewMode,
   expandedDirs,
+  loadingDirs,
   onItemClick,
   renderFileIcon,
   formatFileSize,
@@ -59,6 +61,7 @@ export default function FileTreeList({
           level={0}
           viewMode={viewMode}
           expandedDirs={expandedDirs}
+          loadingDirs={loadingDirs}
           onItemClick={onItemClick}
           renderFileIcon={renderFileIcon}
           formatFileSize={formatFileSize}

--- a/src/components/file-tree/view/FileTreeNode.tsx
+++ b/src/components/file-tree/view/FileTreeNode.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode, RefObject } from 'react';
-import { ChevronRight, Folder, FolderOpen } from 'lucide-react';
+import { ChevronRight, Folder, FolderOpen, Loader2 } from 'lucide-react';
 import { cn } from '../../../lib/utils';
 import type { FileTreeNode as FileTreeNodeType, FileTreeViewMode } from '../types/types';
 import { Input } from '../../../shared/view/ui';
@@ -10,6 +10,7 @@ type FileTreeNodeProps = {
   level: number;
   viewMode: FileTreeViewMode;
   expandedDirs: Set<string>;
+  loadingDirs?: Set<string>;
   onItemClick: (item: FileTreeNodeType) => void;
   renderFileIcon: (filename: string) => ReactNode;
   formatFileSize: (bytes?: number) => string;
@@ -64,6 +65,7 @@ export default function FileTreeNode({
   level,
   viewMode,
   expandedDirs,
+  loadingDirs,
   onItemClick,
   renderFileIcon,
   formatFileSize,
@@ -85,7 +87,8 @@ export default function FileTreeNode({
 }: FileTreeNodeProps) {
   const isDirectory = item.type === 'directory';
   const isOpen = isDirectory && expandedDirs.has(item.path);
-  const hasChildren = Boolean(isDirectory && item.children && item.children.length > 0);
+  const hasChildren = isDirectory;
+  const isLoading = isDirectory && loadingDirs?.has(item.path);
   const isRenaming = renamingItem?.path === item.path;
 
   const nameClassName = cn(
@@ -201,18 +204,25 @@ export default function FileTreeNode({
 
       {isDirectory && isOpen && hasChildren && (
         <div className="relative">
+          {isLoading ? (
+            <div className="py-1" style={{ paddingLeft: `${(level + 1) * 16 + 4}px` }}>
+              <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
+            </div>
+          ) : item.children && item.children.length > 0 ? (
+          <>
           <span
             className="absolute bottom-0 top-0 border-l border-border/40"
             style={{ left: `${level * 16 + 14}px` }}
             aria-hidden="true"
           />
-          {item.children?.map((child) => (
+          {item.children.map((child) => (
             <FileTreeNode
               key={child.path}
               item={child}
               level={level + 1}
               viewMode={viewMode}
               expandedDirs={expandedDirs}
+              loadingDirs={loadingDirs}
               onItemClick={onItemClick}
               renderFileIcon={renderFileIcon}
               formatFileSize={formatFileSize}
@@ -233,6 +243,8 @@ export default function FileTreeNode({
               operationLoading={operationLoading}
             />
           ))}
+          </>
+          ) : null}
         </div>
       )}
     </div>

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -128,6 +128,9 @@ export const api = {
   getFiles: (projectId, options = {}) =>
     authenticatedFetch(`/api/projects/${projectId}/files`, options),
 
+  getFileChildren: (projectId, dirPath, options = {}) =>
+    authenticatedFetch(`/api/projects/${projectId}/files/children?dirPath=${encodeURIComponent(dirPath)}`, options),
+
   // File operations
   createFile: (projectId, { path, type, name }) =>
     authenticatedFetch(`/api/projects/${projectId}/files/create`, {

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -128,6 +128,9 @@ export const api = {
   getFiles: (projectId, options = {}) =>
     authenticatedFetch(`/api/projects/${projectId}/files`, options),
 
+  getFilesDeep: (projectId, depth = 5, options = {}) =>
+    authenticatedFetch(`/api/projects/${projectId}/files?depth=${depth}`, options),
+
   getFileChildren: (projectId, dirPath, options = {}) =>
     authenticatedFetch(`/api/projects/${projectId}/files/children?dirPath=${encodeURIComponent(dirPath)}`, options),
 


### PR DESCRIPTION
## Summary

- Replace deep recursive file tree loading (maxDepth=10) with shallow initial load (maxDepth=1) and on-demand child fetching when directories are expanded
- Prevents Invalid string length errors on large projects and significantly reduces initial load time

## Changes

### Backend
- Reduce initial file tree maxDepth from 10 to 1
- Add GET /api/projects/:projectId/files/children?dirPath=... endpoint for lazy loading with path traversal security validation

### Frontend
- useFileTreeData: Add loadDirectoryChildren() with loadingDirs state and insertChildren() tree merge helper
- FileTree: Trigger lazy-load when expanding a directory whose children have not been fetched
- FileTreeNode: Show Loader2 spinner while fetching children
- api.js: Add getFileChildren() method
- Thread loadingDirs prop through FileTreeBody and FileTreeList

## Test plan
- [x] Frontend builds without TypeScript errors
- [x] Backend maxDepth=1 verified with Node.js test
- [ ] Manual browser test: expand sub-directory and verify lazy load
- [ ] Loading spinner appears while fetching
- [ ] No regression on file operations (create, rename, delete)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Directories are lazy-loaded on demand when expanded, with per-directory loading indicators.
  * File listing supports a configurable depth (defaults to 1, capped for safety) for broader or shallower views.
  * Command palette fetches a deeper file view for more comprehensive results.

* **Improvements**
  * Abort previous file-list requests to avoid stale results and improve responsiveness.
  * Refreshes can target specific directories to update scoped views.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->