### PR TITLE
fix: consolidate chat message display fixes, session name sync, completion sound, and image tool_result filter / 修复聊天消息显示、会话名同步、完成音效、截图过滤

### DIFF
--- a/server/claude-sdk.js
+++ b/server/claude-sdk.js
@@ -36,6 +36,17 @@ const TOOL_APPROVAL_TIMEOUT_MS = parseInt(process.env.CLAUDE_TOOL_APPROVAL_TIMEO
 
 const TOOLS_REQUIRING_INTERACTION = new Set(['AskUserQuestion', 'ExitPlanMode']);
 
+/**
+ * Extracts the prompt text from a Task subagent tool_use input.
+ * Mirrors the logic in claude-sessions.provider.ts extractSubagentPrompt().
+ */
+function extractSubagentPrompt(toolInput) {
+  if (!toolInput || typeof toolInput !== 'object') return null;
+  const prompt = typeof toolInput.prompt === 'string' ? toolInput.prompt : null;
+  if (!prompt) return null;
+  return prompt.replace(/\r\n/g, '\n').replace(/\r/g, '\n').trim();
+}
+
 function createRequestId() {
   if (typeof crypto.randomUUID === 'function') {
     return crypto.randomUUID();
@@ -481,6 +492,7 @@ async function queryClaudeSDK(command, options = {}, ws) {
   let sessionCreatedSent = false;
   let tempImagePaths = [];
   let tempDir = null;
+  const streamingSubagentPrompts = new Set();
 
   const emitNotification = (event) => {
     notifyUserIfEnabled({
@@ -664,9 +676,37 @@ async function queryClaudeSDK(command, options = {}, ws) {
       const transformedMessage = transformMessage(message);
       const sid = capturedSessionId || sessionId || null;
 
+      // Collect Task subagent prompts so they can be filtered during normalization
+      if (message.type === 'assistant' || transformedMessage.message?.role === 'assistant') {
+        if (Array.isArray(transformedMessage.message?.content)) {
+          for (const part of transformedMessage.message.content) {
+            if (part.type === 'tool_use' && part.name === 'Task') {
+              const prompt = extractSubagentPrompt(part.input);
+              if (prompt) {
+                streamingSubagentPrompts.add(prompt);
+              }
+            }
+          }
+        }
+      }
+
+      // DEBUG: log SDK messages with user role to trace streaming bug
+      if (message.type === 'user' || transformedMessage.message?.role === 'user') {
+        console.log('[SDK-DEBUG-USER-MSG] type:', message.type, '| isSynthetic:', transformedMessage.isSynthetic, '| origin:', JSON.stringify(transformedMessage.origin), '| message.role:', transformedMessage.message?.role, '| content preview:', String(transformedMessage.message?.content || '').slice(0, 200), '| shouldQuery:', transformedMessage.shouldQuery, '| parentToolUseId:', transformedMessage.parentToolUseId);
+      }
+
       // Use adapter to normalize SDK events into NormalizedMessage[]
-      const normalized = sessionsService.normalizeMessage('claude', transformedMessage, sid);
+      const normalized = sessionsService.normalizeMessage(
+        'claude',
+        transformedMessage,
+        sid,
+        streamingSubagentPrompts.size > 0 ? streamingSubagentPrompts : null,
+      );
       for (const msg of normalized) {
+        // DEBUG: log normalized messages with user role
+        if (msg.kind === 'text' && msg.role === 'user') {
+          console.log('[NORMALIZED-USER-MSG] id:', msg.id, '| content preview:', String(msg.content || '').slice(0, 200));
+        }
         // Preserve parentToolUseId from SDK wrapper for subagent tool grouping
         if (transformedMessage.parentToolUseId && !msg.parentToolUseId) {
           msg.parentToolUseId = transformedMessage.parentToolUseId;

--- a/server/claude-sdk.js
+++ b/server/claude-sdk.js
@@ -690,11 +690,6 @@ async function queryClaudeSDK(command, options = {}, ws) {
         }
       }
 
-      // DEBUG: log SDK messages with user role to trace streaming bug
-      if (message.type === 'user' || transformedMessage.message?.role === 'user') {
-        console.log('[SDK-DEBUG-USER-MSG] type:', message.type, '| isSynthetic:', transformedMessage.isSynthetic, '| origin:', JSON.stringify(transformedMessage.origin), '| message.role:', transformedMessage.message?.role, '| content preview:', String(transformedMessage.message?.content || '').slice(0, 200), '| shouldQuery:', transformedMessage.shouldQuery, '| parentToolUseId:', transformedMessage.parentToolUseId);
-      }
-
       // Use adapter to normalize SDK events into NormalizedMessage[]
       const normalized = sessionsService.normalizeMessage(
         'claude',
@@ -703,10 +698,6 @@ async function queryClaudeSDK(command, options = {}, ws) {
         streamingSubagentPrompts.size > 0 ? streamingSubagentPrompts : null,
       );
       for (const msg of normalized) {
-        // DEBUG: log normalized messages with user role
-        if (msg.kind === 'text' && msg.role === 'user') {
-          console.log('[NORMALIZED-USER-MSG] id:', msg.id, '| content preview:', String(msg.content || '').slice(0, 200));
-        }
         // Preserve parentToolUseId from SDK wrapper for subagent tool grouping
         if (transformedMessage.parentToolUseId && !msg.parentToolUseId) {
           msg.parentToolUseId = transformedMessage.parentToolUseId;

--- a/server/modules/database/migrations.ts
+++ b/server/modules/database/migrations.ts
@@ -125,6 +125,7 @@ const rebuildProjectsTableWithPrimaryKeySchema = (db: Database): void => {
     addColumnToTableIfNotExists(db, 'projects', columnNames, 'custom_project_name', 'TEXT DEFAULT NULL');
     addColumnToTableIfNotExists(db, 'projects', columnNames, 'isStarred', 'BOOLEAN DEFAULT 0');
     addColumnToTableIfNotExists(db, 'projects', columnNames, 'isArchived', 'BOOLEAN DEFAULT 0');
+    addColumnToTableIfNotExists(db, 'projects', columnNames, 'cached_display_name', 'TEXT DEFAULT NULL');
     db.exec(`
       UPDATE projects
       SET project_id = ${SQLITE_UUID_SQL}
@@ -168,15 +169,22 @@ const rebuildProjectsTableWithPrimaryKeySchema = (db: Database): void => {
         project_id TEXT PRIMARY KEY NOT NULL,
         project_path TEXT NOT NULL UNIQUE,
         custom_project_name TEXT DEFAULT NULL,
+        cached_display_name TEXT DEFAULT NULL,
         isStarred BOOLEAN DEFAULT 0,
         isArchived BOOLEAN DEFAULT 0
       )
     `);
+
+    const cachedDisplayNameExpression = columnNames.includes('cached_display_name')
+      ? 'cached_display_name'
+      : 'NULL';
+
     db.exec(`
       WITH source_rows AS (
         SELECT
           ${projectPathExpression} AS project_path,
           ${customProjectNameExpression} AS custom_project_name,
+          ${cachedDisplayNameExpression} AS cached_display_name,
           ${isStarredExpression} AS isStarred,
           ${isArchivedExpression} AS isArchived,
           ${projectIdExpression} AS candidate_project_id,
@@ -188,6 +196,7 @@ const rebuildProjectsTableWithPrimaryKeySchema = (db: Database): void => {
         SELECT
           project_path,
           custom_project_name,
+          cached_display_name,
           isStarred,
           isArchived,
           candidate_project_id,
@@ -204,6 +213,7 @@ const rebuildProjectsTableWithPrimaryKeySchema = (db: Database): void => {
           END AS project_id,
           project_path,
           custom_project_name,
+          cached_display_name,
           isStarred,
           isArchived
         FROM deduped_paths
@@ -213,6 +223,7 @@ const rebuildProjectsTableWithPrimaryKeySchema = (db: Database): void => {
         project_id,
         project_path,
         custom_project_name,
+        cached_display_name,
         isStarred,
         isArchived
       )
@@ -220,6 +231,7 @@ const rebuildProjectsTableWithPrimaryKeySchema = (db: Database): void => {
         project_id,
         project_path,
         custom_project_name,
+        cached_display_name,
         isStarred,
         isArchived
       FROM prepared_rows

--- a/server/modules/database/repositories/projects.db.ts
+++ b/server/modules/database/repositories/projects.db.ts
@@ -27,7 +27,7 @@ export const projectsDb = {
             ON CONFLICT(project_path) DO UPDATE SET
             isArchived = 0
             WHERE projects.isArchived = 1
-            RETURNING project_id, project_path, custom_project_name, isStarred, isArchived
+            RETURNING project_id, project_path, custom_project_name, cached_display_name, isStarred, isArchived
         `).get(attemptedId, normalizedProjectPath, normalizedProjectName) as ProjectRepositoryRow | undefined;
 
         if (row) {
@@ -48,7 +48,7 @@ export const projectsDb = {
         const db = getConnection();
         const normalizedProjectPath = normalizeProjectPath(projectPath);
         const row = db.prepare(`
-            SELECT project_id, project_path, custom_project_name, isStarred, isArchived
+            SELECT project_id, project_path, custom_project_name, cached_display_name, isStarred, isArchived
             FROM projects
             WHERE project_path = ?
         `).get(normalizedProjectPath) as ProjectRepositoryRow | undefined;
@@ -59,7 +59,7 @@ export const projectsDb = {
     getProjectById(projectId: string): ProjectRepositoryRow | null {
         const db = getConnection();
         const row = db.prepare(`
-            SELECT project_id, project_path, custom_project_name, isStarred, isArchived
+            SELECT project_id, project_path, custom_project_name, cached_display_name, isStarred, isArchived
             FROM projects
             WHERE project_id = ?
         `).get(projectId) as ProjectRepositoryRow | undefined;
@@ -89,7 +89,7 @@ export const projectsDb = {
     getProjectPaths(): ProjectRepositoryRow[] {
         const db = getConnection();
         return db.prepare(`
-            SELECT project_id, project_path, custom_project_name, isStarred, isArchived
+            SELECT project_id, project_path, custom_project_name, cached_display_name, isStarred, isArchived
             FROM projects
             WHERE isArchived = 0
         `).all() as ProjectRepositoryRow[];
@@ -102,7 +102,7 @@ export const projectsDb = {
     getArchivedProjectPaths(): ProjectRepositoryRow[] {
         const db = getConnection();
         return db.prepare(`
-            SELECT project_id, project_path, custom_project_name, isStarred, isArchived
+            SELECT project_id, project_path, custom_project_name, cached_display_name, isStarred, isArchived
             FROM projects
             WHERE isArchived = 1
         `).all() as ProjectRepositoryRow[];
@@ -192,5 +192,14 @@ export const projectsDb = {
             DELETE FROM projects
             WHERE project_id = ?
         `).run(projectId);
+    },
+
+    setCachedDisplayName(projectId: string, displayName: string | null): void {
+        const db = getConnection();
+        db.prepare(`
+            UPDATE projects
+            SET cached_display_name = ?
+            WHERE project_id = ?
+        `).run(displayName, projectId);
     },
 };

--- a/server/modules/database/repositories/sessions.db.ts
+++ b/server/modules/database/repositories/sessions.db.ts
@@ -59,7 +59,7 @@ export const sessionsDb = {
        ON CONFLICT(session_id) DO UPDATE SET
          provider = excluded.provider,
          updated_at = excluded.updated_at,
-         project_path = excluded.project_path,
+         project_path = COALESCE(NULLIF(excluded.project_path, ''), sessions.project_path),
          jsonl_path = excluded.jsonl_path,
          isArchived = 0,
          custom_name = COALESCE(excluded.custom_name, sessions.custom_name)`

--- a/server/modules/database/repositories/sessions.db.ts
+++ b/server/modules/database/repositories/sessions.db.ts
@@ -222,4 +222,20 @@ export const sessionsDb = {
     const db = getConnection();
     return db.prepare('DELETE FROM sessions WHERE session_id = ?').run(sessionId).changes > 0;
   },
+
+  /**
+   * Returns all sessions that have a non-empty custom_name so the service layer
+   * can sync them to the provider's history file on startup.
+   */
+  getSessionsWithCustomName(): Array<{ session_id: string; custom_name: string; project_path: string | null; jsonl_path: string | null; created_at: string }> {
+    const db = getConnection();
+    return db
+      .prepare(
+        `SELECT session_id, custom_name, project_path, jsonl_path, created_at
+         FROM sessions
+         WHERE custom_name IS NOT NULL AND custom_name != ''
+         ORDER BY updated_at DESC`
+      )
+      .all() as Array<{ session_id: string; custom_name: string; project_path: string | null; jsonl_path: string | null; created_at: string }>;
+  },
 };

--- a/server/modules/database/schema.ts
+++ b/server/modules/database/schema.ts
@@ -74,6 +74,7 @@ CREATE TABLE IF NOT EXISTS projects (
     project_id TEXT PRIMARY KEY NOT NULL,
     project_path TEXT NOT NULL UNIQUE,
     custom_project_name TEXT DEFAULT NULL,
+    cached_display_name TEXT DEFAULT NULL,
     isStarred BOOLEAN DEFAULT 0,
     isArchived BOOLEAN DEFAULT 0
 );

--- a/server/modules/projects/services/projects-with-sessions-fetch.service.ts
+++ b/server/modules/projects/services/projects-with-sessions-fetch.service.ts
@@ -12,6 +12,7 @@ type SessionSummary = {
   summary: string;
   messageCount: number;
   lastActivity: string;
+  projectPath?: string;
 };
 
 type SessionsByProvider = Record<'claude' | 'cursor' | 'codex' | 'gemini', SessionSummary[]>;
@@ -19,6 +20,7 @@ type SessionsByProvider = Record<'claude' | 'cursor' | 'codex' | 'gemini', Sessi
 type SessionRepositoryRow = {
   provider: string;
   session_id: string;
+  project_path?: string | null;
   custom_name?: string | null;
   updated_at?: string | null;
   created_at?: string | null;
@@ -130,6 +132,7 @@ function mapSessionRowToSummary(row: SessionRepositoryRow): SessionSummary {
     summary: row.custom_name || '',
     messageCount: 0,
     lastActivity: row.updated_at ?? row.created_at ?? new Date().toISOString(),
+    projectPath: row.project_path ?? undefined,
   };
 }
 

--- a/server/modules/projects/services/projects-with-sessions-fetch.service.ts
+++ b/server/modules/projects/services/projects-with-sessions-fetch.service.ts
@@ -205,6 +205,7 @@ function broadcastProgress(progress: ProgressUpdate) {
 
 /**
  * Reads all projects from DB and returns provider-bucketed session summaries.
+ * Uses cached_display_name to avoid reading package.json on every call.
  */
 export async function getProjectsWithSessions(
   options: GetProjectsWithSessionsOptions = {}
@@ -217,11 +218,39 @@ export async function getProjectsWithSessions(
     project_id: string;
     project_path: string;
     custom_project_name?: string | null;
+    cached_display_name?: string | null;
     isStarred?: number;
   }>;
   const totalProjects = projectRows.length;
   const projects: ProjectListItem[] = [];
   let processedProjects = 0;
+
+  // Collect projects that need their display name resolved from disk
+  const needsRefresh = new Map<string, typeof projectRows[0]>();
+
+  for (const row of projectRows) {
+    const hasCustomName = row.custom_project_name && row.custom_project_name.trim().length > 0;
+    const hasCache = row.cached_display_name && row.cached_display_name.trim().length > 0;
+    if (!hasCustomName && !hasCache) {
+      needsRefresh.set(row.project_id, row);
+    }
+  }
+
+  // Batch-resolve missing display names in parallel
+  const resolved = await Promise.allSettled(
+    Array.from(needsRefresh.values()).map(async (row) => {
+      const name = await generateDisplayName(path.basename(row.project_path) || row.project_path, row.project_path);
+      projectsDb.setCachedDisplayName(row.project_id, name);
+      return { projectId: row.project_id, name };
+    }),
+  );
+
+  const cacheMap = new Map<string, string>();
+  for (const r of resolved) {
+    if (r.status === 'fulfilled') {
+      cacheMap.set(r.value.projectId, r.value.name);
+    }
+  }
 
   for (const row of projectRows) {
     processedProjects += 1;
@@ -237,9 +266,11 @@ export async function getProjectsWithSessions(
     });
 
     const displayName =
-      row.custom_project_name && row.custom_project_name.trim().length > 0
+      (row.custom_project_name && row.custom_project_name.trim().length > 0)
         ? row.custom_project_name
-        : await generateDisplayName(path.basename(projectPath) || projectPath, projectPath);
+        : (row.cached_display_name && row.cached_display_name.trim().length > 0)
+          ? row.cached_display_name
+          : cacheMap.get(projectId) || path.basename(projectPath) || projectPath;
 
     const sessionsPage = readProjectSessionsPageByPath(projectPath, {
       limit: options.sessionsLimit,
@@ -288,6 +319,7 @@ export async function getArchivedProjectsWithSessions(
     project_id: string;
     project_path: string;
     custom_project_name?: string | null;
+    cached_display_name?: string | null;
     isStarred?: number;
   }>;
 
@@ -295,9 +327,11 @@ export async function getArchivedProjectsWithSessions(
 
   for (const row of projectRows) {
     const displayName =
-      row.custom_project_name && row.custom_project_name.trim().length > 0
+      (row.custom_project_name && row.custom_project_name.trim().length > 0)
         ? row.custom_project_name
-        : await generateDisplayName(path.basename(row.project_path) || row.project_path, row.project_path);
+        : (row.cached_display_name && row.cached_display_name.trim().length > 0)
+          ? row.cached_display_name
+          : await generateDisplayName(path.basename(row.project_path) || row.project_path, row.project_path);
 
     const sessionsPage = readProjectSessionsIncludingArchived(row.project_path);
 

--- a/server/modules/projects/tests/project-management.service.test.ts
+++ b/server/modules/projects/tests/project-management.service.test.ts
@@ -8,6 +8,7 @@ const projectRow = {
   project_id: 'project-1',
   project_path: '/workspace/my-project',
   custom_project_name: 'my-project',
+  cached_display_name: null,
   isStarred: 0,
   isArchived: 0,
 };

--- a/server/modules/projects/tests/project-star.service.test.ts
+++ b/server/modules/projects/tests/project-star.service.test.ts
@@ -9,6 +9,7 @@ type ProjectRow = {
   project_id: string;
   project_path: string;
   custom_project_name: string | null;
+  cached_display_name: string | null;
   isStarred: number;
   isArchived: number;
 };
@@ -52,6 +53,7 @@ test('toggleProjectStar flips star state and persists it', () => {
         project_id: 'project-1',
         project_path: '/workspace/project-1',
         custom_project_name: 'project-1',
+        cached_display_name: null,
         isStarred: 0,
         isArchived: 0,
       }) as ProjectRow;
@@ -84,6 +86,7 @@ test('applyLegacyStarredProjectIds stars only valid, unstarred projects', () => 
           project_id: 'project-a',
           project_path: '/workspace/project-a',
           custom_project_name: 'A',
+          cached_display_name: null,
           isStarred: 0,
           isArchived: 0,
         } as ProjectRow;

--- a/server/modules/providers/list/claude/claude-session-synchronizer.provider.ts
+++ b/server/modules/providers/list/claude/claude-session-synchronizer.provider.ts
@@ -38,6 +38,12 @@ export class ClaudeSessionSynchronizer implements IProviderSessionSynchronizer {
 
     let processed = 0;
     for (const filePath of files) {
+      // Skip subagent JSONL files — they share the parent session's sessionId
+      // and would overwrite the correct jsonl_path with the subagent path
+      if (path.basename(path.dirname(filePath)) === 'subagents') {
+        continue;
+      }
+
       const parsed = await this.processSessionFile(filePath, nameMap);
       if (!parsed) {
         continue;

--- a/server/modules/providers/list/claude/claude-session-synchronizer.provider.ts
+++ b/server/modules/providers/list/claude/claude-session-synchronizer.provider.ts
@@ -74,6 +74,13 @@ export class ClaudeSessionSynchronizer implements IProviderSessionSynchronizer {
       return null;
     }
 
+    // Skip subagent JSONL files — they share the parent session's sessionId
+    // and would overwrite the correct jsonl_path with the subagent path
+    const pathSegments = path.normalize(filePath).split(path.sep);
+    if (pathSegments.includes('subagents')) {
+      return null;
+    }
+
     const nameMap = await buildLookupMap(path.join(this.claudeHome, 'history.jsonl'), 'sessionId', 'display');
     const parsed = await this.processSessionFile(filePath, nameMap);
     if (!parsed) {

--- a/server/modules/providers/list/claude/claude-session-synchronizer.provider.ts
+++ b/server/modules/providers/list/claude/claude-session-synchronizer.provider.ts
@@ -40,7 +40,8 @@ export class ClaudeSessionSynchronizer implements IProviderSessionSynchronizer {
     for (const filePath of files) {
       // Skip subagent JSONL files — they share the parent session's sessionId
       // and would overwrite the correct jsonl_path with the subagent path
-      if (path.basename(path.dirname(filePath)) === 'subagents') {
+      const pathSegments = path.normalize(filePath).split(path.sep);
+      if (pathSegments.includes('subagents')) {
         continue;
       }
 

--- a/server/modules/providers/list/claude/claude-sessions.provider.ts
+++ b/server/modules/providers/list/claude/claude-sessions.provider.ts
@@ -53,7 +53,8 @@ async function parseAgentTools(filePath: string): Promise<AnyRecord[]> {
       try {
         const entry = JSON.parse(line) as AnyRecord;
 
-        if (entry.message?.role === 'assistant' && Array.isArray(entry.message?.content)) {
+        const isAssistantEntry = entry.message?.role === 'assistant' || entry.type === 'assistant';
+        if (isAssistantEntry && Array.isArray(entry.message?.content)) {
           for (const part of entry.message.content as AnyRecord[]) {
             if (part.type === 'tool_use') {
               tools.push({
@@ -348,7 +349,10 @@ export class ClaudeSessionsProvider implements IProviderSessions {
       return messages;
     }
 
-    if (raw.message?.role === 'assistant' && raw.message?.content) {
+    // Claude Desktop uses top-level `type: 'assistant'` instead of `message.role`,
+    // so check both to support CLI and Desktop transcript formats.
+    const isAssistant = raw.message?.role === 'assistant' || raw.type === 'assistant';
+    if (isAssistant && raw.message?.content) {
       if (Array.isArray(raw.message.content)) {
         let partIndex = 0;
         for (const part of raw.message.content) {

--- a/server/modules/providers/list/claude/claude-sessions.provider.ts
+++ b/server/modules/providers/list/claude/claude-sessions.provider.ts
@@ -241,6 +241,24 @@ type ClaudeLocalCommandPayload = {
 };
 
 /**
+ * Detects SDK-generated context resumption summaries that appear as user-role
+ * messages with no isSynthetic or origin markers. These are injected by the
+ * Claude Code SDK when a conversation runs out of context and needs to resume.
+ */
+function isContextResumptionSummary(raw: AnyRecord): boolean {
+  const content = raw.message?.content;
+  if (!content) return false;
+
+  const text = typeof content === 'string'
+    ? content
+    : Array.isArray(content)
+      ? content.filter((p: AnyRecord) => p.type === 'text').map((p: AnyRecord) => p.text).join('\n')
+      : '';
+
+  return text.trim().startsWith('This session is being continued from a previous conversation');
+}
+
+/**
  * Converts Claude's hidden local command wrapper into structured metadata.
  *
  * The three tags often coexist in one string payload. Returning `null` lets the
@@ -373,6 +391,10 @@ export class ClaudeSessionsProvider implements IProviderSessions {
       && (raw.origin?.kind === undefined || raw.origin?.kind === 'human');
 
     if (raw.message?.role === 'user' && raw.message?.content && raw.isMeta !== true) {
+      if (isContextResumptionSummary(raw)) {
+        return messages;
+      }
+
       if (Array.isArray(raw.message.content)) {
         for (let partIndex = 0; partIndex < raw.message.content.length; partIndex++) {
           const part = raw.message.content[partIndex];

--- a/server/modules/providers/list/claude/claude-sessions.provider.ts
+++ b/server/modules/providers/list/claude/claude-sessions.provider.ts
@@ -387,22 +387,33 @@ export class ClaudeSessionsProvider implements IProviderSessions {
     const baseId = raw.uuid || generateMessageId('claude');
 
     /*
-     * Filter out non-human user-role messages during streaming.
-     * SDK emits synthetic user messages (subagent prompts, internal
-     * bookkeeping) that have message.role === 'user' but should NOT be
-     * rendered as user chat bubbles. The `isSynthetic` flag or a non-`human`
-     * origin indicate these are system-generated, not keyboard input.
-     * This check is a no-op for pure tool_result containers — they have no
-     * text parts and are handled by the tool_result branch below.
+     * SDK emits `type: 'user'` messages that are NOT real user keyboard input.
+     * They are context injection (skill directories, image metadata, tool errors)
+     * and subagent task prompts. Real user messages are rendered client-side via
+     * the pendingUserMessage mechanism, so SDK user-role text echoes are redundant.
+     *
+     * We detect these by checking if the message contains ONLY tool_result parts
+     * (valid, needed for attachment) vs having text parts (should be filtered).
+     *
+     * Note: isSynthetic/origin fields are NOT available in current SDK versions.
      */
-    const isHumanOrigin =
-      !raw.isSynthetic
-      && (raw.origin?.kind === undefined || raw.origin?.kind === 'human');
-
     if (raw.message?.role === 'user' && raw.message?.content && raw.isMeta !== true) {
       if (isContextResumptionSummary(raw)) {
         return messages;
       }
+
+      /*
+       * SDK streaming `type: 'user'` messages are NOT real user keyboard input.
+       * They are system context injection (skill directories, image metadata,
+       * tool errors) and subagent task prompts. Real user messages are rendered
+       * client-side via the pendingUserMessage mechanism.
+       *
+       * JSONL history messages don't have `type: 'user'` at the top level —
+       * they use `message.role === 'user'` instead. Use this to distinguish.
+       *
+       * Note: isSynthetic/origin fields are NOT available in current SDK versions.
+       */
+      const isSdkStreamingUser = raw.type === 'user';
 
       if (Array.isArray(raw.message.content)) {
         for (let partIndex = 0; partIndex < raw.message.content.length; partIndex++) {
@@ -422,7 +433,9 @@ export class ClaudeSessionsProvider implements IProviderSessions {
             }));
           } else if (part.type === 'text') {
             const text = part.text || '';
-            if (text && !isInternalContent(text) && isHumanOrigin) {
+            // Skip SDK streaming text — they're system context, not user input
+            if (isSdkStreamingUser) continue;
+            if (text && !isInternalContent(text)) {
               if (isImageContent(text)) {
                 continue;
               }
@@ -539,7 +552,7 @@ export class ClaudeSessionsProvider implements IProviderSessions {
           return messages;
         }
 
-        if (text && !isInternalContent(text) && isHumanOrigin) {
+        if (text && !isInternalContent(text) && !isSdkStreamingUser) {
           if (!isSubagentPromptEcho(text, subagentPrompts)) {
             messages.push(createNormalizedMessage({
               id: baseId,

--- a/server/modules/providers/list/claude/claude-sessions.provider.ts
+++ b/server/modules/providers/list/claude/claude-sessions.provider.ts
@@ -284,15 +284,56 @@ function buildLocalCommandDisplayText(payload: ClaudeLocalCommandPayload): strin
  * captured from the terminal. The web chat should receive readable plain text.
  */
 function stripAnsiFormatting(text: string): string {
-  return text.replace(/\u001B\[[0-9;?]*[ -/]*[@-~]/g, '');
+  return text.replace(/\[[0-9;?]*[ -/]*[@-~]/g, '');
+}
+
+/**
+ * Extracts the prompt text from a Task tool input for subagent echo-filtering.
+ */
+function extractSubagentPrompt(toolInput: unknown): string | null {
+  if (!toolInput) return null;
+  let parsed: AnyRecord = toolInput;
+  if (typeof toolInput === 'string') {
+    try {
+      parsed = JSON.parse(toolInput);
+    } catch {
+      return null;
+    }
+  }
+  return typeof parsed.prompt === 'string' ? parsed.prompt : null;
+}
+
+function normalizeWhitespace(s: string): string {
+  return s.replace(/[ \t]+/g, ' ').trim();
+}
+
+function isSubagentPromptEcho(text: string, subagentPrompts: Set<string> | null): boolean {
+  if (!subagentPrompts) return false;
+  const normalized = normalizeWhitespace(text);
+  for (const prompt of subagentPrompts) {
+    const np = normalizeWhitespace(prompt);
+    if (normalized === np || normalized.startsWith(np)) {
+      return true;
+    }
+  }
+  return false;
 }
 
 export class ClaudeSessionsProvider implements IProviderSessions {
   /**
    * Normalizes one Claude JSONL entry or live SDK stream event into the shared
    * message shape consumed by REST and WebSocket clients.
+   *
+   * @param subagentPrompts - Set of subagent task prompts to filter out.
+   *   These are "Task" tool prompts that also appear as separate user-role
+   *   messages in the JSONL — normalizing them would render them as user
+   *   chat bubbles which is incorrect.
    */
-  normalizeMessage(rawMessage: unknown, sessionId: string | null): NormalizedMessage[] {
+  normalizeMessage(
+    rawMessage: unknown,
+    sessionId: string | null,
+    subagentPrompts: Set<string> | null = null,
+  ): NormalizedMessage[] {
     const raw = readObjectRecord(rawMessage);
     if (!raw) {
       return [];
@@ -329,15 +370,18 @@ export class ClaudeSessionsProvider implements IProviderSessions {
           } else if (part.type === 'text') {
             const text = part.text || '';
             if (text && !isInternalContent(text)) {
-              messages.push(createNormalizedMessage({
-                id: `${baseId}_text_${partIndex}`,
-                sessionId,
-                timestamp: ts,
-                provider: PROVIDER,
-                kind: 'text',
-                role: 'user',
-                content: text,
-              }));
+              const isEcho = isSubagentPromptEcho(text, subagentPrompts);
+              if (!isEcho) {
+                messages.push(createNormalizedMessage({
+                  id: `${baseId}_text_${partIndex}`,
+                  sessionId,
+                  timestamp: ts,
+                  provider: PROVIDER,
+                  kind: 'text',
+                  role: 'user',
+                  content: text,
+                }));
+              }
             }
           }
         }
@@ -349,15 +393,18 @@ export class ClaudeSessionsProvider implements IProviderSessions {
             .filter(Boolean)
             .join('\n');
           if (textParts && !isInternalContent(textParts)) {
-            messages.push(createNormalizedMessage({
-              id: `${baseId}_text`,
-              sessionId,
-              timestamp: ts,
-              provider: PROVIDER,
-              kind: 'text',
-              role: 'user',
-              content: textParts,
-            }));
+            const isEcho = isSubagentPromptEcho(textParts, subagentPrompts);
+            if (!isEcho) {
+              messages.push(createNormalizedMessage({
+                id: `${baseId}_text`,
+                sessionId,
+                timestamp: ts,
+                provider: PROVIDER,
+                kind: 'text',
+                role: 'user',
+                content: textParts,
+              }));
+            }
           }
         }
       } else if (typeof raw.message.content === 'string') {
@@ -437,15 +484,17 @@ export class ClaudeSessionsProvider implements IProviderSessions {
         }
 
         if (text && !isInternalContent(text)) {
-          messages.push(createNormalizedMessage({
-            id: baseId,
-            sessionId,
-            timestamp: ts,
-            provider: PROVIDER,
-            kind: 'text',
-            role: 'user',
-            content: text,
-          }));
+          if (!isSubagentPromptEcho(text, subagentPrompts)) {
+            messages.push(createNormalizedMessage({
+              id: baseId,
+              sessionId,
+              timestamp: ts,
+              provider: PROVIDER,
+              kind: 'text',
+              role: 'user',
+              content: text,
+            }));
+          }
         }
       }
       return messages;
@@ -571,6 +620,29 @@ export class ClaudeSessionsProvider implements IProviderSessions {
 
     const rawMessages = Array.isArray(result) ? result : (result.messages || []);
 
+    /*
+     * Collect Task subagent prompts from raw messages so duplicate user-role
+     * echo messages can be filtered out during normalization.
+     */
+    const subagentPrompts = new Set<string>();
+    for (const raw of rawMessages) {
+      if (raw.message?.role === 'assistant' && Array.isArray(raw.message?.content)) {
+        for (const part of raw.message.content) {
+          if (part.type === 'tool_use' && part.name === 'Task') {
+            const prompt = extractSubagentPrompt(part.input);
+            if (prompt) {
+              subagentPrompts.add(prompt);
+            }
+          }
+        }
+      }
+    }
+
+    const normalized: NormalizedMessage[] = [];
+    for (const raw of rawMessages) {
+      normalized.push(...this.normalizeMessage(raw, sessionId, subagentPrompts.size > 0 ? subagentPrompts : null));
+    }
+
     const toolResultMap = new Map<string, ClaudeToolResult>();
     for (const raw of rawMessages) {
       if (raw.message?.role === 'user' && Array.isArray(raw.message?.content)) {
@@ -585,11 +657,6 @@ export class ClaudeSessionsProvider implements IProviderSessions {
           }
         }
       }
-    }
-
-    const normalized: NormalizedMessage[] = [];
-    for (const raw of rawMessages) {
-      normalized.push(...this.normalizeMessage(raw, sessionId));
     }
 
     for (const msg of normalized) {

--- a/server/modules/providers/list/claude/claude-sessions.provider.ts
+++ b/server/modules/providers/list/claude/claude-sessions.provider.ts
@@ -359,6 +359,19 @@ export class ClaudeSessionsProvider implements IProviderSessions {
     const ts = raw.timestamp || new Date().toISOString();
     const baseId = raw.uuid || generateMessageId('claude');
 
+    /*
+     * Filter out non-human user-role messages during streaming.
+     * SDK emits synthetic user messages (subagent prompts, internal
+     * bookkeeping) that have message.role === 'user' but should NOT be
+     * rendered as user chat bubbles. The `isSynthetic` flag or a non-`human`
+     * origin indicate these are system-generated, not keyboard input.
+     * This check is a no-op for pure tool_result containers — they have no
+     * text parts and are handled by the tool_result branch below.
+     */
+    const isHumanOrigin =
+      !raw.isSynthetic
+      && (raw.origin?.kind === undefined || raw.origin?.kind === 'human');
+
     if (raw.message?.role === 'user' && raw.message?.content && raw.isMeta !== true) {
       if (Array.isArray(raw.message.content)) {
         for (let partIndex = 0; partIndex < raw.message.content.length; partIndex++) {
@@ -378,7 +391,7 @@ export class ClaudeSessionsProvider implements IProviderSessions {
             }));
           } else if (part.type === 'text') {
             const text = part.text || '';
-            if (text && !isInternalContent(text)) {
+            if (text && !isInternalContent(text) && isHumanOrigin) {
               const isEcho = isSubagentPromptEcho(text, subagentPrompts);
               if (!isEcho) {
                 messages.push(createNormalizedMessage({
@@ -492,7 +505,7 @@ export class ClaudeSessionsProvider implements IProviderSessions {
           return messages;
         }
 
-        if (text && !isInternalContent(text)) {
+        if (text && !isInternalContent(text) && isHumanOrigin) {
           if (!isSubagentPromptEcho(text, subagentPrompts)) {
             messages.push(createNormalizedMessage({
               id: baseId,

--- a/server/modules/providers/list/claude/claude-sessions.provider.ts
+++ b/server/modules/providers/list/claude/claude-sessions.provider.ts
@@ -223,6 +223,15 @@ function isInternalContent(content: string): boolean {
   return INTERNAL_CONTENT_PREFIXES.some((prefix) => content.startsWith(prefix));
 }
 
+/** Check if text content is an image (base64 or data URI) that should not render as a user chat bubble. */
+function isImageContent(text: string): boolean {
+  const trimmed = text.trim();
+  if (trimmed.startsWith('data:image/')) {
+    return true;
+  }
+  return false;
+}
+
 /**
  * Claude wraps local slash-command metadata in lightweight XML-like tags inside
  * a plain string payload. We intentionally parse only the small tag surface we
@@ -414,6 +423,9 @@ export class ClaudeSessionsProvider implements IProviderSessions {
           } else if (part.type === 'text') {
             const text = part.text || '';
             if (text && !isInternalContent(text) && isHumanOrigin) {
+              if (isImageContent(text)) {
+                continue;
+              }
               const isEcho = isSubagentPromptEcho(text, subagentPrompts);
               if (!isEcho) {
                 messages.push(createNormalizedMessage({

--- a/server/modules/providers/list/claude/claude-sessions.provider.ts
+++ b/server/modules/providers/list/claude/claude-sessions.provider.ts
@@ -403,17 +403,14 @@ export class ClaudeSessionsProvider implements IProviderSessions {
       }
 
       /*
-       * SDK streaming `type: 'user'` messages are NOT real user keyboard input.
-       * They are system context injection (skill directories, image metadata,
-       * tool errors) and subagent task prompts. Real user messages are rendered
-       * client-side via the pendingUserMessage mechanism.
-       *
-       * JSONL history messages don't have `type: 'user'` at the top level —
-       * they use `message.role === 'user'` instead. Use this to distinguish.
-       *
-       * Note: isSynthetic/origin fields are NOT available in current SDK versions.
+       * Only real user keyboard input messages have `permissionMode`
+       * (set by the CLI when writing to JSONL). SDK streaming messages,
+       * subagent tool results, and system context injection do NOT.
+       * Real user messages are rendered client-side via pendingUserMessage,
+       * so we only show text content when permissionMode is present.
+       * Tool result parts are always preserved for attachments.
        */
-      const isSdkStreamingUser = raw.type === 'user';
+      const isRealUserMessage = !!raw.permissionMode;
 
       if (Array.isArray(raw.message.content)) {
         for (let partIndex = 0; partIndex < raw.message.content.length; partIndex++) {
@@ -433,8 +430,8 @@ export class ClaudeSessionsProvider implements IProviderSessions {
             }));
           } else if (part.type === 'text') {
             const text = part.text || '';
-            // Skip SDK streaming text — they're system context, not user input
-            if (isSdkStreamingUser) continue;
+            // Only show text content for real user messages (has permissionMode)
+            if (!isRealUserMessage) continue;
             if (text && !isInternalContent(text)) {
               if (isImageContent(text)) {
                 continue;
@@ -455,7 +452,7 @@ export class ClaudeSessionsProvider implements IProviderSessions {
           }
         }
 
-        if (messages.length === 0) {
+        if (messages.length === 0 && isRealUserMessage) {
           const textParts = raw.message.content
             .filter((part: AnyRecord) => part.type === 'text')
             .map((part: AnyRecord) => part.text)
@@ -552,7 +549,7 @@ export class ClaudeSessionsProvider implements IProviderSessions {
           return messages;
         }
 
-        if (text && !isInternalContent(text) && !isSdkStreamingUser) {
+        if (text && !isInternalContent(text) && isRealUserMessage) {
           if (!isSubagentPromptEcho(text, subagentPrompts)) {
             messages.push(createNormalizedMessage({
               id: baseId,

--- a/server/modules/providers/list/claude/claude-sessions.provider.ts
+++ b/server/modules/providers/list/claude/claude-sessions.provider.ts
@@ -287,8 +287,13 @@ function buildLocalCommandDisplayText(payload: ClaudeLocalCommandPayload): strin
  * captured from the terminal. The web chat should receive readable plain text.
  */
 function stripAnsiFormatting(text: string): string {
-  return text.replace(/\[[0-9;?]*[ -/]*[@-~]/g, '');
+  return text
+    .replace(/\x1b\[[0-9;?]*[ -/]*[@-~]/g, '')  // CSI sequences
+    .replace(/\x1b\][^\x07]*(?:\x07)?/g, '')    // OSC sequences
+    .replace(/\x1b[^\x1b[\x07-\r\n]/g, '')      // control sequences
+    .replace(/\r/g, '');
 }
+
 
 /**
  * Extracts the prompt text from a Task tool input for subagent echo-filtering.

--- a/server/modules/providers/list/claude/claude-sessions.provider.ts
+++ b/server/modules/providers/list/claude/claude-sessions.provider.ts
@@ -311,9 +311,9 @@ function extractSubagentPrompt(toolInput: unknown): string | null {
   return typeof parsed.prompt === 'string' ? parsed.prompt : null;
 }
 
-/** Collapse all whitespace runs into single spaces and trim. */
+/** Collapse all whitespace runs (including newlines) into single spaces and trim. */
 function normalizeWhitespace(s: string): string {
-  return s.replace(/[ \t]+/g, ' ').trim();
+  return s.replace(/\s+/g, ' ').trim();
 }
 
 function isSubagentPromptEcho(text: string, subagentPrompts: Set<string> | null): boolean {

--- a/server/modules/providers/list/claude/claude-sessions.provider.ts
+++ b/server/modules/providers/list/claude/claude-sessions.provider.ts
@@ -53,7 +53,8 @@ async function parseAgentTools(filePath: string): Promise<AnyRecord[]> {
       try {
         const entry = JSON.parse(line) as AnyRecord;
 
-        if (entry.message?.role === 'assistant' && Array.isArray(entry.message?.content)) {
+        const isAssistantEntry = entry.message?.role === 'assistant' || entry.type === 'assistant';
+        if (isAssistantEntry && Array.isArray(entry.message?.content)) {
           for (const part of entry.message.content as AnyRecord[]) {
             if (part.type === 'tool_use') {
               tools.push({
@@ -490,7 +491,10 @@ export class ClaudeSessionsProvider implements IProviderSessions {
       return messages;
     }
 
-    if (raw.message?.role === 'assistant' && raw.message?.content) {
+    // Claude Desktop uses top-level `type: 'assistant'` instead of `message.role`,
+    // so check both to support CLI and Desktop transcript formats.
+    const isAssistant = raw.message?.role === 'assistant' || raw.type === 'assistant';
+    if (isAssistant && raw.message?.content) {
       if (Array.isArray(raw.message.content)) {
         let partIndex = 0;
         for (const part of raw.message.content) {

--- a/server/modules/providers/list/claude/claude-sessions.provider.ts
+++ b/server/modules/providers/list/claude/claude-sessions.provider.ts
@@ -35,6 +35,7 @@ type ClaudeHistoryMessagesResult =
     limit?: number | null;
   };
 
+/** Parse agent JSONL files to extract tool use/result pairs for injection into main messages. */
 async function parseAgentTools(filePath: string): Promise<AnyRecord[]> {
   const tools: AnyRecord[] = [];
 
@@ -102,6 +103,7 @@ async function parseAgentTools(filePath: string): Promise<AnyRecord[]> {
   return tools;
 }
 
+/** Read the main JSONL transcript and merge in subagent tool messages from agent-*.jsonl files. */
 async function getSessionMessages(
   sessionId: string,
   limit: number | null,
@@ -216,6 +218,7 @@ const INTERNAL_CONTENT_PREFIXES = [
   '[Request interrupted',
 ] as const;
 
+/** Check if content is an internal Claude CLI artifact that should not be shown to the user. */
 function isInternalContent(content: string): boolean {
   return INTERNAL_CONTENT_PREFIXES.some((prefix) => content.startsWith(prefix));
 }
@@ -303,6 +306,7 @@ function extractSubagentPrompt(toolInput: unknown): string | null {
   return typeof parsed.prompt === 'string' ? parsed.prompt : null;
 }
 
+/** Collapse all whitespace runs into single spaces and trim. */
 function normalizeWhitespace(s: string): string {
   return s.replace(/[ \t]+/g, ' ').trim();
 }
@@ -626,7 +630,8 @@ export class ClaudeSessionsProvider implements IProviderSessions {
      */
     const subagentPrompts = new Set<string>();
     for (const raw of rawMessages) {
-      if (raw.message?.role === 'assistant' && Array.isArray(raw.message?.content)) {
+      const isAssistant = raw.message?.role === 'assistant' || raw.type === 'assistant';
+      if (isAssistant && Array.isArray(raw.message?.content)) {
         for (const part of raw.message.content) {
           if (part.type === 'tool_use' && part.name === 'Task') {
             const prompt = extractSubagentPrompt(part.input);
@@ -677,24 +682,19 @@ export class ClaudeSessionsProvider implements IProviderSessions {
       }
     }
 
-    const totalNormalized = normalized.length;
-    let total = 0;
-    for (const msg of normalized) {
-      if (msg.kind !== 'tool_result') {
-        total += 1;
-      }
-    }
+    const paginableMessages = normalized.filter((msg) => msg.kind !== 'tool_result');
+    const total = paginableMessages.length;
     const normalizedOffset = Math.max(0, offset);
     const normalizedLimit = limit === null ? null : Math.max(0, limit);
     const messages = normalizedLimit === null
-      ? normalized
-      : normalized.slice(
-          Math.max(0, totalNormalized - normalizedOffset - normalizedLimit),
-          Math.max(0, totalNormalized - normalizedOffset),
+      ? paginableMessages
+      : paginableMessages.slice(
+          Math.max(0, total - normalizedOffset - normalizedLimit),
+          Math.max(0, total - normalizedOffset),
         );
     const hasMore = normalizedLimit === null
       ? false
-      : Math.max(0, totalNormalized - normalizedOffset - normalizedLimit) > 0;
+      : Math.max(0, total - normalizedOffset - normalizedLimit) > 0;
 
     return {
       messages,

--- a/server/modules/providers/provider.routes.ts
+++ b/server/modules/providers/provider.routes.ts
@@ -359,7 +359,7 @@ router.put(
   asyncHandler(async (req: Request, res: Response) => {
     const sessionId = parseSessionId(req.params.sessionId);
     const summary = parseSessionRenameSummary(req.body);
-    const result = sessionsService.renameSessionById(sessionId, summary);
+    const result = await sessionsService.renameSessionById(sessionId, summary);
     res.json(createApiSuccessResponse(result));
   }),
 );

--- a/server/modules/providers/services/sessions-watcher.service.ts
+++ b/server/modules/providers/services/sessions-watcher.service.ts
@@ -5,6 +5,7 @@ import { promises as fsPromises } from 'node:fs';
 import chokidar, { type FSWatcher } from 'chokidar';
 
 import { sessionSynchronizerService } from '@/modules/providers/services/session-synchronizer.service.js';
+import { sessionsService } from '@/modules/providers/services/sessions.service.js';
 import { WS_OPEN_STATE, connectedClients } from '@/modules/websocket/index.js';
 import type { LLMProvider } from '@/shared/types.js';
 import { getProjectsWithSessions } from '@/modules/projects/index.js';
@@ -222,6 +223,13 @@ export async function initializeSessionsWatcher(): Promise<void> {
     processedByProvider: initialSync.processedByProvider,
     failures: initialSync.failures,
   });
+
+  try {
+    await sessionsService.syncSessionNames();
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error('Failed to sync session names to history', { error: message });
+  }
 
   for (const { provider, rootPath } of PROVIDER_WATCH_PATHS) {
     try {

--- a/server/modules/providers/services/sessions.service.ts
+++ b/server/modules/providers/services/sessions.service.ts
@@ -64,21 +64,44 @@ function resolveProjectDisplayName(
 }
 
 /**
- * Sets the custom title for a session by appending a custom-title entry
- * to the session's JSONL file. This is what `claude -r` reads to display
- * session names.
+ * Writes a custom-title entry to the session's JSONL file as the last line.
+ * Any existing custom-title entries for the same session are removed first,
+ * so new messages appended by Claude CLI don't bury the entry.
  */
 async function setSessionTitle(sessionId: string, title: string): Promise<void> {
   const session = sessionsDb.getSessionById(sessionId);
   if (!session?.jsonl_path) return;
 
   try {
+    const content = await fsp.readFile(session.jsonl_path, 'utf8');
+    const lines = content.split(/\r?\n/);
+    // Strip any existing custom-title entries for this session
+    const cleaned = lines.filter((line) => {
+      const trimmed = line.trim();
+      if (!trimmed) return true;
+      try {
+        const parsed = JSON.parse(trimmed);
+        if (
+          typeof parsed === 'object' &&
+          parsed !== null &&
+          (parsed as Record<string, unknown>).type === 'custom-title' &&
+          (parsed as Record<string, unknown>).sessionId === sessionId
+        ) {
+          return false;
+        }
+      } catch {
+        // skip non-JSON lines
+      }
+      return true;
+    });
+
     const entry = JSON.stringify({
       type: 'custom-title',
       customTitle: title,
       sessionId,
     });
-    await fsp.appendFile(session.jsonl_path, '\n' + entry, 'utf8');
+    const result = cleaned.filter((l) => l.length > 0).join('\n') + '\n' + entry;
+    await fsp.writeFile(session.jsonl_path, result, 'utf8');
   } catch {
     // Session file may not exist or may be locked
   }
@@ -87,6 +110,8 @@ async function setSessionTitle(sessionId: string, title: string): Promise<void> 
 /**
  * Scans all sessions with custom_name and syncs them to their session JSONL files
  * on startup so `claude -r` displays the CloudCLI session names.
+ * Removes any existing custom-title entries and appends a fresh one at the end,
+ * so entries buried by subsequent messages are re-surfaced.
  */
 async function syncAllSessionNamesToHistory(): Promise<void> {
   const sessions = sessionsDb.getSessionsWithCustomName();
@@ -98,11 +123,10 @@ async function syncAllSessionNamesToHistory(): Promise<void> {
     try {
       const content = await fsp.readFile(session.jsonl_path, 'utf8');
       const lines = content.split(/\r?\n/);
-      let hasCustomTitle = false;
-
-      for (const line of lines) {
+      // Strip any existing custom-title entries for this session
+      const cleaned = lines.filter((line) => {
         const trimmed = line.trim();
-        if (!trimmed) continue;
+        if (!trimmed) return true;
         try {
           const parsed = JSON.parse(trimmed);
           if (
@@ -111,23 +135,22 @@ async function syncAllSessionNamesToHistory(): Promise<void> {
             (parsed as Record<string, unknown>).type === 'custom-title' &&
             (parsed as Record<string, unknown>).sessionId === session.session_id
           ) {
-            hasCustomTitle = true;
-            break;
+            return false;
           }
         } catch {
           // skip non-JSON lines
         }
-      }
+        return true;
+      });
 
-      if (!hasCustomTitle) {
-        const entry = JSON.stringify({
-          type: 'custom-title',
-          customTitle: session.custom_name,
-          sessionId: session.session_id,
-        });
-        await fsp.appendFile(session.jsonl_path, '\n' + entry, 'utf8');
-        synced++;
-      }
+      const entry = JSON.stringify({
+        type: 'custom-title',
+        customTitle: session.custom_name,
+        sessionId: session.session_id,
+      });
+      const result = cleaned.filter((l) => l.length > 0).join('\n') + '\n' + entry;
+      await fsp.writeFile(session.jsonl_path, result, 'utf8');
+      synced++;
     } catch {
       // Session file may not exist
     }

--- a/server/modules/providers/services/sessions.service.ts
+++ b/server/modules/providers/services/sessions.service.ts
@@ -1,4 +1,5 @@
 import fsp from 'node:fs/promises';
+import os from 'node:os';
 import path from 'node:path';
 
 import { projectsDb, sessionsDb } from '@/modules/database/index.js';
@@ -60,6 +61,81 @@ function resolveProjectDisplayName(
   }
 
   return path.basename(projectPath) || projectPath;
+}
+
+/**
+ * Sets the custom title for a session by appending a custom-title entry
+ * to the session's JSONL file. This is what `claude -r` reads to display
+ * session names.
+ */
+async function setSessionTitle(sessionId: string, title: string): Promise<void> {
+  const session = sessionsDb.getSessionById(sessionId);
+  if (!session?.jsonl_path) return;
+
+  try {
+    const entry = JSON.stringify({
+      type: 'custom-title',
+      customTitle: title,
+      sessionId,
+    });
+    await fsp.appendFile(session.jsonl_path, '\n' + entry, 'utf8');
+  } catch {
+    // Session file may not exist or may be locked
+  }
+}
+
+/**
+ * Scans all sessions with custom_name and syncs them to their session JSONL files
+ * on startup so `claude -r` displays the CloudCLI session names.
+ */
+async function syncAllSessionNamesToHistory(): Promise<void> {
+  const sessions = sessionsDb.getSessionsWithCustomName();
+  if (sessions.length === 0) return;
+
+  let synced = 0;
+  for (const session of sessions) {
+    if (!session.jsonl_path) continue;
+    try {
+      const content = await fsp.readFile(session.jsonl_path, 'utf8');
+      const lines = content.split(/\r?\n/);
+      let hasCustomTitle = false;
+
+      for (const line of lines) {
+        const trimmed = line.trim();
+        if (!trimmed) continue;
+        try {
+          const parsed = JSON.parse(trimmed);
+          if (
+            typeof parsed === 'object' &&
+            parsed !== null &&
+            (parsed as Record<string, unknown>).type === 'custom-title' &&
+            (parsed as Record<string, unknown>).sessionId === session.session_id
+          ) {
+            hasCustomTitle = true;
+            break;
+          }
+        } catch {
+          // skip non-JSON lines
+        }
+      }
+
+      if (!hasCustomTitle) {
+        const entry = JSON.stringify({
+          type: 'custom-title',
+          customTitle: session.custom_name,
+          sessionId: session.session_id,
+        });
+        await fsp.appendFile(session.jsonl_path, '\n' + entry, 'utf8');
+        synced++;
+      }
+    } catch {
+      // Session file may not exist
+    }
+  }
+
+  if (synced > 0) {
+    console.log(`[Sessions] Synced ${synced} session name(s) to session JSONL files`);
+  }
 }
 
 /**
@@ -221,9 +297,9 @@ export const sessionsService = {
   },
 
   /**
-   * Renames one session by id without requiring the caller to pass provider.
+   * Renames one session by id and syncs the name to the provider's history file.
    */
-  renameSessionById(sessionId: string, summary: string): { sessionId: string; summary: string } {
+  async renameSessionById(sessionId: string, summary: string): Promise<{ sessionId: string; summary: string }> {
     const session = sessionsDb.getSessionById(sessionId);
     if (!session) {
       throw new AppError(`Session "${sessionId}" was not found.`, {
@@ -233,6 +309,16 @@ export const sessionsService = {
     }
 
     sessionsDb.updateSessionCustomName(sessionId, summary);
+    void setSessionTitle(sessionId, summary);
     return { sessionId, summary };
+  },
+
+  /**
+   * Scans all indexed sessions with custom_name and syncs them to their
+   * session JSONL files so `claude -r` displays the CloudCLI session names.
+   * Runs once at startup to keep existing sessions in sync.
+   */
+  async syncSessionNames(): Promise<void> {
+    await syncAllSessionNamesToHistory();
   },
 };

--- a/server/modules/providers/services/sessions.service.ts
+++ b/server/modules/providers/services/sessions.service.ts
@@ -63,55 +63,70 @@ function resolveProjectDisplayName(
   return path.basename(projectPath) || projectPath;
 }
 
+const HISTORY_JSONL_PATH = path.join(os.homedir(), '.claude', 'history.jsonl');
+
 /**
- * Writes a custom-title entry to the session's JSONL file as the last line.
- * Any existing custom-title entries for the same session are removed first,
- * so new messages appended by Claude CLI don't bury the entry.
+ * Updates the display name for a session in ~/.claude/history.jsonl.
+ * `claude -r` reads entries from this global file, grouped by project path.
+ * All existing entries for the session are updated in-place so the project
+ * path stays correct. If no entries exist, a new one is created using the
+ * session's project_path from the DB.
  */
-async function setSessionTitle(sessionId: string, title: string): Promise<void> {
+async function updateSessionDisplayNameInHistory(sessionId: string, displayName: string): Promise<void> {
   const session = sessionsDb.getSessionById(sessionId);
-  if (!session?.jsonl_path) return;
+  const projectPath = session?.project_path || os.homedir();
 
   try {
-    const content = await fsp.readFile(session.jsonl_path, 'utf8');
+    const content = await fsp.readFile(HISTORY_JSONL_PATH, 'utf8');
     const lines = content.split(/\r?\n/);
-    // Strip any existing custom-title entries for this session
-    const cleaned = lines.filter((line) => {
+    const updatedLines = [];
+    let found = false;
+
+    for (const line of lines) {
       const trimmed = line.trim();
-      if (!trimmed) return true;
+      if (!trimmed) {
+        updatedLines.push(line);
+        continue;
+      }
       try {
         const parsed = JSON.parse(trimmed);
         if (
           typeof parsed === 'object' &&
           parsed !== null &&
-          (parsed as Record<string, unknown>).type === 'custom-title' &&
           (parsed as Record<string, unknown>).sessionId === sessionId
         ) {
-          return false;
+          found = true;
+          (parsed as Record<string, unknown>).display = displayName;
+          updatedLines.push(JSON.stringify(parsed));
+          continue;
         }
       } catch {
         // skip non-JSON lines
       }
-      return true;
-    });
+      updatedLines.push(line);
+    }
 
-    const entry = JSON.stringify({
-      type: 'custom-title',
-      customTitle: title,
-      sessionId,
-    });
-    const result = cleaned.filter((l) => l.length > 0).join('\n') + '\n' + entry;
-    await fsp.writeFile(session.jsonl_path, result, 'utf8');
+    // If no existing entry, append one with the correct project path
+    if (!found) {
+      const newEntry = JSON.stringify({
+        display: displayName,
+        pastedContents: {},
+        timestamp: Date.now(),
+        project: projectPath,
+        sessionId,
+      });
+      updatedLines.push(newEntry);
+    }
+
+    await fsp.writeFile(HISTORY_JSONL_PATH, updatedLines.join('\n'), 'utf8');
   } catch {
-    // Session file may not exist or may be locked
+    // history.jsonl may not exist
   }
 }
 
 /**
- * Scans all sessions with custom_name and syncs them to their session JSONL files
- * on startup so `claude -r` displays the CloudCLI session names.
- * Removes any existing custom-title entries and appends a fresh one at the end,
- * so entries buried by subsequent messages are re-surfaced.
+ * Scans all sessions with custom_name and updates ~/.claude/history.jsonl
+ * so `claude -r` displays the CloudCLI session names.
  */
 async function syncAllSessionNamesToHistory(): Promise<void> {
   const sessions = sessionsDb.getSessionsWithCustomName();
@@ -119,45 +134,16 @@ async function syncAllSessionNamesToHistory(): Promise<void> {
 
   let synced = 0;
   for (const session of sessions) {
-    if (!session.jsonl_path) continue;
     try {
-      const content = await fsp.readFile(session.jsonl_path, 'utf8');
-      const lines = content.split(/\r?\n/);
-      // Strip any existing custom-title entries for this session
-      const cleaned = lines.filter((line) => {
-        const trimmed = line.trim();
-        if (!trimmed) return true;
-        try {
-          const parsed = JSON.parse(trimmed);
-          if (
-            typeof parsed === 'object' &&
-            parsed !== null &&
-            (parsed as Record<string, unknown>).type === 'custom-title' &&
-            (parsed as Record<string, unknown>).sessionId === session.session_id
-          ) {
-            return false;
-          }
-        } catch {
-          // skip non-JSON lines
-        }
-        return true;
-      });
-
-      const entry = JSON.stringify({
-        type: 'custom-title',
-        customTitle: session.custom_name,
-        sessionId: session.session_id,
-      });
-      const result = cleaned.filter((l) => l.length > 0).join('\n') + '\n' + entry;
-      await fsp.writeFile(session.jsonl_path, result, 'utf8');
+      await updateSessionDisplayNameInHistory(session.session_id, session.custom_name);
       synced++;
     } catch {
-      // Session file may not exist
+      // Skip failed sessions
     }
   }
 
   if (synced > 0) {
-    console.log(`[Sessions] Synced ${synced} session name(s) to session JSONL files`);
+    console.log(`[Sessions] Synced ${synced} session name(s) to ~/.claude/history.jsonl`);
   }
 }
 
@@ -332,7 +318,7 @@ export const sessionsService = {
     }
 
     sessionsDb.updateSessionCustomName(sessionId, summary);
-    void setSessionTitle(sessionId, summary);
+    void updateSessionDisplayNameInHistory(sessionId, summary);
     return { sessionId, summary };
   },
 

--- a/server/modules/providers/services/sessions.service.ts
+++ b/server/modules/providers/services/sessions.service.ts
@@ -84,8 +84,13 @@ export const sessionsService = {
     providerName: string,
     raw: unknown,
     sessionId: string | null,
+    subagentPrompts: Set<string> | null = null,
   ): NormalizedMessage[] {
-    return providerRegistry.resolveProvider(providerName).sessions.normalizeMessage(raw, sessionId);
+    return providerRegistry.resolveProvider(providerName).sessions.normalizeMessage(
+      raw,
+      sessionId,
+      subagentPrompts,
+    );
   },
 
   /**

--- a/server/modules/providers/services/sessions.service.ts
+++ b/server/modules/providers/services/sessions.service.ts
@@ -1,6 +1,8 @@
 import fsp from 'node:fs/promises';
+import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
+import readline from 'node:readline';
 
 import { projectsDb, sessionsDb } from '@/modules/database/index.js';
 import { providerRegistry } from '@/modules/providers/provider.registry.js';
@@ -11,6 +13,8 @@ import type {
   NormalizedMessage,
 } from '@/shared/types.js';
 import { AppError } from '@/shared/utils.js';
+
+const CLAUDE_PROJECTS_DIR = path.join(os.homedir(), '.claude', 'projects');
 
 type ArchivedSessionListItem = {
   sessionId: string;
@@ -67,10 +71,10 @@ const HISTORY_JSONL_PATH = path.join(os.homedir(), '.claude', 'history.jsonl');
 
 /**
  * Updates the display name for a session in ~/.claude/history.jsonl.
- * `claude -r` reads entries from this global file, grouped by project path.
- * All existing entries for the session are updated in-place so the project
- * path stays correct. If no entries exist, a new one is created using the
- * session's project_path from the DB.
+ * `claude -r` reads entries from this global file with a 100-entry limit per
+ * project. Duplicate entries for the same session consume slots, so we keep
+ * only one entry per session — the latest one with the correct display name.
+ * If no entries exist, a new one is created.
  */
 async function updateSessionDisplayNameInHistory(sessionId: string, displayName: string): Promise<void> {
   const session = sessionsDb.getSessionById(sessionId);
@@ -79,13 +83,16 @@ async function updateSessionDisplayNameInHistory(sessionId: string, displayName:
   try {
     const content = await fsp.readFile(HISTORY_JSONL_PATH, 'utf8');
     const lines = content.split(/\r?\n/);
-    const updatedLines = [];
-    let found = false;
+
+    // Collect all entries, keeping only the last one per sessionId
+    const lastBySession = new Map<string, string>();
+    const otherLines = [];
+    const nonJsonLines = []; // lines that aren't valid JSON objects
 
     for (const line of lines) {
       const trimmed = line.trim();
       if (!trimmed) {
-        updatedLines.push(line);
+        nonJsonLines.push(line);
         continue;
       }
       try {
@@ -93,57 +100,259 @@ async function updateSessionDisplayNameInHistory(sessionId: string, displayName:
         if (
           typeof parsed === 'object' &&
           parsed !== null &&
-          (parsed as Record<string, unknown>).sessionId === sessionId
+          (parsed as Record<string, unknown>).sessionId !== undefined
         ) {
-          found = true;
-          (parsed as Record<string, unknown>).display = displayName;
-          updatedLines.push(JSON.stringify(parsed));
+          const sid = String((parsed as Record<string, unknown>).sessionId);
+          // Update display for our target, keep last entry per session
+          if (sid === sessionId) {
+            (parsed as Record<string, unknown>).display = displayName;
+          }
+          lastBySession.set(sid, JSON.stringify(parsed));
           continue;
         }
       } catch {
         // skip non-JSON lines
       }
-      updatedLines.push(line);
+      nonJsonLines.push(line);
     }
 
     // If no existing entry, append one with the correct project path
-    if (!found) {
-      const newEntry = JSON.stringify({
+    if (!lastBySession.has(sessionId)) {
+      lastBySession.set(sessionId, JSON.stringify({
         display: displayName,
         pastedContents: {},
         timestamp: Date.now(),
         project: projectPath,
         sessionId,
-      });
-      updatedLines.push(newEntry);
+      }));
     }
 
-    await fsp.writeFile(HISTORY_JSONL_PATH, updatedLines.join('\n'), 'utf8');
+    // Sort all entries by timestamp to preserve file order
+    const sortedEntries = [...lastBySession.values()].sort((a, b) => {
+      try {
+        const ta = (JSON.parse(a) as Record<string, unknown>).timestamp;
+        const tb = (JSON.parse(b) as Record<string, unknown>).timestamp;
+        return Number(ta) - Number(tb);
+      } catch {
+        return 0;
+      }
+    });
+
+    const finalLines = [...nonJsonLines, ...sortedEntries];
+    await fsp.writeFile(HISTORY_JSONL_PATH, finalLines.join('\n'), 'utf8');
   } catch {
     // history.jsonl may not exist
   }
 }
 
 /**
- * Scans all sessions with custom_name and updates ~/.claude/history.jsonl
- * so `claude -r` displays the CloudCLI session names.
+ * Writes a custom-title entry to a session JSONL file so `claude -r` can
+ * pick it up. `claude -r` reads the **last** custom-title, so we update all
+ * existing entries and also prepend one as fallback.
  */
-async function syncAllSessionNamesToHistory(): Promise<void> {
-  const sessions = sessionsDb.getSessionsWithCustomName();
-  if (sessions.length === 0) return;
+async function writeSessionCustomTitle(sessionId: string, jsonlPath: string, title: string): Promise<void> {
+  try {
+    const content = await fsp.readFile(jsonlPath, 'utf8');
+    const lines = content.split(/\n/);
+    let found = false;
 
-  let synced = 0;
-  for (const session of sessions) {
-    try {
-      await updateSessionDisplayNameInHistory(session.session_id, session.custom_name);
-      synced++;
-    } catch {
-      // Skip failed sessions
+    // Update ALL existing custom-title entries (claude -r reads the last one)
+    for (let i = 0; i < lines.length; i++) {
+      try {
+        const data = JSON.parse(lines[i].trim()) as Record<string, unknown>;
+        if (data.type === 'custom-title') {
+          (data as Record<string, unknown>).customTitle = title;
+          lines[i] = JSON.stringify(data);
+          found = true;
+        }
+      } catch {
+        // skip non-JSON lines
+      }
     }
+
+    if (found) {
+      await fsp.writeFile(jsonlPath, lines.join('\n'), 'utf8');
+      return;
+    }
+
+    // No custom-title found — prepend one
+    const newEntry = JSON.stringify({ type: 'custom-title', customTitle: title });
+    const newLines = [newEntry, ...lines];
+    await fsp.writeFile(jsonlPath, newLines.join('\n'), 'utf8');
+  } catch {
+    // file may not exist or be unreadable
+  }
+}
+
+/**
+ * Extracts a display name from a session JSONL file.
+ * Priority: custom-title > ai-title > last-prompt
+ */
+async function extractSessionDisplayName(filePath: string): Promise<string | null> {
+  try {
+    const fileStream = fs.createReadStream(filePath, { encoding: 'utf8' });
+    const rl = readline.createInterface({ input: fileStream, crlfDelay: Infinity });
+
+    let aiTitle: string | undefined;
+    let lastPrompt: string | undefined;
+
+    for await (const line of rl) {
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+      try {
+        const data = JSON.parse(trimmed) as Record<string, unknown>;
+        const type = typeof data.type === 'string' ? data.type : undefined;
+        if (type === 'custom-title' && typeof data.customTitle === 'string') {
+          return data.customTitle.trim() || null;
+        }
+        if (type === 'ai-title' && typeof data.aiTitle === 'string') {
+          aiTitle = data.aiTitle.trim() || undefined;
+        }
+        if (type === 'last-prompt' && typeof data.lastPrompt === 'string') {
+          lastPrompt = data.lastPrompt.trim() || undefined;
+        }
+      } catch {
+        // skip non-JSON lines
+      }
+    }
+
+    return (aiTitle || lastPrompt || null)?.trim() || null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Builds a Map<sessionId, { displayName, projectPath }> from all session JSONL
+ * files on disk + DB custom_names (DB takes precedence).
+ */
+async function buildSessionNameMap(): Promise<Map<string, { displayName: string; projectPath: string }>> {
+  const nameMap = new Map<string, { displayName: string; projectPath: string }>();
+
+  // 1. DB custom_name entries (highest priority)
+  const dbSessions = sessionsDb.getSessionsWithCustomName();
+  for (const s of dbSessions) {
+    nameMap.set(s.session_id, { displayName: s.custom_name, projectPath: s.project_path || os.homedir() });
   }
 
-  if (synced > 0) {
-    console.log(`[Sessions] Synced ${synced} session name(s) to ~/.claude/history.jsonl`);
+  // 2. All session JSONL files on disk
+  try {
+    const entries = await fsp.readdir(CLAUDE_PROJECTS_DIR, { withFileTypes: true });
+    for (const entry of entries) {
+      if (!entry.isDirectory()) continue;
+      const projectDir = path.join(CLAUDE_PROJECTS_DIR, entry.name);
+      try {
+        const files = await fsp.readdir(projectDir);
+        for (const fileName of files) {
+          if (!fileName.endsWith('.jsonl')) continue;
+          const filePath = path.join(projectDir, fileName);
+          const sessionId = fileName.slice(0, -6);
+
+          // Skip if already in DB
+          if (nameMap.has(sessionId)) continue;
+
+          const displayName = await extractSessionDisplayName(filePath);
+          if (!displayName) continue;
+
+          // Determine project path from directory name
+          // Directory names are URL-encoded paths like "-Users-xiawenhua" or "-Users-xiawenhua-hermes-agent"
+          const dirName = entry.name;
+          let projectPath = os.homedir();
+          try {
+            const decoded = decodeURIComponent(dirName);
+            projectPath = decoded.startsWith('/') ? decoded : os.homedir();
+          } catch {
+            // keep default
+          }
+
+          nameMap.set(sessionId, { displayName, projectPath });
+        }
+      } catch {
+        // skip unreadable directories
+      }
+    }
+  } catch {
+    // claude/projects directory may not exist
+  }
+
+  return nameMap;
+}
+
+/**
+ * Scans all sessions with custom_name and updates ~/.claude/history.jsonl
+ * so `claude -r` displays the CloudCLI session names.
+ * Also discovers sessions on disk that aren't in the DB yet.
+ */
+async function syncAllSessionNamesToHistory(): Promise<void> {
+  const nameMap = await buildSessionNameMap();
+  if (nameMap.size === 0) return;
+
+  try {
+    const content = await fsp.readFile(HISTORY_JSONL_PATH, 'utf8');
+    const lines = content.split(/\r?\n/);
+
+    // Keep only the last entry per session, update display names
+    const lastBySession = new Map<string, string>();
+    const nonJsonLines = [];
+
+    for (const line of lines) {
+      const trimmed = line.trim();
+      if (!trimmed) {
+        nonJsonLines.push(line);
+        continue;
+      }
+      try {
+        const parsed = JSON.parse(trimmed);
+        if (typeof parsed === 'object' && parsed !== null && (parsed as Record<string, unknown>).sessionId !== undefined) {
+          const sid = String((parsed as Record<string, unknown>).sessionId);
+          const nameEntry = nameMap.get(sid);
+          if (nameEntry) {
+            (parsed as Record<string, unknown>).display = nameEntry.displayName;
+            (parsed as Record<string, unknown>).project = nameEntry.projectPath;
+          }
+          lastBySession.set(sid, JSON.stringify(parsed));
+          continue;
+        }
+      } catch {
+        // skip non-JSON lines
+      }
+      nonJsonLines.push(line);
+    }
+
+    // Add entries for sessions not yet in history.jsonl
+    for (const [sid, info] of nameMap) {
+      if (!lastBySession.has(sid)) {
+        lastBySession.set(sid, JSON.stringify({
+          display: info.displayName,
+          pastedContents: {},
+          timestamp: Date.now(),
+          project: info.projectPath,
+          sessionId: sid,
+        }));
+      }
+    }
+
+    // Sort by timestamp
+    const sortedEntries = [...lastBySession.values()].sort((a, b) => {
+      try {
+        return Number(JSON.parse(a).timestamp) - Number(JSON.parse(b).timestamp);
+      } catch {
+        return 0;
+      }
+    });
+
+    const finalLines = [...nonJsonLines, ...sortedEntries];
+    await fsp.writeFile(HISTORY_JSONL_PATH, finalLines.join('\n'), 'utf8');
+    console.log(`[Sessions] Synced ${nameMap.size} session name(s) to ~/.claude/history.jsonl`);
+  } catch {
+    // history.jsonl may not exist — fall back to per-session sync
+    for (const [sid, info] of nameMap) {
+      try {
+        await updateSessionDisplayNameInHistory(sid, info.displayName);
+      } catch {
+        // skip
+      }
+    }
   }
 }
 
@@ -319,6 +528,9 @@ export const sessionsService = {
 
     sessionsDb.updateSessionCustomName(sessionId, summary);
     void updateSessionDisplayNameInHistory(sessionId, summary);
+    if (session.jsonl_path) {
+      void writeSessionCustomTitle(sessionId, session.jsonl_path, summary);
+    }
     return { sessionId, summary };
   },
 

--- a/server/shared/interfaces.ts
+++ b/server/shared/interfaces.ts
@@ -84,7 +84,7 @@ export interface IProviderMcp {
  * shared transport shapes consumed by API routes and realtime streams.
  */
 export interface IProviderSessions {
-  normalizeMessage(raw: unknown, sessionId: string | null): NormalizedMessage[];
+  normalizeMessage(raw: unknown, sessionId: string | null, subagentPrompts?: Set<string> | null): NormalizedMessage[];
   fetchHistory(sessionId: string, options?: FetchHistoryOptions): Promise<FetchHistoryResult>;
 }
 

--- a/server/shared/types.ts
+++ b/server/shared/types.ts
@@ -365,6 +365,7 @@ export type ProjectRepositoryRow = {
   project_id: string;
   project_path: string;
   custom_project_name: string | null;
+  cached_display_name: string | null;
   isStarred: number;
   isArchived: number;
 };

--- a/src/components/chat/hooks/useChatComposerState.ts
+++ b/src/components/chat/hooks/useChatComposerState.ts
@@ -26,6 +26,16 @@ import { escapeRegExp } from '../utils/chatFormatting';
 import { useFileMentions } from './useFileMentions';
 import { type SlashCommand, useSlashCommands } from './useSlashCommands';
 
+function resolveEffectiveProjectPath(
+  session: ProjectSession | null,
+  project: Project | null,
+): string {
+  if (session?.projectPath) {
+    return session.projectPath;
+  }
+  return (project?.fullPath || project?.path || '') ?? '';
+}
+
 type PendingViewSession = {
   sessionId: string | null;
   startedAt: number;
@@ -594,7 +604,7 @@ export function useChatComposerState({
       };
 
       const toolsSettings = getToolsSettings();
-      const resolvedProjectPath = selectedProject.fullPath || selectedProject.path || '';
+      const resolvedProjectPath = resolveEffectiveProjectPath(selectedSession, selectedProject);
       const sessionSummary = getNotificationSessionSummary(selectedSession, currentInput);
 
       if (provider === 'cursor') {

--- a/src/components/chat/hooks/useChatMessages.ts
+++ b/src/components/chat/hooks/useChatMessages.ts
@@ -44,7 +44,7 @@ export function normalizedToChatMessages(messages: NormalizedMessage[]): ChatMes
 
         if (msg.role === 'user') {
           // Parse task notifications
-          const taskNotifRegex = /<task-notification>\s*<task-id>[^<]*<\/task-id>\s*<output-file>[^<]*<\/output-file>\s*<status>([^<]*)<\/status>\s*<summary>([^<]*)<\/summary>\s*<\/task-notification>/g;
+          const taskNotifRegex = /<task-notification>[\s\S]*?<status>([^<]*)<\/status>[\s\S]*?<summary>([^<]*)<\/summary>[\s\S]*?<\/task-notification>/;
           const taskNotifMatch = taskNotifRegex.exec(content);
           if (taskNotifMatch) {
             converted.push({

--- a/src/components/chat/hooks/useChatMessages.ts
+++ b/src/components/chat/hooks/useChatMessages.ts
@@ -44,7 +44,7 @@ export function normalizedToChatMessages(messages: NormalizedMessage[]): ChatMes
 
         if (msg.role === 'user') {
           // Parse task notifications
-          const taskNotifRegex = /<task-notification>[\s\S]*?<status>([^<]*)<\/status>[\s\S]*?<summary>([^<]*)<\/summary>[\s\S]*?<\/task-notification>/;
+          const taskNotifRegex = /^<task-notification>[\s\S]*?<status>([^<]*)<\/status>[\s\S]*?<summary>([^<]*)<\/summary>[\s\S]*?<\/task-notification>$/;
           const taskNotifMatch = taskNotifRegex.exec(content);
           if (taskNotifMatch) {
             converted.push({

--- a/src/components/chat/hooks/useChatMessages.ts
+++ b/src/components/chat/hooks/useChatMessages.ts
@@ -44,7 +44,7 @@ export function normalizedToChatMessages(messages: NormalizedMessage[]): ChatMes
 
         if (msg.role === 'user') {
           // Parse task notifications
-          const taskNotifRegex = /^<task-notification>[\s\S]*?<status>([^<]*)<\/status>[\s\S]*?<summary>([^<]*)<\/summary>[\s\S]*?<\/task-notification>$/;
+          const taskNotifRegex = /^\s*<task-notification>[\s\S]*?<status>([^<]*)<\/status>[\s\S]*?<summary>([^<]*)<\/summary>[\s\S]*?<\/task-notification>\s*$/;
           const taskNotifMatch = taskNotifRegex.exec(content);
           if (taskNotifMatch) {
             converted.push({

--- a/src/components/chat/hooks/useChatRealtimeHandlers.ts
+++ b/src/components/chat/hooks/useChatRealtimeHandlers.ts
@@ -1,6 +1,7 @@
 import { useEffect, useRef } from 'react';
 import type { Dispatch, MutableRefObject, SetStateAction } from 'react';
 
+import { isNotificationSoundEnabled, playCompletionSound } from '../../../utils/notification-sound';
 import { usePaletteOps } from '../../../contexts/PaletteOpsContext';
 import type { PendingPermissionRequest, SessionNavigationOptions } from '../types/types';
 import type { Project, ProjectSession, LLMProvider } from '../../../types/app';
@@ -272,6 +273,11 @@ export function useChatRealtimeHandlers({
           // No special UI action needed beyond clearing loading state above
           // The backend already sent any abort-related messages
           break;
+        }
+
+        // Play completion sound if enabled
+        if (isNotificationSoundEnabled()) {
+          playCompletionSound();
         }
 
         const actualSessionId =

--- a/src/components/chat/hooks/useChatRealtimeHandlers.ts
+++ b/src/components/chat/hooks/useChatRealtimeHandlers.ts
@@ -260,13 +260,6 @@ export function useChatRealtimeHandlers({
         }
         accumulatedStreamRef.current = '';
 
-        // Refresh from server so the canonical JSONL history replaces any
-        // client-side streaming echoes, and the chat view shows the final
-        // committed messages instead of stale realtime copies.
-        if (sid) {
-          void sessionStore.refreshFromServer(sid);
-        }
-
         setIsLoading(false);
         setCanAbortSession(false);
         setClaudeStatus(null);
@@ -320,6 +313,11 @@ export function useChatRealtimeHandlers({
             onNavigateToSession?.(actualSessionId, { replace: true });
             setTimeout(() => { void paletteOps.refreshProjects(); }, 500);
           }
+
+          // Refresh from server using the resolved session ID so we fetch the
+          // correct canonical JSONL history, replacing any client-side streaming
+          // echoes with committed messages.
+          void sessionStore.refreshFromServer(actualSessionId);
           break;
         }
 
@@ -332,6 +330,12 @@ export function useChatRealtimeHandlers({
           }
           sessionStorage.removeItem('pendingSessionId');
           setTimeout(() => { void paletteOps.refreshProjects(); }, 500);
+        }
+
+        // Refresh from server so the canonical JSONL history replaces any
+        // client-side streaming echoes with committed messages.
+        if (sid) {
+          void sessionStore.refreshFromServer(sid);
         }
         break;
       }

--- a/src/components/chat/hooks/useChatRealtimeHandlers.ts
+++ b/src/components/chat/hooks/useChatRealtimeHandlers.ts
@@ -339,9 +339,12 @@ export function useChatRealtimeHandlers({
         }
 
         // Refresh from server so the canonical JSONL history replaces any
-        // client-side streaming echoes with committed messages.
-        if (sid) {
-          void sessionStore.refreshFromServer(sid);
+        // client-side streaming echoes with committed messages. Use the first
+        // available session ID — resolved actual ID, fallback to original sid,
+        // or pending session for the post-submission resolution path.
+        const resolvedSessionId = actualSessionId ?? sid ?? pendingSessionId;
+        if (resolvedSessionId) {
+          void sessionStore.refreshFromServer(resolvedSessionId);
         }
         break;
       }

--- a/src/components/chat/hooks/useChatRealtimeHandlers.ts
+++ b/src/components/chat/hooks/useChatRealtimeHandlers.ts
@@ -260,6 +260,13 @@ export function useChatRealtimeHandlers({
         }
         accumulatedStreamRef.current = '';
 
+        // Refresh from server so the canonical JSONL history replaces any
+        // client-side streaming echoes, and the chat view shows the final
+        // committed messages instead of stale realtime copies.
+        if (sid) {
+          void sessionStore.refreshFromServer(sid);
+        }
+
         setIsLoading(false);
         setCanAbortSession(false);
         setClaudeStatus(null);

--- a/src/components/chat/hooks/useChatSessionState.ts
+++ b/src/components/chat/hooks/useChatSessionState.ts
@@ -754,11 +754,15 @@ export function useChatSessionState({
     setVisibleMessageCount((prev) => prev + 100);
   }, []);
 
-  const loadMoreMessages = useCallback(() => {
+  const loadMoreMessages = useCallback(async () => {
     topLoadLockRef.current = false;
     const container = scrollContainerRef.current;
     if (!container) return;
-    loadOlderMessages(container);
+    try {
+      await loadOlderMessages(container);
+    } catch (error) {
+      console.error('[useChatSessionState] loadMoreMessages failed:', error);
+    }
   }, [loadOlderMessages]);
 
   return {

--- a/src/components/chat/hooks/useChatSessionState.ts
+++ b/src/components/chat/hooks/useChatSessionState.ts
@@ -351,24 +351,13 @@ export function useChatSessionState({
     [hasMoreMessages, isLoadingMoreMessages, selectedProject, selectedSession, sessionStore],
   );
 
-  const handleScroll = useCallback(async () => {
+  const handleScroll = useCallback(() => {
     const container = scrollContainerRef.current;
     if (!container) return;
 
     const nearBottom = isNearBottom();
     setIsUserScrolledUp(!nearBottom);
-
-    if (!allMessagesLoadedRef.current) {
-      const scrolledNearTop = container.scrollTop < 100;
-      if (!scrolledNearTop) { topLoadLockRef.current = false; return; }
-      if (topLoadLockRef.current) {
-        if (container.scrollTop > 20) topLoadLockRef.current = false;
-        return;
-      }
-      const didLoad = await loadOlderMessages(container);
-      if (didLoad) topLoadLockRef.current = true;
-    }
-  }, [isNearBottom, loadOlderMessages]);
+  }, [isNearBottom]);
 
   useLayoutEffect(() => {
     if (!pendingScrollRestoreRef.current || !scrollContainerRef.current) return;
@@ -702,23 +691,10 @@ export function useChatSessionState({
     }
   }, [currentSessionId, isLoading, processingSessions, selectedSession?.id]);
 
-  // "Load all" overlay
-  const prevLoadingRef = useRef(false);
+  // "Load more" buttons — show whenever there are more messages
   useEffect(() => {
-    const wasLoading = prevLoadingRef.current;
-    prevLoadingRef.current = isLoadingMoreMessages;
-
-    if (wasLoading && !isLoadingMoreMessages && hasMoreMessages) {
-      if (loadAllOverlayTimerRef.current) clearTimeout(loadAllOverlayTimerRef.current);
-      setShowLoadAllOverlay(true);
-      loadAllOverlayTimerRef.current = setTimeout(() => setShowLoadAllOverlay(false), 2000);
-    }
-    if (!hasMoreMessages && !isLoadingMoreMessages) {
-      if (loadAllOverlayTimerRef.current) clearTimeout(loadAllOverlayTimerRef.current);
-      setShowLoadAllOverlay(false);
-    }
-    return () => { if (loadAllOverlayTimerRef.current) clearTimeout(loadAllOverlayTimerRef.current); };
-  }, [isLoadingMoreMessages, hasMoreMessages]);
+    setShowLoadAllOverlay(hasMoreMessages && !allMessagesLoaded);
+  }, [hasMoreMessages, allMessagesLoaded]);
 
   const loadAllMessages = useCallback(async () => {
     if (!selectedSession || !selectedProject) return;
@@ -778,6 +754,13 @@ export function useChatSessionState({
     setVisibleMessageCount((prev) => prev + 100);
   }, []);
 
+  const loadMoreMessages = useCallback(() => {
+    topLoadLockRef.current = false;
+    const container = scrollContainerRef.current;
+    if (!container) return;
+    loadOlderMessages(container);
+  }, [loadOlderMessages]);
+
   return {
     chatMessages,
     addMessage,
@@ -801,6 +784,7 @@ export function useChatSessionState({
     visibleMessages,
     loadEarlierMessages,
     loadAllMessages,
+    loadMoreMessages,
     allMessagesLoaded,
     isLoadingAllMessages,
     loadAllJustFinished,

--- a/src/components/chat/hooks/useChatSessionState.ts
+++ b/src/components/chat/hooks/useChatSessionState.ts
@@ -258,9 +258,14 @@ export function useChatSessionState({
 
   const chatMessages = useMemo(() => {
     const all = normalizedToChatMessages(storeMessages);
-    // Show pending user message when no session data exists yet (new session, pre-backend-response)
-    if (pendingUserMessage && all.length === 0) {
-      return [pendingUserMessage];
+    // Show pending user message until a user message actually appears in the store.
+    // This covers both the "no messages yet" case and the race condition where
+    // `stream_delta` (AI content) arrives in realtime before the echoed user
+    // message — without this check the pending message would disappear and the
+    // AI response would briefly appear as the first visible message.
+    const hasUserMessage = all.some((m) => m.type === 'user');
+    if (pendingUserMessage && !hasUserMessage) {
+      return [...all, pendingUserMessage];
     }
     if (viewHiddenCount > 0 && viewHiddenCount < all.length) return all.slice(0, -viewHiddenCount);
     return all;

--- a/src/components/chat/hooks/useChatSessionState.ts
+++ b/src/components/chat/hooks/useChatSessionState.ts
@@ -758,10 +758,13 @@ export function useChatSessionState({
     topLoadLockRef.current = false;
     const container = scrollContainerRef.current;
     if (!container) return;
+    setIsLoadingMoreMessages(true);
     try {
       await loadOlderMessages(container);
     } catch (error) {
       console.error('[useChatSessionState] loadMoreMessages failed:', error);
+    } finally {
+      setIsLoadingMoreMessages(false);
     }
   }, [loadOlderMessages]);
 

--- a/src/components/chat/view/ChatInterface.tsx
+++ b/src/components/chat/view/ChatInterface.tsx
@@ -104,10 +104,10 @@ function ChatInterface({
     visibleMessages,
     loadEarlierMessages,
     loadAllMessages,
+    loadMoreMessages,
     allMessagesLoaded,
     isLoadingAllMessages,
     loadAllJustFinished,
-    showLoadAllOverlay,
     claudeStatus,
     setClaudeStatus,
     createDiff,
@@ -306,6 +306,7 @@ function ChatInterface({
             chatMessages={chatMessages}
             loadAllMessages={loadAllMessages}
             allMessagesLoaded={allMessagesLoaded}
+            hasMoreMessages={hasMoreMessages}
             totalMessages={totalMessages}
             sessionMessagesCount={chatMessages.length}
           />
@@ -341,10 +342,10 @@ function ChatInterface({
           visibleMessages={visibleMessages}
           loadEarlierMessages={loadEarlierMessages}
           loadAllMessages={loadAllMessages}
+          loadMoreMessages={loadMoreMessages}
           allMessagesLoaded={allMessagesLoaded}
           isLoadingAllMessages={isLoadingAllMessages}
           loadAllJustFinished={loadAllJustFinished}
-          showLoadAllOverlay={showLoadAllOverlay}
           createDiff={createDiff}
           onFileOpen={onFileOpen}
           onShowSettings={onShowSettings}

--- a/src/components/chat/view/ChatInterface.tsx
+++ b/src/components/chat/view/ChatInterface.tsx
@@ -305,6 +305,7 @@ function ChatInterface({
             scrollContainerRef={scrollContainerRef}
             chatMessages={chatMessages}
           />
+          <div className="absolute inset-0">
           <ChatMessagesPane
           scrollContainerRef={scrollContainerRef}
           onWheel={handleScroll}
@@ -349,6 +350,7 @@ function ChatInterface({
           showThinking={showThinking}
           selectedProject={selectedProject}
         />
+          </div>
         </div>
 
         <ChatComposer

--- a/src/components/chat/view/ChatInterface.tsx
+++ b/src/components/chat/view/ChatInterface.tsx
@@ -304,6 +304,10 @@ function ChatInterface({
           <ScrollNavigation
             scrollContainerRef={scrollContainerRef}
             chatMessages={chatMessages}
+            loadAllMessages={loadAllMessages}
+            allMessagesLoaded={allMessagesLoaded}
+            totalMessages={totalMessages}
+            sessionMessagesCount={chatMessages.length}
           />
           <div className="absolute inset-0">
           <ChatMessagesPane

--- a/src/components/chat/view/ChatInterface.tsx
+++ b/src/components/chat/view/ChatInterface.tsx
@@ -14,6 +14,7 @@ import { useSessionStore } from '../../../stores/useSessionStore';
 
 import ChatMessagesPane from './subcomponents/ChatMessagesPane';
 import ChatComposer from './subcomponents/ChatComposer';
+import ScrollNavigation from './subcomponents/ScrollNavigation';
 
 
 type PendingViewSession = {
@@ -299,7 +300,12 @@ function ChatInterface({
   return (
     <PermissionContext.Provider value={permissionContextValue}>
       <div className="flex h-full flex-col">
-        <ChatMessagesPane
+        <div className="relative flex-1">
+          <ScrollNavigation
+            scrollContainerRef={scrollContainerRef}
+            chatMessages={chatMessages}
+          />
+          <ChatMessagesPane
           scrollContainerRef={scrollContainerRef}
           onWheel={handleScroll}
           onTouchMove={handleScroll}
@@ -343,6 +349,7 @@ function ChatInterface({
           showThinking={showThinking}
           selectedProject={selectedProject}
         />
+        </div>
 
         <ChatComposer
           pendingPermissionRequests={pendingPermissionRequests}

--- a/src/components/chat/view/subcomponents/ChatMessagesPane.tsx
+++ b/src/components/chat/view/subcomponents/ChatMessagesPane.tsx
@@ -256,6 +256,8 @@ export default function ChatMessagesPane({
       <ScrollNavigation
         scrollContainerRef={scrollContainerRef}
         chatMessages={chatMessages}
+        allMessagesLoaded={allMessagesLoaded}
+        loadAllMessages={loadAllMessages}
       />
     </div>
   );

--- a/src/components/chat/view/subcomponents/ChatMessagesPane.tsx
+++ b/src/components/chat/view/subcomponents/ChatMessagesPane.tsx
@@ -228,25 +228,37 @@ export default function ChatMessagesPane({
             </div>
           )}
 
-          {visibleMessages.map((message, index) => {
-            const prevMessage = index > 0 ? visibleMessages[index - 1] : null;
-            return (
-              <MessageComponent
-                key={getMessageKey(message)}
-                message={message}
-                prevMessage={prevMessage}
-                createDiff={createDiff}
-                onFileOpen={onFileOpen}
-                onShowSettings={onShowSettings}
-                onGrantToolPermission={onGrantToolPermission}
-                autoExpandTools={autoExpandTools}
-                showRawParameters={showRawParameters}
-                showThinking={showThinking}
-                selectedProject={selectedProject}
-                provider={provider}
-              />
-            );
-          })}
+          {(() => {
+            let userIdx = 0;
+            // Count user messages before visibleMessages to know the starting index
+            const visStartIdx = chatMessages.indexOf(visibleMessages[0]);
+            if (visStartIdx >= 0) {
+              for (let i = 0; i < visStartIdx; i++) {
+                if (chatMessages[i].type === 'user') userIdx++;
+              }
+            }
+            return visibleMessages.map((message, index) => {
+              const prevMessage = index > 0 ? visibleMessages[index - 1] : null;
+              const uIdx: number | undefined = message.type === 'user' ? userIdx++ : undefined;
+              return (
+                <MessageComponent
+                  key={getMessageKey(message)}
+                  message={message}
+                  prevMessage={prevMessage}
+                  userMessageIndex={uIdx}
+                  createDiff={createDiff}
+                  onFileOpen={onFileOpen}
+                  onShowSettings={onShowSettings}
+                  onGrantToolPermission={onGrantToolPermission}
+                  autoExpandTools={autoExpandTools}
+                  showRawParameters={showRawParameters}
+                  showThinking={showThinking}
+                  selectedProject={selectedProject}
+                  provider={provider}
+                />
+              );
+            });
+          })()}
         </>
       )}
     </div>

--- a/src/components/chat/view/subcomponents/ChatMessagesPane.tsx
+++ b/src/components/chat/view/subcomponents/ChatMessagesPane.tsx
@@ -6,7 +6,6 @@ import type { Project, ProjectSession, LLMProvider } from '../../../../types/app
 import { getIntrinsicMessageKey } from '../../utils/messageKeys';
 import MessageComponent from './MessageComponent';
 import ProviderSelectionEmptyState from './ProviderSelectionEmptyState';
-import ScrollNavigation from './ScrollNavigation';
 
 interface ChatMessagesPaneProps {
   scrollContainerRef: RefObject<HTMLDivElement>;
@@ -131,7 +130,7 @@ export default function ChatMessagesPane({
       ref={scrollContainerRef}
       onWheel={onWheel}
       onTouchMove={onTouchMove}
-      className="relative flex-1 space-y-3 overflow-y-auto overflow-x-hidden px-0 py-3 sm:space-y-4 sm:p-4"
+      className="relative h-full space-y-3 overflow-y-auto overflow-x-hidden px-0 py-3 sm:space-y-4 sm:p-4"
     >
       {isLoadingSessionMessages && chatMessages.length === 0 ? (
         <div className="mt-8 text-center text-gray-500 dark:text-gray-400">
@@ -252,13 +251,6 @@ export default function ChatMessagesPane({
           })}
         </>
       )}
-
-      <ScrollNavigation
-        scrollContainerRef={scrollContainerRef}
-        chatMessages={chatMessages}
-        allMessagesLoaded={allMessagesLoaded}
-        loadAllMessages={loadAllMessages}
-      />
     </div>
   );
 }

--- a/src/components/chat/view/subcomponents/ChatMessagesPane.tsx
+++ b/src/components/chat/view/subcomponents/ChatMessagesPane.tsx
@@ -38,10 +38,10 @@ interface ChatMessagesPaneProps {
   visibleMessages: ChatMessage[];
   loadEarlierMessages: () => void;
   loadAllMessages: () => void;
+  loadMoreMessages: () => void;
   allMessagesLoaded: boolean;
   isLoadingAllMessages: boolean;
   loadAllJustFinished: boolean;
-  showLoadAllOverlay: boolean;
   createDiff: any;
   onFileOpen?: (filePath: string, diffInfo?: unknown) => void;
   onShowSettings?: () => void;
@@ -83,10 +83,10 @@ export default function ChatMessagesPane({
   visibleMessages,
   loadEarlierMessages,
   loadAllMessages,
+  loadMoreMessages,
   allMessagesLoaded,
   isLoadingAllMessages,
   loadAllJustFinished,
-  showLoadAllOverlay,
   createDiff,
   onFileOpen,
   onShowSettings,
@@ -161,55 +161,53 @@ export default function ChatMessagesPane({
         />
       ) : (
         <>
-          {/* Loading indicator for older messages (hide when load-all is active) */}
-          {isLoadingMoreMessages && !isLoadingAllMessages && !allMessagesLoaded && (
+          {/* Loading indicator for older messages */}
+          {(isLoadingMoreMessages || isLoadingAllMessages) && !allMessagesLoaded && (
             <div className="py-3 text-center text-gray-500 dark:text-gray-400">
               <div className="flex items-center justify-center space-x-2">
                 <div className="h-4 w-4 animate-spin rounded-full border-b-2 border-gray-400" />
-                <p className="text-sm">{t('session.loading.olderMessages')}</p>
+                <p className="text-sm">{isLoadingAllMessages ? t('session.messages.loadingAll') : t('session.loading.olderMessages')}</p>
               </div>
             </div>
           )}
 
-          {/* Indicator showing there are more messages to load (hide when all loaded) */}
-          {hasMoreMessages && !isLoadingMoreMessages && !allMessagesLoaded && (
+          {/* "Load more" buttons — show when there are more messages */}
+          {hasMoreMessages && !isLoadingMoreMessages && !isLoadingAllMessages && !allMessagesLoaded && (
             <div className="border-b border-gray-200 py-2 text-center text-sm text-gray-500 dark:border-gray-700 dark:text-gray-400">
               {totalMessages > 0 && (
                 <span>
                   {t('session.messages.showingOf', { shown: sessionMessagesCount, total: totalMessages })}{' '}
-                  <span className="text-xs">{t('session.messages.scrollToLoad')}</span>
                 </span>
               )}
+              <div className="mt-1.5 flex items-center justify-center gap-3">
+                <button
+                  className="flex items-center space-x-1 rounded-full bg-gray-200 px-3 py-1 text-xs font-medium text-gray-700 shadow transition-all duration-200 hover:bg-gray-300 dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600"
+                  onClick={loadMoreMessages}
+                >
+                  <svg className="h-3 w-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 14l-7 7m0 0l-7-7m7 7V3" />
+                  </svg>
+                  <span>{t('session.messages.loadMore', { count: 20 }) || `加载更多(20条)`}</span>
+                </button>
+                <button
+                  className="flex items-center space-x-1 rounded-full bg-blue-600 px-3 py-1 text-xs font-medium text-white shadow transition-all duration-200 hover:scale-105 hover:bg-blue-700 dark:bg-blue-500 dark:hover:bg-blue-600"
+                  onClick={loadAllMessages}
+                >
+                  <span>{t('session.messages.loadAll')} {totalMessages > 0 && `(${totalMessages})`}</span>
+                </button>
+              </div>
             </div>
           )}
 
-          {/* Floating "Load all messages" overlay */}
-          {(showLoadAllOverlay || isLoadingAllMessages || loadAllJustFinished) && (
+          {/* "All loaded" success indicator */}
+          {loadAllJustFinished && (
             <div className="pointer-events-none sticky top-2 z-20 flex justify-center">
-              {loadAllJustFinished ? (
-                <div className="flex items-center space-x-2 rounded-full bg-green-600 px-4 py-1.5 text-xs font-medium text-white shadow-lg dark:bg-green-500">
-                  <svg className="h-3 w-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={3} d="M5 13l4 4L19 7" />
-                  </svg>
-                  <span>{t('session.messages.allLoaded')}</span>
-                </div>
-              ) : (
-                <button
-                  className="pointer-events-auto flex items-center space-x-2 rounded-full bg-blue-600 px-4 py-1.5 text-xs font-medium text-white shadow-lg transition-all duration-200 hover:scale-105 hover:bg-blue-700 disabled:cursor-wait disabled:opacity-75 dark:bg-blue-500 dark:hover:bg-blue-600"
-                  onClick={loadAllMessages}
-                  disabled={isLoadingAllMessages}
-                >
-                  {isLoadingAllMessages && (
-                    <div className="h-3 w-3 animate-spin rounded-full border-2 border-white/30 border-t-white" />
-                  )}
-                  <span>
-                    {isLoadingAllMessages
-                      ? t('session.messages.loadingAll')
-                      : <>{t('session.messages.loadAll')} {totalMessages > 0 && `(${totalMessages})`}</>
-                    }
-                  </span>
-                </button>
-              )}
+              <div className="flex items-center space-x-2 rounded-full bg-green-600 px-4 py-1.5 text-xs font-medium text-white shadow-lg dark:bg-green-500">
+                <svg className="h-3 w-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={3} d="M5 13l4 4L19 7" />
+                </svg>
+                <span>{t('session.messages.allLoaded')}</span>
+              </div>
             </div>
           )}
 

--- a/src/components/chat/view/subcomponents/ChatMessagesPane.tsx
+++ b/src/components/chat/view/subcomponents/ChatMessagesPane.tsx
@@ -6,6 +6,7 @@ import type { Project, ProjectSession, LLMProvider } from '../../../../types/app
 import { getIntrinsicMessageKey } from '../../utils/messageKeys';
 import MessageComponent from './MessageComponent';
 import ProviderSelectionEmptyState from './ProviderSelectionEmptyState';
+import ScrollNavigation from './ScrollNavigation';
 
 interface ChatMessagesPaneProps {
   scrollContainerRef: RefObject<HTMLDivElement>;
@@ -251,6 +252,11 @@ export default function ChatMessagesPane({
           })}
         </>
       )}
+
+      <ScrollNavigation
+        scrollContainerRef={scrollContainerRef}
+        chatMessages={chatMessages}
+      />
     </div>
   );
 }

--- a/src/components/chat/view/subcomponents/MessageComponent.tsx
+++ b/src/components/chat/view/subcomponents/MessageComponent.tsx
@@ -28,6 +28,7 @@ type MessageComponentProps = {
   onFileOpen?: (filePath: string, diffInfo?: unknown) => void;
   onShowSettings?: () => void;
   onGrantToolPermission?: (suggestion: ClaudePermissionSuggestion) => PermissionGrantResult | null | undefined;
+  userMessageIndex?: number;
   autoExpandTools?: boolean;
   showRawParameters?: boolean;
   showThinking?: boolean;
@@ -44,7 +45,7 @@ type InteractiveOption = {
 type PermissionGrantState = 'idle' | 'granted' | 'error';
 const COPY_HIDDEN_TOOL_NAMES = new Set(['Bash', 'Edit', 'Write', 'ApplyPatch']);
 
-const MessageComponent = memo(({ message, prevMessage, createDiff, onFileOpen, onShowSettings, onGrantToolPermission, autoExpandTools, showRawParameters, showThinking, selectedProject, provider }: MessageComponentProps) => {
+const MessageComponent = memo(({ message, prevMessage, createDiff, onFileOpen, onShowSettings, onGrantToolPermission, autoExpandTools, showRawParameters, showThinking, selectedProject, provider, userMessageIndex }: MessageComponentProps) => {
   const { t } = useTranslation('chat');
   const isGrouped = prevMessage && prevMessage.type === message.type &&
     ((prevMessage.type === 'assistant') ||
@@ -115,6 +116,7 @@ const MessageComponent = memo(({ message, prevMessage, createDiff, onFileOpen, o
       ref={messageRef}
       data-message-timestamp={message.timestamp || undefined}
       className={`chat-message ${message.type} ${isGrouped ? 'grouped' : ''} ${message.type === 'user' ? 'flex justify-end px-3 sm:px-0' : 'px-3 sm:px-0'}`}
+      data-user-index={message.type === 'user' && userMessageIndex !== undefined ? userMessageIndex : undefined}
     >
       {message.type === 'user' ? (
         /* User message bubble on the right */

--- a/src/components/chat/view/subcomponents/ScrollNavigation.tsx
+++ b/src/components/chat/view/subcomponents/ScrollNavigation.tsx
@@ -21,34 +21,34 @@ function truncateSnippet(content: string): string {
 
 function ArrowUpIcon() {
   return (
-    <svg width="10" height="10" viewBox="0 0 10 10" fill="none" stroke="currentColor" strokeWidth="1.5">
-      <path d="M5 8V2M5 2L2 5M5 2L8 5" />
+    <svg width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
+      <path d="M9 7L6 4L3 7" />
     </svg>
   );
 }
 
 function ArrowDownIcon() {
   return (
-    <svg width="10" height="10" viewBox="0 0 10 10" fill="none" stroke="currentColor" strokeWidth="1.5">
-      <path d="M5 2V8M5 8L2 5M5 8L8 5" />
+    <svg width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
+      <path d="M3 5L6 8L9 5" />
     </svg>
   );
 }
 
-function DoubleUpIcon() {
+function TopIcon() {
   return (
-    <svg width="10" height="10" viewBox="0 0 10 10" fill="none" stroke="currentColor" strokeWidth="1.5">
-      <path d="M5 8V3M5 3L2 5.5M5 3L8 5.5" />
-      <path d="M5 6V1M5 1L2 3.5M5 1L8 3.5" />
+    <svg width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
+      <path d="M2 5h8" />
+      <path d="M6 2L3.5 5.5h5z" />
     </svg>
   );
 }
 
-function DoubleDownIcon() {
+function BottomIcon() {
   return (
-    <svg width="10" height="10" viewBox="0 0 10 10" fill="none" stroke="currentColor" strokeWidth="1.5">
-      <path d="M5 1V6M5 6L2 3.5M5 6L8 3.5" />
-      <path d="M5 3V8M5 8L2 5.5M5 8L8 5.5" />
+    <svg width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
+      <path d="M3.5 6.5L6 10l2.5-3.5" />
+      <path d="M2 7h8" />
     </svg>
   );
 }
@@ -157,7 +157,7 @@ export default function ScrollNavigation({
 
       const elements = container.querySelectorAll<HTMLDivElement>('.chat-message.user');
       if (elements.length > index) {
-        elements[index].scrollIntoView({ block: 'center', behavior: 'smooth' });
+        elements[index].scrollIntoView({ block: 'center', behavior: 'instant' });
         return;
       }
 
@@ -166,43 +166,27 @@ export default function ScrollNavigation({
 
       const targetRatio = index / (totalUserMessages - 1);
       const maxScroll = container.scrollHeight - container.clientHeight;
-      container.scrollTo({
-        top: targetRatio * maxScroll,
-        behavior: 'smooth',
-      });
+      container.scrollTop = targetRatio * maxScroll;
     },
     [scrollContainerRef, userMessages.length],
   );
 
-  const scroll_to_top = useCallback(() => {
+  const scrollToTop = useCallback(() => {
     const container = scrollContainerRef.current;
     if (!container) return;
 
     ensureLoaded();
-
-    const elements = container.querySelectorAll<HTMLDivElement>('.chat-message.user');
-    if (elements.length > 0) {
-      elements[0].scrollIntoView({ block: 'center', behavior: 'smooth' });
-      return;
-    }
-
-    container.scrollTo({ top: 0, behavior: 'smooth' });
+    container.scrollTop = 0;
   }, [scrollContainerRef, ensureLoaded]);
 
-  const scroll_to_bottom = useCallback(() => {
+  const scrollToBottom = useCallback(() => {
     const container = scrollContainerRef.current;
     if (!container) return;
 
-    const elements = container.querySelectorAll<HTMLDivElement>('.chat-message.user');
-    if (elements.length > 0) {
-      elements[elements.length - 1].scrollIntoView({ block: 'center', behavior: 'smooth' });
-      return;
-    }
-
-    container.scrollTo({ top: container.scrollHeight, behavior: 'smooth' });
+    container.scrollTop = container.scrollHeight;
   }, [scrollContainerRef]);
 
-  const scroll_prev = useCallback(() => {
+  const scrollPrev = useCallback(() => {
     const container = scrollContainerRef.current;
     if (!container) return;
 
@@ -223,10 +207,10 @@ export default function ScrollNavigation({
     }
 
     const targetIndex = Math.max(0, currentIndex - 1);
-    elements[targetIndex].scrollIntoView({ block: 'center', behavior: 'smooth' });
+    elements[targetIndex].scrollIntoView({ block: 'center', behavior: 'instant' });
   }, [scrollContainerRef]);
 
-  const scroll_next = useCallback(() => {
+  const scrollNext = useCallback(() => {
     const container = scrollContainerRef.current;
     if (!container) return;
 
@@ -246,7 +230,7 @@ export default function ScrollNavigation({
     }
 
     const targetIndex = Math.min(elements.length - 1, currentIndex + 1);
-    elements[targetIndex].scrollIntoView({ block: 'center', behavior: 'smooth' });
+    elements[targetIndex].scrollIntoView({ block: 'center', behavior: 'instant' });
   }, [scrollContainerRef]);
 
   if (!shouldShow) return null;
@@ -254,23 +238,23 @@ export default function ScrollNavigation({
   const navButtons = [
     {
       label: t('scrollNav.first'),
-      icon: <DoubleUpIcon />,
-      action: scroll_to_top,
+      icon: <TopIcon />,
+      action: scrollToTop,
     },
     {
       label: t('scrollNav.previous'),
       icon: <ArrowUpIcon />,
-      action: scroll_prev,
+      action: scrollPrev,
     },
     {
       label: t('scrollNav.next'),
       icon: <ArrowDownIcon />,
-      action: scroll_next,
+      action: scrollNext,
     },
     {
       label: t('scrollNav.last'),
-      icon: <DoubleDownIcon />,
-      action: scroll_to_bottom,
+      icon: <BottomIcon />,
+      action: scrollToBottom,
     },
   ];
 

--- a/src/components/chat/view/subcomponents/ScrollNavigation.tsx
+++ b/src/components/chat/view/subcomponents/ScrollNavigation.tsx
@@ -110,10 +110,10 @@ export default function ScrollNavigation({
 
   return (
     <div
-      className="pointer-events-none absolute right-0 top-0 z-10 h-full w-5"
+      className="pointer-events-none absolute right-0 top-0 z-10 h-full w-4"
     >
       <div
-        className={`pointer-events-auto flex h-full w-3 flex-col items-center justify-evenly rounded-full border px-0 py-4 backdrop-blur-sm transition-opacity duration-200 ${
+        className={`pointer-events-auto flex h-full w-2 flex-col items-center justify-evenly rounded-full border px-0 py-4 backdrop-blur-sm transition-opacity duration-200 ${
           isStripHovered ? 'opacity-100' : 'opacity-50'
         } bg-background/80 border-border/50`}
         onMouseEnter={() => setIsStripHovered(true)}

--- a/src/components/chat/view/subcomponents/ScrollNavigation.tsx
+++ b/src/components/chat/view/subcomponents/ScrollNavigation.tsx
@@ -83,7 +83,7 @@ export default function ScrollNavigation({
     [chatMessages],
   );
 
-  const shouldShow = userMessages.length >= 1;
+  const shouldShow = chatMessages.length >= 1;
   const hasMore = hasMoreMessages;
 
   const scheduleUpdate = useCallback(() => {
@@ -136,17 +136,10 @@ export default function ScrollNavigation({
     };
   }, []);
 
-  const ensureLoaded = useCallback(() => {
-    if (hasMore && loadAllMessages) {
-      loadAllMessages();
-    }
-  }, [hasMore, loadAllMessages]);
-
   const scrollToDot = useCallback(
     (index: number) => {
       setActiveDotIndex(index);
       skipUpdateRef.current = true;
-      ensureLoaded();
       const container = scrollContainerRef.current;
       if (!container) return;
 
@@ -163,16 +156,15 @@ export default function ScrollNavigation({
       const maxScroll = container.scrollHeight - container.clientHeight;
       container.scrollTop = targetRatio * maxScroll;
     },
-    [scrollContainerRef, userMessages.length, ensureLoaded],
+    [scrollContainerRef, userMessages.length],
   );
 
   const scrollToTop = useCallback(() => {
-    ensureLoaded();
     const container = scrollContainerRef.current;
     if (!container) return;
 
     container.scrollTop = 0;
-  }, [scrollContainerRef, ensureLoaded]);
+  }, [scrollContainerRef]);
 
   const scrollToBottom = useCallback(() => {
     const container = scrollContainerRef.current;
@@ -230,26 +222,31 @@ export default function ScrollNavigation({
 
   if (!shouldShow) return null;
 
+  const hasUserMessages = userMessages.length > 0;
   const navButtons = [
     {
       label: t('scrollNav.first'),
       icon: <TopIcon />,
       action: scrollToTop,
+      disabled: false,
     },
     {
       label: t('scrollNav.previous'),
       icon: <ArrowUpIcon />,
       action: scrollPrev,
+      disabled: !hasUserMessages,
     },
     {
       label: t('scrollNav.next'),
       icon: <ArrowDownIcon />,
       action: scrollNext,
+      disabled: !hasUserMessages,
     },
     {
       label: t('scrollNav.last'),
       icon: <BottomIcon />,
       action: scrollToBottom,
+      disabled: false,
     },
   ];
 
@@ -286,7 +283,12 @@ export default function ScrollNavigation({
               <button
                 type="button"
                 onClick={btn.action}
-                className="rounded p-1 text-muted-foreground transition-all duration-150 hover:text-foreground"
+                disabled={btn.disabled}
+                className={`rounded p-1 transition-all duration-150 ${
+                  btn.disabled
+                    ? 'text-muted-foreground/30 cursor-default'
+                    : 'text-muted-foreground hover:text-foreground'
+                }`}
                 aria-label={btn.label}
               >
                 {btn.icon}
@@ -295,41 +297,45 @@ export default function ScrollNavigation({
           ))}
         </div>
 
-        {/* Divider */}
-        <div className={`mx-auto my-0.5 border-t border-border/40 transition-all duration-150 ${
-          isStripHovered ? 'w-5 opacity-100' : 'w-0 opacity-0'
-        }`} />
+        {/* Dots section — only render when there are user messages */}
+        {userMessages.length > 0 && (
+          <>
+            {/* Divider */}
+            <div className={`mx-auto my-0.5 border-t border-border/40 transition-all duration-150 ${
+              isStripHovered ? 'w-5 opacity-100' : 'w-0 opacity-0'
+            }`} />
 
-        {/* Dots section */}
-        <div className="flex flex-1 w-full flex-col items-center justify-evenly px-0 py-1">
-          {userMessages.map((msg, i) => {
-            const isActive = i === activeDotIndex;
-            const snippet = truncateSnippet(msg.content || '');
+            <div className="flex flex-1 w-full flex-col items-center justify-evenly px-0 py-1">
+              {userMessages.map((msg, i) => {
+                const isActive = i === activeDotIndex;
+                const snippet = truncateSnippet(msg.content || '');
 
-            return (
-              <Tooltip
-                key={`${i}-${String(msg.timestamp).slice(0, 8)}`}
-                content={t('scrollNav.jumpToMessage', {
-                  index: i + 1,
-                  snippet,
-                })}
-                position="left"
-                delay={150}
-              >
-                <button
-                  type="button"
-                  onClick={() => scrollToDot(i)}
-                  className={`block cursor-pointer rounded-full transition-all duration-150 ${
-                    isActive
-                      ? 'h-[10px] w-[10px] bg-blue-500 hover:bg-blue-400'
-                      : 'h-[7px] w-[7px] bg-muted-foreground/70 hover:bg-muted-foreground hover:h-[9px] hover:w-[9px]'
-                  }`}
-                  aria-label={t('scrollNav.jumpToMessage', { index: i + 1 })}
-                />
-              </Tooltip>
-            );
-          })}
-        </div>
+                return (
+                  <Tooltip
+                    key={`${i}-${String(msg.timestamp).slice(0, 8)}`}
+                    content={t('scrollNav.jumpToMessage', {
+                      index: i + 1,
+                      snippet,
+                    })}
+                    position="left"
+                    delay={150}
+                  >
+                    <button
+                      type="button"
+                      onClick={() => scrollToDot(i)}
+                      className={`block cursor-pointer rounded-full transition-all duration-150 ${
+                        isActive
+                          ? 'h-[10px] w-[10px] bg-blue-500 hover:bg-blue-400'
+                          : 'h-[7px] w-[7px] bg-muted-foreground/70 hover:bg-muted-foreground hover:h-[9px] hover:w-[9px]'
+                      }`}
+                      aria-label={t('scrollNav.jumpToMessage', { index: i + 1 })}
+                    />
+                  </Tooltip>
+                );
+              })}
+            </div>
+          </>
+        )}
       </div>
     </div>
   );

--- a/src/components/chat/view/subcomponents/ScrollNavigation.tsx
+++ b/src/components/chat/view/subcomponents/ScrollNavigation.tsx
@@ -6,6 +6,8 @@ import Tooltip from '../../../../shared/view/ui/Tooltip';
 interface ScrollNavigationProps {
   scrollContainerRef: React.RefObject<HTMLDivElement | null>;
   chatMessages: ChatMessage[];
+  allMessagesLoaded: boolean;
+  loadAllMessages: () => void;
 }
 
 function truncateSnippet(content: string): string {
@@ -15,19 +17,40 @@ function truncateSnippet(content: string): string {
     .slice(0, 60) + ((content || '').length > 60 ? '...' : '');
 }
 
-export default function ScrollNavigation({ scrollContainerRef, chatMessages }: ScrollNavigationProps) {
+export default function ScrollNavigation({
+  scrollContainerRef,
+  chatMessages,
+  allMessagesLoaded,
+  loadAllMessages,
+}: ScrollNavigationProps) {
   const { t } = useTranslation('chat');
   const [activeDotIndex, setActiveDotIndex] = useState(-1);
   const [isStripHovered, setIsStripHovered] = useState(false);
   const rafIdRef = useRef<number | null>(null);
   const mountedRef = useRef(true);
+  const loadAllCalledRef = useRef(false);
 
   const userMessages = useMemo(
     () => chatMessages.filter((m) => m.type === 'user'),
     [chatMessages],
   );
 
-  const shouldShow = userMessages.length >= 3;
+  const shouldShow = userMessages.length >= 1;
+
+  // Auto-load all messages on first mount so every dot appears
+  useEffect(() => {
+    if (!allMessagesLoaded && !loadAllCalledRef.current && userMessages.length > 0) {
+      loadAllCalledRef.current = true;
+      loadAllMessages();
+    }
+  }, [allMessagesLoaded, loadAllMessages, userMessages.length]);
+
+  // Reset loadAllCalledRef when session changes (messages become empty then refill)
+  useEffect(() => {
+    if (chatMessages.length === 0) {
+      loadAllCalledRef.current = false;
+    }
+  }, [chatMessages.length]);
 
   const scheduleUpdate = useCallback(() => {
     if (rafIdRef.current != null) return;
@@ -61,22 +84,18 @@ export default function ScrollNavigation({ scrollContainerRef, chatMessages }: S
     });
   }, [scrollContainerRef]);
 
-  // Scroll listener for active dot tracking
   useEffect(() => {
     const container = scrollContainerRef.current;
     if (!container) return;
-
     container.addEventListener('scroll', scheduleUpdate, { passive: true });
     return () => container.removeEventListener('scroll', scheduleUpdate);
   }, [scrollContainerRef, scheduleUpdate]);
 
-  // Initial position + re-compute when messages change
   useEffect(() => {
-    const timer = setTimeout(() => scheduleUpdate(), 200);
+    const timer = setTimeout(() => scheduleUpdate(), 300);
     return () => clearTimeout(timer);
   }, [chatMessages.length, scheduleUpdate]);
 
-  // Cleanup RAF on unmount
   useEffect(() => {
     mountedRef.current = true;
     return () => {
@@ -100,6 +119,8 @@ export default function ScrollNavigation({ scrollContainerRef, chatMessages }: S
 
   if (!shouldShow) return null;
 
+  const totalDots = userMessages.length;
+
   return (
     <div
       className="pointer-events-none absolute right-0.5 top-1/2 z-10 flex -translate-y-1/2 flex-col items-center"
@@ -107,8 +128,8 @@ export default function ScrollNavigation({ scrollContainerRef, chatMessages }: S
       onMouseLeave={() => setIsStripHovered(false)}
     >
       <div
-        className={`pointer-events-auto flex flex-col items-center rounded-full border py-2 backdrop-blur-sm transition-opacity duration-200 ${
-          isStripHovered ? 'opacity-100' : 'opacity-40'
+        className={`pointer-events-auto flex flex-col items-center rounded-full border px-1.5 py-3 backdrop-blur-sm transition-opacity duration-200 ${
+          isStripHovered ? 'opacity-100' : 'opacity-50'
         } bg-background/80 border-border/50`}
       >
         {userMessages.map((msg, i) => {
@@ -128,12 +149,14 @@ export default function ScrollNavigation({ scrollContainerRef, chatMessages }: S
               <button
                 type="button"
                 onClick={() => scrollToDot(i)}
-                className={`block rounded-full transition-all duration-150 ${
+                className={`block cursor-pointer rounded-full transition-all duration-150 ${
                   isActive
-                    ? 'h-[6px] w-[6px] bg-blue-500 hover:bg-blue-400'
-                    : 'h-[4px] w-[4px] bg-muted-foreground/60 hover:bg-muted-foreground'
+                    ? 'h-[8px] w-[8px] bg-blue-500 hover:bg-blue-400'
+                    : 'h-[6px] w-[6px] bg-muted-foreground/70 hover:bg-muted-foreground hover:h-[8px] hover:w-[8px]'
                 }`}
-                style={{ marginTop: i === 0 ? 0 : 2 }}
+                style={{
+                  marginBlock: totalDots > 1 ? 6 : 0,
+                }}
                 aria-label={t('scrollNav.jumpToMessage', { index: i + 1 })}
               />
             </Tooltip>

--- a/src/components/chat/view/subcomponents/ScrollNavigation.tsx
+++ b/src/components/chat/view/subcomponents/ScrollNavigation.tsx
@@ -110,10 +110,10 @@ export default function ScrollNavigation({
 
   return (
     <div
-      className="pointer-events-none absolute right-0.5 top-0 z-10 flex h-full w-6 flex-col items-center"
+      className="pointer-events-none absolute right-0 top-0 z-10 h-full w-5"
     >
       <div
-        className={`pointer-events-auto flex h-full w-4 flex-col items-center justify-evenly rounded-full border px-0.5 py-4 backdrop-blur-sm transition-opacity duration-200 ${
+        className={`pointer-events-auto flex h-full w-3 flex-col items-center justify-evenly rounded-full border px-0 py-4 backdrop-blur-sm transition-opacity duration-200 ${
           isStripHovered ? 'opacity-100' : 'opacity-50'
         } bg-background/80 border-border/50`}
         onMouseEnter={() => setIsStripHovered(true)}

--- a/src/components/chat/view/subcomponents/ScrollNavigation.tsx
+++ b/src/components/chat/view/subcomponents/ScrollNavigation.tsx
@@ -110,14 +110,14 @@ export default function ScrollNavigation({
 
   return (
     <div
-      className="pointer-events-none absolute right-0.5 top-0 z-20 flex h-full w-6 flex-col items-center"
-      onMouseEnter={() => setIsStripHovered(true)}
-      onMouseLeave={() => setIsStripHovered(false)}
+      className="pointer-events-none absolute right-0.5 top-0 z-10 flex h-full w-6 flex-col items-center"
     >
       <div
-        className={`pointer-events-auto flex h-full w-full flex-col items-center justify-evenly rounded-full border px-1.5 py-8 backdrop-blur-sm transition-opacity duration-200 ${
+        className={`pointer-events-auto flex h-full w-4 flex-col items-center justify-evenly rounded-full border px-0.5 py-4 backdrop-blur-sm transition-opacity duration-200 ${
           isStripHovered ? 'opacity-100' : 'opacity-50'
         } bg-background/80 border-border/50`}
+        onMouseEnter={() => setIsStripHovered(true)}
+        onMouseLeave={() => setIsStripHovered(false)}
       >
         {userMessages.map((msg, i) => {
           const isActive = i === activeDotIndex;

--- a/src/components/chat/view/subcomponents/ScrollNavigation.tsx
+++ b/src/components/chat/view/subcomponents/ScrollNavigation.tsx
@@ -8,6 +8,7 @@ interface ScrollNavigationProps {
   chatMessages: ChatMessage[];
   loadAllMessages?: () => void;
   allMessagesLoaded?: boolean;
+  hasMoreMessages?: boolean;
   totalMessages?: number;
   sessionMessagesCount?: number;
 }
@@ -66,6 +67,7 @@ export default function ScrollNavigation({
   chatMessages,
   loadAllMessages,
   allMessagesLoaded = true,
+  hasMoreMessages = false,
   totalMessages = 0,
   sessionMessagesCount = 0,
 }: ScrollNavigationProps) {
@@ -74,6 +76,7 @@ export default function ScrollNavigation({
   const [isStripHovered, setIsStripHovered] = useState(false);
   const rafIdRef = useRef<number | null>(null);
   const mountedRef = useRef(true);
+  const skipUpdateRef = useRef(false);
 
   const userMessages = useMemo(
     () => chatMessages.filter((m) => m.type === 'user'),
@@ -81,12 +84,16 @@ export default function ScrollNavigation({
   );
 
   const shouldShow = userMessages.length >= 1;
-  const hasMore = totalMessages > 0 && sessionMessagesCount > 0 && !allMessagesLoaded;
+  const hasMore = hasMoreMessages;
 
   const scheduleUpdate = useCallback(() => {
     if (rafIdRef.current != null) return;
     rafIdRef.current = requestAnimationFrame(() => {
       rafIdRef.current = null;
+      if (skipUpdateRef.current) {
+        skipUpdateRef.current = false;
+        return;
+      }
       const container = scrollContainerRef.current;
       if (!container) return;
 
@@ -129,29 +136,17 @@ export default function ScrollNavigation({
     };
   }, []);
 
-  // Lazy-load: ensure all messages are loaded before navigating
   const ensureLoaded = useCallback(() => {
     if (hasMore && loadAllMessages) {
       loadAllMessages();
     }
   }, [hasMore, loadAllMessages]);
 
-  // Load all messages after first paint — non-blocking, doesn't delay initial render
-  useEffect(() => {
-    if (!hasMore || !loadAllMessages) return;
-    const idle = (globalThis.requestIdleCallback ?? ((fn: () => void) => setTimeout(fn, 0)));
-    const handle = idle(() => {
-      if (mountedRef.current && hasMore) loadAllMessages();
-    });
-    return () => {
-      if ('cancelIdleCallback' in globalThis)
-        (globalThis as any).cancelIdleCallback(handle);
-      else clearTimeout(handle as any);
-    };
-  }, [hasMore, loadAllMessages]);
-
   const scrollToDot = useCallback(
     (index: number) => {
+      setActiveDotIndex(index);
+      skipUpdateRef.current = true;
+      ensureLoaded();
       const container = scrollContainerRef.current;
       if (!container) return;
 
@@ -168,14 +163,14 @@ export default function ScrollNavigation({
       const maxScroll = container.scrollHeight - container.clientHeight;
       container.scrollTop = targetRatio * maxScroll;
     },
-    [scrollContainerRef, userMessages.length],
+    [scrollContainerRef, userMessages.length, ensureLoaded],
   );
 
   const scrollToTop = useCallback(() => {
+    ensureLoaded();
     const container = scrollContainerRef.current;
     if (!container) return;
 
-    ensureLoaded();
     container.scrollTop = 0;
   }, [scrollContainerRef, ensureLoaded]);
 

--- a/src/components/chat/view/subcomponents/ScrollNavigation.tsx
+++ b/src/components/chat/view/subcomponents/ScrollNavigation.tsx
@@ -6,8 +6,6 @@ import Tooltip from '../../../../shared/view/ui/Tooltip';
 interface ScrollNavigationProps {
   scrollContainerRef: React.RefObject<HTMLDivElement | null>;
   chatMessages: ChatMessage[];
-  allMessagesLoaded: boolean;
-  loadAllMessages: () => void;
 }
 
 function truncateSnippet(content: string): string {
@@ -20,15 +18,12 @@ function truncateSnippet(content: string): string {
 export default function ScrollNavigation({
   scrollContainerRef,
   chatMessages,
-  allMessagesLoaded,
-  loadAllMessages,
 }: ScrollNavigationProps) {
   const { t } = useTranslation('chat');
   const [activeDotIndex, setActiveDotIndex] = useState(-1);
   const [isStripHovered, setIsStripHovered] = useState(false);
   const rafIdRef = useRef<number | null>(null);
   const mountedRef = useRef(true);
-  const loadAllCalledRef = useRef(false);
 
   const userMessages = useMemo(
     () => chatMessages.filter((m) => m.type === 'user'),
@@ -37,21 +32,6 @@ export default function ScrollNavigation({
 
   const shouldShow = userMessages.length >= 1;
 
-  // Auto-load all messages on first mount so every dot appears
-  useEffect(() => {
-    if (!allMessagesLoaded && !loadAllCalledRef.current && userMessages.length > 0) {
-      loadAllCalledRef.current = true;
-      loadAllMessages();
-    }
-  }, [allMessagesLoaded, loadAllMessages, userMessages.length]);
-
-  // Reset loadAllCalledRef when session changes (messages become empty then refill)
-  useEffect(() => {
-    if (chatMessages.length === 0) {
-      loadAllCalledRef.current = false;
-    }
-  }, [chatMessages.length]);
-
   const scheduleUpdate = useCallback(() => {
     if (rafIdRef.current != null) return;
     rafIdRef.current = requestAnimationFrame(() => {
@@ -59,30 +39,26 @@ export default function ScrollNavigation({
       const container = scrollContainerRef.current;
       if (!container) return;
 
-      const elements = container.querySelectorAll<HTMLDivElement>('.chat-message.user');
-      if (elements.length === 0) {
-        setActiveDotIndex(-1);
+      const { scrollTop, scrollHeight, clientHeight } = container;
+      const maxScroll = scrollHeight - clientHeight;
+      if (maxScroll <= 0) {
+        setActiveDotIndex(userMessages.length > 0 ? userMessages.length - 1 : -1);
         return;
       }
 
-      const { scrollTop, clientHeight } = container;
-      const viewCenter = scrollTop + clientHeight / 2;
+      // Proportional position of scroll within content
+      const scrollRatio = scrollTop / maxScroll;
+      // Map to the closest user message index
+      const totalUserMessages = userMessages.length;
+      if (totalUserMessages <= 1) {
+        setActiveDotIndex(0);
+        return;
+      }
 
-      let bestIndex = 0;
-      let bestDist = Infinity;
-
-      elements.forEach((el, i) => {
-        const center = el.offsetTop + el.clientHeight / 2;
-        const dist = Math.abs(center - viewCenter);
-        if (dist < bestDist) {
-          bestDist = dist;
-          bestIndex = i;
-        }
-      });
-
-      if (mountedRef.current) setActiveDotIndex(bestIndex);
+      const activeIdx = Math.round(scrollRatio * (totalUserMessages - 1));
+      if (mountedRef.current) setActiveDotIndex(activeIdx);
     });
-  }, [scrollContainerRef]);
+  }, [scrollContainerRef, userMessages.length]);
 
   useEffect(() => {
     const container = scrollContainerRef.current;
@@ -92,7 +68,7 @@ export default function ScrollNavigation({
   }, [scrollContainerRef, scheduleUpdate]);
 
   useEffect(() => {
-    const timer = setTimeout(() => scheduleUpdate(), 300);
+    const timer = setTimeout(() => scheduleUpdate(), 200);
     return () => clearTimeout(timer);
   }, [chatMessages.length, scheduleUpdate]);
 
@@ -108,27 +84,38 @@ export default function ScrollNavigation({
     (index: number) => {
       const container = scrollContainerRef.current;
       if (!container) return;
+
       const elements = container.querySelectorAll<HTMLDivElement>('.chat-message.user');
-      const target = elements[index];
-      if (target) {
-        target.scrollIntoView({ block: 'center', behavior: 'smooth' });
+      if (elements.length > index) {
+        // Message is rendered, scroll directly
+        elements[index].scrollIntoView({ block: 'center', behavior: 'smooth' });
+        return;
       }
+
+      // Message not rendered yet — scroll proportionally
+      const totalUserMessages = userMessages.length;
+      if (totalUserMessages <= 1) return;
+
+      const targetRatio = index / (totalUserMessages - 1);
+      const maxScroll = container.scrollHeight - container.clientHeight;
+      container.scrollTo({
+        top: targetRatio * maxScroll,
+        behavior: 'smooth',
+      });
     },
-    [scrollContainerRef],
+    [scrollContainerRef, userMessages.length],
   );
 
   if (!shouldShow) return null;
 
-  const totalDots = userMessages.length;
-
   return (
     <div
-      className="pointer-events-none absolute right-0.5 top-1/2 z-10 flex -translate-y-1/2 flex-col items-center"
+      className="pointer-events-none absolute right-0.5 top-0 z-20 flex h-full w-6 flex-col items-center"
       onMouseEnter={() => setIsStripHovered(true)}
       onMouseLeave={() => setIsStripHovered(false)}
     >
       <div
-        className={`pointer-events-auto flex flex-col items-center rounded-full border px-1.5 py-3 backdrop-blur-sm transition-opacity duration-200 ${
+        className={`pointer-events-auto flex h-full w-full flex-col items-center justify-evenly rounded-full border px-1.5 py-8 backdrop-blur-sm transition-opacity duration-200 ${
           isStripHovered ? 'opacity-100' : 'opacity-50'
         } bg-background/80 border-border/50`}
       >
@@ -151,12 +138,9 @@ export default function ScrollNavigation({
                 onClick={() => scrollToDot(i)}
                 className={`block cursor-pointer rounded-full transition-all duration-150 ${
                   isActive
-                    ? 'h-[8px] w-[8px] bg-blue-500 hover:bg-blue-400'
-                    : 'h-[6px] w-[6px] bg-muted-foreground/70 hover:bg-muted-foreground hover:h-[8px] hover:w-[8px]'
+                    ? 'h-[10px] w-[10px] bg-blue-500 hover:bg-blue-400'
+                    : 'h-[7px] w-[7px] bg-muted-foreground/70 hover:bg-muted-foreground hover:h-[9px] hover:w-[9px]'
                 }`}
-                style={{
-                  marginBlock: totalDots > 1 ? 6 : 0,
-                }}
                 aria-label={t('scrollNav.jumpToMessage', { index: i + 1 })}
               />
             </Tooltip>

--- a/src/components/chat/view/subcomponents/ScrollNavigation.tsx
+++ b/src/components/chat/view/subcomponents/ScrollNavigation.tsx
@@ -144,12 +144,16 @@ export default function ScrollNavigation({
       const container = scrollContainerRef.current;
       if (!container) return;
 
-      const elements = container.querySelectorAll<HTMLDivElement>('.chat-message.user');
-      if (elements.length > index) {
-        elements[index].scrollIntoView({ block: 'center', behavior: 'instant' });
+      // Use data-user-index to find the exact logical user message
+      const el = container.querySelector<HTMLDivElement>(
+        `.chat-message.user[data-user-index="${index}"]`,
+      );
+      if (el) {
+        el.scrollIntoView({ block: 'center', behavior: 'instant' });
         return;
       }
 
+      // Fallback: ratio-based scroll for messages not in DOM
       const totalUserMessages = userMessages.length;
       if (totalUserMessages <= 1) return;
 
@@ -175,51 +179,14 @@ export default function ScrollNavigation({
   }, [scrollContainerRef]);
 
   const scrollPrev = useCallback(() => {
-    const container = scrollContainerRef.current;
-    if (!container) return;
-
-    const elements = container.querySelectorAll<HTMLDivElement>('.chat-message.user');
-    if (elements.length === 0) return;
-
-    const { scrollTop, clientHeight } = container;
-    const viewportCenter = scrollTop + clientHeight / 2;
-
-    let currentIndex = 0;
-    for (let i = 0; i < elements.length; i++) {
-      const top = elements[i].getBoundingClientRect().top - container.getBoundingClientRect().top + scrollTop;
-      if (top <= viewportCenter) {
-        currentIndex = i;
-      } else {
-        break;
-      }
-    }
-
-    const targetIndex = Math.max(0, currentIndex - 1);
-    elements[targetIndex].scrollIntoView({ block: 'center', behavior: 'instant' });
-  }, [scrollContainerRef]);
+    const targetIndex = Math.max(0, activeDotIndex - 1);
+    scrollToDot(targetIndex);
+  }, [activeDotIndex, scrollToDot]);
 
   const scrollNext = useCallback(() => {
-    const container = scrollContainerRef.current;
-    if (!container) return;
-
-    const elements = container.querySelectorAll<HTMLDivElement>('.chat-message.user');
-    if (elements.length === 0) return;
-
-    const { scrollTop, clientHeight } = container;
-    const viewportCenter = scrollTop + clientHeight / 2;
-
-    let currentIndex = elements.length - 1;
-    for (let i = elements.length - 1; i >= 0; i--) {
-      const top = elements[i].getBoundingClientRect().top - container.getBoundingClientRect().top + scrollTop;
-      if (top <= viewportCenter) {
-        currentIndex = i;
-        break;
-      }
-    }
-
-    const targetIndex = Math.min(elements.length - 1, currentIndex + 1);
-    elements[targetIndex].scrollIntoView({ block: 'center', behavior: 'instant' });
-  }, [scrollContainerRef]);
+    const targetIndex = Math.min(userMessages.length - 1, activeDotIndex + 1);
+    scrollToDot(targetIndex);
+  }, [activeDotIndex, userMessages.length, scrollToDot]);
 
   if (!shouldShow) return null;
 

--- a/src/components/chat/view/subcomponents/ScrollNavigation.tsx
+++ b/src/components/chat/view/subcomponents/ScrollNavigation.tsx
@@ -6,6 +6,10 @@ import Tooltip from '../../../../shared/view/ui/Tooltip';
 interface ScrollNavigationProps {
   scrollContainerRef: React.RefObject<HTMLDivElement | null>;
   chatMessages: ChatMessage[];
+  loadAllMessages?: () => void;
+  allMessagesLoaded?: boolean;
+  totalMessages?: number;
+  sessionMessagesCount?: number;
 }
 
 function truncateSnippet(content: string): string {
@@ -15,9 +19,55 @@ function truncateSnippet(content: string): string {
     .slice(0, 60) + ((content || '').length > 60 ? '...' : '');
 }
 
+function ArrowUpIcon() {
+  return (
+    <svg width="10" height="10" viewBox="0 0 10 10" fill="none" stroke="currentColor" strokeWidth="1.5">
+      <path d="M5 8V2M5 2L2 5M5 2L8 5" />
+    </svg>
+  );
+}
+
+function ArrowDownIcon() {
+  return (
+    <svg width="10" height="10" viewBox="0 0 10 10" fill="none" stroke="currentColor" strokeWidth="1.5">
+      <path d="M5 2V8M5 8L2 5M5 8L8 5" />
+    </svg>
+  );
+}
+
+function DoubleUpIcon() {
+  return (
+    <svg width="10" height="10" viewBox="0 0 10 10" fill="none" stroke="currentColor" strokeWidth="1.5">
+      <path d="M5 8V3M5 3L2 5.5M5 3L8 5.5" />
+      <path d="M5 6V1M5 1L2 3.5M5 1L8 3.5" />
+    </svg>
+  );
+}
+
+function DoubleDownIcon() {
+  return (
+    <svg width="10" height="10" viewBox="0 0 10 10" fill="none" stroke="currentColor" strokeWidth="1.5">
+      <path d="M5 1V6M5 6L2 3.5M5 6L8 3.5" />
+      <path d="M5 3V8M5 8L2 5.5M5 8L8 5.5" />
+    </svg>
+  );
+}
+
+function LoadAllIcon() {
+  return (
+    <svg width="10" height="10" viewBox="0 0 10 10" fill="none" stroke="currentColor" strokeWidth="1.5">
+      <path d="M1 3h8M1 5h6M1 7h7" />
+    </svg>
+  );
+}
+
 export default function ScrollNavigation({
   scrollContainerRef,
   chatMessages,
+  loadAllMessages,
+  allMessagesLoaded = true,
+  totalMessages = 0,
+  sessionMessagesCount = 0,
 }: ScrollNavigationProps) {
   const { t } = useTranslation('chat');
   const [activeDotIndex, setActiveDotIndex] = useState(-1);
@@ -31,6 +81,7 @@ export default function ScrollNavigation({
   );
 
   const shouldShow = userMessages.length >= 1;
+  const hasMore = totalMessages > 0 && sessionMessagesCount > 0 && !allMessagesLoaded;
 
   const scheduleUpdate = useCallback(() => {
     if (rafIdRef.current != null) return;
@@ -46,9 +97,7 @@ export default function ScrollNavigation({
         return;
       }
 
-      // Proportional position of scroll within content
       const scrollRatio = scrollTop / maxScroll;
-      // Map to the closest user message index
       const totalUserMessages = userMessages.length;
       if (totalUserMessages <= 1) {
         setActiveDotIndex(0);
@@ -80,6 +129,27 @@ export default function ScrollNavigation({
     };
   }, []);
 
+  // Lazy-load: ensure all messages are loaded before navigating
+  const ensureLoaded = useCallback(() => {
+    if (hasMore && loadAllMessages) {
+      loadAllMessages();
+    }
+  }, [hasMore, loadAllMessages]);
+
+  // Load all messages after first paint — non-blocking, doesn't delay initial render
+  useEffect(() => {
+    if (!hasMore || !loadAllMessages) return;
+    const idle = (globalThis.requestIdleCallback ?? ((fn: () => void) => setTimeout(fn, 0)));
+    const handle = idle(() => {
+      if (mountedRef.current && hasMore) loadAllMessages();
+    });
+    return () => {
+      if ('cancelIdleCallback' in globalThis)
+        (globalThis as any).cancelIdleCallback(handle);
+      else clearTimeout(handle as any);
+    };
+  }, [hasMore, loadAllMessages]);
+
   const scrollToDot = useCallback(
     (index: number) => {
       const container = scrollContainerRef.current;
@@ -87,12 +157,10 @@ export default function ScrollNavigation({
 
       const elements = container.querySelectorAll<HTMLDivElement>('.chat-message.user');
       if (elements.length > index) {
-        // Message is rendered, scroll directly
         elements[index].scrollIntoView({ block: 'center', behavior: 'smooth' });
         return;
       }
 
-      // Message not rendered yet — scroll proportionally
       const totalUserMessages = userMessages.length;
       if (totalUserMessages <= 1) return;
 
@@ -106,46 +174,183 @@ export default function ScrollNavigation({
     [scrollContainerRef, userMessages.length],
   );
 
+  const scroll_to_top = useCallback(() => {
+    const container = scrollContainerRef.current;
+    if (!container) return;
+
+    ensureLoaded();
+
+    const elements = container.querySelectorAll<HTMLDivElement>('.chat-message.user');
+    if (elements.length > 0) {
+      elements[0].scrollIntoView({ block: 'center', behavior: 'smooth' });
+      return;
+    }
+
+    container.scrollTo({ top: 0, behavior: 'smooth' });
+  }, [scrollContainerRef, ensureLoaded]);
+
+  const scroll_to_bottom = useCallback(() => {
+    const container = scrollContainerRef.current;
+    if (!container) return;
+
+    const elements = container.querySelectorAll<HTMLDivElement>('.chat-message.user');
+    if (elements.length > 0) {
+      elements[elements.length - 1].scrollIntoView({ block: 'center', behavior: 'smooth' });
+      return;
+    }
+
+    container.scrollTo({ top: container.scrollHeight, behavior: 'smooth' });
+  }, [scrollContainerRef]);
+
+  const scroll_prev = useCallback(() => {
+    const container = scrollContainerRef.current;
+    if (!container) return;
+
+    const elements = container.querySelectorAll<HTMLDivElement>('.chat-message.user');
+    if (elements.length === 0) return;
+
+    const { scrollTop, clientHeight } = container;
+    const viewportCenter = scrollTop + clientHeight / 2;
+
+    let currentIndex = 0;
+    for (let i = 0; i < elements.length; i++) {
+      const top = elements[i].getBoundingClientRect().top - container.getBoundingClientRect().top + scrollTop;
+      if (top <= viewportCenter) {
+        currentIndex = i;
+      } else {
+        break;
+      }
+    }
+
+    const targetIndex = Math.max(0, currentIndex - 1);
+    elements[targetIndex].scrollIntoView({ block: 'center', behavior: 'smooth' });
+  }, [scrollContainerRef]);
+
+  const scroll_next = useCallback(() => {
+    const container = scrollContainerRef.current;
+    if (!container) return;
+
+    const elements = container.querySelectorAll<HTMLDivElement>('.chat-message.user');
+    if (elements.length === 0) return;
+
+    const { scrollTop, clientHeight } = container;
+    const viewportCenter = scrollTop + clientHeight / 2;
+
+    let currentIndex = elements.length - 1;
+    for (let i = elements.length - 1; i >= 0; i--) {
+      const top = elements[i].getBoundingClientRect().top - container.getBoundingClientRect().top + scrollTop;
+      if (top <= viewportCenter) {
+        currentIndex = i;
+        break;
+      }
+    }
+
+    const targetIndex = Math.min(elements.length - 1, currentIndex + 1);
+    elements[targetIndex].scrollIntoView({ block: 'center', behavior: 'smooth' });
+  }, [scrollContainerRef]);
+
   if (!shouldShow) return null;
+
+  const navButtons = [
+    {
+      label: t('scrollNav.first'),
+      icon: <DoubleUpIcon />,
+      action: scroll_to_top,
+    },
+    {
+      label: t('scrollNav.previous'),
+      icon: <ArrowUpIcon />,
+      action: scroll_prev,
+    },
+    {
+      label: t('scrollNav.next'),
+      icon: <ArrowDownIcon />,
+      action: scroll_next,
+    },
+    {
+      label: t('scrollNav.last'),
+      icon: <DoubleDownIcon />,
+      action: scroll_to_bottom,
+    },
+  ];
 
   return (
     <div
-      className="pointer-events-none absolute right-0 top-0 z-10 h-full w-4"
+      className="pointer-events-none absolute right-0 top-0 z-10 h-full"
     >
       <div
-        className={`pointer-events-auto flex h-full w-2 flex-col items-center justify-evenly rounded-full border px-0 py-4 backdrop-blur-sm transition-opacity duration-200 ${
-          isStripHovered ? 'opacity-100' : 'opacity-50'
+        className={`pointer-events-auto flex h-full flex-col items-center rounded-full border backdrop-blur-sm transition-all duration-200 ${
+          isStripHovered
+            ? 'w-10 opacity-100'
+            : 'w-2 opacity-50'
         } bg-background/80 border-border/50`}
         onMouseEnter={() => setIsStripHovered(true)}
         onMouseLeave={() => setIsStripHovered(false)}
       >
-        {userMessages.map((msg, i) => {
-          const isActive = i === activeDotIndex;
-          const snippet = truncateSnippet(msg.content || '');
-
-          return (
-            <Tooltip
-              key={`${i}-${String(msg.timestamp).slice(0, 8)}`}
-              content={t('scrollNav.jumpToMessage', {
-                index: i + 1,
-                snippet,
-              })}
-              position="left"
-              delay={150}
-            >
+        {/* Nav buttons section */}
+        <div className="flex flex-col items-center gap-1 py-1">
+          {hasMore && loadAllMessages && (
+            <Tooltip content={t('scrollNav.loadAll')} position="left" delay={150}>
               <button
                 type="button"
-                onClick={() => scrollToDot(i)}
-                className={`block cursor-pointer rounded-full transition-all duration-150 ${
-                  isActive
-                    ? 'h-[10px] w-[10px] bg-blue-500 hover:bg-blue-400'
-                    : 'h-[7px] w-[7px] bg-muted-foreground/70 hover:bg-muted-foreground hover:h-[9px] hover:w-[9px]'
-                }`}
-                aria-label={t('scrollNav.jumpToMessage', { index: i + 1 })}
-              />
+                onClick={loadAllMessages}
+                className="rounded p-1 text-muted-foreground transition-all duration-150 hover:text-foreground"
+                aria-label={t('scrollNav.loadAll')}
+              >
+                <LoadAllIcon />
+              </button>
             </Tooltip>
-          );
-        })}
+          )}
+
+          {navButtons.map((btn) => (
+            <Tooltip key={btn.label} content={btn.label} position="left" delay={150}>
+              <button
+                type="button"
+                onClick={btn.action}
+                className="rounded p-1 text-muted-foreground transition-all duration-150 hover:text-foreground"
+                aria-label={btn.label}
+              >
+                {btn.icon}
+              </button>
+            </Tooltip>
+          ))}
+        </div>
+
+        {/* Divider */}
+        <div className={`mx-auto my-0.5 border-t border-border/40 transition-all duration-150 ${
+          isStripHovered ? 'w-5 opacity-100' : 'w-0 opacity-0'
+        }`} />
+
+        {/* Dots section */}
+        <div className="flex flex-1 w-full flex-col items-center justify-evenly px-0 py-1">
+          {userMessages.map((msg, i) => {
+            const isActive = i === activeDotIndex;
+            const snippet = truncateSnippet(msg.content || '');
+
+            return (
+              <Tooltip
+                key={`${i}-${String(msg.timestamp).slice(0, 8)}`}
+                content={t('scrollNav.jumpToMessage', {
+                  index: i + 1,
+                  snippet,
+                })}
+                position="left"
+                delay={150}
+              >
+                <button
+                  type="button"
+                  onClick={() => scrollToDot(i)}
+                  className={`block cursor-pointer rounded-full transition-all duration-150 ${
+                    isActive
+                      ? 'h-[10px] w-[10px] bg-blue-500 hover:bg-blue-400'
+                      : 'h-[7px] w-[7px] bg-muted-foreground/70 hover:bg-muted-foreground hover:h-[9px] hover:w-[9px]'
+                  }`}
+                  aria-label={t('scrollNav.jumpToMessage', { index: i + 1 })}
+                />
+              </Tooltip>
+            );
+          })}
+        </div>
       </div>
     </div>
   );

--- a/src/components/chat/view/subcomponents/ScrollNavigation.tsx
+++ b/src/components/chat/view/subcomponents/ScrollNavigation.tsx
@@ -1,0 +1,145 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import type { ChatMessage } from '../../types/types';
+import Tooltip from '../../../../shared/view/ui/Tooltip';
+
+interface ScrollNavigationProps {
+  scrollContainerRef: React.RefObject<HTMLDivElement | null>;
+  chatMessages: ChatMessage[];
+}
+
+function truncateSnippet(content: string): string {
+  return (content || '')
+    .replace(/\n/g, ' ')
+    .trim()
+    .slice(0, 60) + ((content || '').length > 60 ? '...' : '');
+}
+
+export default function ScrollNavigation({ scrollContainerRef, chatMessages }: ScrollNavigationProps) {
+  const { t } = useTranslation('chat');
+  const [activeDotIndex, setActiveDotIndex] = useState(-1);
+  const [isStripHovered, setIsStripHovered] = useState(false);
+  const rafIdRef = useRef<number | null>(null);
+  const mountedRef = useRef(true);
+
+  const userMessages = useMemo(
+    () => chatMessages.filter((m) => m.type === 'user'),
+    [chatMessages],
+  );
+
+  const shouldShow = userMessages.length >= 3;
+
+  const scheduleUpdate = useCallback(() => {
+    if (rafIdRef.current != null) return;
+    rafIdRef.current = requestAnimationFrame(() => {
+      rafIdRef.current = null;
+      const container = scrollContainerRef.current;
+      if (!container) return;
+
+      const elements = container.querySelectorAll<HTMLDivElement>('.chat-message.user');
+      if (elements.length === 0) {
+        setActiveDotIndex(-1);
+        return;
+      }
+
+      const { scrollTop, clientHeight } = container;
+      const viewCenter = scrollTop + clientHeight / 2;
+
+      let bestIndex = 0;
+      let bestDist = Infinity;
+
+      elements.forEach((el, i) => {
+        const center = el.offsetTop + el.clientHeight / 2;
+        const dist = Math.abs(center - viewCenter);
+        if (dist < bestDist) {
+          bestDist = dist;
+          bestIndex = i;
+        }
+      });
+
+      if (mountedRef.current) setActiveDotIndex(bestIndex);
+    });
+  }, [scrollContainerRef]);
+
+  // Scroll listener for active dot tracking
+  useEffect(() => {
+    const container = scrollContainerRef.current;
+    if (!container) return;
+
+    container.addEventListener('scroll', scheduleUpdate, { passive: true });
+    return () => container.removeEventListener('scroll', scheduleUpdate);
+  }, [scrollContainerRef, scheduleUpdate]);
+
+  // Initial position + re-compute when messages change
+  useEffect(() => {
+    const timer = setTimeout(() => scheduleUpdate(), 200);
+    return () => clearTimeout(timer);
+  }, [chatMessages.length, scheduleUpdate]);
+
+  // Cleanup RAF on unmount
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+      if (rafIdRef.current != null) cancelAnimationFrame(rafIdRef.current);
+    };
+  }, []);
+
+  const scrollToDot = useCallback(
+    (index: number) => {
+      const container = scrollContainerRef.current;
+      if (!container) return;
+      const elements = container.querySelectorAll<HTMLDivElement>('.chat-message.user');
+      const target = elements[index];
+      if (target) {
+        target.scrollIntoView({ block: 'center', behavior: 'smooth' });
+      }
+    },
+    [scrollContainerRef],
+  );
+
+  if (!shouldShow) return null;
+
+  return (
+    <div
+      className="pointer-events-none absolute right-0.5 top-1/2 z-10 flex -translate-y-1/2 flex-col items-center"
+      onMouseEnter={() => setIsStripHovered(true)}
+      onMouseLeave={() => setIsStripHovered(false)}
+    >
+      <div
+        className={`pointer-events-auto flex flex-col items-center rounded-full border py-2 backdrop-blur-sm transition-opacity duration-200 ${
+          isStripHovered ? 'opacity-100' : 'opacity-40'
+        } bg-background/80 border-border/50`}
+      >
+        {userMessages.map((msg, i) => {
+          const isActive = i === activeDotIndex;
+          const snippet = truncateSnippet(msg.content || '');
+
+          return (
+            <Tooltip
+              key={`${i}-${String(msg.timestamp).slice(0, 8)}`}
+              content={t('scrollNav.jumpToMessage', {
+                index: i + 1,
+                snippet,
+              })}
+              position="left"
+              delay={150}
+            >
+              <button
+                type="button"
+                onClick={() => scrollToDot(i)}
+                className={`block rounded-full transition-all duration-150 ${
+                  isActive
+                    ? 'h-[6px] w-[6px] bg-blue-500 hover:bg-blue-400'
+                    : 'h-[4px] w-[4px] bg-muted-foreground/60 hover:bg-muted-foreground'
+                }`}
+                style={{ marginTop: i === 0 ? 0 : 2 }}
+                aria-label={t('scrollNav.jumpToMessage', { index: i + 1 })}
+              />
+            </Tooltip>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/components/chat/view/subcomponents/ScrollNavigation.tsx
+++ b/src/components/chat/view/subcomponents/ScrollNavigation.tsx
@@ -62,6 +62,7 @@ function LoadAllIcon() {
   );
 }
 
+/** Vertical scroll navigation strip with dots, quick-jump buttons, and load-more controls. */
 export default function ScrollNavigation({
   scrollContainerRef,
   chatMessages,

--- a/src/components/settings/view/tabs/NotificationsSettingsTab.tsx
+++ b/src/components/settings/view/tabs/NotificationsSettingsTab.tsx
@@ -167,26 +167,36 @@ export default function NotificationsSettingsTab({
               <div className="text-xs text-muted-foreground">{t('notifications.sound.description')}</div>
             </div>
           </div>
-          <button
-            type="button"
-            role="switch"
-            aria-checked={soundEnabled}
-            aria-label={t('notifications.sound.enabled')}
-            onClick={handleToggleSound}
-            className={`relative inline-flex h-7 w-12 flex-shrink-0 touch-manipulation cursor-pointer items-center rounded-full border-2 transition-colors duration-200 ${
-              soundEnabled
-                ? 'border-primary bg-primary'
-                : 'border-border bg-muted'
-            }`}
-          >
-            <span
-              className={`pointer-events-none inline-block h-5 w-5 rounded-full shadow-sm transition-transform duration-200 ${
+          <div className="flex items-center gap-3">
+            <button
+              type="button"
+              onClick={() => playCompletionSound()}
+              className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-md border border-border bg-background text-foreground hover:bg-accent transition-colors"
+            >
+              <Volume2 className="w-3.5 h-3.5" />
+              {t('notifications.sound.test')}
+            </button>
+            <button
+              type="button"
+              role="switch"
+              aria-checked={soundEnabled}
+              aria-label={t('notifications.sound.enabled')}
+              onClick={handleToggleSound}
+              className={`relative inline-flex h-7 w-12 flex-shrink-0 touch-manipulation cursor-pointer items-center rounded-full border-2 transition-colors duration-200 ${
                 soundEnabled
-                  ? 'translate-x-[22px] bg-white'
-                  : 'translate-x-[2px] bg-foreground/60 dark:bg-foreground/80'
+                  ? 'border-primary bg-primary'
+                  : 'border-border bg-muted'
               }`}
-            />
-          </button>
+            >
+              <span
+                className={`pointer-events-none inline-block h-5 w-5 rounded-full shadow-sm transition-transform duration-200 ${
+                  soundEnabled
+                    ? 'translate-x-[22px] bg-white'
+                    : 'translate-x-[2px] bg-foreground/60 dark:bg-foreground/80'
+                }`}
+              />
+            </button>
+          </div>
         </div>
       </div>
     </div>

--- a/src/components/settings/view/tabs/NotificationsSettingsTab.tsx
+++ b/src/components/settings/view/tabs/NotificationsSettingsTab.tsx
@@ -1,5 +1,7 @@
-import { Bell, BellOff, BellRing, Loader2 } from 'lucide-react';
+import { useState } from 'react';
+import { Bell, BellOff, BellRing, Loader2, Volume2, VolumeX } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
+import { isNotificationSoundEnabled, playCompletionSound, setNotificationSoundEnabled } from '../../../../utils/notification-sound';
 import type { NotificationPreferencesState } from '../../types/types';
 
 type NotificationsSettingsTabProps = {
@@ -22,9 +24,19 @@ export default function NotificationsSettingsTab({
   onDisablePush,
 }: NotificationsSettingsTabProps) {
   const { t } = useTranslation('settings');
+  const [soundEnabled, setSoundEnabled] = useState(() => isNotificationSoundEnabled());
 
   const pushSupported = pushPermission !== 'unsupported';
   const pushDenied = pushPermission === 'denied';
+
+  const handleToggleSound = () => {
+    const next = !soundEnabled;
+    setSoundEnabled(next);
+    setNotificationSoundEnabled(next);
+    if (next) {
+      playCompletionSound();
+    }
+  };
 
   return (
     <div className="space-y-6 md:space-y-8">
@@ -138,6 +150,43 @@ export default function NotificationsSettingsTab({
             />
             {t('notifications.events.error')}
           </label>
+        </div>
+      </div>
+
+      <div className="space-y-4 bg-card border border-border rounded-lg p-4">
+        <h4 className="font-medium text-foreground">{t('notifications.sound.title')}</h4>
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-2">
+            {soundEnabled ? (
+              <Volume2 className="w-4 h-4 text-blue-600" />
+            ) : (
+              <VolumeX className="w-4 h-4 text-muted-foreground" />
+            )}
+            <div>
+              <div className="text-sm text-foreground">{t('notifications.sound.enabled')}</div>
+              <div className="text-xs text-muted-foreground">{t('notifications.sound.description')}</div>
+            </div>
+          </div>
+          <button
+            type="button"
+            role="switch"
+            aria-checked={soundEnabled}
+            aria-label={t('notifications.sound.enabled')}
+            onClick={handleToggleSound}
+            className={`relative inline-flex h-7 w-12 flex-shrink-0 touch-manipulation cursor-pointer items-center rounded-full border-2 transition-colors duration-200 ${
+              soundEnabled
+                ? 'border-primary bg-primary'
+                : 'border-border bg-muted'
+            }`}
+          >
+            <span
+              className={`pointer-events-none inline-block h-5 w-5 rounded-full shadow-sm transition-transform duration-200 ${
+                soundEnabled
+                  ? 'translate-x-[22px] bg-white'
+                  : 'translate-x-[2px] bg-foreground/60 dark:bg-foreground/80'
+              }`}
+            />
+          </button>
         </div>
       </div>
     </div>

--- a/src/components/shell/hooks/useShellConnection.ts
+++ b/src/components/shell/hooks/useShellConnection.ts
@@ -6,6 +6,16 @@ import type { Project, ProjectSession } from '../../../types/app';
 import { TERMINAL_INIT_DELAY_MS } from '../constants/constants';
 import { getShellWebSocketUrl, parseShellMessage, sendSocketMessage } from '../utils/socket';
 
+function resolveShellProjectPath(
+  session: ProjectSession | null | undefined,
+  project: Project | null | undefined,
+): string {
+  if (session?.projectPath) {
+    return session.projectPath;
+  }
+  return (project?.fullPath || project?.path || '') ?? '';
+}
+
 const ANSI_ESCAPE_REGEX =
   /(?:\u001B\[[0-?]*[ -/]*[@-~]|\u009B[0-?]*[ -/]*[@-~]|\u001B\][^\u0007\u001B]*(?:\u0007|\u001B\\)|\u009D[^\u0007\u009C]*(?:\u0007|\u009C)|\u001B[PX^_][^\u001B]*\u001B\\|[\u0090\u0098\u009E\u009F][^\u009C]*\u009C|\u001B[@-Z\\-_])/g;
 const PROCESS_EXIT_REGEX = /Process exited with code (\d+)/;
@@ -144,7 +154,7 @@ export function useShellConnection({
 
             sendSocketMessage(socket, {
               type: 'init',
-              projectPath: currentProject.fullPath || currentProject.path || '',
+              projectPath: resolveShellProjectPath(selectedSessionRef.current, currentProject),
               sessionId: isPlainShellRef.current ? null : selectedSessionRef.current?.id || null,
               hasSession: isPlainShellRef.current ? false : Boolean(selectedSessionRef.current),
               provider: isPlainShellRef.current ? 'plain-shell' : (selectedSessionRef.current?.__provider || localStorage.getItem('selected-provider') || 'claude'),

--- a/src/i18n/locales/de/chat.json
+++ b/src/i18n/locales/de/chat.json
@@ -271,5 +271,9 @@
   },
   "tasks": {
     "nextTaskPrompt": "Nächste Aufgabe starten"
+  },
+  "scrollNav": {
+    "jumpTo": "Springe zu: {{snippet}}",
+    "jumpToMessage": "Springe zu Nachricht {{index}}"
   }
 }

--- a/src/i18n/locales/de/chat.json
+++ b/src/i18n/locales/de/chat.json
@@ -274,6 +274,11 @@
   },
   "scrollNav": {
     "jumpTo": "Springe zu: {{snippet}}",
-    "jumpToMessage": "Springe zu Nachricht {{index}}"
+    "jumpToMessage": "Springe zu Nachricht {{index}}",
+    "loadAll": "Alle laden",
+    "first": "Erste",
+    "previous": "Vorherige",
+    "next": "Nächste",
+    "last": "Letzte"
   }
 }

--- a/src/i18n/locales/en/chat.json
+++ b/src/i18n/locales/en/chat.json
@@ -208,6 +208,7 @@
       "showingLast": "Showing last {{count}} messages ({{total}} total)",
       "loadEarlier": "Load earlier messages",
       "loadAll": "Load all messages",
+      "loadMore": "Load {{count}} more",
       "loadingAll": "Loading all messages...",
       "allLoaded": "All messages loaded",
       "perfWarning": "All messages loaded — scrolling may be slower. Click \"Scroll to bottom\" to restore performance."

--- a/src/i18n/locales/en/chat.json
+++ b/src/i18n/locales/en/chat.json
@@ -279,9 +279,9 @@
     "fromYou": "You",
     "aiReply": "AI Reply",
     "loadAll": "Load all",
-    "first": "First",
+    "first": "Top",
     "previous": "Previous",
     "next": "Next",
-    "last": "Last"
+    "last": "Bottom"
   }
 }

--- a/src/i18n/locales/en/chat.json
+++ b/src/i18n/locales/en/chat.json
@@ -274,6 +274,11 @@
   },
   "scrollNav": {
     "jumpTo": "Jump to: {{snippet}}",
-    "jumpToMessage": "Jump to message {{index}}"
+    "jumpToMessage": "Jump to message {{index}}",
+    "loadAll": "Load all",
+    "first": "First",
+    "previous": "Previous",
+    "next": "Next",
+    "last": "Last"
   }
 }

--- a/src/i18n/locales/en/chat.json
+++ b/src/i18n/locales/en/chat.json
@@ -276,6 +276,8 @@
   "scrollNav": {
     "jumpTo": "Jump to: {{snippet}}",
     "jumpToMessage": "Jump to message {{index}}",
+    "fromYou": "You",
+    "aiReply": "AI Reply",
     "loadAll": "Load all",
     "first": "First",
     "previous": "Previous",

--- a/src/i18n/locales/en/chat.json
+++ b/src/i18n/locales/en/chat.json
@@ -271,5 +271,9 @@
   },
   "tasks": {
     "nextTaskPrompt": "Start the next task"
+  },
+  "scrollNav": {
+    "jumpTo": "Jump to: {{snippet}}",
+    "jumpToMessage": "Jump to message {{index}}"
   }
 }

--- a/src/i18n/locales/en/settings.json
+++ b/src/i18n/locales/en/settings.json
@@ -115,6 +115,11 @@
       "actionRequired": "Action required",
       "stop": "Run stopped",
       "error": "Run failed"
+    },
+    "sound": {
+      "title": "Sound",
+      "enabled": "Completion Sound",
+      "description": "Play a sound when a run finishes"
     }
   },
   "appearanceSettings": {

--- a/src/i18n/locales/en/settings.json
+++ b/src/i18n/locales/en/settings.json
@@ -119,7 +119,8 @@
     "sound": {
       "title": "Sound",
       "enabled": "Completion Sound",
-      "description": "Play a sound when a run finishes"
+      "description": "Play a sound when a run finishes",
+      "test": "Test"
     }
   },
   "appearanceSettings": {

--- a/src/i18n/locales/it/chat.json
+++ b/src/i18n/locales/it/chat.json
@@ -274,6 +274,11 @@
   },
   "scrollNav": {
     "jumpTo": "Vai a: {{snippet}}",
-    "jumpToMessage": "Vai al messaggio {{index}}"
+    "jumpToMessage": "Vai al messaggio {{index}}",
+    "loadAll": "Carica tutto",
+    "first": "Primo",
+    "previous": "Precedente",
+    "next": "Successivo",
+    "last": "Ultimo"
   }
 }

--- a/src/i18n/locales/it/chat.json
+++ b/src/i18n/locales/it/chat.json
@@ -271,5 +271,9 @@
   },
   "tasks": {
     "nextTaskPrompt": "Inizia l'attività successiva"
+  },
+  "scrollNav": {
+    "jumpTo": "Vai a: {{snippet}}",
+    "jumpToMessage": "Vai al messaggio {{index}}"
   }
 }

--- a/src/i18n/locales/ja/chat.json
+++ b/src/i18n/locales/ja/chat.json
@@ -241,6 +241,11 @@
   },
   "scrollNav": {
     "jumpTo": "ジャンプ: {{snippet}}",
-    "jumpToMessage": "{{index}}番目のメッセージに移動"
+    "jumpToMessage": "{{index}}番目のメッセージに移動",
+    "loadAll": "全ロード",
+    "first": "最初",
+    "previous": "前へ",
+    "next": "次へ",
+    "last": "最後"
   }
 }

--- a/src/i18n/locales/ja/chat.json
+++ b/src/i18n/locales/ja/chat.json
@@ -238,5 +238,9 @@
     "providers": {
       "assistant": "Assistant"
     }
+  },
+  "scrollNav": {
+    "jumpTo": "ジャンプ: {{snippet}}",
+    "jumpToMessage": "{{index}}番目のメッセージに移動"
   }
 }

--- a/src/i18n/locales/ko/chat.json
+++ b/src/i18n/locales/ko/chat.json
@@ -253,5 +253,9 @@
   },
   "tasks": {
     "nextTaskPrompt": "다음 작업 시작"
+  },
+  "scrollNav": {
+    "jumpTo": "이동: {{snippet}}",
+    "jumpToMessage": "{{index}}번 메시지로 이동"
   }
 }

--- a/src/i18n/locales/ko/chat.json
+++ b/src/i18n/locales/ko/chat.json
@@ -256,6 +256,11 @@
   },
   "scrollNav": {
     "jumpTo": "이동: {{snippet}}",
-    "jumpToMessage": "{{index}}번 메시지로 이동"
+    "jumpToMessage": "{{index}}번 메시지로 이동",
+    "loadAll": "전체 로드",
+    "first": "첫 번째",
+    "previous": "이전",
+    "next": "다음",
+    "last": "마지막"
   }
 }

--- a/src/i18n/locales/ru/chat.json
+++ b/src/i18n/locales/ru/chat.json
@@ -271,5 +271,9 @@
   },
   "tasks": {
     "nextTaskPrompt": "Начать следующую задачу"
+  },
+  "scrollNav": {
+    "jumpTo": "Перейти к: {{snippet}}",
+    "jumpToMessage": "Перейти к сообщению {{index}}"
   }
 }

--- a/src/i18n/locales/ru/chat.json
+++ b/src/i18n/locales/ru/chat.json
@@ -274,6 +274,11 @@
   },
   "scrollNav": {
     "jumpTo": "Перейти к: {{snippet}}",
-    "jumpToMessage": "Перейти к сообщению {{index}}"
+    "jumpToMessage": "Перейти к сообщению {{index}}",
+    "loadAll": "Загрузить всё",
+    "first": "Первое",
+    "previous": "Предыдущее",
+    "next": "Следующее",
+    "last": "Последнее"
   }
 }

--- a/src/i18n/locales/tr/chat.json
+++ b/src/i18n/locales/tr/chat.json
@@ -274,6 +274,11 @@
   },
   "scrollNav": {
     "jumpTo": "Git: {{snippet}}",
-    "jumpToMessage": "{{index}}. mesaja git"
+    "jumpToMessage": "{{index}}. mesaja git",
+    "loadAll": "Tümünü yükle",
+    "first": "İlk",
+    "previous": "Önceki",
+    "next": "Sonraki",
+    "last": "Son"
   }
 }

--- a/src/i18n/locales/tr/chat.json
+++ b/src/i18n/locales/tr/chat.json
@@ -271,5 +271,9 @@
   },
   "tasks": {
     "nextTaskPrompt": "Sonraki görevi başlat"
+  },
+  "scrollNav": {
+    "jumpTo": "Git: {{snippet}}",
+    "jumpToMessage": "{{index}}. mesaja git"
   }
 }

--- a/src/i18n/locales/zh-CN/chat.json
+++ b/src/i18n/locales/zh-CN/chat.json
@@ -258,6 +258,8 @@
   "scrollNav": {
     "jumpTo": "跳转到: {{snippet}}",
     "jumpToMessage": "跳转到第 {{index}} 条消息",
+    "fromYou": "你",
+    "aiReply": "AI 回复",
     "loadAll": "加载全部",
     "first": "第一条",
     "previous": "上一条",

--- a/src/i18n/locales/zh-CN/chat.json
+++ b/src/i18n/locales/zh-CN/chat.json
@@ -190,6 +190,7 @@
       "showingLast": "显示最近 {{count}} 条消息（共 {{total}} 条）",
       "loadEarlier": "加载更早的消息",
       "loadAll": "加载全部消息",
+      "loadMore": "加载更多({{count}}条)",
       "loadingAll": "正在加载全部消息...",
       "allLoaded": "全部消息已加载",
       "perfWarning": "已加载全部消息 - 滚动可能变慢。点击「滚动到底部」恢复性能。"

--- a/src/i18n/locales/zh-CN/chat.json
+++ b/src/i18n/locales/zh-CN/chat.json
@@ -261,9 +261,9 @@
     "fromYou": "你",
     "aiReply": "AI 回复",
     "loadAll": "加载全部",
-    "first": "第一条",
+    "first": "顶部",
     "previous": "上一条",
     "next": "下一条",
-    "last": "最后一条"
+    "last": "底部"
   }
 }

--- a/src/i18n/locales/zh-CN/chat.json
+++ b/src/i18n/locales/zh-CN/chat.json
@@ -256,6 +256,11 @@
   },
   "scrollNav": {
     "jumpTo": "跳转到: {{snippet}}",
-    "jumpToMessage": "跳转到第 {{index}} 条消息"
+    "jumpToMessage": "跳转到第 {{index}} 条消息",
+    "loadAll": "加载全部",
+    "first": "第一条",
+    "previous": "上一条",
+    "next": "下一条",
+    "last": "最后一条"
   }
 }

--- a/src/i18n/locales/zh-CN/chat.json
+++ b/src/i18n/locales/zh-CN/chat.json
@@ -253,5 +253,9 @@
   },
   "tasks": {
     "nextTaskPrompt": "开始下一个任务"
+  },
+  "scrollNav": {
+    "jumpTo": "跳转到: {{snippet}}",
+    "jumpToMessage": "跳转到第 {{index}} 条消息"
   }
 }

--- a/src/i18n/locales/zh-CN/settings.json
+++ b/src/i18n/locales/zh-CN/settings.json
@@ -115,6 +115,11 @@
       "actionRequired": "需要处理",
       "stop": "运行已停止",
       "error": "运行失败"
+    },
+    "sound": {
+      "title": "声音",
+      "enabled": "完成音效",
+      "description": "运行完成时播放提示音"
     }
   },
   "appearanceSettings": {

--- a/src/i18n/locales/zh-CN/settings.json
+++ b/src/i18n/locales/zh-CN/settings.json
@@ -119,7 +119,8 @@
     "sound": {
       "title": "声音",
       "enabled": "完成音效",
-      "description": "运行完成时播放提示音"
+      "description": "运行完成时播放提示音",
+      "test": "试听"
     }
   },
   "appearanceSettings": {

--- a/src/types/app.ts
+++ b/src/types/app.ts
@@ -12,6 +12,10 @@ export interface ProjectSession {
   updated_at?: string;
   lastActivity?: string;
   messageCount?: number;
+  /** Original project_path from the sessions DB row. Used to resolve the correct
+   * cwd when resuming a session whose project differs from the currently
+   * selected project in the sidebar. */
+  projectPath?: string;
   __provider?: LLMProvider;
   // Tags the session with the owning project's DB `projectId` so UI handlers
   // (session switching, sidebar focus, etc.) can match against selectedProject.

--- a/src/utils/notification-sound.ts
+++ b/src/utils/notification-sound.ts
@@ -33,8 +33,9 @@ export function playCompletionSound(): void {
     const now = ctx.currentTime;
     playTone(880, now, 0.12);
     playTone(1100, now + 0.15, 0.2);
-    ctx.close();
-  } catch {
-    // AudioContext not available
+    setTimeout(() => ctx.close(), 600);
+    console.log('[notification-sound] playing completion sound');
+  } catch (err) {
+    console.error('[notification-sound] failed to play:', err);
   }
 }

--- a/src/utils/notification-sound.ts
+++ b/src/utils/notification-sound.ts
@@ -1,5 +1,8 @@
 const STORAGE_KEY = 'notificationSoundEnabled';
 
+/**
+ * Returns whether the notification sound is enabled.
+ */
 export function isNotificationSoundEnabled(): boolean {
   if (typeof window === 'undefined') return false;
   try {
@@ -9,6 +12,9 @@ export function isNotificationSoundEnabled(): boolean {
   }
 }
 
+/**
+ * Persists the notification sound preference to localStorage.
+ */
 export function setNotificationSoundEnabled(enabled: boolean): void {
   if (typeof window === 'undefined') return;
   try {
@@ -18,6 +24,9 @@ export function setNotificationSoundEnabled(enabled: boolean): void {
   }
 }
 
+/**
+ * Plays a two-tone completion sound using the Web Audio API.
+ */
 export function playCompletionSound(): void {
   if (typeof window === 'undefined') return;
   try {

--- a/src/utils/notification-sound.ts
+++ b/src/utils/notification-sound.ts
@@ -11,7 +11,11 @@ export function isNotificationSoundEnabled(): boolean {
 
 export function setNotificationSoundEnabled(enabled: boolean): void {
   if (typeof window === 'undefined') return;
-  localStorage.setItem(STORAGE_KEY, String(enabled));
+  try {
+    localStorage.setItem(STORAGE_KEY, String(enabled));
+  } catch {
+    // Restricted storage context
+  }
 }
 
 export function playCompletionSound(): void {

--- a/src/utils/notification-sound.ts
+++ b/src/utils/notification-sound.ts
@@ -1,0 +1,40 @@
+const STORAGE_KEY = 'notificationSoundEnabled';
+
+export function isNotificationSoundEnabled(): boolean {
+  if (typeof window === 'undefined') return false;
+  try {
+    return localStorage.getItem(STORAGE_KEY) === 'true';
+  } catch {
+    return false;
+  }
+}
+
+export function setNotificationSoundEnabled(enabled: boolean): void {
+  if (typeof window === 'undefined') return;
+  localStorage.setItem(STORAGE_KEY, String(enabled));
+}
+
+export function playCompletionSound(): void {
+  if (typeof window === 'undefined') return;
+  try {
+    const ctx = new AudioContext();
+    const playTone = (frequency: number, startTime: number, duration: number) => {
+      const osc = ctx.createOscillator();
+      const gain = ctx.createGain();
+      osc.type = 'sine';
+      osc.frequency.value = frequency;
+      gain.gain.setValueAtTime(0.3, startTime);
+      gain.gain.exponentialRampToValueAtTime(0.01, startTime + duration);
+      osc.connect(gain);
+      gain.connect(ctx.destination);
+      osc.start(startTime);
+      osc.stop(startTime + duration);
+    };
+    const now = ctx.currentTime;
+    playTone(880, now, 0.12);
+    playTone(1100, now + 0.15, 0.2);
+    ctx.close();
+  } catch {
+    // AudioContext not available
+  }
+}


### PR DESCRIPTION
## Summary / 摘要

This PR consolidates multiple chat message display issues, session recovery bugs, streaming race conditions, session name sync, and image tool_result filtering.

### Fixes / 修复内容

1. **Streaming race condition / 流式传输竞态条件**
   - `stream_delta` (AI content) arrives before the SDK echoes the user message
   - Fixed by checking `hasUserMessage` instead of `all.length === 0`

2. **Subagent prompt echo / 子代理 prompt 回显**
   - Task subagent prompts appear as both `tool_use` AND `role:user` in JSONL
   - Now collects subagent prompts and filters matching user text

3. **Streaming synthetic user messages / 流式合成用户消息**
   - SDK emits synthetic user messages during streaming that are rendered as user chat bubbles
   - Added `isHumanOrigin` gate using `isSynthetic` and `origin.kind` fields
   - `sessionsService.normalizeMessage` now forwards `subagentPrompts` to provider
   - `claude-sdk.js` accumulates Task subagent prompts during streaming and passes them to `normalizeMessage` each iteration

4. **Session recovery from wrong project / 会话恢复目录错误**
   - When a session was created in project A but user switched to project B, terminal and chat composer used the wrong cwd
   - `useChatComposerState.ts` and `useShellConnection.ts` now use `session.projectPath` instead of selected project's `fullPath`

5. **Session rename overwrites project_path / 重命名覆盖 project_path**
   - Session syncer's `INSERT OR UPDATE ON CONFLICT` unconditionally overwrote `project_path`
   - Now uses `COALESCE(NULLIF(excluded.project_path, ''), sessions.project_path)` to preserve existing value

6. **Local command artifacts / 本地命令保留**
   - Slash commands were filtered as internal content
   - Now parses tagged command metadata and remaps to correct roles

7. **fetchHistory optimization / 历史加载优化**
   - Loads full history first for accurate total count

8. **Synchronizer fix / 同步器修复**
   - Skip subagent JSONL files to prevent overwriting main session's jsonl_path

9. **Session name sync to Claude CLI / 会话名同步到 Claude CLI**
   - CloudCLI session rename now writes `custom-title` to session JSONL so `claude -r` displays the same name
   - Startup sync automatically syncs existing sessions with `custom_name`

10. **Completion sound notification / 完成音效通知**
    - Plays a Web Audio API sound when streaming completes (non-aborted)
    - Configurable in Settings → Notifications with toggle and test button

11. **Image tool_result filter / 截图过滤**
    - AI screenshot data (`data:image/...` base64) was rendered as user chat bubble
    - Added `isImageContent` filter to skip base64 image content in user messages

## Test plan / 测试计划
- [x] Open session created in different project → terminal recovers correctly
- [x] Rename session → project_path preserved in database
- [x] Open existing session with subagent calls → no phantom user bubbles during streaming
- [x] Start new session → user message appears before AI response
- [ ] Use slash command → appears in chat history
- [ ] Refresh page → message order preserved
- [ ] Rename session in CloudCLI → `claude -r` shows updated name
- [ ] Completion sound plays when streaming finishes
- [ ] AI screenshot no longer renders as user chat bubble

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public-assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/siteboon/claudecodeui/pull/777?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->