### PR TITLE
docs: add claude-watch to Available Plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ CloudCLI has a plugin system that lets you add custom tabs with their own fronte
 | **[Project Stats](https://github.com/cloudcli-ai/cloudcli-plugin-starter)** | Shows file counts, lines of code, file-type breakdown, largest files, and recently modified files for your current project |
 | **[Web Terminal](https://github.com/cloudcli-ai/cloudcli-plugin-terminal)** | Full xterm.js terminal with multi-tab support|
 | **[CloudCLI Scheduler](https://github.com/grostim/cloudcli-cron)** | Create workspace-scoped scheduled prompts and execute them through a local CLI such as Codex, Claude Code, or Gemini CLI|
+| **[claude-watch](https://github.com/satsuki19980613/cloudcli-claude-watch)** | Surfaces Claude Code stalls from a watchdog log as a tab — expand to see process details, kill the offending PID, and highlight stalls under the current project |
 ### Build Your Own
 
 **[Plugin Starter Template →](https://github.com/cloudcli-ai/cloudcli-plugin-starter)** — fork this repo to create your own plugin. It includes a working example with frontend rendering, live context updates, and RPC communication to a backend server.

--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ CloudCLI has a plugin system that lets you add custom tabs with their own fronte
 | **[Web Terminal](https://github.com/cloudcli-ai/cloudcli-plugin-terminal)** | Full xterm.js terminal with multi-tab support|
 | **[CloudCLI Scheduler](https://github.com/grostim/cloudcli-cron)** | Create workspace-scoped scheduled prompts and execute them through a local CLI such as Codex, Claude Code, or Gemini CLI|
 | **[claude-watch](https://github.com/satsuki19980613/cloudcli-claude-watch)** | Surfaces Claude Code stalls from a watchdog log as a tab — expand to see process details, kill the offending PID, and highlight stalls under the current project |
+
 ### Build Your Own
 
 **[Plugin Starter Template →](https://github.com/cloudcli-ai/cloudcli-plugin-starter)** — fork this repo to create your own plugin. It includes a working example with frontend rendering, live context updates, and RPC communication to a backend server.


### PR DESCRIPTION
## What is this plugin?

**[cloudcli-claude-watch](https://github.com/satsuki19980613/cloudcli-claude-watch)** is a CloudCLI plugin adapter for [claude-watch](https://github.com/satsuki19980613/claude-watch), a watchdog tool for Claude Code.

When Claude Code stalls (a common pain point for long-running sessions), `claude-watch` writes stall alerts to `~/.claude/watchdog.log`. This plugin surfaces those alerts as a CloudCLI tab so you can:

- **See** active stalls with process details (cmdline, cwd, uid, start time, git branch)
- **Kill** the offending PID with SIGTERM/SIGKILL via a confirmation dialog
- **Identify** stalls belonging to the currently selected project (highlighted in blue)

## Verified on CloudCLI v1.31.5

Installed via Settings → Plugins (git URL), dogfooded end-to-end:

- Tab renders with live polling
- Stall row expands → shows process + git details
- SIGTERM dialog appears and kills the process
- In-project highlight works when the stall's cwd matches the active project

### Screenshots

| Empty state | Stall expanded | Kill dialog | In-project highlight |
|---|---|---|---|
| ![empty](https://raw.githubusercontent.com/satsuki19980613/cloudcli-claude-watch/main/docs/screenshots/tab-empty.png) | ![expanded](https://raw.githubusercontent.com/satsuki19980613/cloudcli-claude-watch/main/docs/screenshots/tab-stall-expanded.png) | ![kill](https://raw.githubusercontent.com/satsuki19980613/cloudcli-claude-watch/main/docs/screenshots/tab-kill-dialog.png) | ![in-project](https://raw.githubusercontent.com/satsuki19980613/cloudcli-claude-watch/main/docs/screenshots/tab-in-project.png) |

Full screenshot index: [docs/screenshots/README.md](https://github.com/satsuki19980613/cloudcli-claude-watch/blob/main/docs/screenshots/README.md)

## Details

- **Install**: paste `https://github.com/satsuki19980613/cloudcli-claude-watch.git` into Settings → Plugins
- **License**: MIT
- **Prerequisite**: [`@satsuki0710624/claude-watch`](https://www.npmjs.com/package/@satsuki0710624/claude-watch) running and writing to `~/.claude/watchdog.log`
- **Maintainer**: [@satsuki19980613](https://github.com/satsuki19980613)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added the "claude-watch" plugin to Available Plugins. Visible features: watchdog log with tab-level visibility, expandable process details, controls to terminate offending PIDs, and highlighting of stalls scoped to the current project.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/siteboon/claudecodeui/pull/761)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->