### PR TITLE
fix(chat): fix streaming race where AI content appears before user message / 修复流式传输竞态导致用户消息消失

### DIFF
--- a/src/components/chat/hooks/useChatSessionState.ts
+++ b/src/components/chat/hooks/useChatSessionState.ts
@@ -258,9 +258,14 @@ export function useChatSessionState({
 
   const chatMessages = useMemo(() => {
     const all = normalizedToChatMessages(storeMessages);
-    // Show pending user message when no session data exists yet (new session, pre-backend-response)
-    if (pendingUserMessage && all.length === 0) {
-      return [pendingUserMessage];
+    // Show pending user message until a user message actually appears in the store.
+    // This covers both the "no messages yet" case and the race condition where
+    // `stream_delta` (AI content) arrives in realtime before the echoed user
+    // message — without this check the pending message would disappear and the
+    // AI response would briefly appear as the first visible message.
+    const hasUserMessage = all.some((m) => m.type === 'user');
+    if (pendingUserMessage && !hasUserMessage) {
+      return [...all, pendingUserMessage];
     }
     if (viewHiddenCount > 0 && viewHiddenCount < all.length) return all.slice(0, -viewHiddenCount);
     return all;


### PR DESCRIPTION
## Summary / 摘要

在新会话中，AI 的 `stream_delta` 消息可能比 SDK 回传的用户消息先到。前端的 `pendingUserMessage` 只在 `chatMessages.length === 0` 时显示，一旦任何实时消息到达就消失，导致用户消息不见，AI 回复成了第一条消息。

---

During a new session, `stream_delta` events (AI content) can arrive in realtime before the SDK echoes back the user message. The `pendingUserMessage` check only triggered when `chatMessages.length === 0`, so it would disappear once any realtime message arrived, leaving the AI response as the first visible message with the user message gone.

## Fix / 修复方案

改为检查是否有任何 `type === 'user'` 的消息，而不仅是消息总数。确保用户消息在真正出现前不会消失。

---

Changed the condition to check whether any `type === 'user'` message exists, rather than checking message count. This ensures the pending user message persists until the actual user message arrives from the backend.

## Test plan / 测试计划

- [ ] 创建新会话并发送消息，流式传输期间用户消息始终可见
- [ ] AI 消息不会在用户消息之前短暂显示
- [ ] Create a new session and send a message — user message stays visible during streaming
- [ ] AI response does not briefly appear before the user message

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where pending user messages could disappear from chat during rapid exchanges. Users will now see their messages consistently displayed, even when AI responses arrive quickly.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/siteboon/claudecodeui/pull/772?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->