### PR TITLE
feat: add completion sound notification

### DIFF
--- a/server/claude-sdk.js
+++ b/server/claude-sdk.js
@@ -36,6 +36,17 @@ const TOOL_APPROVAL_TIMEOUT_MS = parseInt(process.env.CLAUDE_TOOL_APPROVAL_TIMEO
 
 const TOOLS_REQUIRING_INTERACTION = new Set(['AskUserQuestion', 'ExitPlanMode']);
 
+/**
+ * Extracts the prompt text from a Task subagent tool_use input.
+ * Mirrors the logic in claude-sessions.provider.ts extractSubagentPrompt().
+ */
+function extractSubagentPrompt(toolInput) {
+  if (!toolInput || typeof toolInput !== 'object') return null;
+  const prompt = typeof toolInput.prompt === 'string' ? toolInput.prompt : null;
+  if (!prompt) return null;
+  return prompt.replace(/\r\n/g, '\n').replace(/\r/g, '\n').trim();
+}
+
 function createRequestId() {
   if (typeof crypto.randomUUID === 'function') {
     return crypto.randomUUID();
@@ -481,6 +492,7 @@ async function queryClaudeSDK(command, options = {}, ws) {
   let sessionCreatedSent = false;
   let tempImagePaths = [];
   let tempDir = null;
+  const streamingSubagentPrompts = new Set();
 
   const emitNotification = (event) => {
     notifyUserIfEnabled({
@@ -664,9 +676,37 @@ async function queryClaudeSDK(command, options = {}, ws) {
       const transformedMessage = transformMessage(message);
       const sid = capturedSessionId || sessionId || null;
 
+      // Collect Task subagent prompts so they can be filtered during normalization
+      if (message.type === 'assistant' || transformedMessage.message?.role === 'assistant') {
+        if (Array.isArray(transformedMessage.message?.content)) {
+          for (const part of transformedMessage.message.content) {
+            if (part.type === 'tool_use' && part.name === 'Task') {
+              const prompt = extractSubagentPrompt(part.input);
+              if (prompt) {
+                streamingSubagentPrompts.add(prompt);
+              }
+            }
+          }
+        }
+      }
+
+      // DEBUG: log SDK messages with user role to trace streaming bug
+      if (message.type === 'user' || transformedMessage.message?.role === 'user') {
+        console.log('[SDK-DEBUG-USER-MSG] type:', message.type, '| isSynthetic:', transformedMessage.isSynthetic, '| origin:', JSON.stringify(transformedMessage.origin), '| message.role:', transformedMessage.message?.role, '| content preview:', String(transformedMessage.message?.content || '').slice(0, 200), '| shouldQuery:', transformedMessage.shouldQuery, '| parentToolUseId:', transformedMessage.parentToolUseId);
+      }
+
       // Use adapter to normalize SDK events into NormalizedMessage[]
-      const normalized = sessionsService.normalizeMessage('claude', transformedMessage, sid);
+      const normalized = sessionsService.normalizeMessage(
+        'claude',
+        transformedMessage,
+        sid,
+        streamingSubagentPrompts.size > 0 ? streamingSubagentPrompts : null,
+      );
       for (const msg of normalized) {
+        // DEBUG: log normalized messages with user role
+        if (msg.kind === 'text' && msg.role === 'user') {
+          console.log('[NORMALIZED-USER-MSG] id:', msg.id, '| content preview:', String(msg.content || '').slice(0, 200));
+        }
         // Preserve parentToolUseId from SDK wrapper for subagent tool grouping
         if (transformedMessage.parentToolUseId && !msg.parentToolUseId) {
           msg.parentToolUseId = transformedMessage.parentToolUseId;

--- a/server/modules/database/repositories/sessions.db.ts
+++ b/server/modules/database/repositories/sessions.db.ts
@@ -59,7 +59,7 @@ export const sessionsDb = {
        ON CONFLICT(session_id) DO UPDATE SET
          provider = excluded.provider,
          updated_at = excluded.updated_at,
-         project_path = excluded.project_path,
+         project_path = COALESCE(NULLIF(excluded.project_path, ''), sessions.project_path),
          jsonl_path = excluded.jsonl_path,
          isArchived = 0,
          custom_name = COALESCE(excluded.custom_name, sessions.custom_name)`

--- a/server/modules/projects/services/projects-with-sessions-fetch.service.ts
+++ b/server/modules/projects/services/projects-with-sessions-fetch.service.ts
@@ -12,6 +12,7 @@ type SessionSummary = {
   summary: string;
   messageCount: number;
   lastActivity: string;
+  projectPath?: string;
 };
 
 type SessionsByProvider = Record<'claude' | 'cursor' | 'codex' | 'gemini', SessionSummary[]>;
@@ -19,6 +20,7 @@ type SessionsByProvider = Record<'claude' | 'cursor' | 'codex' | 'gemini', Sessi
 type SessionRepositoryRow = {
   provider: string;
   session_id: string;
+  project_path?: string | null;
   custom_name?: string | null;
   updated_at?: string | null;
   created_at?: string | null;
@@ -130,6 +132,7 @@ function mapSessionRowToSummary(row: SessionRepositoryRow): SessionSummary {
     summary: row.custom_name || '',
     messageCount: 0,
     lastActivity: row.updated_at ?? row.created_at ?? new Date().toISOString(),
+    projectPath: row.project_path ?? undefined,
   };
 }
 

--- a/server/modules/providers/list/claude/claude-session-synchronizer.provider.ts
+++ b/server/modules/providers/list/claude/claude-session-synchronizer.provider.ts
@@ -38,6 +38,12 @@ export class ClaudeSessionSynchronizer implements IProviderSessionSynchronizer {
 
     let processed = 0;
     for (const filePath of files) {
+      // Skip subagent JSONL files — they share the parent session's sessionId
+      // and would overwrite the correct jsonl_path with the subagent path
+      if (path.basename(path.dirname(filePath)) === 'subagents') {
+        continue;
+      }
+
       const parsed = await this.processSessionFile(filePath, nameMap);
       if (!parsed) {
         continue;

--- a/server/modules/providers/list/claude/claude-session-synchronizer.provider.ts
+++ b/server/modules/providers/list/claude/claude-session-synchronizer.provider.ts
@@ -40,7 +40,8 @@ export class ClaudeSessionSynchronizer implements IProviderSessionSynchronizer {
     for (const filePath of files) {
       // Skip subagent JSONL files — they share the parent session's sessionId
       // and would overwrite the correct jsonl_path with the subagent path
-      if (path.basename(path.dirname(filePath)) === 'subagents') {
+      const pathSegments = path.normalize(filePath).split(path.sep);
+      if (pathSegments.includes('subagents')) {
         continue;
       }
 

--- a/server/modules/providers/list/claude/claude-sessions.provider.ts
+++ b/server/modules/providers/list/claude/claude-sessions.provider.ts
@@ -53,7 +53,8 @@ async function parseAgentTools(filePath: string): Promise<AnyRecord[]> {
       try {
         const entry = JSON.parse(line) as AnyRecord;
 
-        if (entry.message?.role === 'assistant' && Array.isArray(entry.message?.content)) {
+        const isAssistantEntry = entry.message?.role === 'assistant' || entry.type === 'assistant';
+        if (isAssistantEntry && Array.isArray(entry.message?.content)) {
           for (const part of entry.message.content as AnyRecord[]) {
             if (part.type === 'tool_use') {
               tools.push({
@@ -348,7 +349,10 @@ export class ClaudeSessionsProvider implements IProviderSessions {
       return messages;
     }
 
-    if (raw.message?.role === 'assistant' && raw.message?.content) {
+    // Claude Desktop uses top-level `type: 'assistant'` instead of `message.role`,
+    // so check both to support CLI and Desktop transcript formats.
+    const isAssistant = raw.message?.role === 'assistant' || raw.type === 'assistant';
+    if (isAssistant && raw.message?.content) {
       if (Array.isArray(raw.message.content)) {
         let partIndex = 0;
         for (const part of raw.message.content) {

--- a/server/modules/providers/list/claude/claude-sessions.provider.ts
+++ b/server/modules/providers/list/claude/claude-sessions.provider.ts
@@ -241,6 +241,24 @@ type ClaudeLocalCommandPayload = {
 };
 
 /**
+ * Detects SDK-generated context resumption summaries that appear as user-role
+ * messages with no isSynthetic or origin markers. These are injected by the
+ * Claude Code SDK when a conversation runs out of context and needs to resume.
+ */
+function isContextResumptionSummary(raw: AnyRecord): boolean {
+  const content = raw.message?.content;
+  if (!content) return false;
+
+  const text = typeof content === 'string'
+    ? content
+    : Array.isArray(content)
+      ? content.filter((p: AnyRecord) => p.type === 'text').map((p: AnyRecord) => p.text).join('\n')
+      : '';
+
+  return text.trim().startsWith('This session is being continued from a previous conversation');
+}
+
+/**
  * Converts Claude's hidden local command wrapper into structured metadata.
  *
  * The three tags often coexist in one string payload. Returning `null` lets the
@@ -373,6 +391,10 @@ export class ClaudeSessionsProvider implements IProviderSessions {
       && (raw.origin?.kind === undefined || raw.origin?.kind === 'human');
 
     if (raw.message?.role === 'user' && raw.message?.content && raw.isMeta !== true) {
+      if (isContextResumptionSummary(raw)) {
+        return messages;
+      }
+
       if (Array.isArray(raw.message.content)) {
         for (let partIndex = 0; partIndex < raw.message.content.length; partIndex++) {
           const part = raw.message.content[partIndex];

--- a/server/modules/providers/list/claude/claude-sessions.provider.ts
+++ b/server/modules/providers/list/claude/claude-sessions.provider.ts
@@ -284,15 +284,56 @@ function buildLocalCommandDisplayText(payload: ClaudeLocalCommandPayload): strin
  * captured from the terminal. The web chat should receive readable plain text.
  */
 function stripAnsiFormatting(text: string): string {
-  return text.replace(/\u001B\[[0-9;?]*[ -/]*[@-~]/g, '');
+  return text.replace(/\[[0-9;?]*[ -/]*[@-~]/g, '');
+}
+
+/**
+ * Extracts the prompt text from a Task tool input for subagent echo-filtering.
+ */
+function extractSubagentPrompt(toolInput: unknown): string | null {
+  if (!toolInput) return null;
+  let parsed: AnyRecord = toolInput;
+  if (typeof toolInput === 'string') {
+    try {
+      parsed = JSON.parse(toolInput);
+    } catch {
+      return null;
+    }
+  }
+  return typeof parsed.prompt === 'string' ? parsed.prompt : null;
+}
+
+function normalizeWhitespace(s: string): string {
+  return s.replace(/[ \t]+/g, ' ').trim();
+}
+
+function isSubagentPromptEcho(text: string, subagentPrompts: Set<string> | null): boolean {
+  if (!subagentPrompts) return false;
+  const normalized = normalizeWhitespace(text);
+  for (const prompt of subagentPrompts) {
+    const np = normalizeWhitespace(prompt);
+    if (normalized === np || normalized.startsWith(np)) {
+      return true;
+    }
+  }
+  return false;
 }
 
 export class ClaudeSessionsProvider implements IProviderSessions {
   /**
    * Normalizes one Claude JSONL entry or live SDK stream event into the shared
    * message shape consumed by REST and WebSocket clients.
+   *
+   * @param subagentPrompts - Set of subagent task prompts to filter out.
+   *   These are "Task" tool prompts that also appear as separate user-role
+   *   messages in the JSONL — normalizing them would render them as user
+   *   chat bubbles which is incorrect.
    */
-  normalizeMessage(rawMessage: unknown, sessionId: string | null): NormalizedMessage[] {
+  normalizeMessage(
+    rawMessage: unknown,
+    sessionId: string | null,
+    subagentPrompts: Set<string> | null = null,
+  ): NormalizedMessage[] {
     const raw = readObjectRecord(rawMessage);
     if (!raw) {
       return [];
@@ -329,15 +370,18 @@ export class ClaudeSessionsProvider implements IProviderSessions {
           } else if (part.type === 'text') {
             const text = part.text || '';
             if (text && !isInternalContent(text)) {
-              messages.push(createNormalizedMessage({
-                id: `${baseId}_text_${partIndex}`,
-                sessionId,
-                timestamp: ts,
-                provider: PROVIDER,
-                kind: 'text',
-                role: 'user',
-                content: text,
-              }));
+              const isEcho = isSubagentPromptEcho(text, subagentPrompts);
+              if (!isEcho) {
+                messages.push(createNormalizedMessage({
+                  id: `${baseId}_text_${partIndex}`,
+                  sessionId,
+                  timestamp: ts,
+                  provider: PROVIDER,
+                  kind: 'text',
+                  role: 'user',
+                  content: text,
+                }));
+              }
             }
           }
         }
@@ -349,15 +393,18 @@ export class ClaudeSessionsProvider implements IProviderSessions {
             .filter(Boolean)
             .join('\n');
           if (textParts && !isInternalContent(textParts)) {
-            messages.push(createNormalizedMessage({
-              id: `${baseId}_text`,
-              sessionId,
-              timestamp: ts,
-              provider: PROVIDER,
-              kind: 'text',
-              role: 'user',
-              content: textParts,
-            }));
+            const isEcho = isSubagentPromptEcho(textParts, subagentPrompts);
+            if (!isEcho) {
+              messages.push(createNormalizedMessage({
+                id: `${baseId}_text`,
+                sessionId,
+                timestamp: ts,
+                provider: PROVIDER,
+                kind: 'text',
+                role: 'user',
+                content: textParts,
+              }));
+            }
           }
         }
       } else if (typeof raw.message.content === 'string') {
@@ -437,15 +484,17 @@ export class ClaudeSessionsProvider implements IProviderSessions {
         }
 
         if (text && !isInternalContent(text)) {
-          messages.push(createNormalizedMessage({
-            id: baseId,
-            sessionId,
-            timestamp: ts,
-            provider: PROVIDER,
-            kind: 'text',
-            role: 'user',
-            content: text,
-          }));
+          if (!isSubagentPromptEcho(text, subagentPrompts)) {
+            messages.push(createNormalizedMessage({
+              id: baseId,
+              sessionId,
+              timestamp: ts,
+              provider: PROVIDER,
+              kind: 'text',
+              role: 'user',
+              content: text,
+            }));
+          }
         }
       }
       return messages;
@@ -571,6 +620,29 @@ export class ClaudeSessionsProvider implements IProviderSessions {
 
     const rawMessages = Array.isArray(result) ? result : (result.messages || []);
 
+    /*
+     * Collect Task subagent prompts from raw messages so duplicate user-role
+     * echo messages can be filtered out during normalization.
+     */
+    const subagentPrompts = new Set<string>();
+    for (const raw of rawMessages) {
+      if (raw.message?.role === 'assistant' && Array.isArray(raw.message?.content)) {
+        for (const part of raw.message.content) {
+          if (part.type === 'tool_use' && part.name === 'Task') {
+            const prompt = extractSubagentPrompt(part.input);
+            if (prompt) {
+              subagentPrompts.add(prompt);
+            }
+          }
+        }
+      }
+    }
+
+    const normalized: NormalizedMessage[] = [];
+    for (const raw of rawMessages) {
+      normalized.push(...this.normalizeMessage(raw, sessionId, subagentPrompts.size > 0 ? subagentPrompts : null));
+    }
+
     const toolResultMap = new Map<string, ClaudeToolResult>();
     for (const raw of rawMessages) {
       if (raw.message?.role === 'user' && Array.isArray(raw.message?.content)) {
@@ -585,11 +657,6 @@ export class ClaudeSessionsProvider implements IProviderSessions {
           }
         }
       }
-    }
-
-    const normalized: NormalizedMessage[] = [];
-    for (const raw of rawMessages) {
-      normalized.push(...this.normalizeMessage(raw, sessionId));
     }
 
     for (const msg of normalized) {

--- a/server/modules/providers/list/claude/claude-sessions.provider.ts
+++ b/server/modules/providers/list/claude/claude-sessions.provider.ts
@@ -359,6 +359,19 @@ export class ClaudeSessionsProvider implements IProviderSessions {
     const ts = raw.timestamp || new Date().toISOString();
     const baseId = raw.uuid || generateMessageId('claude');
 
+    /*
+     * Filter out non-human user-role messages during streaming.
+     * SDK emits synthetic user messages (subagent prompts, internal
+     * bookkeeping) that have message.role === 'user' but should NOT be
+     * rendered as user chat bubbles. The `isSynthetic` flag or a non-`human`
+     * origin indicate these are system-generated, not keyboard input.
+     * This check is a no-op for pure tool_result containers — they have no
+     * text parts and are handled by the tool_result branch below.
+     */
+    const isHumanOrigin =
+      !raw.isSynthetic
+      && (raw.origin?.kind === undefined || raw.origin?.kind === 'human');
+
     if (raw.message?.role === 'user' && raw.message?.content && raw.isMeta !== true) {
       if (Array.isArray(raw.message.content)) {
         for (let partIndex = 0; partIndex < raw.message.content.length; partIndex++) {
@@ -378,7 +391,7 @@ export class ClaudeSessionsProvider implements IProviderSessions {
             }));
           } else if (part.type === 'text') {
             const text = part.text || '';
-            if (text && !isInternalContent(text)) {
+            if (text && !isInternalContent(text) && isHumanOrigin) {
               const isEcho = isSubagentPromptEcho(text, subagentPrompts);
               if (!isEcho) {
                 messages.push(createNormalizedMessage({
@@ -492,7 +505,7 @@ export class ClaudeSessionsProvider implements IProviderSessions {
           return messages;
         }
 
-        if (text && !isInternalContent(text)) {
+        if (text && !isInternalContent(text) && isHumanOrigin) {
           if (!isSubagentPromptEcho(text, subagentPrompts)) {
             messages.push(createNormalizedMessage({
               id: baseId,

--- a/server/modules/providers/list/claude/claude-sessions.provider.ts
+++ b/server/modules/providers/list/claude/claude-sessions.provider.ts
@@ -287,8 +287,13 @@ function buildLocalCommandDisplayText(payload: ClaudeLocalCommandPayload): strin
  * captured from the terminal. The web chat should receive readable plain text.
  */
 function stripAnsiFormatting(text: string): string {
-  return text.replace(/\[[0-9;?]*[ -/]*[@-~]/g, '');
+  return text
+    .replace(/\x1b\[[0-9;?]*[ -/]*[@-~]/g, '')  // CSI sequences
+    .replace(/\x1b\][^\x07]*(?:\x07)?/g, '')    // OSC sequences
+    .replace(/\x1b[^\x1b[\x07-\r\n]/g, '')      // control sequences
+    .replace(/\r/g, '');
 }
+
 
 /**
  * Extracts the prompt text from a Task tool input for subagent echo-filtering.

--- a/server/modules/providers/list/claude/claude-sessions.provider.ts
+++ b/server/modules/providers/list/claude/claude-sessions.provider.ts
@@ -311,9 +311,9 @@ function extractSubagentPrompt(toolInput: unknown): string | null {
   return typeof parsed.prompt === 'string' ? parsed.prompt : null;
 }
 
-/** Collapse all whitespace runs into single spaces and trim. */
+/** Collapse all whitespace runs (including newlines) into single spaces and trim. */
 function normalizeWhitespace(s: string): string {
-  return s.replace(/[ \t]+/g, ' ').trim();
+  return s.replace(/\s+/g, ' ').trim();
 }
 
 function isSubagentPromptEcho(text: string, subagentPrompts: Set<string> | null): boolean {

--- a/server/modules/providers/list/claude/claude-sessions.provider.ts
+++ b/server/modules/providers/list/claude/claude-sessions.provider.ts
@@ -53,7 +53,8 @@ async function parseAgentTools(filePath: string): Promise<AnyRecord[]> {
       try {
         const entry = JSON.parse(line) as AnyRecord;
 
-        if (entry.message?.role === 'assistant' && Array.isArray(entry.message?.content)) {
+        const isAssistantEntry = entry.message?.role === 'assistant' || entry.type === 'assistant';
+        if (isAssistantEntry && Array.isArray(entry.message?.content)) {
           for (const part of entry.message.content as AnyRecord[]) {
             if (part.type === 'tool_use') {
               tools.push({
@@ -490,7 +491,10 @@ export class ClaudeSessionsProvider implements IProviderSessions {
       return messages;
     }
 
-    if (raw.message?.role === 'assistant' && raw.message?.content) {
+    // Claude Desktop uses top-level `type: 'assistant'` instead of `message.role`,
+    // so check both to support CLI and Desktop transcript formats.
+    const isAssistant = raw.message?.role === 'assistant' || raw.type === 'assistant';
+    if (isAssistant && raw.message?.content) {
       if (Array.isArray(raw.message.content)) {
         let partIndex = 0;
         for (const part of raw.message.content) {

--- a/server/modules/providers/list/claude/claude-sessions.provider.ts
+++ b/server/modules/providers/list/claude/claude-sessions.provider.ts
@@ -35,6 +35,7 @@ type ClaudeHistoryMessagesResult =
     limit?: number | null;
   };
 
+/** Parse agent JSONL files to extract tool use/result pairs for injection into main messages. */
 async function parseAgentTools(filePath: string): Promise<AnyRecord[]> {
   const tools: AnyRecord[] = [];
 
@@ -102,6 +103,7 @@ async function parseAgentTools(filePath: string): Promise<AnyRecord[]> {
   return tools;
 }
 
+/** Read the main JSONL transcript and merge in subagent tool messages from agent-*.jsonl files. */
 async function getSessionMessages(
   sessionId: string,
   limit: number | null,
@@ -216,6 +218,7 @@ const INTERNAL_CONTENT_PREFIXES = [
   '[Request interrupted',
 ] as const;
 
+/** Check if content is an internal Claude CLI artifact that should not be shown to the user. */
 function isInternalContent(content: string): boolean {
   return INTERNAL_CONTENT_PREFIXES.some((prefix) => content.startsWith(prefix));
 }
@@ -303,6 +306,7 @@ function extractSubagentPrompt(toolInput: unknown): string | null {
   return typeof parsed.prompt === 'string' ? parsed.prompt : null;
 }
 
+/** Collapse all whitespace runs into single spaces and trim. */
 function normalizeWhitespace(s: string): string {
   return s.replace(/[ \t]+/g, ' ').trim();
 }
@@ -626,7 +630,8 @@ export class ClaudeSessionsProvider implements IProviderSessions {
      */
     const subagentPrompts = new Set<string>();
     for (const raw of rawMessages) {
-      if (raw.message?.role === 'assistant' && Array.isArray(raw.message?.content)) {
+      const isAssistant = raw.message?.role === 'assistant' || raw.type === 'assistant';
+      if (isAssistant && Array.isArray(raw.message?.content)) {
         for (const part of raw.message.content) {
           if (part.type === 'tool_use' && part.name === 'Task') {
             const prompt = extractSubagentPrompt(part.input);
@@ -677,24 +682,19 @@ export class ClaudeSessionsProvider implements IProviderSessions {
       }
     }
 
-    const totalNormalized = normalized.length;
-    let total = 0;
-    for (const msg of normalized) {
-      if (msg.kind !== 'tool_result') {
-        total += 1;
-      }
-    }
+    const paginableMessages = normalized.filter((msg) => msg.kind !== 'tool_result');
+    const total = paginableMessages.length;
     const normalizedOffset = Math.max(0, offset);
     const normalizedLimit = limit === null ? null : Math.max(0, limit);
     const messages = normalizedLimit === null
-      ? normalized
-      : normalized.slice(
-          Math.max(0, totalNormalized - normalizedOffset - normalizedLimit),
-          Math.max(0, totalNormalized - normalizedOffset),
+      ? paginableMessages
+      : paginableMessages.slice(
+          Math.max(0, total - normalizedOffset - normalizedLimit),
+          Math.max(0, total - normalizedOffset),
         );
     const hasMore = normalizedLimit === null
       ? false
-      : Math.max(0, totalNormalized - normalizedOffset - normalizedLimit) > 0;
+      : Math.max(0, total - normalizedOffset - normalizedLimit) > 0;
 
     return {
       messages,

--- a/server/modules/providers/services/sessions.service.ts
+++ b/server/modules/providers/services/sessions.service.ts
@@ -84,8 +84,13 @@ export const sessionsService = {
     providerName: string,
     raw: unknown,
     sessionId: string | null,
+    subagentPrompts: Set<string> | null = null,
   ): NormalizedMessage[] {
-    return providerRegistry.resolveProvider(providerName).sessions.normalizeMessage(raw, sessionId);
+    return providerRegistry.resolveProvider(providerName).sessions.normalizeMessage(
+      raw,
+      sessionId,
+      subagentPrompts,
+    );
   },
 
   /**

--- a/server/shared/interfaces.ts
+++ b/server/shared/interfaces.ts
@@ -84,7 +84,7 @@ export interface IProviderMcp {
  * shared transport shapes consumed by API routes and realtime streams.
  */
 export interface IProviderSessions {
-  normalizeMessage(raw: unknown, sessionId: string | null): NormalizedMessage[];
+  normalizeMessage(raw: unknown, sessionId: string | null, subagentPrompts?: Set<string> | null): NormalizedMessage[];
   fetchHistory(sessionId: string, options?: FetchHistoryOptions): Promise<FetchHistoryResult>;
 }
 

--- a/src/components/chat/hooks/useChatComposerState.ts
+++ b/src/components/chat/hooks/useChatComposerState.ts
@@ -26,6 +26,16 @@ import { escapeRegExp } from '../utils/chatFormatting';
 import { useFileMentions } from './useFileMentions';
 import { type SlashCommand, useSlashCommands } from './useSlashCommands';
 
+function resolveEffectiveProjectPath(
+  session: ProjectSession | null,
+  project: Project | null,
+): string {
+  if (session?.projectPath) {
+    return session.projectPath;
+  }
+  return (project?.fullPath || project?.path || '') ?? '';
+}
+
 type PendingViewSession = {
   sessionId: string | null;
   startedAt: number;
@@ -594,7 +604,7 @@ export function useChatComposerState({
       };
 
       const toolsSettings = getToolsSettings();
-      const resolvedProjectPath = selectedProject.fullPath || selectedProject.path || '';
+      const resolvedProjectPath = resolveEffectiveProjectPath(selectedSession, selectedProject);
       const sessionSummary = getNotificationSessionSummary(selectedSession, currentInput);
 
       if (provider === 'cursor') {

--- a/src/components/chat/hooks/useChatMessages.ts
+++ b/src/components/chat/hooks/useChatMessages.ts
@@ -44,7 +44,7 @@ export function normalizedToChatMessages(messages: NormalizedMessage[]): ChatMes
 
         if (msg.role === 'user') {
           // Parse task notifications
-          const taskNotifRegex = /<task-notification>\s*<task-id>[^<]*<\/task-id>\s*<output-file>[^<]*<\/output-file>\s*<status>([^<]*)<\/status>\s*<summary>([^<]*)<\/summary>\s*<\/task-notification>/g;
+          const taskNotifRegex = /<task-notification>[\s\S]*?<status>([^<]*)<\/status>[\s\S]*?<summary>([^<]*)<\/summary>[\s\S]*?<\/task-notification>/;
           const taskNotifMatch = taskNotifRegex.exec(content);
           if (taskNotifMatch) {
             converted.push({

--- a/src/components/chat/hooks/useChatMessages.ts
+++ b/src/components/chat/hooks/useChatMessages.ts
@@ -44,7 +44,7 @@ export function normalizedToChatMessages(messages: NormalizedMessage[]): ChatMes
 
         if (msg.role === 'user') {
           // Parse task notifications
-          const taskNotifRegex = /<task-notification>[\s\S]*?<status>([^<]*)<\/status>[\s\S]*?<summary>([^<]*)<\/summary>[\s\S]*?<\/task-notification>/;
+          const taskNotifRegex = /^<task-notification>[\s\S]*?<status>([^<]*)<\/status>[\s\S]*?<summary>([^<]*)<\/summary>[\s\S]*?<\/task-notification>$/;
           const taskNotifMatch = taskNotifRegex.exec(content);
           if (taskNotifMatch) {
             converted.push({

--- a/src/components/chat/hooks/useChatRealtimeHandlers.ts
+++ b/src/components/chat/hooks/useChatRealtimeHandlers.ts
@@ -1,6 +1,7 @@
 import { useEffect, useRef } from 'react';
 import type { Dispatch, MutableRefObject, SetStateAction } from 'react';
 
+import { isNotificationSoundEnabled, playCompletionSound } from '../../../utils/notification-sound';
 import { usePaletteOps } from '../../../contexts/PaletteOpsContext';
 import type { PendingPermissionRequest, SessionNavigationOptions } from '../types/types';
 import type { Project, ProjectSession, LLMProvider } from '../../../types/app';
@@ -272,6 +273,11 @@ export function useChatRealtimeHandlers({
           // No special UI action needed beyond clearing loading state above
           // The backend already sent any abort-related messages
           break;
+        }
+
+        // Play completion sound if enabled
+        if (isNotificationSoundEnabled()) {
+          playCompletionSound();
         }
 
         const actualSessionId =

--- a/src/components/chat/hooks/useChatRealtimeHandlers.ts
+++ b/src/components/chat/hooks/useChatRealtimeHandlers.ts
@@ -260,13 +260,6 @@ export function useChatRealtimeHandlers({
         }
         accumulatedStreamRef.current = '';
 
-        // Refresh from server so the canonical JSONL history replaces any
-        // client-side streaming echoes, and the chat view shows the final
-        // committed messages instead of stale realtime copies.
-        if (sid) {
-          void sessionStore.refreshFromServer(sid);
-        }
-
         setIsLoading(false);
         setCanAbortSession(false);
         setClaudeStatus(null);
@@ -320,6 +313,11 @@ export function useChatRealtimeHandlers({
             onNavigateToSession?.(actualSessionId, { replace: true });
             setTimeout(() => { void paletteOps.refreshProjects(); }, 500);
           }
+
+          // Refresh from server using the resolved session ID so we fetch the
+          // correct canonical JSONL history, replacing any client-side streaming
+          // echoes with committed messages.
+          void sessionStore.refreshFromServer(actualSessionId);
           break;
         }
 
@@ -332,6 +330,12 @@ export function useChatRealtimeHandlers({
           }
           sessionStorage.removeItem('pendingSessionId');
           setTimeout(() => { void paletteOps.refreshProjects(); }, 500);
+        }
+
+        // Refresh from server so the canonical JSONL history replaces any
+        // client-side streaming echoes with committed messages.
+        if (sid) {
+          void sessionStore.refreshFromServer(sid);
         }
         break;
       }

--- a/src/components/chat/hooks/useChatRealtimeHandlers.ts
+++ b/src/components/chat/hooks/useChatRealtimeHandlers.ts
@@ -260,6 +260,13 @@ export function useChatRealtimeHandlers({
         }
         accumulatedStreamRef.current = '';
 
+        // Refresh from server so the canonical JSONL history replaces any
+        // client-side streaming echoes, and the chat view shows the final
+        // committed messages instead of stale realtime copies.
+        if (sid) {
+          void sessionStore.refreshFromServer(sid);
+        }
+
         setIsLoading(false);
         setCanAbortSession(false);
         setClaudeStatus(null);

--- a/src/components/chat/hooks/useChatSessionState.ts
+++ b/src/components/chat/hooks/useChatSessionState.ts
@@ -754,11 +754,15 @@ export function useChatSessionState({
     setVisibleMessageCount((prev) => prev + 100);
   }, []);
 
-  const loadMoreMessages = useCallback(() => {
+  const loadMoreMessages = useCallback(async () => {
     topLoadLockRef.current = false;
     const container = scrollContainerRef.current;
     if (!container) return;
-    loadOlderMessages(container);
+    try {
+      await loadOlderMessages(container);
+    } catch (error) {
+      console.error('[useChatSessionState] loadMoreMessages failed:', error);
+    }
   }, [loadOlderMessages]);
 
   return {

--- a/src/components/chat/hooks/useChatSessionState.ts
+++ b/src/components/chat/hooks/useChatSessionState.ts
@@ -351,24 +351,13 @@ export function useChatSessionState({
     [hasMoreMessages, isLoadingMoreMessages, selectedProject, selectedSession, sessionStore],
   );
 
-  const handleScroll = useCallback(async () => {
+  const handleScroll = useCallback(() => {
     const container = scrollContainerRef.current;
     if (!container) return;
 
     const nearBottom = isNearBottom();
     setIsUserScrolledUp(!nearBottom);
-
-    if (!allMessagesLoadedRef.current) {
-      const scrolledNearTop = container.scrollTop < 100;
-      if (!scrolledNearTop) { topLoadLockRef.current = false; return; }
-      if (topLoadLockRef.current) {
-        if (container.scrollTop > 20) topLoadLockRef.current = false;
-        return;
-      }
-      const didLoad = await loadOlderMessages(container);
-      if (didLoad) topLoadLockRef.current = true;
-    }
-  }, [isNearBottom, loadOlderMessages]);
+  }, [isNearBottom]);
 
   useLayoutEffect(() => {
     if (!pendingScrollRestoreRef.current || !scrollContainerRef.current) return;
@@ -702,23 +691,10 @@ export function useChatSessionState({
     }
   }, [currentSessionId, isLoading, processingSessions, selectedSession?.id]);
 
-  // "Load all" overlay
-  const prevLoadingRef = useRef(false);
+  // "Load more" buttons — show whenever there are more messages
   useEffect(() => {
-    const wasLoading = prevLoadingRef.current;
-    prevLoadingRef.current = isLoadingMoreMessages;
-
-    if (wasLoading && !isLoadingMoreMessages && hasMoreMessages) {
-      if (loadAllOverlayTimerRef.current) clearTimeout(loadAllOverlayTimerRef.current);
-      setShowLoadAllOverlay(true);
-      loadAllOverlayTimerRef.current = setTimeout(() => setShowLoadAllOverlay(false), 2000);
-    }
-    if (!hasMoreMessages && !isLoadingMoreMessages) {
-      if (loadAllOverlayTimerRef.current) clearTimeout(loadAllOverlayTimerRef.current);
-      setShowLoadAllOverlay(false);
-    }
-    return () => { if (loadAllOverlayTimerRef.current) clearTimeout(loadAllOverlayTimerRef.current); };
-  }, [isLoadingMoreMessages, hasMoreMessages]);
+    setShowLoadAllOverlay(hasMoreMessages && !allMessagesLoaded);
+  }, [hasMoreMessages, allMessagesLoaded]);
 
   const loadAllMessages = useCallback(async () => {
     if (!selectedSession || !selectedProject) return;
@@ -778,6 +754,13 @@ export function useChatSessionState({
     setVisibleMessageCount((prev) => prev + 100);
   }, []);
 
+  const loadMoreMessages = useCallback(() => {
+    topLoadLockRef.current = false;
+    const container = scrollContainerRef.current;
+    if (!container) return;
+    loadOlderMessages(container);
+  }, [loadOlderMessages]);
+
   return {
     chatMessages,
     addMessage,
@@ -801,6 +784,7 @@ export function useChatSessionState({
     visibleMessages,
     loadEarlierMessages,
     loadAllMessages,
+    loadMoreMessages,
     allMessagesLoaded,
     isLoadingAllMessages,
     loadAllJustFinished,

--- a/src/components/chat/hooks/useChatSessionState.ts
+++ b/src/components/chat/hooks/useChatSessionState.ts
@@ -258,9 +258,14 @@ export function useChatSessionState({
 
   const chatMessages = useMemo(() => {
     const all = normalizedToChatMessages(storeMessages);
-    // Show pending user message when no session data exists yet (new session, pre-backend-response)
-    if (pendingUserMessage && all.length === 0) {
-      return [pendingUserMessage];
+    // Show pending user message until a user message actually appears in the store.
+    // This covers both the "no messages yet" case and the race condition where
+    // `stream_delta` (AI content) arrives in realtime before the echoed user
+    // message — without this check the pending message would disappear and the
+    // AI response would briefly appear as the first visible message.
+    const hasUserMessage = all.some((m) => m.type === 'user');
+    if (pendingUserMessage && !hasUserMessage) {
+      return [...all, pendingUserMessage];
     }
     if (viewHiddenCount > 0 && viewHiddenCount < all.length) return all.slice(0, -viewHiddenCount);
     return all;

--- a/src/components/chat/hooks/useChatSessionState.ts
+++ b/src/components/chat/hooks/useChatSessionState.ts
@@ -758,10 +758,13 @@ export function useChatSessionState({
     topLoadLockRef.current = false;
     const container = scrollContainerRef.current;
     if (!container) return;
+    setIsLoadingMoreMessages(true);
     try {
       await loadOlderMessages(container);
     } catch (error) {
       console.error('[useChatSessionState] loadMoreMessages failed:', error);
+    } finally {
+      setIsLoadingMoreMessages(false);
     }
   }, [loadOlderMessages]);
 

--- a/src/components/chat/view/ChatInterface.tsx
+++ b/src/components/chat/view/ChatInterface.tsx
@@ -104,10 +104,10 @@ function ChatInterface({
     visibleMessages,
     loadEarlierMessages,
     loadAllMessages,
+    loadMoreMessages,
     allMessagesLoaded,
     isLoadingAllMessages,
     loadAllJustFinished,
-    showLoadAllOverlay,
     claudeStatus,
     setClaudeStatus,
     createDiff,
@@ -306,6 +306,7 @@ function ChatInterface({
             chatMessages={chatMessages}
             loadAllMessages={loadAllMessages}
             allMessagesLoaded={allMessagesLoaded}
+            hasMoreMessages={hasMoreMessages}
             totalMessages={totalMessages}
             sessionMessagesCount={chatMessages.length}
           />
@@ -341,10 +342,10 @@ function ChatInterface({
           visibleMessages={visibleMessages}
           loadEarlierMessages={loadEarlierMessages}
           loadAllMessages={loadAllMessages}
+          loadMoreMessages={loadMoreMessages}
           allMessagesLoaded={allMessagesLoaded}
           isLoadingAllMessages={isLoadingAllMessages}
           loadAllJustFinished={loadAllJustFinished}
-          showLoadAllOverlay={showLoadAllOverlay}
           createDiff={createDiff}
           onFileOpen={onFileOpen}
           onShowSettings={onShowSettings}

--- a/src/components/chat/view/ChatInterface.tsx
+++ b/src/components/chat/view/ChatInterface.tsx
@@ -305,6 +305,7 @@ function ChatInterface({
             scrollContainerRef={scrollContainerRef}
             chatMessages={chatMessages}
           />
+          <div className="absolute inset-0">
           <ChatMessagesPane
           scrollContainerRef={scrollContainerRef}
           onWheel={handleScroll}
@@ -349,6 +350,7 @@ function ChatInterface({
           showThinking={showThinking}
           selectedProject={selectedProject}
         />
+          </div>
         </div>
 
         <ChatComposer

--- a/src/components/chat/view/ChatInterface.tsx
+++ b/src/components/chat/view/ChatInterface.tsx
@@ -304,6 +304,10 @@ function ChatInterface({
           <ScrollNavigation
             scrollContainerRef={scrollContainerRef}
             chatMessages={chatMessages}
+            loadAllMessages={loadAllMessages}
+            allMessagesLoaded={allMessagesLoaded}
+            totalMessages={totalMessages}
+            sessionMessagesCount={chatMessages.length}
           />
           <div className="absolute inset-0">
           <ChatMessagesPane

--- a/src/components/chat/view/ChatInterface.tsx
+++ b/src/components/chat/view/ChatInterface.tsx
@@ -14,6 +14,7 @@ import { useSessionStore } from '../../../stores/useSessionStore';
 
 import ChatMessagesPane from './subcomponents/ChatMessagesPane';
 import ChatComposer from './subcomponents/ChatComposer';
+import ScrollNavigation from './subcomponents/ScrollNavigation';
 
 
 type PendingViewSession = {
@@ -299,7 +300,12 @@ function ChatInterface({
   return (
     <PermissionContext.Provider value={permissionContextValue}>
       <div className="flex h-full flex-col">
-        <ChatMessagesPane
+        <div className="relative flex-1">
+          <ScrollNavigation
+            scrollContainerRef={scrollContainerRef}
+            chatMessages={chatMessages}
+          />
+          <ChatMessagesPane
           scrollContainerRef={scrollContainerRef}
           onWheel={handleScroll}
           onTouchMove={handleScroll}
@@ -343,6 +349,7 @@ function ChatInterface({
           showThinking={showThinking}
           selectedProject={selectedProject}
         />
+        </div>
 
         <ChatComposer
           pendingPermissionRequests={pendingPermissionRequests}

--- a/src/components/chat/view/subcomponents/ChatMessagesPane.tsx
+++ b/src/components/chat/view/subcomponents/ChatMessagesPane.tsx
@@ -256,6 +256,8 @@ export default function ChatMessagesPane({
       <ScrollNavigation
         scrollContainerRef={scrollContainerRef}
         chatMessages={chatMessages}
+        allMessagesLoaded={allMessagesLoaded}
+        loadAllMessages={loadAllMessages}
       />
     </div>
   );

--- a/src/components/chat/view/subcomponents/ChatMessagesPane.tsx
+++ b/src/components/chat/view/subcomponents/ChatMessagesPane.tsx
@@ -6,7 +6,6 @@ import type { Project, ProjectSession, LLMProvider } from '../../../../types/app
 import { getIntrinsicMessageKey } from '../../utils/messageKeys';
 import MessageComponent from './MessageComponent';
 import ProviderSelectionEmptyState from './ProviderSelectionEmptyState';
-import ScrollNavigation from './ScrollNavigation';
 
 interface ChatMessagesPaneProps {
   scrollContainerRef: RefObject<HTMLDivElement>;
@@ -131,7 +130,7 @@ export default function ChatMessagesPane({
       ref={scrollContainerRef}
       onWheel={onWheel}
       onTouchMove={onTouchMove}
-      className="relative flex-1 space-y-3 overflow-y-auto overflow-x-hidden px-0 py-3 sm:space-y-4 sm:p-4"
+      className="relative h-full space-y-3 overflow-y-auto overflow-x-hidden px-0 py-3 sm:space-y-4 sm:p-4"
     >
       {isLoadingSessionMessages && chatMessages.length === 0 ? (
         <div className="mt-8 text-center text-gray-500 dark:text-gray-400">
@@ -252,13 +251,6 @@ export default function ChatMessagesPane({
           })}
         </>
       )}
-
-      <ScrollNavigation
-        scrollContainerRef={scrollContainerRef}
-        chatMessages={chatMessages}
-        allMessagesLoaded={allMessagesLoaded}
-        loadAllMessages={loadAllMessages}
-      />
     </div>
   );
 }

--- a/src/components/chat/view/subcomponents/ChatMessagesPane.tsx
+++ b/src/components/chat/view/subcomponents/ChatMessagesPane.tsx
@@ -38,10 +38,10 @@ interface ChatMessagesPaneProps {
   visibleMessages: ChatMessage[];
   loadEarlierMessages: () => void;
   loadAllMessages: () => void;
+  loadMoreMessages: () => void;
   allMessagesLoaded: boolean;
   isLoadingAllMessages: boolean;
   loadAllJustFinished: boolean;
-  showLoadAllOverlay: boolean;
   createDiff: any;
   onFileOpen?: (filePath: string, diffInfo?: unknown) => void;
   onShowSettings?: () => void;
@@ -83,10 +83,10 @@ export default function ChatMessagesPane({
   visibleMessages,
   loadEarlierMessages,
   loadAllMessages,
+  loadMoreMessages,
   allMessagesLoaded,
   isLoadingAllMessages,
   loadAllJustFinished,
-  showLoadAllOverlay,
   createDiff,
   onFileOpen,
   onShowSettings,
@@ -161,55 +161,53 @@ export default function ChatMessagesPane({
         />
       ) : (
         <>
-          {/* Loading indicator for older messages (hide when load-all is active) */}
-          {isLoadingMoreMessages && !isLoadingAllMessages && !allMessagesLoaded && (
+          {/* Loading indicator for older messages */}
+          {(isLoadingMoreMessages || isLoadingAllMessages) && !allMessagesLoaded && (
             <div className="py-3 text-center text-gray-500 dark:text-gray-400">
               <div className="flex items-center justify-center space-x-2">
                 <div className="h-4 w-4 animate-spin rounded-full border-b-2 border-gray-400" />
-                <p className="text-sm">{t('session.loading.olderMessages')}</p>
+                <p className="text-sm">{isLoadingAllMessages ? t('session.messages.loadingAll') : t('session.loading.olderMessages')}</p>
               </div>
             </div>
           )}
 
-          {/* Indicator showing there are more messages to load (hide when all loaded) */}
-          {hasMoreMessages && !isLoadingMoreMessages && !allMessagesLoaded && (
+          {/* "Load more" buttons — show when there are more messages */}
+          {hasMoreMessages && !isLoadingMoreMessages && !isLoadingAllMessages && !allMessagesLoaded && (
             <div className="border-b border-gray-200 py-2 text-center text-sm text-gray-500 dark:border-gray-700 dark:text-gray-400">
               {totalMessages > 0 && (
                 <span>
                   {t('session.messages.showingOf', { shown: sessionMessagesCount, total: totalMessages })}{' '}
-                  <span className="text-xs">{t('session.messages.scrollToLoad')}</span>
                 </span>
               )}
+              <div className="mt-1.5 flex items-center justify-center gap-3">
+                <button
+                  className="flex items-center space-x-1 rounded-full bg-gray-200 px-3 py-1 text-xs font-medium text-gray-700 shadow transition-all duration-200 hover:bg-gray-300 dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600"
+                  onClick={loadMoreMessages}
+                >
+                  <svg className="h-3 w-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 14l-7 7m0 0l-7-7m7 7V3" />
+                  </svg>
+                  <span>{t('session.messages.loadMore', { count: 20 }) || `加载更多(20条)`}</span>
+                </button>
+                <button
+                  className="flex items-center space-x-1 rounded-full bg-blue-600 px-3 py-1 text-xs font-medium text-white shadow transition-all duration-200 hover:scale-105 hover:bg-blue-700 dark:bg-blue-500 dark:hover:bg-blue-600"
+                  onClick={loadAllMessages}
+                >
+                  <span>{t('session.messages.loadAll')} {totalMessages > 0 && `(${totalMessages})`}</span>
+                </button>
+              </div>
             </div>
           )}
 
-          {/* Floating "Load all messages" overlay */}
-          {(showLoadAllOverlay || isLoadingAllMessages || loadAllJustFinished) && (
+          {/* "All loaded" success indicator */}
+          {loadAllJustFinished && (
             <div className="pointer-events-none sticky top-2 z-20 flex justify-center">
-              {loadAllJustFinished ? (
-                <div className="flex items-center space-x-2 rounded-full bg-green-600 px-4 py-1.5 text-xs font-medium text-white shadow-lg dark:bg-green-500">
-                  <svg className="h-3 w-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={3} d="M5 13l4 4L19 7" />
-                  </svg>
-                  <span>{t('session.messages.allLoaded')}</span>
-                </div>
-              ) : (
-                <button
-                  className="pointer-events-auto flex items-center space-x-2 rounded-full bg-blue-600 px-4 py-1.5 text-xs font-medium text-white shadow-lg transition-all duration-200 hover:scale-105 hover:bg-blue-700 disabled:cursor-wait disabled:opacity-75 dark:bg-blue-500 dark:hover:bg-blue-600"
-                  onClick={loadAllMessages}
-                  disabled={isLoadingAllMessages}
-                >
-                  {isLoadingAllMessages && (
-                    <div className="h-3 w-3 animate-spin rounded-full border-2 border-white/30 border-t-white" />
-                  )}
-                  <span>
-                    {isLoadingAllMessages
-                      ? t('session.messages.loadingAll')
-                      : <>{t('session.messages.loadAll')} {totalMessages > 0 && `(${totalMessages})`}</>
-                    }
-                  </span>
-                </button>
-              )}
+              <div className="flex items-center space-x-2 rounded-full bg-green-600 px-4 py-1.5 text-xs font-medium text-white shadow-lg dark:bg-green-500">
+                <svg className="h-3 w-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={3} d="M5 13l4 4L19 7" />
+                </svg>
+                <span>{t('session.messages.allLoaded')}</span>
+              </div>
             </div>
           )}
 

--- a/src/components/chat/view/subcomponents/ChatMessagesPane.tsx
+++ b/src/components/chat/view/subcomponents/ChatMessagesPane.tsx
@@ -6,6 +6,7 @@ import type { Project, ProjectSession, LLMProvider } from '../../../../types/app
 import { getIntrinsicMessageKey } from '../../utils/messageKeys';
 import MessageComponent from './MessageComponent';
 import ProviderSelectionEmptyState from './ProviderSelectionEmptyState';
+import ScrollNavigation from './ScrollNavigation';
 
 interface ChatMessagesPaneProps {
   scrollContainerRef: RefObject<HTMLDivElement>;
@@ -251,6 +252,11 @@ export default function ChatMessagesPane({
           })}
         </>
       )}
+
+      <ScrollNavigation
+        scrollContainerRef={scrollContainerRef}
+        chatMessages={chatMessages}
+      />
     </div>
   );
 }

--- a/src/components/chat/view/subcomponents/ScrollNavigation.tsx
+++ b/src/components/chat/view/subcomponents/ScrollNavigation.tsx
@@ -21,34 +21,34 @@ function truncateSnippet(content: string): string {
 
 function ArrowUpIcon() {
   return (
-    <svg width="10" height="10" viewBox="0 0 10 10" fill="none" stroke="currentColor" strokeWidth="1.5">
-      <path d="M5 8V2M5 2L2 5M5 2L8 5" />
+    <svg width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
+      <path d="M9 7L6 4L3 7" />
     </svg>
   );
 }
 
 function ArrowDownIcon() {
   return (
-    <svg width="10" height="10" viewBox="0 0 10 10" fill="none" stroke="currentColor" strokeWidth="1.5">
-      <path d="M5 2V8M5 8L2 5M5 8L8 5" />
+    <svg width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
+      <path d="M3 5L6 8L9 5" />
     </svg>
   );
 }
 
-function DoubleUpIcon() {
+function TopIcon() {
   return (
-    <svg width="10" height="10" viewBox="0 0 10 10" fill="none" stroke="currentColor" strokeWidth="1.5">
-      <path d="M5 8V3M5 3L2 5.5M5 3L8 5.5" />
-      <path d="M5 6V1M5 1L2 3.5M5 1L8 3.5" />
+    <svg width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
+      <path d="M2 5h8" />
+      <path d="M6 2L3.5 5.5h5z" />
     </svg>
   );
 }
 
-function DoubleDownIcon() {
+function BottomIcon() {
   return (
-    <svg width="10" height="10" viewBox="0 0 10 10" fill="none" stroke="currentColor" strokeWidth="1.5">
-      <path d="M5 1V6M5 6L2 3.5M5 6L8 3.5" />
-      <path d="M5 3V8M5 8L2 5.5M5 8L8 5.5" />
+    <svg width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
+      <path d="M3.5 6.5L6 10l2.5-3.5" />
+      <path d="M2 7h8" />
     </svg>
   );
 }
@@ -157,7 +157,7 @@ export default function ScrollNavigation({
 
       const elements = container.querySelectorAll<HTMLDivElement>('.chat-message.user');
       if (elements.length > index) {
-        elements[index].scrollIntoView({ block: 'center', behavior: 'smooth' });
+        elements[index].scrollIntoView({ block: 'center', behavior: 'instant' });
         return;
       }
 
@@ -166,43 +166,27 @@ export default function ScrollNavigation({
 
       const targetRatio = index / (totalUserMessages - 1);
       const maxScroll = container.scrollHeight - container.clientHeight;
-      container.scrollTo({
-        top: targetRatio * maxScroll,
-        behavior: 'smooth',
-      });
+      container.scrollTop = targetRatio * maxScroll;
     },
     [scrollContainerRef, userMessages.length],
   );
 
-  const scroll_to_top = useCallback(() => {
+  const scrollToTop = useCallback(() => {
     const container = scrollContainerRef.current;
     if (!container) return;
 
     ensureLoaded();
-
-    const elements = container.querySelectorAll<HTMLDivElement>('.chat-message.user');
-    if (elements.length > 0) {
-      elements[0].scrollIntoView({ block: 'center', behavior: 'smooth' });
-      return;
-    }
-
-    container.scrollTo({ top: 0, behavior: 'smooth' });
+    container.scrollTop = 0;
   }, [scrollContainerRef, ensureLoaded]);
 
-  const scroll_to_bottom = useCallback(() => {
+  const scrollToBottom = useCallback(() => {
     const container = scrollContainerRef.current;
     if (!container) return;
 
-    const elements = container.querySelectorAll<HTMLDivElement>('.chat-message.user');
-    if (elements.length > 0) {
-      elements[elements.length - 1].scrollIntoView({ block: 'center', behavior: 'smooth' });
-      return;
-    }
-
-    container.scrollTo({ top: container.scrollHeight, behavior: 'smooth' });
+    container.scrollTop = container.scrollHeight;
   }, [scrollContainerRef]);
 
-  const scroll_prev = useCallback(() => {
+  const scrollPrev = useCallback(() => {
     const container = scrollContainerRef.current;
     if (!container) return;
 
@@ -223,10 +207,10 @@ export default function ScrollNavigation({
     }
 
     const targetIndex = Math.max(0, currentIndex - 1);
-    elements[targetIndex].scrollIntoView({ block: 'center', behavior: 'smooth' });
+    elements[targetIndex].scrollIntoView({ block: 'center', behavior: 'instant' });
   }, [scrollContainerRef]);
 
-  const scroll_next = useCallback(() => {
+  const scrollNext = useCallback(() => {
     const container = scrollContainerRef.current;
     if (!container) return;
 
@@ -246,7 +230,7 @@ export default function ScrollNavigation({
     }
 
     const targetIndex = Math.min(elements.length - 1, currentIndex + 1);
-    elements[targetIndex].scrollIntoView({ block: 'center', behavior: 'smooth' });
+    elements[targetIndex].scrollIntoView({ block: 'center', behavior: 'instant' });
   }, [scrollContainerRef]);
 
   if (!shouldShow) return null;
@@ -254,23 +238,23 @@ export default function ScrollNavigation({
   const navButtons = [
     {
       label: t('scrollNav.first'),
-      icon: <DoubleUpIcon />,
-      action: scroll_to_top,
+      icon: <TopIcon />,
+      action: scrollToTop,
     },
     {
       label: t('scrollNav.previous'),
       icon: <ArrowUpIcon />,
-      action: scroll_prev,
+      action: scrollPrev,
     },
     {
       label: t('scrollNav.next'),
       icon: <ArrowDownIcon />,
-      action: scroll_next,
+      action: scrollNext,
     },
     {
       label: t('scrollNav.last'),
-      icon: <DoubleDownIcon />,
-      action: scroll_to_bottom,
+      icon: <BottomIcon />,
+      action: scrollToBottom,
     },
   ];
 

--- a/src/components/chat/view/subcomponents/ScrollNavigation.tsx
+++ b/src/components/chat/view/subcomponents/ScrollNavigation.tsx
@@ -110,10 +110,10 @@ export default function ScrollNavigation({
 
   return (
     <div
-      className="pointer-events-none absolute right-0 top-0 z-10 h-full w-5"
+      className="pointer-events-none absolute right-0 top-0 z-10 h-full w-4"
     >
       <div
-        className={`pointer-events-auto flex h-full w-3 flex-col items-center justify-evenly rounded-full border px-0 py-4 backdrop-blur-sm transition-opacity duration-200 ${
+        className={`pointer-events-auto flex h-full w-2 flex-col items-center justify-evenly rounded-full border px-0 py-4 backdrop-blur-sm transition-opacity duration-200 ${
           isStripHovered ? 'opacity-100' : 'opacity-50'
         } bg-background/80 border-border/50`}
         onMouseEnter={() => setIsStripHovered(true)}

--- a/src/components/chat/view/subcomponents/ScrollNavigation.tsx
+++ b/src/components/chat/view/subcomponents/ScrollNavigation.tsx
@@ -83,7 +83,7 @@ export default function ScrollNavigation({
     [chatMessages],
   );
 
-  const shouldShow = userMessages.length >= 1;
+  const shouldShow = chatMessages.length >= 1;
   const hasMore = hasMoreMessages;
 
   const scheduleUpdate = useCallback(() => {
@@ -136,17 +136,10 @@ export default function ScrollNavigation({
     };
   }, []);
 
-  const ensureLoaded = useCallback(() => {
-    if (hasMore && loadAllMessages) {
-      loadAllMessages();
-    }
-  }, [hasMore, loadAllMessages]);
-
   const scrollToDot = useCallback(
     (index: number) => {
       setActiveDotIndex(index);
       skipUpdateRef.current = true;
-      ensureLoaded();
       const container = scrollContainerRef.current;
       if (!container) return;
 
@@ -163,16 +156,15 @@ export default function ScrollNavigation({
       const maxScroll = container.scrollHeight - container.clientHeight;
       container.scrollTop = targetRatio * maxScroll;
     },
-    [scrollContainerRef, userMessages.length, ensureLoaded],
+    [scrollContainerRef, userMessages.length],
   );
 
   const scrollToTop = useCallback(() => {
-    ensureLoaded();
     const container = scrollContainerRef.current;
     if (!container) return;
 
     container.scrollTop = 0;
-  }, [scrollContainerRef, ensureLoaded]);
+  }, [scrollContainerRef]);
 
   const scrollToBottom = useCallback(() => {
     const container = scrollContainerRef.current;
@@ -230,26 +222,31 @@ export default function ScrollNavigation({
 
   if (!shouldShow) return null;
 
+  const hasUserMessages = userMessages.length > 0;
   const navButtons = [
     {
       label: t('scrollNav.first'),
       icon: <TopIcon />,
       action: scrollToTop,
+      disabled: false,
     },
     {
       label: t('scrollNav.previous'),
       icon: <ArrowUpIcon />,
       action: scrollPrev,
+      disabled: !hasUserMessages,
     },
     {
       label: t('scrollNav.next'),
       icon: <ArrowDownIcon />,
       action: scrollNext,
+      disabled: !hasUserMessages,
     },
     {
       label: t('scrollNav.last'),
       icon: <BottomIcon />,
       action: scrollToBottom,
+      disabled: false,
     },
   ];
 
@@ -286,7 +283,12 @@ export default function ScrollNavigation({
               <button
                 type="button"
                 onClick={btn.action}
-                className="rounded p-1 text-muted-foreground transition-all duration-150 hover:text-foreground"
+                disabled={btn.disabled}
+                className={`rounded p-1 transition-all duration-150 ${
+                  btn.disabled
+                    ? 'text-muted-foreground/30 cursor-default'
+                    : 'text-muted-foreground hover:text-foreground'
+                }`}
                 aria-label={btn.label}
               >
                 {btn.icon}
@@ -295,41 +297,45 @@ export default function ScrollNavigation({
           ))}
         </div>
 
-        {/* Divider */}
-        <div className={`mx-auto my-0.5 border-t border-border/40 transition-all duration-150 ${
-          isStripHovered ? 'w-5 opacity-100' : 'w-0 opacity-0'
-        }`} />
+        {/* Dots section — only render when there are user messages */}
+        {userMessages.length > 0 && (
+          <>
+            {/* Divider */}
+            <div className={`mx-auto my-0.5 border-t border-border/40 transition-all duration-150 ${
+              isStripHovered ? 'w-5 opacity-100' : 'w-0 opacity-0'
+            }`} />
 
-        {/* Dots section */}
-        <div className="flex flex-1 w-full flex-col items-center justify-evenly px-0 py-1">
-          {userMessages.map((msg, i) => {
-            const isActive = i === activeDotIndex;
-            const snippet = truncateSnippet(msg.content || '');
+            <div className="flex flex-1 w-full flex-col items-center justify-evenly px-0 py-1">
+              {userMessages.map((msg, i) => {
+                const isActive = i === activeDotIndex;
+                const snippet = truncateSnippet(msg.content || '');
 
-            return (
-              <Tooltip
-                key={`${i}-${String(msg.timestamp).slice(0, 8)}`}
-                content={t('scrollNav.jumpToMessage', {
-                  index: i + 1,
-                  snippet,
-                })}
-                position="left"
-                delay={150}
-              >
-                <button
-                  type="button"
-                  onClick={() => scrollToDot(i)}
-                  className={`block cursor-pointer rounded-full transition-all duration-150 ${
-                    isActive
-                      ? 'h-[10px] w-[10px] bg-blue-500 hover:bg-blue-400'
-                      : 'h-[7px] w-[7px] bg-muted-foreground/70 hover:bg-muted-foreground hover:h-[9px] hover:w-[9px]'
-                  }`}
-                  aria-label={t('scrollNav.jumpToMessage', { index: i + 1 })}
-                />
-              </Tooltip>
-            );
-          })}
-        </div>
+                return (
+                  <Tooltip
+                    key={`${i}-${String(msg.timestamp).slice(0, 8)}`}
+                    content={t('scrollNav.jumpToMessage', {
+                      index: i + 1,
+                      snippet,
+                    })}
+                    position="left"
+                    delay={150}
+                  >
+                    <button
+                      type="button"
+                      onClick={() => scrollToDot(i)}
+                      className={`block cursor-pointer rounded-full transition-all duration-150 ${
+                        isActive
+                          ? 'h-[10px] w-[10px] bg-blue-500 hover:bg-blue-400'
+                          : 'h-[7px] w-[7px] bg-muted-foreground/70 hover:bg-muted-foreground hover:h-[9px] hover:w-[9px]'
+                      }`}
+                      aria-label={t('scrollNav.jumpToMessage', { index: i + 1 })}
+                    />
+                  </Tooltip>
+                );
+              })}
+            </div>
+          </>
+        )}
       </div>
     </div>
   );

--- a/src/components/chat/view/subcomponents/ScrollNavigation.tsx
+++ b/src/components/chat/view/subcomponents/ScrollNavigation.tsx
@@ -6,6 +6,8 @@ import Tooltip from '../../../../shared/view/ui/Tooltip';
 interface ScrollNavigationProps {
   scrollContainerRef: React.RefObject<HTMLDivElement | null>;
   chatMessages: ChatMessage[];
+  allMessagesLoaded: boolean;
+  loadAllMessages: () => void;
 }
 
 function truncateSnippet(content: string): string {
@@ -15,19 +17,40 @@ function truncateSnippet(content: string): string {
     .slice(0, 60) + ((content || '').length > 60 ? '...' : '');
 }
 
-export default function ScrollNavigation({ scrollContainerRef, chatMessages }: ScrollNavigationProps) {
+export default function ScrollNavigation({
+  scrollContainerRef,
+  chatMessages,
+  allMessagesLoaded,
+  loadAllMessages,
+}: ScrollNavigationProps) {
   const { t } = useTranslation('chat');
   const [activeDotIndex, setActiveDotIndex] = useState(-1);
   const [isStripHovered, setIsStripHovered] = useState(false);
   const rafIdRef = useRef<number | null>(null);
   const mountedRef = useRef(true);
+  const loadAllCalledRef = useRef(false);
 
   const userMessages = useMemo(
     () => chatMessages.filter((m) => m.type === 'user'),
     [chatMessages],
   );
 
-  const shouldShow = userMessages.length >= 3;
+  const shouldShow = userMessages.length >= 1;
+
+  // Auto-load all messages on first mount so every dot appears
+  useEffect(() => {
+    if (!allMessagesLoaded && !loadAllCalledRef.current && userMessages.length > 0) {
+      loadAllCalledRef.current = true;
+      loadAllMessages();
+    }
+  }, [allMessagesLoaded, loadAllMessages, userMessages.length]);
+
+  // Reset loadAllCalledRef when session changes (messages become empty then refill)
+  useEffect(() => {
+    if (chatMessages.length === 0) {
+      loadAllCalledRef.current = false;
+    }
+  }, [chatMessages.length]);
 
   const scheduleUpdate = useCallback(() => {
     if (rafIdRef.current != null) return;
@@ -61,22 +84,18 @@ export default function ScrollNavigation({ scrollContainerRef, chatMessages }: S
     });
   }, [scrollContainerRef]);
 
-  // Scroll listener for active dot tracking
   useEffect(() => {
     const container = scrollContainerRef.current;
     if (!container) return;
-
     container.addEventListener('scroll', scheduleUpdate, { passive: true });
     return () => container.removeEventListener('scroll', scheduleUpdate);
   }, [scrollContainerRef, scheduleUpdate]);
 
-  // Initial position + re-compute when messages change
   useEffect(() => {
-    const timer = setTimeout(() => scheduleUpdate(), 200);
+    const timer = setTimeout(() => scheduleUpdate(), 300);
     return () => clearTimeout(timer);
   }, [chatMessages.length, scheduleUpdate]);
 
-  // Cleanup RAF on unmount
   useEffect(() => {
     mountedRef.current = true;
     return () => {
@@ -100,6 +119,8 @@ export default function ScrollNavigation({ scrollContainerRef, chatMessages }: S
 
   if (!shouldShow) return null;
 
+  const totalDots = userMessages.length;
+
   return (
     <div
       className="pointer-events-none absolute right-0.5 top-1/2 z-10 flex -translate-y-1/2 flex-col items-center"
@@ -107,8 +128,8 @@ export default function ScrollNavigation({ scrollContainerRef, chatMessages }: S
       onMouseLeave={() => setIsStripHovered(false)}
     >
       <div
-        className={`pointer-events-auto flex flex-col items-center rounded-full border py-2 backdrop-blur-sm transition-opacity duration-200 ${
-          isStripHovered ? 'opacity-100' : 'opacity-40'
+        className={`pointer-events-auto flex flex-col items-center rounded-full border px-1.5 py-3 backdrop-blur-sm transition-opacity duration-200 ${
+          isStripHovered ? 'opacity-100' : 'opacity-50'
         } bg-background/80 border-border/50`}
       >
         {userMessages.map((msg, i) => {
@@ -128,12 +149,14 @@ export default function ScrollNavigation({ scrollContainerRef, chatMessages }: S
               <button
                 type="button"
                 onClick={() => scrollToDot(i)}
-                className={`block rounded-full transition-all duration-150 ${
+                className={`block cursor-pointer rounded-full transition-all duration-150 ${
                   isActive
-                    ? 'h-[6px] w-[6px] bg-blue-500 hover:bg-blue-400'
-                    : 'h-[4px] w-[4px] bg-muted-foreground/60 hover:bg-muted-foreground'
+                    ? 'h-[8px] w-[8px] bg-blue-500 hover:bg-blue-400'
+                    : 'h-[6px] w-[6px] bg-muted-foreground/70 hover:bg-muted-foreground hover:h-[8px] hover:w-[8px]'
                 }`}
-                style={{ marginTop: i === 0 ? 0 : 2 }}
+                style={{
+                  marginBlock: totalDots > 1 ? 6 : 0,
+                }}
                 aria-label={t('scrollNav.jumpToMessage', { index: i + 1 })}
               />
             </Tooltip>

--- a/src/components/chat/view/subcomponents/ScrollNavigation.tsx
+++ b/src/components/chat/view/subcomponents/ScrollNavigation.tsx
@@ -110,10 +110,10 @@ export default function ScrollNavigation({
 
   return (
     <div
-      className="pointer-events-none absolute right-0.5 top-0 z-10 flex h-full w-6 flex-col items-center"
+      className="pointer-events-none absolute right-0 top-0 z-10 h-full w-5"
     >
       <div
-        className={`pointer-events-auto flex h-full w-4 flex-col items-center justify-evenly rounded-full border px-0.5 py-4 backdrop-blur-sm transition-opacity duration-200 ${
+        className={`pointer-events-auto flex h-full w-3 flex-col items-center justify-evenly rounded-full border px-0 py-4 backdrop-blur-sm transition-opacity duration-200 ${
           isStripHovered ? 'opacity-100' : 'opacity-50'
         } bg-background/80 border-border/50`}
         onMouseEnter={() => setIsStripHovered(true)}

--- a/src/components/chat/view/subcomponents/ScrollNavigation.tsx
+++ b/src/components/chat/view/subcomponents/ScrollNavigation.tsx
@@ -110,14 +110,14 @@ export default function ScrollNavigation({
 
   return (
     <div
-      className="pointer-events-none absolute right-0.5 top-0 z-20 flex h-full w-6 flex-col items-center"
-      onMouseEnter={() => setIsStripHovered(true)}
-      onMouseLeave={() => setIsStripHovered(false)}
+      className="pointer-events-none absolute right-0.5 top-0 z-10 flex h-full w-6 flex-col items-center"
     >
       <div
-        className={`pointer-events-auto flex h-full w-full flex-col items-center justify-evenly rounded-full border px-1.5 py-8 backdrop-blur-sm transition-opacity duration-200 ${
+        className={`pointer-events-auto flex h-full w-4 flex-col items-center justify-evenly rounded-full border px-0.5 py-4 backdrop-blur-sm transition-opacity duration-200 ${
           isStripHovered ? 'opacity-100' : 'opacity-50'
         } bg-background/80 border-border/50`}
+        onMouseEnter={() => setIsStripHovered(true)}
+        onMouseLeave={() => setIsStripHovered(false)}
       >
         {userMessages.map((msg, i) => {
           const isActive = i === activeDotIndex;

--- a/src/components/chat/view/subcomponents/ScrollNavigation.tsx
+++ b/src/components/chat/view/subcomponents/ScrollNavigation.tsx
@@ -8,6 +8,7 @@ interface ScrollNavigationProps {
   chatMessages: ChatMessage[];
   loadAllMessages?: () => void;
   allMessagesLoaded?: boolean;
+  hasMoreMessages?: boolean;
   totalMessages?: number;
   sessionMessagesCount?: number;
 }
@@ -66,6 +67,7 @@ export default function ScrollNavigation({
   chatMessages,
   loadAllMessages,
   allMessagesLoaded = true,
+  hasMoreMessages = false,
   totalMessages = 0,
   sessionMessagesCount = 0,
 }: ScrollNavigationProps) {
@@ -74,6 +76,7 @@ export default function ScrollNavigation({
   const [isStripHovered, setIsStripHovered] = useState(false);
   const rafIdRef = useRef<number | null>(null);
   const mountedRef = useRef(true);
+  const skipUpdateRef = useRef(false);
 
   const userMessages = useMemo(
     () => chatMessages.filter((m) => m.type === 'user'),
@@ -81,12 +84,16 @@ export default function ScrollNavigation({
   );
 
   const shouldShow = userMessages.length >= 1;
-  const hasMore = totalMessages > 0 && sessionMessagesCount > 0 && !allMessagesLoaded;
+  const hasMore = hasMoreMessages;
 
   const scheduleUpdate = useCallback(() => {
     if (rafIdRef.current != null) return;
     rafIdRef.current = requestAnimationFrame(() => {
       rafIdRef.current = null;
+      if (skipUpdateRef.current) {
+        skipUpdateRef.current = false;
+        return;
+      }
       const container = scrollContainerRef.current;
       if (!container) return;
 
@@ -129,29 +136,17 @@ export default function ScrollNavigation({
     };
   }, []);
 
-  // Lazy-load: ensure all messages are loaded before navigating
   const ensureLoaded = useCallback(() => {
     if (hasMore && loadAllMessages) {
       loadAllMessages();
     }
   }, [hasMore, loadAllMessages]);
 
-  // Load all messages after first paint — non-blocking, doesn't delay initial render
-  useEffect(() => {
-    if (!hasMore || !loadAllMessages) return;
-    const idle = (globalThis.requestIdleCallback ?? ((fn: () => void) => setTimeout(fn, 0)));
-    const handle = idle(() => {
-      if (mountedRef.current && hasMore) loadAllMessages();
-    });
-    return () => {
-      if ('cancelIdleCallback' in globalThis)
-        (globalThis as any).cancelIdleCallback(handle);
-      else clearTimeout(handle as any);
-    };
-  }, [hasMore, loadAllMessages]);
-
   const scrollToDot = useCallback(
     (index: number) => {
+      setActiveDotIndex(index);
+      skipUpdateRef.current = true;
+      ensureLoaded();
       const container = scrollContainerRef.current;
       if (!container) return;
 
@@ -168,14 +163,14 @@ export default function ScrollNavigation({
       const maxScroll = container.scrollHeight - container.clientHeight;
       container.scrollTop = targetRatio * maxScroll;
     },
-    [scrollContainerRef, userMessages.length],
+    [scrollContainerRef, userMessages.length, ensureLoaded],
   );
 
   const scrollToTop = useCallback(() => {
+    ensureLoaded();
     const container = scrollContainerRef.current;
     if (!container) return;
 
-    ensureLoaded();
     container.scrollTop = 0;
   }, [scrollContainerRef, ensureLoaded]);
 

--- a/src/components/chat/view/subcomponents/ScrollNavigation.tsx
+++ b/src/components/chat/view/subcomponents/ScrollNavigation.tsx
@@ -6,8 +6,6 @@ import Tooltip from '../../../../shared/view/ui/Tooltip';
 interface ScrollNavigationProps {
   scrollContainerRef: React.RefObject<HTMLDivElement | null>;
   chatMessages: ChatMessage[];
-  allMessagesLoaded: boolean;
-  loadAllMessages: () => void;
 }
 
 function truncateSnippet(content: string): string {
@@ -20,15 +18,12 @@ function truncateSnippet(content: string): string {
 export default function ScrollNavigation({
   scrollContainerRef,
   chatMessages,
-  allMessagesLoaded,
-  loadAllMessages,
 }: ScrollNavigationProps) {
   const { t } = useTranslation('chat');
   const [activeDotIndex, setActiveDotIndex] = useState(-1);
   const [isStripHovered, setIsStripHovered] = useState(false);
   const rafIdRef = useRef<number | null>(null);
   const mountedRef = useRef(true);
-  const loadAllCalledRef = useRef(false);
 
   const userMessages = useMemo(
     () => chatMessages.filter((m) => m.type === 'user'),
@@ -37,21 +32,6 @@ export default function ScrollNavigation({
 
   const shouldShow = userMessages.length >= 1;
 
-  // Auto-load all messages on first mount so every dot appears
-  useEffect(() => {
-    if (!allMessagesLoaded && !loadAllCalledRef.current && userMessages.length > 0) {
-      loadAllCalledRef.current = true;
-      loadAllMessages();
-    }
-  }, [allMessagesLoaded, loadAllMessages, userMessages.length]);
-
-  // Reset loadAllCalledRef when session changes (messages become empty then refill)
-  useEffect(() => {
-    if (chatMessages.length === 0) {
-      loadAllCalledRef.current = false;
-    }
-  }, [chatMessages.length]);
-
   const scheduleUpdate = useCallback(() => {
     if (rafIdRef.current != null) return;
     rafIdRef.current = requestAnimationFrame(() => {
@@ -59,30 +39,26 @@ export default function ScrollNavigation({
       const container = scrollContainerRef.current;
       if (!container) return;
 
-      const elements = container.querySelectorAll<HTMLDivElement>('.chat-message.user');
-      if (elements.length === 0) {
-        setActiveDotIndex(-1);
+      const { scrollTop, scrollHeight, clientHeight } = container;
+      const maxScroll = scrollHeight - clientHeight;
+      if (maxScroll <= 0) {
+        setActiveDotIndex(userMessages.length > 0 ? userMessages.length - 1 : -1);
         return;
       }
 
-      const { scrollTop, clientHeight } = container;
-      const viewCenter = scrollTop + clientHeight / 2;
+      // Proportional position of scroll within content
+      const scrollRatio = scrollTop / maxScroll;
+      // Map to the closest user message index
+      const totalUserMessages = userMessages.length;
+      if (totalUserMessages <= 1) {
+        setActiveDotIndex(0);
+        return;
+      }
 
-      let bestIndex = 0;
-      let bestDist = Infinity;
-
-      elements.forEach((el, i) => {
-        const center = el.offsetTop + el.clientHeight / 2;
-        const dist = Math.abs(center - viewCenter);
-        if (dist < bestDist) {
-          bestDist = dist;
-          bestIndex = i;
-        }
-      });
-
-      if (mountedRef.current) setActiveDotIndex(bestIndex);
+      const activeIdx = Math.round(scrollRatio * (totalUserMessages - 1));
+      if (mountedRef.current) setActiveDotIndex(activeIdx);
     });
-  }, [scrollContainerRef]);
+  }, [scrollContainerRef, userMessages.length]);
 
   useEffect(() => {
     const container = scrollContainerRef.current;
@@ -92,7 +68,7 @@ export default function ScrollNavigation({
   }, [scrollContainerRef, scheduleUpdate]);
 
   useEffect(() => {
-    const timer = setTimeout(() => scheduleUpdate(), 300);
+    const timer = setTimeout(() => scheduleUpdate(), 200);
     return () => clearTimeout(timer);
   }, [chatMessages.length, scheduleUpdate]);
 
@@ -108,27 +84,38 @@ export default function ScrollNavigation({
     (index: number) => {
       const container = scrollContainerRef.current;
       if (!container) return;
+
       const elements = container.querySelectorAll<HTMLDivElement>('.chat-message.user');
-      const target = elements[index];
-      if (target) {
-        target.scrollIntoView({ block: 'center', behavior: 'smooth' });
+      if (elements.length > index) {
+        // Message is rendered, scroll directly
+        elements[index].scrollIntoView({ block: 'center', behavior: 'smooth' });
+        return;
       }
+
+      // Message not rendered yet — scroll proportionally
+      const totalUserMessages = userMessages.length;
+      if (totalUserMessages <= 1) return;
+
+      const targetRatio = index / (totalUserMessages - 1);
+      const maxScroll = container.scrollHeight - container.clientHeight;
+      container.scrollTo({
+        top: targetRatio * maxScroll,
+        behavior: 'smooth',
+      });
     },
-    [scrollContainerRef],
+    [scrollContainerRef, userMessages.length],
   );
 
   if (!shouldShow) return null;
 
-  const totalDots = userMessages.length;
-
   return (
     <div
-      className="pointer-events-none absolute right-0.5 top-1/2 z-10 flex -translate-y-1/2 flex-col items-center"
+      className="pointer-events-none absolute right-0.5 top-0 z-20 flex h-full w-6 flex-col items-center"
       onMouseEnter={() => setIsStripHovered(true)}
       onMouseLeave={() => setIsStripHovered(false)}
     >
       <div
-        className={`pointer-events-auto flex flex-col items-center rounded-full border px-1.5 py-3 backdrop-blur-sm transition-opacity duration-200 ${
+        className={`pointer-events-auto flex h-full w-full flex-col items-center justify-evenly rounded-full border px-1.5 py-8 backdrop-blur-sm transition-opacity duration-200 ${
           isStripHovered ? 'opacity-100' : 'opacity-50'
         } bg-background/80 border-border/50`}
       >
@@ -151,12 +138,9 @@ export default function ScrollNavigation({
                 onClick={() => scrollToDot(i)}
                 className={`block cursor-pointer rounded-full transition-all duration-150 ${
                   isActive
-                    ? 'h-[8px] w-[8px] bg-blue-500 hover:bg-blue-400'
-                    : 'h-[6px] w-[6px] bg-muted-foreground/70 hover:bg-muted-foreground hover:h-[8px] hover:w-[8px]'
+                    ? 'h-[10px] w-[10px] bg-blue-500 hover:bg-blue-400'
+                    : 'h-[7px] w-[7px] bg-muted-foreground/70 hover:bg-muted-foreground hover:h-[9px] hover:w-[9px]'
                 }`}
-                style={{
-                  marginBlock: totalDots > 1 ? 6 : 0,
-                }}
                 aria-label={t('scrollNav.jumpToMessage', { index: i + 1 })}
               />
             </Tooltip>

--- a/src/components/chat/view/subcomponents/ScrollNavigation.tsx
+++ b/src/components/chat/view/subcomponents/ScrollNavigation.tsx
@@ -6,6 +6,10 @@ import Tooltip from '../../../../shared/view/ui/Tooltip';
 interface ScrollNavigationProps {
   scrollContainerRef: React.RefObject<HTMLDivElement | null>;
   chatMessages: ChatMessage[];
+  loadAllMessages?: () => void;
+  allMessagesLoaded?: boolean;
+  totalMessages?: number;
+  sessionMessagesCount?: number;
 }
 
 function truncateSnippet(content: string): string {
@@ -15,9 +19,55 @@ function truncateSnippet(content: string): string {
     .slice(0, 60) + ((content || '').length > 60 ? '...' : '');
 }
 
+function ArrowUpIcon() {
+  return (
+    <svg width="10" height="10" viewBox="0 0 10 10" fill="none" stroke="currentColor" strokeWidth="1.5">
+      <path d="M5 8V2M5 2L2 5M5 2L8 5" />
+    </svg>
+  );
+}
+
+function ArrowDownIcon() {
+  return (
+    <svg width="10" height="10" viewBox="0 0 10 10" fill="none" stroke="currentColor" strokeWidth="1.5">
+      <path d="M5 2V8M5 8L2 5M5 8L8 5" />
+    </svg>
+  );
+}
+
+function DoubleUpIcon() {
+  return (
+    <svg width="10" height="10" viewBox="0 0 10 10" fill="none" stroke="currentColor" strokeWidth="1.5">
+      <path d="M5 8V3M5 3L2 5.5M5 3L8 5.5" />
+      <path d="M5 6V1M5 1L2 3.5M5 1L8 3.5" />
+    </svg>
+  );
+}
+
+function DoubleDownIcon() {
+  return (
+    <svg width="10" height="10" viewBox="0 0 10 10" fill="none" stroke="currentColor" strokeWidth="1.5">
+      <path d="M5 1V6M5 6L2 3.5M5 6L8 3.5" />
+      <path d="M5 3V8M5 8L2 5.5M5 8L8 5.5" />
+    </svg>
+  );
+}
+
+function LoadAllIcon() {
+  return (
+    <svg width="10" height="10" viewBox="0 0 10 10" fill="none" stroke="currentColor" strokeWidth="1.5">
+      <path d="M1 3h8M1 5h6M1 7h7" />
+    </svg>
+  );
+}
+
 export default function ScrollNavigation({
   scrollContainerRef,
   chatMessages,
+  loadAllMessages,
+  allMessagesLoaded = true,
+  totalMessages = 0,
+  sessionMessagesCount = 0,
 }: ScrollNavigationProps) {
   const { t } = useTranslation('chat');
   const [activeDotIndex, setActiveDotIndex] = useState(-1);
@@ -31,6 +81,7 @@ export default function ScrollNavigation({
   );
 
   const shouldShow = userMessages.length >= 1;
+  const hasMore = totalMessages > 0 && sessionMessagesCount > 0 && !allMessagesLoaded;
 
   const scheduleUpdate = useCallback(() => {
     if (rafIdRef.current != null) return;
@@ -46,9 +97,7 @@ export default function ScrollNavigation({
         return;
       }
 
-      // Proportional position of scroll within content
       const scrollRatio = scrollTop / maxScroll;
-      // Map to the closest user message index
       const totalUserMessages = userMessages.length;
       if (totalUserMessages <= 1) {
         setActiveDotIndex(0);
@@ -80,6 +129,27 @@ export default function ScrollNavigation({
     };
   }, []);
 
+  // Lazy-load: ensure all messages are loaded before navigating
+  const ensureLoaded = useCallback(() => {
+    if (hasMore && loadAllMessages) {
+      loadAllMessages();
+    }
+  }, [hasMore, loadAllMessages]);
+
+  // Load all messages after first paint — non-blocking, doesn't delay initial render
+  useEffect(() => {
+    if (!hasMore || !loadAllMessages) return;
+    const idle = (globalThis.requestIdleCallback ?? ((fn: () => void) => setTimeout(fn, 0)));
+    const handle = idle(() => {
+      if (mountedRef.current && hasMore) loadAllMessages();
+    });
+    return () => {
+      if ('cancelIdleCallback' in globalThis)
+        (globalThis as any).cancelIdleCallback(handle);
+      else clearTimeout(handle as any);
+    };
+  }, [hasMore, loadAllMessages]);
+
   const scrollToDot = useCallback(
     (index: number) => {
       const container = scrollContainerRef.current;
@@ -87,12 +157,10 @@ export default function ScrollNavigation({
 
       const elements = container.querySelectorAll<HTMLDivElement>('.chat-message.user');
       if (elements.length > index) {
-        // Message is rendered, scroll directly
         elements[index].scrollIntoView({ block: 'center', behavior: 'smooth' });
         return;
       }
 
-      // Message not rendered yet — scroll proportionally
       const totalUserMessages = userMessages.length;
       if (totalUserMessages <= 1) return;
 
@@ -106,46 +174,183 @@ export default function ScrollNavigation({
     [scrollContainerRef, userMessages.length],
   );
 
+  const scroll_to_top = useCallback(() => {
+    const container = scrollContainerRef.current;
+    if (!container) return;
+
+    ensureLoaded();
+
+    const elements = container.querySelectorAll<HTMLDivElement>('.chat-message.user');
+    if (elements.length > 0) {
+      elements[0].scrollIntoView({ block: 'center', behavior: 'smooth' });
+      return;
+    }
+
+    container.scrollTo({ top: 0, behavior: 'smooth' });
+  }, [scrollContainerRef, ensureLoaded]);
+
+  const scroll_to_bottom = useCallback(() => {
+    const container = scrollContainerRef.current;
+    if (!container) return;
+
+    const elements = container.querySelectorAll<HTMLDivElement>('.chat-message.user');
+    if (elements.length > 0) {
+      elements[elements.length - 1].scrollIntoView({ block: 'center', behavior: 'smooth' });
+      return;
+    }
+
+    container.scrollTo({ top: container.scrollHeight, behavior: 'smooth' });
+  }, [scrollContainerRef]);
+
+  const scroll_prev = useCallback(() => {
+    const container = scrollContainerRef.current;
+    if (!container) return;
+
+    const elements = container.querySelectorAll<HTMLDivElement>('.chat-message.user');
+    if (elements.length === 0) return;
+
+    const { scrollTop, clientHeight } = container;
+    const viewportCenter = scrollTop + clientHeight / 2;
+
+    let currentIndex = 0;
+    for (let i = 0; i < elements.length; i++) {
+      const top = elements[i].getBoundingClientRect().top - container.getBoundingClientRect().top + scrollTop;
+      if (top <= viewportCenter) {
+        currentIndex = i;
+      } else {
+        break;
+      }
+    }
+
+    const targetIndex = Math.max(0, currentIndex - 1);
+    elements[targetIndex].scrollIntoView({ block: 'center', behavior: 'smooth' });
+  }, [scrollContainerRef]);
+
+  const scroll_next = useCallback(() => {
+    const container = scrollContainerRef.current;
+    if (!container) return;
+
+    const elements = container.querySelectorAll<HTMLDivElement>('.chat-message.user');
+    if (elements.length === 0) return;
+
+    const { scrollTop, clientHeight } = container;
+    const viewportCenter = scrollTop + clientHeight / 2;
+
+    let currentIndex = elements.length - 1;
+    for (let i = elements.length - 1; i >= 0; i--) {
+      const top = elements[i].getBoundingClientRect().top - container.getBoundingClientRect().top + scrollTop;
+      if (top <= viewportCenter) {
+        currentIndex = i;
+        break;
+      }
+    }
+
+    const targetIndex = Math.min(elements.length - 1, currentIndex + 1);
+    elements[targetIndex].scrollIntoView({ block: 'center', behavior: 'smooth' });
+  }, [scrollContainerRef]);
+
   if (!shouldShow) return null;
+
+  const navButtons = [
+    {
+      label: t('scrollNav.first'),
+      icon: <DoubleUpIcon />,
+      action: scroll_to_top,
+    },
+    {
+      label: t('scrollNav.previous'),
+      icon: <ArrowUpIcon />,
+      action: scroll_prev,
+    },
+    {
+      label: t('scrollNav.next'),
+      icon: <ArrowDownIcon />,
+      action: scroll_next,
+    },
+    {
+      label: t('scrollNav.last'),
+      icon: <DoubleDownIcon />,
+      action: scroll_to_bottom,
+    },
+  ];
 
   return (
     <div
-      className="pointer-events-none absolute right-0 top-0 z-10 h-full w-4"
+      className="pointer-events-none absolute right-0 top-0 z-10 h-full"
     >
       <div
-        className={`pointer-events-auto flex h-full w-2 flex-col items-center justify-evenly rounded-full border px-0 py-4 backdrop-blur-sm transition-opacity duration-200 ${
-          isStripHovered ? 'opacity-100' : 'opacity-50'
+        className={`pointer-events-auto flex h-full flex-col items-center rounded-full border backdrop-blur-sm transition-all duration-200 ${
+          isStripHovered
+            ? 'w-10 opacity-100'
+            : 'w-2 opacity-50'
         } bg-background/80 border-border/50`}
         onMouseEnter={() => setIsStripHovered(true)}
         onMouseLeave={() => setIsStripHovered(false)}
       >
-        {userMessages.map((msg, i) => {
-          const isActive = i === activeDotIndex;
-          const snippet = truncateSnippet(msg.content || '');
-
-          return (
-            <Tooltip
-              key={`${i}-${String(msg.timestamp).slice(0, 8)}`}
-              content={t('scrollNav.jumpToMessage', {
-                index: i + 1,
-                snippet,
-              })}
-              position="left"
-              delay={150}
-            >
+        {/* Nav buttons section */}
+        <div className="flex flex-col items-center gap-1 py-1">
+          {hasMore && loadAllMessages && (
+            <Tooltip content={t('scrollNav.loadAll')} position="left" delay={150}>
               <button
                 type="button"
-                onClick={() => scrollToDot(i)}
-                className={`block cursor-pointer rounded-full transition-all duration-150 ${
-                  isActive
-                    ? 'h-[10px] w-[10px] bg-blue-500 hover:bg-blue-400'
-                    : 'h-[7px] w-[7px] bg-muted-foreground/70 hover:bg-muted-foreground hover:h-[9px] hover:w-[9px]'
-                }`}
-                aria-label={t('scrollNav.jumpToMessage', { index: i + 1 })}
-              />
+                onClick={loadAllMessages}
+                className="rounded p-1 text-muted-foreground transition-all duration-150 hover:text-foreground"
+                aria-label={t('scrollNav.loadAll')}
+              >
+                <LoadAllIcon />
+              </button>
             </Tooltip>
-          );
-        })}
+          )}
+
+          {navButtons.map((btn) => (
+            <Tooltip key={btn.label} content={btn.label} position="left" delay={150}>
+              <button
+                type="button"
+                onClick={btn.action}
+                className="rounded p-1 text-muted-foreground transition-all duration-150 hover:text-foreground"
+                aria-label={btn.label}
+              >
+                {btn.icon}
+              </button>
+            </Tooltip>
+          ))}
+        </div>
+
+        {/* Divider */}
+        <div className={`mx-auto my-0.5 border-t border-border/40 transition-all duration-150 ${
+          isStripHovered ? 'w-5 opacity-100' : 'w-0 opacity-0'
+        }`} />
+
+        {/* Dots section */}
+        <div className="flex flex-1 w-full flex-col items-center justify-evenly px-0 py-1">
+          {userMessages.map((msg, i) => {
+            const isActive = i === activeDotIndex;
+            const snippet = truncateSnippet(msg.content || '');
+
+            return (
+              <Tooltip
+                key={`${i}-${String(msg.timestamp).slice(0, 8)}`}
+                content={t('scrollNav.jumpToMessage', {
+                  index: i + 1,
+                  snippet,
+                })}
+                position="left"
+                delay={150}
+              >
+                <button
+                  type="button"
+                  onClick={() => scrollToDot(i)}
+                  className={`block cursor-pointer rounded-full transition-all duration-150 ${
+                    isActive
+                      ? 'h-[10px] w-[10px] bg-blue-500 hover:bg-blue-400'
+                      : 'h-[7px] w-[7px] bg-muted-foreground/70 hover:bg-muted-foreground hover:h-[9px] hover:w-[9px]'
+                  }`}
+                  aria-label={t('scrollNav.jumpToMessage', { index: i + 1 })}
+                />
+              </Tooltip>
+            );
+          })}
+        </div>
       </div>
     </div>
   );

--- a/src/components/chat/view/subcomponents/ScrollNavigation.tsx
+++ b/src/components/chat/view/subcomponents/ScrollNavigation.tsx
@@ -1,0 +1,145 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import type { ChatMessage } from '../../types/types';
+import Tooltip from '../../../../shared/view/ui/Tooltip';
+
+interface ScrollNavigationProps {
+  scrollContainerRef: React.RefObject<HTMLDivElement | null>;
+  chatMessages: ChatMessage[];
+}
+
+function truncateSnippet(content: string): string {
+  return (content || '')
+    .replace(/\n/g, ' ')
+    .trim()
+    .slice(0, 60) + ((content || '').length > 60 ? '...' : '');
+}
+
+export default function ScrollNavigation({ scrollContainerRef, chatMessages }: ScrollNavigationProps) {
+  const { t } = useTranslation('chat');
+  const [activeDotIndex, setActiveDotIndex] = useState(-1);
+  const [isStripHovered, setIsStripHovered] = useState(false);
+  const rafIdRef = useRef<number | null>(null);
+  const mountedRef = useRef(true);
+
+  const userMessages = useMemo(
+    () => chatMessages.filter((m) => m.type === 'user'),
+    [chatMessages],
+  );
+
+  const shouldShow = userMessages.length >= 3;
+
+  const scheduleUpdate = useCallback(() => {
+    if (rafIdRef.current != null) return;
+    rafIdRef.current = requestAnimationFrame(() => {
+      rafIdRef.current = null;
+      const container = scrollContainerRef.current;
+      if (!container) return;
+
+      const elements = container.querySelectorAll<HTMLDivElement>('.chat-message.user');
+      if (elements.length === 0) {
+        setActiveDotIndex(-1);
+        return;
+      }
+
+      const { scrollTop, clientHeight } = container;
+      const viewCenter = scrollTop + clientHeight / 2;
+
+      let bestIndex = 0;
+      let bestDist = Infinity;
+
+      elements.forEach((el, i) => {
+        const center = el.offsetTop + el.clientHeight / 2;
+        const dist = Math.abs(center - viewCenter);
+        if (dist < bestDist) {
+          bestDist = dist;
+          bestIndex = i;
+        }
+      });
+
+      if (mountedRef.current) setActiveDotIndex(bestIndex);
+    });
+  }, [scrollContainerRef]);
+
+  // Scroll listener for active dot tracking
+  useEffect(() => {
+    const container = scrollContainerRef.current;
+    if (!container) return;
+
+    container.addEventListener('scroll', scheduleUpdate, { passive: true });
+    return () => container.removeEventListener('scroll', scheduleUpdate);
+  }, [scrollContainerRef, scheduleUpdate]);
+
+  // Initial position + re-compute when messages change
+  useEffect(() => {
+    const timer = setTimeout(() => scheduleUpdate(), 200);
+    return () => clearTimeout(timer);
+  }, [chatMessages.length, scheduleUpdate]);
+
+  // Cleanup RAF on unmount
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+      if (rafIdRef.current != null) cancelAnimationFrame(rafIdRef.current);
+    };
+  }, []);
+
+  const scrollToDot = useCallback(
+    (index: number) => {
+      const container = scrollContainerRef.current;
+      if (!container) return;
+      const elements = container.querySelectorAll<HTMLDivElement>('.chat-message.user');
+      const target = elements[index];
+      if (target) {
+        target.scrollIntoView({ block: 'center', behavior: 'smooth' });
+      }
+    },
+    [scrollContainerRef],
+  );
+
+  if (!shouldShow) return null;
+
+  return (
+    <div
+      className="pointer-events-none absolute right-0.5 top-1/2 z-10 flex -translate-y-1/2 flex-col items-center"
+      onMouseEnter={() => setIsStripHovered(true)}
+      onMouseLeave={() => setIsStripHovered(false)}
+    >
+      <div
+        className={`pointer-events-auto flex flex-col items-center rounded-full border py-2 backdrop-blur-sm transition-opacity duration-200 ${
+          isStripHovered ? 'opacity-100' : 'opacity-40'
+        } bg-background/80 border-border/50`}
+      >
+        {userMessages.map((msg, i) => {
+          const isActive = i === activeDotIndex;
+          const snippet = truncateSnippet(msg.content || '');
+
+          return (
+            <Tooltip
+              key={`${i}-${String(msg.timestamp).slice(0, 8)}`}
+              content={t('scrollNav.jumpToMessage', {
+                index: i + 1,
+                snippet,
+              })}
+              position="left"
+              delay={150}
+            >
+              <button
+                type="button"
+                onClick={() => scrollToDot(i)}
+                className={`block rounded-full transition-all duration-150 ${
+                  isActive
+                    ? 'h-[6px] w-[6px] bg-blue-500 hover:bg-blue-400'
+                    : 'h-[4px] w-[4px] bg-muted-foreground/60 hover:bg-muted-foreground'
+                }`}
+                style={{ marginTop: i === 0 ? 0 : 2 }}
+                aria-label={t('scrollNav.jumpToMessage', { index: i + 1 })}
+              />
+            </Tooltip>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/components/chat/view/subcomponents/ScrollNavigation.tsx
+++ b/src/components/chat/view/subcomponents/ScrollNavigation.tsx
@@ -62,6 +62,7 @@ function LoadAllIcon() {
   );
 }
 
+/** Vertical scroll navigation strip with dots, quick-jump buttons, and load-more controls. */
 export default function ScrollNavigation({
   scrollContainerRef,
   chatMessages,

--- a/src/components/settings/view/tabs/NotificationsSettingsTab.tsx
+++ b/src/components/settings/view/tabs/NotificationsSettingsTab.tsx
@@ -167,26 +167,36 @@ export default function NotificationsSettingsTab({
               <div className="text-xs text-muted-foreground">{t('notifications.sound.description')}</div>
             </div>
           </div>
-          <button
-            type="button"
-            role="switch"
-            aria-checked={soundEnabled}
-            aria-label={t('notifications.sound.enabled')}
-            onClick={handleToggleSound}
-            className={`relative inline-flex h-7 w-12 flex-shrink-0 touch-manipulation cursor-pointer items-center rounded-full border-2 transition-colors duration-200 ${
-              soundEnabled
-                ? 'border-primary bg-primary'
-                : 'border-border bg-muted'
-            }`}
-          >
-            <span
-              className={`pointer-events-none inline-block h-5 w-5 rounded-full shadow-sm transition-transform duration-200 ${
+          <div className="flex items-center gap-3">
+            <button
+              type="button"
+              onClick={() => playCompletionSound()}
+              className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-md border border-border bg-background text-foreground hover:bg-accent transition-colors"
+            >
+              <Volume2 className="w-3.5 h-3.5" />
+              {t('notifications.sound.test')}
+            </button>
+            <button
+              type="button"
+              role="switch"
+              aria-checked={soundEnabled}
+              aria-label={t('notifications.sound.enabled')}
+              onClick={handleToggleSound}
+              className={`relative inline-flex h-7 w-12 flex-shrink-0 touch-manipulation cursor-pointer items-center rounded-full border-2 transition-colors duration-200 ${
                 soundEnabled
-                  ? 'translate-x-[22px] bg-white'
-                  : 'translate-x-[2px] bg-foreground/60 dark:bg-foreground/80'
+                  ? 'border-primary bg-primary'
+                  : 'border-border bg-muted'
               }`}
-            />
-          </button>
+            >
+              <span
+                className={`pointer-events-none inline-block h-5 w-5 rounded-full shadow-sm transition-transform duration-200 ${
+                  soundEnabled
+                    ? 'translate-x-[22px] bg-white'
+                    : 'translate-x-[2px] bg-foreground/60 dark:bg-foreground/80'
+                }`}
+              />
+            </button>
+          </div>
         </div>
       </div>
     </div>

--- a/src/components/settings/view/tabs/NotificationsSettingsTab.tsx
+++ b/src/components/settings/view/tabs/NotificationsSettingsTab.tsx
@@ -1,5 +1,7 @@
-import { Bell, BellOff, BellRing, Loader2 } from 'lucide-react';
+import { useState } from 'react';
+import { Bell, BellOff, BellRing, Loader2, Volume2, VolumeX } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
+import { isNotificationSoundEnabled, playCompletionSound, setNotificationSoundEnabled } from '../../../../utils/notification-sound';
 import type { NotificationPreferencesState } from '../../types/types';
 
 type NotificationsSettingsTabProps = {
@@ -22,9 +24,19 @@ export default function NotificationsSettingsTab({
   onDisablePush,
 }: NotificationsSettingsTabProps) {
   const { t } = useTranslation('settings');
+  const [soundEnabled, setSoundEnabled] = useState(() => isNotificationSoundEnabled());
 
   const pushSupported = pushPermission !== 'unsupported';
   const pushDenied = pushPermission === 'denied';
+
+  const handleToggleSound = () => {
+    const next = !soundEnabled;
+    setSoundEnabled(next);
+    setNotificationSoundEnabled(next);
+    if (next) {
+      playCompletionSound();
+    }
+  };
 
   return (
     <div className="space-y-6 md:space-y-8">
@@ -138,6 +150,43 @@ export default function NotificationsSettingsTab({
             />
             {t('notifications.events.error')}
           </label>
+        </div>
+      </div>
+
+      <div className="space-y-4 bg-card border border-border rounded-lg p-4">
+        <h4 className="font-medium text-foreground">{t('notifications.sound.title')}</h4>
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-2">
+            {soundEnabled ? (
+              <Volume2 className="w-4 h-4 text-blue-600" />
+            ) : (
+              <VolumeX className="w-4 h-4 text-muted-foreground" />
+            )}
+            <div>
+              <div className="text-sm text-foreground">{t('notifications.sound.enabled')}</div>
+              <div className="text-xs text-muted-foreground">{t('notifications.sound.description')}</div>
+            </div>
+          </div>
+          <button
+            type="button"
+            role="switch"
+            aria-checked={soundEnabled}
+            aria-label={t('notifications.sound.enabled')}
+            onClick={handleToggleSound}
+            className={`relative inline-flex h-7 w-12 flex-shrink-0 touch-manipulation cursor-pointer items-center rounded-full border-2 transition-colors duration-200 ${
+              soundEnabled
+                ? 'border-primary bg-primary'
+                : 'border-border bg-muted'
+            }`}
+          >
+            <span
+              className={`pointer-events-none inline-block h-5 w-5 rounded-full shadow-sm transition-transform duration-200 ${
+                soundEnabled
+                  ? 'translate-x-[22px] bg-white'
+                  : 'translate-x-[2px] bg-foreground/60 dark:bg-foreground/80'
+              }`}
+            />
+          </button>
         </div>
       </div>
     </div>

--- a/src/components/shell/hooks/useShellConnection.ts
+++ b/src/components/shell/hooks/useShellConnection.ts
@@ -6,6 +6,16 @@ import type { Project, ProjectSession } from '../../../types/app';
 import { TERMINAL_INIT_DELAY_MS } from '../constants/constants';
 import { getShellWebSocketUrl, parseShellMessage, sendSocketMessage } from '../utils/socket';
 
+function resolveShellProjectPath(
+  session: ProjectSession | null | undefined,
+  project: Project | null | undefined,
+): string {
+  if (session?.projectPath) {
+    return session.projectPath;
+  }
+  return (project?.fullPath || project?.path || '') ?? '';
+}
+
 const ANSI_ESCAPE_REGEX =
   /(?:\u001B\[[0-?]*[ -/]*[@-~]|\u009B[0-?]*[ -/]*[@-~]|\u001B\][^\u0007\u001B]*(?:\u0007|\u001B\\)|\u009D[^\u0007\u009C]*(?:\u0007|\u009C)|\u001B[PX^_][^\u001B]*\u001B\\|[\u0090\u0098\u009E\u009F][^\u009C]*\u009C|\u001B[@-Z\\-_])/g;
 const PROCESS_EXIT_REGEX = /Process exited with code (\d+)/;
@@ -144,7 +154,7 @@ export function useShellConnection({
 
             sendSocketMessage(socket, {
               type: 'init',
-              projectPath: currentProject.fullPath || currentProject.path || '',
+              projectPath: resolveShellProjectPath(selectedSessionRef.current, currentProject),
               sessionId: isPlainShellRef.current ? null : selectedSessionRef.current?.id || null,
               hasSession: isPlainShellRef.current ? false : Boolean(selectedSessionRef.current),
               provider: isPlainShellRef.current ? 'plain-shell' : (selectedSessionRef.current?.__provider || localStorage.getItem('selected-provider') || 'claude'),

--- a/src/i18n/locales/de/chat.json
+++ b/src/i18n/locales/de/chat.json
@@ -271,5 +271,9 @@
   },
   "tasks": {
     "nextTaskPrompt": "Nächste Aufgabe starten"
+  },
+  "scrollNav": {
+    "jumpTo": "Springe zu: {{snippet}}",
+    "jumpToMessage": "Springe zu Nachricht {{index}}"
   }
 }

--- a/src/i18n/locales/de/chat.json
+++ b/src/i18n/locales/de/chat.json
@@ -274,6 +274,11 @@
   },
   "scrollNav": {
     "jumpTo": "Springe zu: {{snippet}}",
-    "jumpToMessage": "Springe zu Nachricht {{index}}"
+    "jumpToMessage": "Springe zu Nachricht {{index}}",
+    "loadAll": "Alle laden",
+    "first": "Erste",
+    "previous": "Vorherige",
+    "next": "Nächste",
+    "last": "Letzte"
   }
 }

--- a/src/i18n/locales/en/chat.json
+++ b/src/i18n/locales/en/chat.json
@@ -208,6 +208,7 @@
       "showingLast": "Showing last {{count}} messages ({{total}} total)",
       "loadEarlier": "Load earlier messages",
       "loadAll": "Load all messages",
+      "loadMore": "Load {{count}} more",
       "loadingAll": "Loading all messages...",
       "allLoaded": "All messages loaded",
       "perfWarning": "All messages loaded — scrolling may be slower. Click \"Scroll to bottom\" to restore performance."

--- a/src/i18n/locales/en/chat.json
+++ b/src/i18n/locales/en/chat.json
@@ -279,9 +279,9 @@
     "fromYou": "You",
     "aiReply": "AI Reply",
     "loadAll": "Load all",
-    "first": "First",
+    "first": "Top",
     "previous": "Previous",
     "next": "Next",
-    "last": "Last"
+    "last": "Bottom"
   }
 }

--- a/src/i18n/locales/en/chat.json
+++ b/src/i18n/locales/en/chat.json
@@ -274,6 +274,11 @@
   },
   "scrollNav": {
     "jumpTo": "Jump to: {{snippet}}",
-    "jumpToMessage": "Jump to message {{index}}"
+    "jumpToMessage": "Jump to message {{index}}",
+    "loadAll": "Load all",
+    "first": "First",
+    "previous": "Previous",
+    "next": "Next",
+    "last": "Last"
   }
 }

--- a/src/i18n/locales/en/chat.json
+++ b/src/i18n/locales/en/chat.json
@@ -276,6 +276,8 @@
   "scrollNav": {
     "jumpTo": "Jump to: {{snippet}}",
     "jumpToMessage": "Jump to message {{index}}",
+    "fromYou": "You",
+    "aiReply": "AI Reply",
     "loadAll": "Load all",
     "first": "First",
     "previous": "Previous",

--- a/src/i18n/locales/en/chat.json
+++ b/src/i18n/locales/en/chat.json
@@ -271,5 +271,9 @@
   },
   "tasks": {
     "nextTaskPrompt": "Start the next task"
+  },
+  "scrollNav": {
+    "jumpTo": "Jump to: {{snippet}}",
+    "jumpToMessage": "Jump to message {{index}}"
   }
 }

--- a/src/i18n/locales/en/settings.json
+++ b/src/i18n/locales/en/settings.json
@@ -115,6 +115,11 @@
       "actionRequired": "Action required",
       "stop": "Run stopped",
       "error": "Run failed"
+    },
+    "sound": {
+      "title": "Sound",
+      "enabled": "Completion Sound",
+      "description": "Play a sound when a run finishes"
     }
   },
   "appearanceSettings": {

--- a/src/i18n/locales/it/chat.json
+++ b/src/i18n/locales/it/chat.json
@@ -274,6 +274,11 @@
   },
   "scrollNav": {
     "jumpTo": "Vai a: {{snippet}}",
-    "jumpToMessage": "Vai al messaggio {{index}}"
+    "jumpToMessage": "Vai al messaggio {{index}}",
+    "loadAll": "Carica tutto",
+    "first": "Primo",
+    "previous": "Precedente",
+    "next": "Successivo",
+    "last": "Ultimo"
   }
 }

--- a/src/i18n/locales/it/chat.json
+++ b/src/i18n/locales/it/chat.json
@@ -271,5 +271,9 @@
   },
   "tasks": {
     "nextTaskPrompt": "Inizia l'attività successiva"
+  },
+  "scrollNav": {
+    "jumpTo": "Vai a: {{snippet}}",
+    "jumpToMessage": "Vai al messaggio {{index}}"
   }
 }

--- a/src/i18n/locales/ja/chat.json
+++ b/src/i18n/locales/ja/chat.json
@@ -241,6 +241,11 @@
   },
   "scrollNav": {
     "jumpTo": "ジャンプ: {{snippet}}",
-    "jumpToMessage": "{{index}}番目のメッセージに移動"
+    "jumpToMessage": "{{index}}番目のメッセージに移動",
+    "loadAll": "全ロード",
+    "first": "最初",
+    "previous": "前へ",
+    "next": "次へ",
+    "last": "最後"
   }
 }

--- a/src/i18n/locales/ja/chat.json
+++ b/src/i18n/locales/ja/chat.json
@@ -238,5 +238,9 @@
     "providers": {
       "assistant": "Assistant"
     }
+  },
+  "scrollNav": {
+    "jumpTo": "ジャンプ: {{snippet}}",
+    "jumpToMessage": "{{index}}番目のメッセージに移動"
   }
 }

--- a/src/i18n/locales/ko/chat.json
+++ b/src/i18n/locales/ko/chat.json
@@ -253,5 +253,9 @@
   },
   "tasks": {
     "nextTaskPrompt": "다음 작업 시작"
+  },
+  "scrollNav": {
+    "jumpTo": "이동: {{snippet}}",
+    "jumpToMessage": "{{index}}번 메시지로 이동"
   }
 }

--- a/src/i18n/locales/ko/chat.json
+++ b/src/i18n/locales/ko/chat.json
@@ -256,6 +256,11 @@
   },
   "scrollNav": {
     "jumpTo": "이동: {{snippet}}",
-    "jumpToMessage": "{{index}}번 메시지로 이동"
+    "jumpToMessage": "{{index}}번 메시지로 이동",
+    "loadAll": "전체 로드",
+    "first": "첫 번째",
+    "previous": "이전",
+    "next": "다음",
+    "last": "마지막"
   }
 }

--- a/src/i18n/locales/ru/chat.json
+++ b/src/i18n/locales/ru/chat.json
@@ -271,5 +271,9 @@
   },
   "tasks": {
     "nextTaskPrompt": "Начать следующую задачу"
+  },
+  "scrollNav": {
+    "jumpTo": "Перейти к: {{snippet}}",
+    "jumpToMessage": "Перейти к сообщению {{index}}"
   }
 }

--- a/src/i18n/locales/ru/chat.json
+++ b/src/i18n/locales/ru/chat.json
@@ -274,6 +274,11 @@
   },
   "scrollNav": {
     "jumpTo": "Перейти к: {{snippet}}",
-    "jumpToMessage": "Перейти к сообщению {{index}}"
+    "jumpToMessage": "Перейти к сообщению {{index}}",
+    "loadAll": "Загрузить всё",
+    "first": "Первое",
+    "previous": "Предыдущее",
+    "next": "Следующее",
+    "last": "Последнее"
   }
 }

--- a/src/i18n/locales/tr/chat.json
+++ b/src/i18n/locales/tr/chat.json
@@ -274,6 +274,11 @@
   },
   "scrollNav": {
     "jumpTo": "Git: {{snippet}}",
-    "jumpToMessage": "{{index}}. mesaja git"
+    "jumpToMessage": "{{index}}. mesaja git",
+    "loadAll": "Tümünü yükle",
+    "first": "İlk",
+    "previous": "Önceki",
+    "next": "Sonraki",
+    "last": "Son"
   }
 }

--- a/src/i18n/locales/tr/chat.json
+++ b/src/i18n/locales/tr/chat.json
@@ -271,5 +271,9 @@
   },
   "tasks": {
     "nextTaskPrompt": "Sonraki görevi başlat"
+  },
+  "scrollNav": {
+    "jumpTo": "Git: {{snippet}}",
+    "jumpToMessage": "{{index}}. mesaja git"
   }
 }

--- a/src/i18n/locales/zh-CN/chat.json
+++ b/src/i18n/locales/zh-CN/chat.json
@@ -258,6 +258,8 @@
   "scrollNav": {
     "jumpTo": "跳转到: {{snippet}}",
     "jumpToMessage": "跳转到第 {{index}} 条消息",
+    "fromYou": "你",
+    "aiReply": "AI 回复",
     "loadAll": "加载全部",
     "first": "第一条",
     "previous": "上一条",

--- a/src/i18n/locales/zh-CN/chat.json
+++ b/src/i18n/locales/zh-CN/chat.json
@@ -190,6 +190,7 @@
       "showingLast": "显示最近 {{count}} 条消息（共 {{total}} 条）",
       "loadEarlier": "加载更早的消息",
       "loadAll": "加载全部消息",
+      "loadMore": "加载更多({{count}}条)",
       "loadingAll": "正在加载全部消息...",
       "allLoaded": "全部消息已加载",
       "perfWarning": "已加载全部消息 - 滚动可能变慢。点击「滚动到底部」恢复性能。"

--- a/src/i18n/locales/zh-CN/chat.json
+++ b/src/i18n/locales/zh-CN/chat.json
@@ -261,9 +261,9 @@
     "fromYou": "你",
     "aiReply": "AI 回复",
     "loadAll": "加载全部",
-    "first": "第一条",
+    "first": "顶部",
     "previous": "上一条",
     "next": "下一条",
-    "last": "最后一条"
+    "last": "底部"
   }
 }

--- a/src/i18n/locales/zh-CN/chat.json
+++ b/src/i18n/locales/zh-CN/chat.json
@@ -256,6 +256,11 @@
   },
   "scrollNav": {
     "jumpTo": "跳转到: {{snippet}}",
-    "jumpToMessage": "跳转到第 {{index}} 条消息"
+    "jumpToMessage": "跳转到第 {{index}} 条消息",
+    "loadAll": "加载全部",
+    "first": "第一条",
+    "previous": "上一条",
+    "next": "下一条",
+    "last": "最后一条"
   }
 }

--- a/src/i18n/locales/zh-CN/chat.json
+++ b/src/i18n/locales/zh-CN/chat.json
@@ -253,5 +253,9 @@
   },
   "tasks": {
     "nextTaskPrompt": "开始下一个任务"
+  },
+  "scrollNav": {
+    "jumpTo": "跳转到: {{snippet}}",
+    "jumpToMessage": "跳转到第 {{index}} 条消息"
   }
 }

--- a/src/i18n/locales/zh-CN/settings.json
+++ b/src/i18n/locales/zh-CN/settings.json
@@ -115,6 +115,11 @@
       "actionRequired": "需要处理",
       "stop": "运行已停止",
       "error": "运行失败"
+    },
+    "sound": {
+      "title": "声音",
+      "enabled": "完成音效",
+      "description": "运行完成时播放提示音"
     }
   },
   "appearanceSettings": {

--- a/src/types/app.ts
+++ b/src/types/app.ts
@@ -12,6 +12,10 @@ export interface ProjectSession {
   updated_at?: string;
   lastActivity?: string;
   messageCount?: number;
+  /** Original project_path from the sessions DB row. Used to resolve the correct
+   * cwd when resuming a session whose project differs from the currently
+   * selected project in the sidebar. */
+  projectPath?: string;
   __provider?: LLMProvider;
   // Tags the session with the owning project's DB `projectId` so UI handlers
   // (session switching, sidebar focus, etc.) can match against selectedProject.

--- a/src/utils/notification-sound.ts
+++ b/src/utils/notification-sound.ts
@@ -33,8 +33,9 @@ export function playCompletionSound(): void {
     const now = ctx.currentTime;
     playTone(880, now, 0.12);
     playTone(1100, now + 0.15, 0.2);
-    ctx.close();
-  } catch {
-    // AudioContext not available
+    setTimeout(() => ctx.close(), 600);
+    console.log('[notification-sound] playing completion sound');
+  } catch (err) {
+    console.error('[notification-sound] failed to play:', err);
   }
 }

--- a/src/utils/notification-sound.ts
+++ b/src/utils/notification-sound.ts
@@ -1,0 +1,40 @@
+const STORAGE_KEY = 'notificationSoundEnabled';
+
+export function isNotificationSoundEnabled(): boolean {
+  if (typeof window === 'undefined') return false;
+  try {
+    return localStorage.getItem(STORAGE_KEY) === 'true';
+  } catch {
+    return false;
+  }
+}
+
+export function setNotificationSoundEnabled(enabled: boolean): void {
+  if (typeof window === 'undefined') return;
+  localStorage.setItem(STORAGE_KEY, String(enabled));
+}
+
+export function playCompletionSound(): void {
+  if (typeof window === 'undefined') return;
+  try {
+    const ctx = new AudioContext();
+    const playTone = (frequency: number, startTime: number, duration: number) => {
+      const osc = ctx.createOscillator();
+      const gain = ctx.createGain();
+      osc.type = 'sine';
+      osc.frequency.value = frequency;
+      gain.gain.setValueAtTime(0.3, startTime);
+      gain.gain.exponentialRampToValueAtTime(0.01, startTime + duration);
+      osc.connect(gain);
+      gain.connect(ctx.destination);
+      osc.start(startTime);
+      osc.stop(startTime + duration);
+    };
+    const now = ctx.currentTime;
+    playTone(880, now, 0.12);
+    playTone(1100, now + 0.15, 0.2);
+    ctx.close();
+  } catch {
+    // AudioContext not available
+  }
+}


### PR DESCRIPTION
## Summary
- Added a completion sound notification that plays when a chat run finishes
- Users can toggle via the **Notifications** settings tab (Sound → Completion Sound toggle)
- Uses Web Audio API to generate tones — no external audio assets required
- Sound setting persists in `localStorage`; only plays for normal completions (not aborted sessions)

## Test plan
- [ ] Open Settings → Notifications and toggle "Completion Sound" on/off
- [ ] Send a message and confirm sound plays when the run completes
- [ ] Verify sound does NOT play when the session is aborted
- [ ] Verify toggling the switch plays a preview sound
- [ ] Verify setting persists across page reloads

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Notification sound setting with test button; completion sounds play when enabled and on run completion.
  * New chat Scroll Navigation for jumping between messages and quick top/bottom navigation.

* **UI/UX Improvements**
  * Simplified "load more"/"load all" flows and improved scroll/scrollbar behavior; pending user messages remain visible during realtime races.
  * Session resume now respects a session-specific project path when applicable.

* **Bug Fixes**
  * Improved parsing of Claude transcripts to reduce duplicate/ spurious session artifacts.

* **Localization**
  * Added translations for notification sound and scroll navigation across multiple locales.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/siteboon/claudecodeui/pull/784?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->