### PR TITLE
fix(chat): refresh messages from server after streaming completes / 流式传输完成后从服务器刷新消息

### DIFF
--- a/src/components/chat/hooks/useChatRealtimeHandlers.ts
+++ b/src/components/chat/hooks/useChatRealtimeHandlers.ts
@@ -260,6 +260,13 @@ export function useChatRealtimeHandlers({
         }
         accumulatedStreamRef.current = '';
 
+        // Refresh from server so the canonical JSONL history replaces any
+        // client-side streaming echoes, and the chat view shows the final
+        // committed messages instead of stale realtime copies.
+        if (sid) {
+          void sessionStore.refreshFromServer(sid);
+        }
+
         setIsLoading(false);
         setCanAbortSession(false);
         setClaudeStatus(null);


### PR DESCRIPTION
## Summary / 摘要

流式传输结束后，聊天界面显示过时或重复的内容。

完成处理器更新了内部状态但未调用 `refreshFromServer()`，导致客户端流式数据的"回声"持续显示。

---

The chat UI displayed stale or duplicated content after WebSocket streaming finished. The `complete` handler finalized internal state but did not call `refreshFromServer()`, causing client-side streaming echoes to persist.

## Fix / 修复方案

在 `complete` handler 中直接调用 `refreshFromServer()`，确保服务器端的权威消息历史替换所有客户端流式数据。

---

Added `sessionStore.refreshFromServer(sid)` in the `complete` handler before clearing loading state, guaranteeing the canonical server-side message history replaces all client-side streaming data.

## Test plan / 测试计划

- [ ] 流式传输完成后，界面显示最终消息，无重复
- [ ] 切换会话时显示正确更新
- [ ] 构建通过
- [ ] After streaming completes, UI shows final messages without duplicates
- [ ] Session switching updates correctly
- [ ] Build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)