### PR TITLE
feat(chat): add scroll navigation with dots and quick-jump buttons / 添加滚动导航圆点和快速跳转按钮

### DIFF
--- a/src/components/chat/hooks/useChatMessages.ts
+++ b/src/components/chat/hooks/useChatMessages.ts
@@ -44,7 +44,7 @@ export function normalizedToChatMessages(messages: NormalizedMessage[]): ChatMes
 
         if (msg.role === 'user') {
           // Parse task notifications
-          const taskNotifRegex = /<task-notification>\s*<task-id>[^<]*<\/task-id>\s*<output-file>[^<]*<\/output-file>\s*<status>([^<]*)<\/status>\s*<summary>([^<]*)<\/summary>\s*<\/task-notification>/g;
+          const taskNotifRegex = /<task-notification>[\s\S]*?<status>([^<]*)<\/status>[\s\S]*?<summary>([^<]*)<\/summary>[\s\S]*?<\/task-notification>/;
           const taskNotifMatch = taskNotifRegex.exec(content);
           if (taskNotifMatch) {
             converted.push({

--- a/src/components/chat/view/ChatInterface.tsx
+++ b/src/components/chat/view/ChatInterface.tsx
@@ -305,6 +305,7 @@ function ChatInterface({
             scrollContainerRef={scrollContainerRef}
             chatMessages={chatMessages}
           />
+          <div className="absolute inset-0">
           <ChatMessagesPane
           scrollContainerRef={scrollContainerRef}
           onWheel={handleScroll}
@@ -349,6 +350,7 @@ function ChatInterface({
           showThinking={showThinking}
           selectedProject={selectedProject}
         />
+          </div>
         </div>
 
         <ChatComposer

--- a/src/components/chat/view/ChatInterface.tsx
+++ b/src/components/chat/view/ChatInterface.tsx
@@ -304,6 +304,10 @@ function ChatInterface({
           <ScrollNavigation
             scrollContainerRef={scrollContainerRef}
             chatMessages={chatMessages}
+            loadAllMessages={loadAllMessages}
+            allMessagesLoaded={allMessagesLoaded}
+            totalMessages={totalMessages}
+            sessionMessagesCount={chatMessages.length}
           />
           <div className="absolute inset-0">
           <ChatMessagesPane

--- a/src/components/chat/view/ChatInterface.tsx
+++ b/src/components/chat/view/ChatInterface.tsx
@@ -14,6 +14,7 @@ import { useSessionStore } from '../../../stores/useSessionStore';
 
 import ChatMessagesPane from './subcomponents/ChatMessagesPane';
 import ChatComposer from './subcomponents/ChatComposer';
+import ScrollNavigation from './subcomponents/ScrollNavigation';
 
 
 type PendingViewSession = {
@@ -299,7 +300,12 @@ function ChatInterface({
   return (
     <PermissionContext.Provider value={permissionContextValue}>
       <div className="flex h-full flex-col">
-        <ChatMessagesPane
+        <div className="relative flex-1">
+          <ScrollNavigation
+            scrollContainerRef={scrollContainerRef}
+            chatMessages={chatMessages}
+          />
+          <ChatMessagesPane
           scrollContainerRef={scrollContainerRef}
           onWheel={handleScroll}
           onTouchMove={handleScroll}
@@ -343,6 +349,7 @@ function ChatInterface({
           showThinking={showThinking}
           selectedProject={selectedProject}
         />
+        </div>
 
         <ChatComposer
           pendingPermissionRequests={pendingPermissionRequests}

--- a/src/components/chat/view/subcomponents/ChatMessagesPane.tsx
+++ b/src/components/chat/view/subcomponents/ChatMessagesPane.tsx
@@ -256,6 +256,8 @@ export default function ChatMessagesPane({
       <ScrollNavigation
         scrollContainerRef={scrollContainerRef}
         chatMessages={chatMessages}
+        allMessagesLoaded={allMessagesLoaded}
+        loadAllMessages={loadAllMessages}
       />
     </div>
   );

--- a/src/components/chat/view/subcomponents/ChatMessagesPane.tsx
+++ b/src/components/chat/view/subcomponents/ChatMessagesPane.tsx
@@ -6,7 +6,6 @@ import type { Project, ProjectSession, LLMProvider } from '../../../../types/app
 import { getIntrinsicMessageKey } from '../../utils/messageKeys';
 import MessageComponent from './MessageComponent';
 import ProviderSelectionEmptyState from './ProviderSelectionEmptyState';
-import ScrollNavigation from './ScrollNavigation';
 
 interface ChatMessagesPaneProps {
   scrollContainerRef: RefObject<HTMLDivElement>;
@@ -131,7 +130,7 @@ export default function ChatMessagesPane({
       ref={scrollContainerRef}
       onWheel={onWheel}
       onTouchMove={onTouchMove}
-      className="relative flex-1 space-y-3 overflow-y-auto overflow-x-hidden px-0 py-3 sm:space-y-4 sm:p-4"
+      className="relative h-full space-y-3 overflow-y-auto overflow-x-hidden px-0 py-3 sm:space-y-4 sm:p-4"
     >
       {isLoadingSessionMessages && chatMessages.length === 0 ? (
         <div className="mt-8 text-center text-gray-500 dark:text-gray-400">
@@ -252,13 +251,6 @@ export default function ChatMessagesPane({
           })}
         </>
       )}
-
-      <ScrollNavigation
-        scrollContainerRef={scrollContainerRef}
-        chatMessages={chatMessages}
-        allMessagesLoaded={allMessagesLoaded}
-        loadAllMessages={loadAllMessages}
-      />
     </div>
   );
 }

--- a/src/components/chat/view/subcomponents/ChatMessagesPane.tsx
+++ b/src/components/chat/view/subcomponents/ChatMessagesPane.tsx
@@ -6,6 +6,7 @@ import type { Project, ProjectSession, LLMProvider } from '../../../../types/app
 import { getIntrinsicMessageKey } from '../../utils/messageKeys';
 import MessageComponent from './MessageComponent';
 import ProviderSelectionEmptyState from './ProviderSelectionEmptyState';
+import ScrollNavigation from './ScrollNavigation';
 
 interface ChatMessagesPaneProps {
   scrollContainerRef: RefObject<HTMLDivElement>;
@@ -251,6 +252,11 @@ export default function ChatMessagesPane({
           })}
         </>
       )}
+
+      <ScrollNavigation
+        scrollContainerRef={scrollContainerRef}
+        chatMessages={chatMessages}
+      />
     </div>
   );
 }

--- a/src/components/chat/view/subcomponents/ScrollNavigation.tsx
+++ b/src/components/chat/view/subcomponents/ScrollNavigation.tsx
@@ -110,10 +110,10 @@ export default function ScrollNavigation({
 
   return (
     <div
-      className="pointer-events-none absolute right-0 top-0 z-10 h-full w-5"
+      className="pointer-events-none absolute right-0 top-0 z-10 h-full w-4"
     >
       <div
-        className={`pointer-events-auto flex h-full w-3 flex-col items-center justify-evenly rounded-full border px-0 py-4 backdrop-blur-sm transition-opacity duration-200 ${
+        className={`pointer-events-auto flex h-full w-2 flex-col items-center justify-evenly rounded-full border px-0 py-4 backdrop-blur-sm transition-opacity duration-200 ${
           isStripHovered ? 'opacity-100' : 'opacity-50'
         } bg-background/80 border-border/50`}
         onMouseEnter={() => setIsStripHovered(true)}

--- a/src/components/chat/view/subcomponents/ScrollNavigation.tsx
+++ b/src/components/chat/view/subcomponents/ScrollNavigation.tsx
@@ -6,6 +6,8 @@ import Tooltip from '../../../../shared/view/ui/Tooltip';
 interface ScrollNavigationProps {
   scrollContainerRef: React.RefObject<HTMLDivElement | null>;
   chatMessages: ChatMessage[];
+  allMessagesLoaded: boolean;
+  loadAllMessages: () => void;
 }
 
 function truncateSnippet(content: string): string {
@@ -15,19 +17,40 @@ function truncateSnippet(content: string): string {
     .slice(0, 60) + ((content || '').length > 60 ? '...' : '');
 }
 
-export default function ScrollNavigation({ scrollContainerRef, chatMessages }: ScrollNavigationProps) {
+export default function ScrollNavigation({
+  scrollContainerRef,
+  chatMessages,
+  allMessagesLoaded,
+  loadAllMessages,
+}: ScrollNavigationProps) {
   const { t } = useTranslation('chat');
   const [activeDotIndex, setActiveDotIndex] = useState(-1);
   const [isStripHovered, setIsStripHovered] = useState(false);
   const rafIdRef = useRef<number | null>(null);
   const mountedRef = useRef(true);
+  const loadAllCalledRef = useRef(false);
 
   const userMessages = useMemo(
     () => chatMessages.filter((m) => m.type === 'user'),
     [chatMessages],
   );
 
-  const shouldShow = userMessages.length >= 3;
+  const shouldShow = userMessages.length >= 1;
+
+  // Auto-load all messages on first mount so every dot appears
+  useEffect(() => {
+    if (!allMessagesLoaded && !loadAllCalledRef.current && userMessages.length > 0) {
+      loadAllCalledRef.current = true;
+      loadAllMessages();
+    }
+  }, [allMessagesLoaded, loadAllMessages, userMessages.length]);
+
+  // Reset loadAllCalledRef when session changes (messages become empty then refill)
+  useEffect(() => {
+    if (chatMessages.length === 0) {
+      loadAllCalledRef.current = false;
+    }
+  }, [chatMessages.length]);
 
   const scheduleUpdate = useCallback(() => {
     if (rafIdRef.current != null) return;
@@ -61,22 +84,18 @@ export default function ScrollNavigation({ scrollContainerRef, chatMessages }: S
     });
   }, [scrollContainerRef]);
 
-  // Scroll listener for active dot tracking
   useEffect(() => {
     const container = scrollContainerRef.current;
     if (!container) return;
-
     container.addEventListener('scroll', scheduleUpdate, { passive: true });
     return () => container.removeEventListener('scroll', scheduleUpdate);
   }, [scrollContainerRef, scheduleUpdate]);
 
-  // Initial position + re-compute when messages change
   useEffect(() => {
-    const timer = setTimeout(() => scheduleUpdate(), 200);
+    const timer = setTimeout(() => scheduleUpdate(), 300);
     return () => clearTimeout(timer);
   }, [chatMessages.length, scheduleUpdate]);
 
-  // Cleanup RAF on unmount
   useEffect(() => {
     mountedRef.current = true;
     return () => {
@@ -100,6 +119,8 @@ export default function ScrollNavigation({ scrollContainerRef, chatMessages }: S
 
   if (!shouldShow) return null;
 
+  const totalDots = userMessages.length;
+
   return (
     <div
       className="pointer-events-none absolute right-0.5 top-1/2 z-10 flex -translate-y-1/2 flex-col items-center"
@@ -107,8 +128,8 @@ export default function ScrollNavigation({ scrollContainerRef, chatMessages }: S
       onMouseLeave={() => setIsStripHovered(false)}
     >
       <div
-        className={`pointer-events-auto flex flex-col items-center rounded-full border py-2 backdrop-blur-sm transition-opacity duration-200 ${
-          isStripHovered ? 'opacity-100' : 'opacity-40'
+        className={`pointer-events-auto flex flex-col items-center rounded-full border px-1.5 py-3 backdrop-blur-sm transition-opacity duration-200 ${
+          isStripHovered ? 'opacity-100' : 'opacity-50'
         } bg-background/80 border-border/50`}
       >
         {userMessages.map((msg, i) => {
@@ -128,12 +149,14 @@ export default function ScrollNavigation({ scrollContainerRef, chatMessages }: S
               <button
                 type="button"
                 onClick={() => scrollToDot(i)}
-                className={`block rounded-full transition-all duration-150 ${
+                className={`block cursor-pointer rounded-full transition-all duration-150 ${
                   isActive
-                    ? 'h-[6px] w-[6px] bg-blue-500 hover:bg-blue-400'
-                    : 'h-[4px] w-[4px] bg-muted-foreground/60 hover:bg-muted-foreground'
+                    ? 'h-[8px] w-[8px] bg-blue-500 hover:bg-blue-400'
+                    : 'h-[6px] w-[6px] bg-muted-foreground/70 hover:bg-muted-foreground hover:h-[8px] hover:w-[8px]'
                 }`}
-                style={{ marginTop: i === 0 ? 0 : 2 }}
+                style={{
+                  marginBlock: totalDots > 1 ? 6 : 0,
+                }}
                 aria-label={t('scrollNav.jumpToMessage', { index: i + 1 })}
               />
             </Tooltip>

--- a/src/components/chat/view/subcomponents/ScrollNavigation.tsx
+++ b/src/components/chat/view/subcomponents/ScrollNavigation.tsx
@@ -110,10 +110,10 @@ export default function ScrollNavigation({
 
   return (
     <div
-      className="pointer-events-none absolute right-0.5 top-0 z-10 flex h-full w-6 flex-col items-center"
+      className="pointer-events-none absolute right-0 top-0 z-10 h-full w-5"
     >
       <div
-        className={`pointer-events-auto flex h-full w-4 flex-col items-center justify-evenly rounded-full border px-0.5 py-4 backdrop-blur-sm transition-opacity duration-200 ${
+        className={`pointer-events-auto flex h-full w-3 flex-col items-center justify-evenly rounded-full border px-0 py-4 backdrop-blur-sm transition-opacity duration-200 ${
           isStripHovered ? 'opacity-100' : 'opacity-50'
         } bg-background/80 border-border/50`}
         onMouseEnter={() => setIsStripHovered(true)}

--- a/src/components/chat/view/subcomponents/ScrollNavigation.tsx
+++ b/src/components/chat/view/subcomponents/ScrollNavigation.tsx
@@ -110,14 +110,14 @@ export default function ScrollNavigation({
 
   return (
     <div
-      className="pointer-events-none absolute right-0.5 top-0 z-20 flex h-full w-6 flex-col items-center"
-      onMouseEnter={() => setIsStripHovered(true)}
-      onMouseLeave={() => setIsStripHovered(false)}
+      className="pointer-events-none absolute right-0.5 top-0 z-10 flex h-full w-6 flex-col items-center"
     >
       <div
-        className={`pointer-events-auto flex h-full w-full flex-col items-center justify-evenly rounded-full border px-1.5 py-8 backdrop-blur-sm transition-opacity duration-200 ${
+        className={`pointer-events-auto flex h-full w-4 flex-col items-center justify-evenly rounded-full border px-0.5 py-4 backdrop-blur-sm transition-opacity duration-200 ${
           isStripHovered ? 'opacity-100' : 'opacity-50'
         } bg-background/80 border-border/50`}
+        onMouseEnter={() => setIsStripHovered(true)}
+        onMouseLeave={() => setIsStripHovered(false)}
       >
         {userMessages.map((msg, i) => {
           const isActive = i === activeDotIndex;

--- a/src/components/chat/view/subcomponents/ScrollNavigation.tsx
+++ b/src/components/chat/view/subcomponents/ScrollNavigation.tsx
@@ -6,8 +6,6 @@ import Tooltip from '../../../../shared/view/ui/Tooltip';
 interface ScrollNavigationProps {
   scrollContainerRef: React.RefObject<HTMLDivElement | null>;
   chatMessages: ChatMessage[];
-  allMessagesLoaded: boolean;
-  loadAllMessages: () => void;
 }
 
 function truncateSnippet(content: string): string {
@@ -20,15 +18,12 @@ function truncateSnippet(content: string): string {
 export default function ScrollNavigation({
   scrollContainerRef,
   chatMessages,
-  allMessagesLoaded,
-  loadAllMessages,
 }: ScrollNavigationProps) {
   const { t } = useTranslation('chat');
   const [activeDotIndex, setActiveDotIndex] = useState(-1);
   const [isStripHovered, setIsStripHovered] = useState(false);
   const rafIdRef = useRef<number | null>(null);
   const mountedRef = useRef(true);
-  const loadAllCalledRef = useRef(false);
 
   const userMessages = useMemo(
     () => chatMessages.filter((m) => m.type === 'user'),
@@ -37,21 +32,6 @@ export default function ScrollNavigation({
 
   const shouldShow = userMessages.length >= 1;
 
-  // Auto-load all messages on first mount so every dot appears
-  useEffect(() => {
-    if (!allMessagesLoaded && !loadAllCalledRef.current && userMessages.length > 0) {
-      loadAllCalledRef.current = true;
-      loadAllMessages();
-    }
-  }, [allMessagesLoaded, loadAllMessages, userMessages.length]);
-
-  // Reset loadAllCalledRef when session changes (messages become empty then refill)
-  useEffect(() => {
-    if (chatMessages.length === 0) {
-      loadAllCalledRef.current = false;
-    }
-  }, [chatMessages.length]);
-
   const scheduleUpdate = useCallback(() => {
     if (rafIdRef.current != null) return;
     rafIdRef.current = requestAnimationFrame(() => {
@@ -59,30 +39,26 @@ export default function ScrollNavigation({
       const container = scrollContainerRef.current;
       if (!container) return;
 
-      const elements = container.querySelectorAll<HTMLDivElement>('.chat-message.user');
-      if (elements.length === 0) {
-        setActiveDotIndex(-1);
+      const { scrollTop, scrollHeight, clientHeight } = container;
+      const maxScroll = scrollHeight - clientHeight;
+      if (maxScroll <= 0) {
+        setActiveDotIndex(userMessages.length > 0 ? userMessages.length - 1 : -1);
         return;
       }
 
-      const { scrollTop, clientHeight } = container;
-      const viewCenter = scrollTop + clientHeight / 2;
+      // Proportional position of scroll within content
+      const scrollRatio = scrollTop / maxScroll;
+      // Map to the closest user message index
+      const totalUserMessages = userMessages.length;
+      if (totalUserMessages <= 1) {
+        setActiveDotIndex(0);
+        return;
+      }
 
-      let bestIndex = 0;
-      let bestDist = Infinity;
-
-      elements.forEach((el, i) => {
-        const center = el.offsetTop + el.clientHeight / 2;
-        const dist = Math.abs(center - viewCenter);
-        if (dist < bestDist) {
-          bestDist = dist;
-          bestIndex = i;
-        }
-      });
-
-      if (mountedRef.current) setActiveDotIndex(bestIndex);
+      const activeIdx = Math.round(scrollRatio * (totalUserMessages - 1));
+      if (mountedRef.current) setActiveDotIndex(activeIdx);
     });
-  }, [scrollContainerRef]);
+  }, [scrollContainerRef, userMessages.length]);
 
   useEffect(() => {
     const container = scrollContainerRef.current;
@@ -92,7 +68,7 @@ export default function ScrollNavigation({
   }, [scrollContainerRef, scheduleUpdate]);
 
   useEffect(() => {
-    const timer = setTimeout(() => scheduleUpdate(), 300);
+    const timer = setTimeout(() => scheduleUpdate(), 200);
     return () => clearTimeout(timer);
   }, [chatMessages.length, scheduleUpdate]);
 
@@ -108,27 +84,38 @@ export default function ScrollNavigation({
     (index: number) => {
       const container = scrollContainerRef.current;
       if (!container) return;
+
       const elements = container.querySelectorAll<HTMLDivElement>('.chat-message.user');
-      const target = elements[index];
-      if (target) {
-        target.scrollIntoView({ block: 'center', behavior: 'smooth' });
+      if (elements.length > index) {
+        // Message is rendered, scroll directly
+        elements[index].scrollIntoView({ block: 'center', behavior: 'smooth' });
+        return;
       }
+
+      // Message not rendered yet — scroll proportionally
+      const totalUserMessages = userMessages.length;
+      if (totalUserMessages <= 1) return;
+
+      const targetRatio = index / (totalUserMessages - 1);
+      const maxScroll = container.scrollHeight - container.clientHeight;
+      container.scrollTo({
+        top: targetRatio * maxScroll,
+        behavior: 'smooth',
+      });
     },
-    [scrollContainerRef],
+    [scrollContainerRef, userMessages.length],
   );
 
   if (!shouldShow) return null;
 
-  const totalDots = userMessages.length;
-
   return (
     <div
-      className="pointer-events-none absolute right-0.5 top-1/2 z-10 flex -translate-y-1/2 flex-col items-center"
+      className="pointer-events-none absolute right-0.5 top-0 z-20 flex h-full w-6 flex-col items-center"
       onMouseEnter={() => setIsStripHovered(true)}
       onMouseLeave={() => setIsStripHovered(false)}
     >
       <div
-        className={`pointer-events-auto flex flex-col items-center rounded-full border px-1.5 py-3 backdrop-blur-sm transition-opacity duration-200 ${
+        className={`pointer-events-auto flex h-full w-full flex-col items-center justify-evenly rounded-full border px-1.5 py-8 backdrop-blur-sm transition-opacity duration-200 ${
           isStripHovered ? 'opacity-100' : 'opacity-50'
         } bg-background/80 border-border/50`}
       >
@@ -151,12 +138,9 @@ export default function ScrollNavigation({
                 onClick={() => scrollToDot(i)}
                 className={`block cursor-pointer rounded-full transition-all duration-150 ${
                   isActive
-                    ? 'h-[8px] w-[8px] bg-blue-500 hover:bg-blue-400'
-                    : 'h-[6px] w-[6px] bg-muted-foreground/70 hover:bg-muted-foreground hover:h-[8px] hover:w-[8px]'
+                    ? 'h-[10px] w-[10px] bg-blue-500 hover:bg-blue-400'
+                    : 'h-[7px] w-[7px] bg-muted-foreground/70 hover:bg-muted-foreground hover:h-[9px] hover:w-[9px]'
                 }`}
-                style={{
-                  marginBlock: totalDots > 1 ? 6 : 0,
-                }}
                 aria-label={t('scrollNav.jumpToMessage', { index: i + 1 })}
               />
             </Tooltip>

--- a/src/components/chat/view/subcomponents/ScrollNavigation.tsx
+++ b/src/components/chat/view/subcomponents/ScrollNavigation.tsx
@@ -6,6 +6,10 @@ import Tooltip from '../../../../shared/view/ui/Tooltip';
 interface ScrollNavigationProps {
   scrollContainerRef: React.RefObject<HTMLDivElement | null>;
   chatMessages: ChatMessage[];
+  loadAllMessages?: () => void;
+  allMessagesLoaded?: boolean;
+  totalMessages?: number;
+  sessionMessagesCount?: number;
 }
 
 function truncateSnippet(content: string): string {
@@ -15,9 +19,55 @@ function truncateSnippet(content: string): string {
     .slice(0, 60) + ((content || '').length > 60 ? '...' : '');
 }
 
+function ArrowUpIcon() {
+  return (
+    <svg width="10" height="10" viewBox="0 0 10 10" fill="none" stroke="currentColor" strokeWidth="1.5">
+      <path d="M5 8V2M5 2L2 5M5 2L8 5" />
+    </svg>
+  );
+}
+
+function ArrowDownIcon() {
+  return (
+    <svg width="10" height="10" viewBox="0 0 10 10" fill="none" stroke="currentColor" strokeWidth="1.5">
+      <path d="M5 2V8M5 8L2 5M5 8L8 5" />
+    </svg>
+  );
+}
+
+function DoubleUpIcon() {
+  return (
+    <svg width="10" height="10" viewBox="0 0 10 10" fill="none" stroke="currentColor" strokeWidth="1.5">
+      <path d="M5 8V3M5 3L2 5.5M5 3L8 5.5" />
+      <path d="M5 6V1M5 1L2 3.5M5 1L8 3.5" />
+    </svg>
+  );
+}
+
+function DoubleDownIcon() {
+  return (
+    <svg width="10" height="10" viewBox="0 0 10 10" fill="none" stroke="currentColor" strokeWidth="1.5">
+      <path d="M5 1V6M5 6L2 3.5M5 6L8 3.5" />
+      <path d="M5 3V8M5 8L2 5.5M5 8L8 5.5" />
+    </svg>
+  );
+}
+
+function LoadAllIcon() {
+  return (
+    <svg width="10" height="10" viewBox="0 0 10 10" fill="none" stroke="currentColor" strokeWidth="1.5">
+      <path d="M1 3h8M1 5h6M1 7h7" />
+    </svg>
+  );
+}
+
 export default function ScrollNavigation({
   scrollContainerRef,
   chatMessages,
+  loadAllMessages,
+  allMessagesLoaded = true,
+  totalMessages = 0,
+  sessionMessagesCount = 0,
 }: ScrollNavigationProps) {
   const { t } = useTranslation('chat');
   const [activeDotIndex, setActiveDotIndex] = useState(-1);
@@ -31,6 +81,7 @@ export default function ScrollNavigation({
   );
 
   const shouldShow = userMessages.length >= 1;
+  const hasMore = totalMessages > 0 && sessionMessagesCount > 0 && !allMessagesLoaded;
 
   const scheduleUpdate = useCallback(() => {
     if (rafIdRef.current != null) return;
@@ -46,9 +97,7 @@ export default function ScrollNavigation({
         return;
       }
 
-      // Proportional position of scroll within content
       const scrollRatio = scrollTop / maxScroll;
-      // Map to the closest user message index
       const totalUserMessages = userMessages.length;
       if (totalUserMessages <= 1) {
         setActiveDotIndex(0);
@@ -80,6 +129,27 @@ export default function ScrollNavigation({
     };
   }, []);
 
+  // Lazy-load: ensure all messages are loaded before navigating
+  const ensureLoaded = useCallback(() => {
+    if (hasMore && loadAllMessages) {
+      loadAllMessages();
+    }
+  }, [hasMore, loadAllMessages]);
+
+  // Load all messages after first paint — non-blocking, doesn't delay initial render
+  useEffect(() => {
+    if (!hasMore || !loadAllMessages) return;
+    const idle = (globalThis.requestIdleCallback ?? ((fn: () => void) => setTimeout(fn, 0)));
+    const handle = idle(() => {
+      if (mountedRef.current && hasMore) loadAllMessages();
+    });
+    return () => {
+      if ('cancelIdleCallback' in globalThis)
+        (globalThis as any).cancelIdleCallback(handle);
+      else clearTimeout(handle as any);
+    };
+  }, [hasMore, loadAllMessages]);
+
   const scrollToDot = useCallback(
     (index: number) => {
       const container = scrollContainerRef.current;
@@ -87,12 +157,10 @@ export default function ScrollNavigation({
 
       const elements = container.querySelectorAll<HTMLDivElement>('.chat-message.user');
       if (elements.length > index) {
-        // Message is rendered, scroll directly
         elements[index].scrollIntoView({ block: 'center', behavior: 'smooth' });
         return;
       }
 
-      // Message not rendered yet — scroll proportionally
       const totalUserMessages = userMessages.length;
       if (totalUserMessages <= 1) return;
 
@@ -106,46 +174,183 @@ export default function ScrollNavigation({
     [scrollContainerRef, userMessages.length],
   );
 
+  const scroll_to_top = useCallback(() => {
+    const container = scrollContainerRef.current;
+    if (!container) return;
+
+    ensureLoaded();
+
+    const elements = container.querySelectorAll<HTMLDivElement>('.chat-message.user');
+    if (elements.length > 0) {
+      elements[0].scrollIntoView({ block: 'center', behavior: 'smooth' });
+      return;
+    }
+
+    container.scrollTo({ top: 0, behavior: 'smooth' });
+  }, [scrollContainerRef, ensureLoaded]);
+
+  const scroll_to_bottom = useCallback(() => {
+    const container = scrollContainerRef.current;
+    if (!container) return;
+
+    const elements = container.querySelectorAll<HTMLDivElement>('.chat-message.user');
+    if (elements.length > 0) {
+      elements[elements.length - 1].scrollIntoView({ block: 'center', behavior: 'smooth' });
+      return;
+    }
+
+    container.scrollTo({ top: container.scrollHeight, behavior: 'smooth' });
+  }, [scrollContainerRef]);
+
+  const scroll_prev = useCallback(() => {
+    const container = scrollContainerRef.current;
+    if (!container) return;
+
+    const elements = container.querySelectorAll<HTMLDivElement>('.chat-message.user');
+    if (elements.length === 0) return;
+
+    const { scrollTop, clientHeight } = container;
+    const viewportCenter = scrollTop + clientHeight / 2;
+
+    let currentIndex = 0;
+    for (let i = 0; i < elements.length; i++) {
+      const top = elements[i].getBoundingClientRect().top - container.getBoundingClientRect().top + scrollTop;
+      if (top <= viewportCenter) {
+        currentIndex = i;
+      } else {
+        break;
+      }
+    }
+
+    const targetIndex = Math.max(0, currentIndex - 1);
+    elements[targetIndex].scrollIntoView({ block: 'center', behavior: 'smooth' });
+  }, [scrollContainerRef]);
+
+  const scroll_next = useCallback(() => {
+    const container = scrollContainerRef.current;
+    if (!container) return;
+
+    const elements = container.querySelectorAll<HTMLDivElement>('.chat-message.user');
+    if (elements.length === 0) return;
+
+    const { scrollTop, clientHeight } = container;
+    const viewportCenter = scrollTop + clientHeight / 2;
+
+    let currentIndex = elements.length - 1;
+    for (let i = elements.length - 1; i >= 0; i--) {
+      const top = elements[i].getBoundingClientRect().top - container.getBoundingClientRect().top + scrollTop;
+      if (top <= viewportCenter) {
+        currentIndex = i;
+        break;
+      }
+    }
+
+    const targetIndex = Math.min(elements.length - 1, currentIndex + 1);
+    elements[targetIndex].scrollIntoView({ block: 'center', behavior: 'smooth' });
+  }, [scrollContainerRef]);
+
   if (!shouldShow) return null;
+
+  const navButtons = [
+    {
+      label: t('scrollNav.first'),
+      icon: <DoubleUpIcon />,
+      action: scroll_to_top,
+    },
+    {
+      label: t('scrollNav.previous'),
+      icon: <ArrowUpIcon />,
+      action: scroll_prev,
+    },
+    {
+      label: t('scrollNav.next'),
+      icon: <ArrowDownIcon />,
+      action: scroll_next,
+    },
+    {
+      label: t('scrollNav.last'),
+      icon: <DoubleDownIcon />,
+      action: scroll_to_bottom,
+    },
+  ];
 
   return (
     <div
-      className="pointer-events-none absolute right-0 top-0 z-10 h-full w-4"
+      className="pointer-events-none absolute right-0 top-0 z-10 h-full"
     >
       <div
-        className={`pointer-events-auto flex h-full w-2 flex-col items-center justify-evenly rounded-full border px-0 py-4 backdrop-blur-sm transition-opacity duration-200 ${
-          isStripHovered ? 'opacity-100' : 'opacity-50'
+        className={`pointer-events-auto flex h-full flex-col items-center rounded-full border backdrop-blur-sm transition-all duration-200 ${
+          isStripHovered
+            ? 'w-10 opacity-100'
+            : 'w-2 opacity-50'
         } bg-background/80 border-border/50`}
         onMouseEnter={() => setIsStripHovered(true)}
         onMouseLeave={() => setIsStripHovered(false)}
       >
-        {userMessages.map((msg, i) => {
-          const isActive = i === activeDotIndex;
-          const snippet = truncateSnippet(msg.content || '');
-
-          return (
-            <Tooltip
-              key={`${i}-${String(msg.timestamp).slice(0, 8)}`}
-              content={t('scrollNav.jumpToMessage', {
-                index: i + 1,
-                snippet,
-              })}
-              position="left"
-              delay={150}
-            >
+        {/* Nav buttons section */}
+        <div className="flex flex-col items-center gap-1 py-1">
+          {hasMore && loadAllMessages && (
+            <Tooltip content={t('scrollNav.loadAll')} position="left" delay={150}>
               <button
                 type="button"
-                onClick={() => scrollToDot(i)}
-                className={`block cursor-pointer rounded-full transition-all duration-150 ${
-                  isActive
-                    ? 'h-[10px] w-[10px] bg-blue-500 hover:bg-blue-400'
-                    : 'h-[7px] w-[7px] bg-muted-foreground/70 hover:bg-muted-foreground hover:h-[9px] hover:w-[9px]'
-                }`}
-                aria-label={t('scrollNav.jumpToMessage', { index: i + 1 })}
-              />
+                onClick={loadAllMessages}
+                className="rounded p-1 text-muted-foreground transition-all duration-150 hover:text-foreground"
+                aria-label={t('scrollNav.loadAll')}
+              >
+                <LoadAllIcon />
+              </button>
             </Tooltip>
-          );
-        })}
+          )}
+
+          {navButtons.map((btn) => (
+            <Tooltip key={btn.label} content={btn.label} position="left" delay={150}>
+              <button
+                type="button"
+                onClick={btn.action}
+                className="rounded p-1 text-muted-foreground transition-all duration-150 hover:text-foreground"
+                aria-label={btn.label}
+              >
+                {btn.icon}
+              </button>
+            </Tooltip>
+          ))}
+        </div>
+
+        {/* Divider */}
+        <div className={`mx-auto my-0.5 border-t border-border/40 transition-all duration-150 ${
+          isStripHovered ? 'w-5 opacity-100' : 'w-0 opacity-0'
+        }`} />
+
+        {/* Dots section */}
+        <div className="flex flex-1 w-full flex-col items-center justify-evenly px-0 py-1">
+          {userMessages.map((msg, i) => {
+            const isActive = i === activeDotIndex;
+            const snippet = truncateSnippet(msg.content || '');
+
+            return (
+              <Tooltip
+                key={`${i}-${String(msg.timestamp).slice(0, 8)}`}
+                content={t('scrollNav.jumpToMessage', {
+                  index: i + 1,
+                  snippet,
+                })}
+                position="left"
+                delay={150}
+              >
+                <button
+                  type="button"
+                  onClick={() => scrollToDot(i)}
+                  className={`block cursor-pointer rounded-full transition-all duration-150 ${
+                    isActive
+                      ? 'h-[10px] w-[10px] bg-blue-500 hover:bg-blue-400'
+                      : 'h-[7px] w-[7px] bg-muted-foreground/70 hover:bg-muted-foreground hover:h-[9px] hover:w-[9px]'
+                  }`}
+                  aria-label={t('scrollNav.jumpToMessage', { index: i + 1 })}
+                />
+              </Tooltip>
+            );
+          })}
+        </div>
       </div>
     </div>
   );

--- a/src/components/chat/view/subcomponents/ScrollNavigation.tsx
+++ b/src/components/chat/view/subcomponents/ScrollNavigation.tsx
@@ -1,0 +1,145 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import type { ChatMessage } from '../../types/types';
+import Tooltip from '../../../../shared/view/ui/Tooltip';
+
+interface ScrollNavigationProps {
+  scrollContainerRef: React.RefObject<HTMLDivElement | null>;
+  chatMessages: ChatMessage[];
+}
+
+function truncateSnippet(content: string): string {
+  return (content || '')
+    .replace(/\n/g, ' ')
+    .trim()
+    .slice(0, 60) + ((content || '').length > 60 ? '...' : '');
+}
+
+export default function ScrollNavigation({ scrollContainerRef, chatMessages }: ScrollNavigationProps) {
+  const { t } = useTranslation('chat');
+  const [activeDotIndex, setActiveDotIndex] = useState(-1);
+  const [isStripHovered, setIsStripHovered] = useState(false);
+  const rafIdRef = useRef<number | null>(null);
+  const mountedRef = useRef(true);
+
+  const userMessages = useMemo(
+    () => chatMessages.filter((m) => m.type === 'user'),
+    [chatMessages],
+  );
+
+  const shouldShow = userMessages.length >= 3;
+
+  const scheduleUpdate = useCallback(() => {
+    if (rafIdRef.current != null) return;
+    rafIdRef.current = requestAnimationFrame(() => {
+      rafIdRef.current = null;
+      const container = scrollContainerRef.current;
+      if (!container) return;
+
+      const elements = container.querySelectorAll<HTMLDivElement>('.chat-message.user');
+      if (elements.length === 0) {
+        setActiveDotIndex(-1);
+        return;
+      }
+
+      const { scrollTop, clientHeight } = container;
+      const viewCenter = scrollTop + clientHeight / 2;
+
+      let bestIndex = 0;
+      let bestDist = Infinity;
+
+      elements.forEach((el, i) => {
+        const center = el.offsetTop + el.clientHeight / 2;
+        const dist = Math.abs(center - viewCenter);
+        if (dist < bestDist) {
+          bestDist = dist;
+          bestIndex = i;
+        }
+      });
+
+      if (mountedRef.current) setActiveDotIndex(bestIndex);
+    });
+  }, [scrollContainerRef]);
+
+  // Scroll listener for active dot tracking
+  useEffect(() => {
+    const container = scrollContainerRef.current;
+    if (!container) return;
+
+    container.addEventListener('scroll', scheduleUpdate, { passive: true });
+    return () => container.removeEventListener('scroll', scheduleUpdate);
+  }, [scrollContainerRef, scheduleUpdate]);
+
+  // Initial position + re-compute when messages change
+  useEffect(() => {
+    const timer = setTimeout(() => scheduleUpdate(), 200);
+    return () => clearTimeout(timer);
+  }, [chatMessages.length, scheduleUpdate]);
+
+  // Cleanup RAF on unmount
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+      if (rafIdRef.current != null) cancelAnimationFrame(rafIdRef.current);
+    };
+  }, []);
+
+  const scrollToDot = useCallback(
+    (index: number) => {
+      const container = scrollContainerRef.current;
+      if (!container) return;
+      const elements = container.querySelectorAll<HTMLDivElement>('.chat-message.user');
+      const target = elements[index];
+      if (target) {
+        target.scrollIntoView({ block: 'center', behavior: 'smooth' });
+      }
+    },
+    [scrollContainerRef],
+  );
+
+  if (!shouldShow) return null;
+
+  return (
+    <div
+      className="pointer-events-none absolute right-0.5 top-1/2 z-10 flex -translate-y-1/2 flex-col items-center"
+      onMouseEnter={() => setIsStripHovered(true)}
+      onMouseLeave={() => setIsStripHovered(false)}
+    >
+      <div
+        className={`pointer-events-auto flex flex-col items-center rounded-full border py-2 backdrop-blur-sm transition-opacity duration-200 ${
+          isStripHovered ? 'opacity-100' : 'opacity-40'
+        } bg-background/80 border-border/50`}
+      >
+        {userMessages.map((msg, i) => {
+          const isActive = i === activeDotIndex;
+          const snippet = truncateSnippet(msg.content || '');
+
+          return (
+            <Tooltip
+              key={`${i}-${String(msg.timestamp).slice(0, 8)}`}
+              content={t('scrollNav.jumpToMessage', {
+                index: i + 1,
+                snippet,
+              })}
+              position="left"
+              delay={150}
+            >
+              <button
+                type="button"
+                onClick={() => scrollToDot(i)}
+                className={`block rounded-full transition-all duration-150 ${
+                  isActive
+                    ? 'h-[6px] w-[6px] bg-blue-500 hover:bg-blue-400'
+                    : 'h-[4px] w-[4px] bg-muted-foreground/60 hover:bg-muted-foreground'
+                }`}
+                style={{ marginTop: i === 0 ? 0 : 2 }}
+                aria-label={t('scrollNav.jumpToMessage', { index: i + 1 })}
+              />
+            </Tooltip>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/i18n/locales/de/chat.json
+++ b/src/i18n/locales/de/chat.json
@@ -271,5 +271,9 @@
   },
   "tasks": {
     "nextTaskPrompt": "Nächste Aufgabe starten"
+  },
+  "scrollNav": {
+    "jumpTo": "Springe zu: {{snippet}}",
+    "jumpToMessage": "Springe zu Nachricht {{index}}"
   }
 }

--- a/src/i18n/locales/de/chat.json
+++ b/src/i18n/locales/de/chat.json
@@ -274,6 +274,11 @@
   },
   "scrollNav": {
     "jumpTo": "Springe zu: {{snippet}}",
-    "jumpToMessage": "Springe zu Nachricht {{index}}"
+    "jumpToMessage": "Springe zu Nachricht {{index}}",
+    "loadAll": "Alle laden",
+    "first": "Erste",
+    "previous": "Vorherige",
+    "next": "Nächste",
+    "last": "Letzte"
   }
 }

--- a/src/i18n/locales/en/chat.json
+++ b/src/i18n/locales/en/chat.json
@@ -274,6 +274,11 @@
   },
   "scrollNav": {
     "jumpTo": "Jump to: {{snippet}}",
-    "jumpToMessage": "Jump to message {{index}}"
+    "jumpToMessage": "Jump to message {{index}}",
+    "loadAll": "Load all",
+    "first": "First",
+    "previous": "Previous",
+    "next": "Next",
+    "last": "Last"
   }
 }

--- a/src/i18n/locales/en/chat.json
+++ b/src/i18n/locales/en/chat.json
@@ -271,5 +271,9 @@
   },
   "tasks": {
     "nextTaskPrompt": "Start the next task"
+  },
+  "scrollNav": {
+    "jumpTo": "Jump to: {{snippet}}",
+    "jumpToMessage": "Jump to message {{index}}"
   }
 }

--- a/src/i18n/locales/it/chat.json
+++ b/src/i18n/locales/it/chat.json
@@ -274,6 +274,11 @@
   },
   "scrollNav": {
     "jumpTo": "Vai a: {{snippet}}",
-    "jumpToMessage": "Vai al messaggio {{index}}"
+    "jumpToMessage": "Vai al messaggio {{index}}",
+    "loadAll": "Carica tutto",
+    "first": "Primo",
+    "previous": "Precedente",
+    "next": "Successivo",
+    "last": "Ultimo"
   }
 }

--- a/src/i18n/locales/it/chat.json
+++ b/src/i18n/locales/it/chat.json
@@ -271,5 +271,9 @@
   },
   "tasks": {
     "nextTaskPrompt": "Inizia l'attività successiva"
+  },
+  "scrollNav": {
+    "jumpTo": "Vai a: {{snippet}}",
+    "jumpToMessage": "Vai al messaggio {{index}}"
   }
 }

--- a/src/i18n/locales/ja/chat.json
+++ b/src/i18n/locales/ja/chat.json
@@ -241,6 +241,11 @@
   },
   "scrollNav": {
     "jumpTo": "ジャンプ: {{snippet}}",
-    "jumpToMessage": "{{index}}番目のメッセージに移動"
+    "jumpToMessage": "{{index}}番目のメッセージに移動",
+    "loadAll": "全ロード",
+    "first": "最初",
+    "previous": "前へ",
+    "next": "次へ",
+    "last": "最後"
   }
 }

--- a/src/i18n/locales/ja/chat.json
+++ b/src/i18n/locales/ja/chat.json
@@ -238,5 +238,9 @@
     "providers": {
       "assistant": "Assistant"
     }
+  },
+  "scrollNav": {
+    "jumpTo": "ジャンプ: {{snippet}}",
+    "jumpToMessage": "{{index}}番目のメッセージに移動"
   }
 }

--- a/src/i18n/locales/ko/chat.json
+++ b/src/i18n/locales/ko/chat.json
@@ -253,5 +253,9 @@
   },
   "tasks": {
     "nextTaskPrompt": "다음 작업 시작"
+  },
+  "scrollNav": {
+    "jumpTo": "이동: {{snippet}}",
+    "jumpToMessage": "{{index}}번 메시지로 이동"
   }
 }

--- a/src/i18n/locales/ko/chat.json
+++ b/src/i18n/locales/ko/chat.json
@@ -256,6 +256,11 @@
   },
   "scrollNav": {
     "jumpTo": "이동: {{snippet}}",
-    "jumpToMessage": "{{index}}번 메시지로 이동"
+    "jumpToMessage": "{{index}}번 메시지로 이동",
+    "loadAll": "전체 로드",
+    "first": "첫 번째",
+    "previous": "이전",
+    "next": "다음",
+    "last": "마지막"
   }
 }

--- a/src/i18n/locales/ru/chat.json
+++ b/src/i18n/locales/ru/chat.json
@@ -271,5 +271,9 @@
   },
   "tasks": {
     "nextTaskPrompt": "Начать следующую задачу"
+  },
+  "scrollNav": {
+    "jumpTo": "Перейти к: {{snippet}}",
+    "jumpToMessage": "Перейти к сообщению {{index}}"
   }
 }

--- a/src/i18n/locales/ru/chat.json
+++ b/src/i18n/locales/ru/chat.json
@@ -274,6 +274,11 @@
   },
   "scrollNav": {
     "jumpTo": "Перейти к: {{snippet}}",
-    "jumpToMessage": "Перейти к сообщению {{index}}"
+    "jumpToMessage": "Перейти к сообщению {{index}}",
+    "loadAll": "Загрузить всё",
+    "first": "Первое",
+    "previous": "Предыдущее",
+    "next": "Следующее",
+    "last": "Последнее"
   }
 }

--- a/src/i18n/locales/tr/chat.json
+++ b/src/i18n/locales/tr/chat.json
@@ -274,6 +274,11 @@
   },
   "scrollNav": {
     "jumpTo": "Git: {{snippet}}",
-    "jumpToMessage": "{{index}}. mesaja git"
+    "jumpToMessage": "{{index}}. mesaja git",
+    "loadAll": "Tümünü yükle",
+    "first": "İlk",
+    "previous": "Önceki",
+    "next": "Sonraki",
+    "last": "Son"
   }
 }

--- a/src/i18n/locales/tr/chat.json
+++ b/src/i18n/locales/tr/chat.json
@@ -271,5 +271,9 @@
   },
   "tasks": {
     "nextTaskPrompt": "Sonraki görevi başlat"
+  },
+  "scrollNav": {
+    "jumpTo": "Git: {{snippet}}",
+    "jumpToMessage": "{{index}}. mesaja git"
   }
 }

--- a/src/i18n/locales/zh-CN/chat.json
+++ b/src/i18n/locales/zh-CN/chat.json
@@ -256,6 +256,11 @@
   },
   "scrollNav": {
     "jumpTo": "跳转到: {{snippet}}",
-    "jumpToMessage": "跳转到第 {{index}} 条消息"
+    "jumpToMessage": "跳转到第 {{index}} 条消息",
+    "loadAll": "加载全部",
+    "first": "第一条",
+    "previous": "上一条",
+    "next": "下一条",
+    "last": "最后一条"
   }
 }

--- a/src/i18n/locales/zh-CN/chat.json
+++ b/src/i18n/locales/zh-CN/chat.json
@@ -253,5 +253,9 @@
   },
   "tasks": {
     "nextTaskPrompt": "开始下一个任务"
+  },
+  "scrollNav": {
+    "jumpTo": "跳转到: {{snippet}}",
+    "jumpToMessage": "跳转到第 {{index}} 条消息"
   }
 }


### PR DESCRIPTION
## Summary / 摘要

- 添加聊天界面右侧滚动导航条，悬停时展开，包含圆点和导航按钮
- 每个圆点代表一条用户消息，点击可平滑跳转到对应位置
- 新增首条/上一条/下一条/最后一条快速导航按钮
- 分页消息时显示"加载全部"按钮，后台非阻塞加载所有消息
- 活跃圆点随滚动自动高亮，悬停显示消息摘要预览
- 修复任务通知 XML 解析正则，避免被误识别为用户消息
- 新增 `ScrollNavigation` 组件，通过 `requestAnimationFrame` 节流监听滚动
- i18n 支持 8 种语言

---

- Added a hover-expandable scroll navigation strip on the right side of the chat interface
- Each dot represents a user message turn; clicking smoothly scrolls to that message
- Added first/previous/next/last navigation buttons
- Shows "load all" button when messages are paginated, auto-loads in background via `requestIdleCallback`
- Active dot highlights as you scroll, hover shows tooltip with message preview
- Fixed task-notification XML parsing regex to prevent notifications from being misrendered as user messages
- New `ScrollNavigation` component with `requestAnimationFrame`-throttled scroll listener
- i18n support for 8 locales

## Test plan / 测试计划

- [x] 打开有多轮对话的 session，右侧显示导航条
- [ ] 悬停导航条展开，显示圆点和按钮
- [ ] 点击圆点平滑滚动到对应消息
- [ ] 分页消息自动后台加载，所有圆点显示
- [ ] 任务通知不再被识别为用户消息
- [ ] Open a session with multiple turns, navigation strip appears on right
- [ ] Hover expands strip showing dots and buttons
- [ ] Clicking a dot scrolls to the corresponding message
- [ ] Paginated messages auto-load in background, all dots appear
- [ ] Task notifications no longer misrendered as user messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)