### PR TITLE
fix: add logout button with confirmation dialog

### DIFF
--- a/src/components/sidebar/view/Sidebar.tsx
+++ b/src/components/sidebar/view/Sidebar.tsx
@@ -1,6 +1,7 @@
 import { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import { useAuth } from '../../../components/auth/context/AuthContext';
 import { useDeviceSettings } from '../../../hooks/useDeviceSettings';
 import { useVersionCheck } from '../../../hooks/useVersionCheck';
 import { useUiPreferences } from '../../../hooks/useUiPreferences';
@@ -41,6 +42,7 @@ function Sidebar({
   isMobile,
 }: SidebarProps) {
   const { t } = useTranslation(['sidebar', 'common']);
+  const { logout } = useAuth();
   const { isPWA } = useDeviceSettings({ trackMobile: false });
   const { updateAvailable, latestVersion, currentVersion, releaseInfo, installMode } = useVersionCheck(
     'siteboon',
@@ -220,6 +222,7 @@ function Sidebar({
           onShowSettings={onShowSettings}
           updateAvailable={updateAvailable}
           onShowVersionModal={() => setShowVersionModal(true)}
+          onLogout={logout}
           t={t}
         />
       ) : (

--- a/src/components/sidebar/view/subcomponents/SidebarCollapsed.tsx
+++ b/src/components/sidebar/view/subcomponents/SidebarCollapsed.tsx
@@ -1,5 +1,8 @@
-import { Settings, Sparkles, PanelLeftOpen, Bug } from 'lucide-react';
+import { useState } from 'react';
+import { Settings, Sparkles, PanelLeftOpen, Bug, LogOut } from 'lucide-react';
 import type { TFunction } from 'i18next';
+import { IS_PLATFORM } from '../../../../constants/config';
+import { Dialog, DialogContent } from '../../../../shared/view/ui/Dialog';
 
 const DISCORD_INVITE_URL = 'https://discord.gg/buxwujPNRE';
 const GITHUB_ISSUES_URL = 'https://github.com/siteboon/claudecodeui/issues/new';
@@ -17,6 +20,7 @@ type SidebarCollapsedProps = {
   onShowSettings: () => void;
   updateAvailable: boolean;
   onShowVersionModal: () => void;
+  onLogout: () => void;
   t: TFunction;
 };
 
@@ -25,9 +29,45 @@ export default function SidebarCollapsed({
   onShowSettings,
   updateAvailable,
   onShowVersionModal,
+  onLogout,
   t,
 }: SidebarCollapsedProps) {
+  const [showLogoutConfirm, setShowLogoutConfirm] = useState(false);
+
   return (
+    <>
+      {/* Logout confirmation dialog */}
+      <Dialog open={showLogoutConfirm} onOpenChange={setShowLogoutConfirm}>
+        <DialogContent className="max-w-sm p-6">
+          <div className="flex flex-col gap-4">
+            <div className="flex items-center gap-3">
+              <div className="flex h-10 w-10 items-center justify-center rounded-full bg-red-100 dark:bg-red-900/30">
+                <LogOut className="h-5 w-5 text-red-600 dark:text-red-400" />
+              </div>
+              <h3 className="text-lg font-semibold">{t('actions.logout')}</h3>
+            </div>
+            <p className="text-sm text-muted-foreground">{t('actions.logoutConfirm')}</p>
+            <div className="flex justify-end gap-2">
+              <button
+                className="rounded-lg px-4 py-2 text-sm font-medium transition-colors hover:bg-accent"
+                onClick={() => setShowLogoutConfirm(false)}
+              >
+                {t('actions.cancel')}
+              </button>
+              <button
+                className="rounded-lg bg-red-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-red-700"
+                onClick={() => {
+                  setShowLogoutConfirm(false);
+                  onLogout();
+                }}
+              >
+                {t('actions.logout')}
+              </button>
+            </div>
+          </div>
+        </DialogContent>
+      </Dialog>
+
     <div className="flex h-full w-12 flex-col items-center gap-1 bg-background/80 py-3 backdrop-blur-sm">
       {/* Expand button with brand logo */}
       <button
@@ -50,6 +90,18 @@ export default function SidebarCollapsed({
       >
         <Settings className="h-4 w-4 text-muted-foreground transition-colors group-hover:text-foreground" />
       </button>
+
+      {/* Logout */}
+      {!IS_PLATFORM && (
+        <button
+          onClick={() => setShowLogoutConfirm(true)}
+          className="group flex h-8 w-8 items-center justify-center rounded-lg transition-colors hover:bg-red-50/80 dark:hover:bg-red-900/15"
+          aria-label={t('actions.logout')}
+          title={t('actions.logout')}
+        >
+          <LogOut className="h-4 w-4 text-muted-foreground transition-colors group-hover:text-red-600 dark:group-hover:text-red-400" />
+        </button>
+      )}
 
       {/* Report Issue */}
       <a
@@ -88,5 +140,6 @@ export default function SidebarCollapsed({
         </button>
       )}
     </div>
+    </>
   );
 }

--- a/src/components/sidebar/view/subcomponents/SidebarContent.tsx
+++ b/src/components/sidebar/view/subcomponents/SidebarContent.tsx
@@ -4,6 +4,7 @@ import type { TFunction } from 'i18next';
 import { ScrollArea } from '../../../../shared/view/ui';
 import type { Project } from '../../../../types/app';
 import type { ReleaseInfo } from '../../../../types/sharedTypes';
+import { useAuth } from '../../../auth/context/AuthContext';
 import type { ConversationSearchResults, SearchProgress } from '../../hooks/useSidebarController';
 import type { ArchivedProjectListItem, ArchivedSessionListItem, SidebarSearchMode } from '../../types/types';
 import SessionProviderLogo from '../../../llm-logo-provider/SessionProviderLogo';
@@ -182,6 +183,7 @@ export default function SidebarContent({
   projectListProps,
   t,
 }: SidebarContentProps) {
+  const { logout } = useAuth();
   const showConversationSearch = searchMode === 'conversations' && searchFilter.trim().length >= 2;
   const hasPartialResults = conversationResults && conversationResults.results.length > 0;
   const groupedArchivedSessions = groupArchivedSessionsByProject(archivedSessions);
@@ -520,6 +522,7 @@ export default function SidebarContent({
         currentVersion={currentVersion}
         onShowVersionModal={onShowVersionModal}
         onShowSettings={onShowSettings}
+        onLogout={logout}
         t={t}
       />
     </div>

--- a/src/components/sidebar/view/subcomponents/SidebarFooter.tsx
+++ b/src/components/sidebar/view/subcomponents/SidebarFooter.tsx
@@ -1,6 +1,8 @@
-import { Settings, ArrowUpCircle, Bug } from 'lucide-react';
+import { useState } from 'react';
+import { Settings, ArrowUpCircle, Bug, LogOut } from 'lucide-react';
 import type { TFunction } from 'i18next';
 import { IS_PLATFORM } from '../../../../constants/config';
+import { Dialog, DialogContent } from '../../../../shared/view/ui/Dialog';
 import type { ReleaseInfo } from '../../../../types/sharedTypes';
 
 const GITHUB_ISSUES_URL = 'https://github.com/siteboon/claudecodeui/issues/new';
@@ -24,6 +26,7 @@ type SidebarFooterProps = {
   onShowVersionModal: () => void;
   onShowSettings: () => void;
   t: TFunction;
+  onLogout: () => void;
 };
 
 export default function SidebarFooter({
@@ -34,9 +37,47 @@ export default function SidebarFooter({
   onShowVersionModal,
   onShowSettings,
   t,
+  onLogout,
 }: SidebarFooterProps) {
+  const [showLogoutConfirm, setShowLogoutConfirm] = useState(false);
+
+  const handleLogoutClick = () => setShowLogoutConfirm(true);
+  const handleLogoutConfirm = () => {
+    setShowLogoutConfirm(false);
+    onLogout();
+  };
+
   return (
     <div className="flex-shrink-0" style={{ paddingBottom: 'env(safe-area-inset-bottom, 0)' }}>
+      {/* Logout confirmation dialog */}
+      <Dialog open={showLogoutConfirm} onOpenChange={setShowLogoutConfirm}>
+        <DialogContent className="max-w-sm p-6">
+          <div className="flex flex-col gap-4">
+            <div className="flex items-center gap-3">
+              <div className="flex h-10 w-10 items-center justify-center rounded-full bg-red-100 dark:bg-red-900/30">
+                <LogOut className="h-5 w-5 text-red-600 dark:text-red-400" />
+              </div>
+              <h3 className="text-lg font-semibold">{t('actions.logout')}</h3>
+            </div>
+            <p className="text-sm text-muted-foreground">{t('actions.logoutConfirm')}</p>
+            <div className="flex justify-end gap-2">
+              <button
+                className="rounded-lg px-4 py-2 text-sm font-medium transition-colors hover:bg-accent"
+                onClick={() => setShowLogoutConfirm(false)}
+              >
+                {t('actions.cancel', { ns: 'sidebar' })}
+              </button>
+              <button
+                className="rounded-lg bg-red-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-red-700"
+                onClick={handleLogoutConfirm}
+              >
+                {t('actions.logout')}
+              </button>
+            </div>
+          </div>
+        </DialogContent>
+      </Dialog>
+
       {/* Update banner */}
       {updateAvailable && (
         <>
@@ -125,6 +166,19 @@ export default function SidebarFooter({
         </button>
       </div>
 
+      {/* Desktop logout */}
+      {!IS_PLATFORM && (
+        <div className="hidden px-2 md:block">
+          <button
+            className="flex w-full items-center gap-2 rounded-lg px-2.5 py-1.5 text-muted-foreground transition-colors hover:bg-red-50/80 hover:text-red-600 dark:hover:bg-red-900/15 dark:hover:text-red-400"
+            onClick={handleLogoutClick}
+          >
+            <LogOut className="h-3.5 w-3.5" />
+            <span className="text-sm">{t('actions.logout')}</span>
+          </button>
+        </div>
+      )}
+
       {/* Desktop version brand line (OSS mode only) */}
       {!IS_PLATFORM && (
         <div className="hidden px-3 py-2 text-center md:block">
@@ -181,6 +235,21 @@ export default function SidebarFooter({
           <span className="text-base font-medium text-foreground">{t('actions.settings')}</span>
         </button>
       </div>
+
+      {/* Mobile logout */}
+      {!IS_PLATFORM && (
+        <div className="px-3 pb-3 pt-2 md:hidden">
+          <button
+            className="flex h-12 w-full items-center gap-3.5 rounded-xl bg-muted/40 px-4 transition-all hover:bg-red-50/60 active:scale-[0.98] dark:hover:bg-red-900/15"
+            onClick={handleLogoutClick}
+          >
+            <div className="flex h-8 w-8 items-center justify-center rounded-xl bg-background/80">
+              <LogOut className="w-4.5 h-4.5 text-muted-foreground" />
+            </div>
+            <span className="text-base font-medium text-foreground">{t('actions.logout')}</span>
+          </button>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/i18n/locales/de/sidebar.json
+++ b/src/i18n/locales/de/sidebar.json
@@ -68,7 +68,9 @@
     "rename": "Umbenennen",
     "joinCommunity": "Community beitreten",
     "reportIssue": "Problem melden",
-    "starOnGithub": "Stern auf GitHub"
+    "starOnGithub": "Stern auf GitHub",
+    "logout": "Abmelden",
+    "logoutConfirm": "Möchten Sie sich wirklich abmelden?"
   },
   "branding": {
     "openSource": "Open Source"

--- a/src/i18n/locales/en/sidebar.json
+++ b/src/i18n/locales/en/sidebar.json
@@ -68,7 +68,9 @@
     "rename": "Rename",
     "joinCommunity": "Join Community",
     "reportIssue": "Report Issue",
-    "starOnGithub": "Star on GitHub"
+    "starOnGithub": "Star on GitHub",
+    "logout": "Logout",
+    "logoutConfirm": "Are you sure you want to sign out?"
   },
   "branding": {
     "openSource": "Open Source"

--- a/src/i18n/locales/it/sidebar.json
+++ b/src/i18n/locales/it/sidebar.json
@@ -68,7 +68,9 @@
     "rename": "Rinomina",
     "joinCommunity": "Unisciti alla community",
     "reportIssue": "Segnala problema",
-    "starOnGithub": "Metti stella su GitHub"
+    "starOnGithub": "Metti stella su GitHub",
+    "logout": "Esci",
+    "logoutConfirm": "Sei sicuro di voler uscire?"
   },
   "branding": {
     "openSource": "Open Source"

--- a/src/i18n/locales/ja/sidebar.json
+++ b/src/i18n/locales/ja/sidebar.json
@@ -67,7 +67,9 @@
     "rename": "名前の変更",
     "joinCommunity": "コミュニティに参加",
     "reportIssue": "問題を報告",
-    "starOnGithub": "GitHubでスター"
+    "starOnGithub": "GitHubでスター",
+    "logout": "ログアウト",
+    "logoutConfirm": "ログアウトしますか？"
   },
   "branding": {
     "openSource": "オープンソース"

--- a/src/i18n/locales/ko/sidebar.json
+++ b/src/i18n/locales/ko/sidebar.json
@@ -67,7 +67,9 @@
     "rename": "이름 변경",
     "joinCommunity": "커뮤니티 참여",
     "reportIssue": "문제 신고",
-    "starOnGithub": "GitHub에서 스타"
+    "starOnGithub": "GitHub에서 스타",
+    "logout": "로그아웃",
+    "logoutConfirm": "로그아웃하시겠습니까?"
   },
   "branding": {
     "openSource": "오픈 소스"

--- a/src/i18n/locales/ru/sidebar.json
+++ b/src/i18n/locales/ru/sidebar.json
@@ -68,7 +68,9 @@
     "rename": "Переименовать",
     "joinCommunity": "Присоединиться к сообществу",
     "reportIssue": "Сообщить о проблеме",
-    "starOnGithub": "Звезда на GitHub"
+    "starOnGithub": "Звезда на GitHub",
+    "logout": "Выйти",
+    "logoutConfirm": "Вы уверены, что хотите выйти?"
   },
   "branding": {
     "openSource": "Открытый исходный код"

--- a/src/i18n/locales/tr/sidebar.json
+++ b/src/i18n/locales/tr/sidebar.json
@@ -68,7 +68,9 @@
     "rename": "Yeniden Adlandır",
     "joinCommunity": "Topluluğa Katıl",
     "reportIssue": "Sorun Bildir",
-    "starOnGithub": "GitHub'da Yıldızla"
+    "starOnGithub": "GitHub'da Yıldızla",
+    "logout": "Çıkış Yap",
+    "logoutConfirm": "Çıkış yapmak istediğinizden emin misiniz?"
   },
   "branding": {
     "openSource": "Açık Kaynak"

--- a/src/i18n/locales/zh-CN/sidebar.json
+++ b/src/i18n/locales/zh-CN/sidebar.json
@@ -68,7 +68,9 @@
     "rename": "重命名",
     "joinCommunity": "加入社区",
     "reportIssue": "报告问题",
-    "starOnGithub": "在GitHub上加星"
+    "starOnGithub": "在GitHub上加星",
+    "logout": "退出登录",
+    "logoutConfirm": "确定要退出登录吗？"
   },
   "branding": {
     "openSource": "开源"


### PR DESCRIPTION
## Summary

- Adds a logout button to the sidebar footer, placed below the Settings button
- Adds a logout icon button in the collapsed sidebar state
- Includes a confirmation dialog before signing out
- Adds i18n translations for all 8 supported locales (en, zh-CN, ja, ko, de, it, ru, tr)

Closes #797

## Changes

- `SidebarFooter.tsx` — Logout button with confirmation dialog (desktop + mobile layouts)
- `SidebarCollapsed.tsx` — Logout icon button with confirmation dialog for collapsed sidebar
- `SidebarContent.tsx` — Pass `logout` from `useAuth` to `SidebarFooter`
- `Sidebar.tsx` — Pass `logout` to `SidebarCollapsed`
- `sidebar.json` (8 locales) — Added `actions.logout` and `actions.logoutConfirm` translations

## Test plan

- [x] Login and verify Logout button appears below Settings in expanded sidebar
- [x] Collapse sidebar and verify Logout icon button appears
- [x] Click Logout and verify confirmation dialog appears
- [x] Cancel dialog and verify user stays logged in
- [x] Confirm logout and verify user is signed out
- [x] Verify button is hidden in platform mode (`IS_PLATFORM`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added logout functionality to the sidebar with a confirmation dialog to prevent accidental logouts
  * Implemented localization for logout actions across 8 languages (English, German, Italian, Japanese, Korean, Russian, Turkish, and Simplified Chinese)

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/siteboon/claudecodeui/pull/800?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->