### PR TITLE
fix: 处理 Claude Code JSONL 中的 assistant 消息 / Handle assistant messages from JSONL

### DIFF
--- a/server/modules/providers/list/claude/claude-sessions.provider.ts
+++ b/server/modules/providers/list/claude/claude-sessions.provider.ts
@@ -490,7 +490,7 @@ export class ClaudeSessionsProvider implements IProviderSessions {
       return messages;
     }
 
-    if (raw.message?.role === 'assistant' && raw.message?.content) {
+    if ((raw.message?.role === 'assistant' || raw.type === 'assistant') && raw.message?.content) {
       if (Array.isArray(raw.message.content)) {
         let partIndex = 0;
         for (const part of raw.message.content) {


### PR DESCRIPTION
## Summary / 说明
- 在 `normalizeMessage` 中增加 `raw.type === 'assistant'` 检查，与现有的 `message.role === 'assistant'` 并列
- Claude Code 在 JSONL 中写入 assistant 消息时使用 `type: 'assistant'` 但 `message.role` 为 `undefined`，导致 REST API 在页面刷新或 WebSocket 重连读取历史时，所有 assistant 消息被静默过滤
- Added `raw.type === 'assistant'` check in `normalizeMessage` alongside existing `message.role === 'assistant'` check to fix assistant messages being dropped from session history on page refresh or WebSocket reconnect

## Test plan / 测试方法
- [ ] 重启 CloudCLI 并刷新页面，确认会话历史中 assistant 消息可见 / Restart CloudCLI and refresh page — verify assistant messages are visible in session history
- [ ] 确认实时流消息显示正常，无回归 / Verify messages still display correctly during real-time streaming (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection and handling of assistant-originated responses so all assistant messages are recognized and processed consistently. This fixes cases where parts of an assistant reply might not have been shown or handled correctly, ensuring response content (text, tool outputs, and internal notes) is preserved and displayed reliably.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/siteboon/claudecodeui/pull/774?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->