### PR TITLE
feat: add completion sound notification / 添加完成提示音

### DIFF
--- a/src/components/chat/hooks/useChatRealtimeHandlers.ts
+++ b/src/components/chat/hooks/useChatRealtimeHandlers.ts
@@ -1,6 +1,7 @@
 import { useEffect, useRef } from 'react';
 import type { Dispatch, MutableRefObject, SetStateAction } from 'react';
 
+import { isNotificationSoundEnabled, playCompletionSound } from '../../../utils/notification-sound';
 import { usePaletteOps } from '../../../contexts/PaletteOpsContext';
 import type { PendingPermissionRequest, SessionNavigationOptions } from '../types/types';
 import type { ProjectSession, LLMProvider } from '../../../types/app';
@@ -283,6 +284,11 @@ export function useChatRealtimeHandlers({
           // No special UI action needed beyond clearing loading state above
           // The backend already sent any abort-related messages
           break;
+        }
+
+        // Play completion sound if enabled
+        if (isNotificationSoundEnabled()) {
+          playCompletionSound();
         }
 
         const actualSessionId =

--- a/src/components/settings/view/tabs/NotificationsSettingsTab.tsx
+++ b/src/components/settings/view/tabs/NotificationsSettingsTab.tsx
@@ -1,5 +1,7 @@
-import { Bell, BellOff, BellRing, Loader2 } from 'lucide-react';
+import { useState } from 'react';
+import { Bell, BellOff, BellRing, Loader2, Volume2, VolumeX } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
+import { isNotificationSoundEnabled, playCompletionSound, setNotificationSoundEnabled } from '../../../../utils/notification-sound';
 import type { NotificationPreferencesState } from '../../types/types';
 
 type NotificationsSettingsTabProps = {
@@ -22,9 +24,19 @@ export default function NotificationsSettingsTab({
   onDisablePush,
 }: NotificationsSettingsTabProps) {
   const { t } = useTranslation('settings');
+  const [soundEnabled, setSoundEnabled] = useState(() => isNotificationSoundEnabled());
 
   const pushSupported = pushPermission !== 'unsupported';
   const pushDenied = pushPermission === 'denied';
+
+  const handleToggleSound = () => {
+    const next = !soundEnabled;
+    setSoundEnabled(next);
+    setNotificationSoundEnabled(next);
+    if (next) {
+      playCompletionSound();
+    }
+  };
 
   return (
     <div className="space-y-6 md:space-y-8">
@@ -138,6 +150,53 @@ export default function NotificationsSettingsTab({
             />
             {t('notifications.events.error')}
           </label>
+        </div>
+      </div>
+
+      <div className="space-y-4 bg-card border border-border rounded-lg p-4">
+        <h4 className="font-medium text-foreground">{t('notifications.sound.title')}</h4>
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-2">
+            {soundEnabled ? (
+              <Volume2 className="w-4 h-4 text-blue-600" />
+            ) : (
+              <VolumeX className="w-4 h-4 text-muted-foreground" />
+            )}
+            <div>
+              <div className="text-sm text-foreground">{t('notifications.sound.enabled')}</div>
+              <div className="text-xs text-muted-foreground">{t('notifications.sound.description')}</div>
+            </div>
+          </div>
+          <div className="flex items-center gap-3">
+            <button
+              type="button"
+              onClick={() => playCompletionSound()}
+              className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-md border border-border bg-background text-foreground hover:bg-accent transition-colors"
+            >
+              <Volume2 className="w-3.5 h-3.5" />
+              {t('notifications.sound.test')}
+            </button>
+            <button
+              type="button"
+              role="switch"
+              aria-checked={soundEnabled}
+              aria-label={t('notifications.sound.enabled')}
+              onClick={handleToggleSound}
+              className={`relative inline-flex h-7 w-12 flex-shrink-0 touch-manipulation cursor-pointer items-center rounded-full border-2 transition-colors duration-200 ${
+                soundEnabled
+                  ? 'border-primary bg-primary'
+                  : 'border-border bg-muted'
+              }`}
+            >
+              <span
+                className={`pointer-events-none inline-block h-5 w-5 rounded-full shadow-sm transition-transform duration-200 ${
+                  soundEnabled
+                    ? 'translate-x-[22px] bg-white'
+                    : 'translate-x-[2px] bg-foreground/60 dark:bg-foreground/80'
+                }`}
+              />
+            </button>
+          </div>
         </div>
       </div>
     </div>

--- a/src/components/settings/view/tabs/NotificationsSettingsTab.tsx
+++ b/src/components/settings/view/tabs/NotificationsSettingsTab.tsx
@@ -180,7 +180,7 @@ export default function NotificationsSettingsTab({
               type="button"
               role="switch"
               aria-checked={soundEnabled}
-              aria-label={t('notifications.sound.enabled')}
+              aria-label={t('notifications.sound.title')}
               onClick={handleToggleSound}
               className={`relative inline-flex h-7 w-12 flex-shrink-0 touch-manipulation cursor-pointer items-center rounded-full border-2 transition-colors duration-200 ${
                 soundEnabled

--- a/src/i18n/locales/de/settings.json
+++ b/src/i18n/locales/de/settings.json
@@ -462,28 +462,28 @@
     "runningStatus": "läuft"
   },
   "notifications": {
-    "title": "Notifications",
-    "description": "Control which notification events you receive.",
+    "title": "Benachrichtigungen",
+    "description": "Wähle aus, welche Benachrichtigungen du erhalten möchtest.",
     "webPush": {
-      "title": "Web Push Notifications",
-      "enable": "Enable Push Notifications",
-      "disable": "Disable Push Notifications",
-      "enabled": "Push notifications are enabled",
-      "loading": "Updating...",
-      "unsupported": "Push notifications are not supported in this browser.",
-      "denied": "Push notifications are blocked. Please allow them in your browser settings."
+      "title": "Web-Push-Benachrichtigungen",
+      "enable": "Push-Benachrichtigungen aktivieren",
+      "disable": "Push-Benachrichtigungen deaktivieren",
+      "enabled": "Push-Benachrichtigungen sind aktiviert",
+      "loading": "Wird aktualisiert...",
+      "unsupported": "Push-Benachrichtigungen werden in diesem Browser nicht unterstützt.",
+      "denied": "Push-Benachrichtigungen wurden blockiert. Bitte erlaube sie in deinen Browsereinstellungen."
     },
     "events": {
-      "title": "Event Types",
-      "actionRequired": "Action required",
-      "stop": "Run stopped",
-      "error": "Run failed"
+      "title": "Ereignistypen",
+      "actionRequired": "Aktion erforderlich",
+      "stop": "Ausführung gestoppt",
+      "error": "Ausführung fehlgeschlagen"
     },
     "sound": {
-      "title": "Sound",
-      "enabled": "Completion Sound",
-      "description": "Play a sound when a run finishes",
-      "test": "Test"
+      "title": "Ton",
+      "enabled": "Abschlusston",
+      "description": "Einen Ton abspielen, wenn eine Ausführung abgeschlossen ist",
+      "test": "Testen"
     }
   }
 }

--- a/src/i18n/locales/de/settings.json
+++ b/src/i18n/locales/de/settings.json
@@ -460,5 +460,30 @@
     "installAriaLabel": "Git-Repository-URL des Plugins",
     "tab": "Tab",
     "runningStatus": "läuft"
+  },
+  "notifications": {
+    "title": "Notifications",
+    "description": "Control which notification events you receive.",
+    "webPush": {
+      "title": "Web Push Notifications",
+      "enable": "Enable Push Notifications",
+      "disable": "Disable Push Notifications",
+      "enabled": "Push notifications are enabled",
+      "loading": "Updating...",
+      "unsupported": "Push notifications are not supported in this browser.",
+      "denied": "Push notifications are blocked. Please allow them in your browser settings."
+    },
+    "events": {
+      "title": "Event Types",
+      "actionRequired": "Action required",
+      "stop": "Run stopped",
+      "error": "Run failed"
+    },
+    "sound": {
+      "title": "Sound",
+      "enabled": "Completion Sound",
+      "description": "Play a sound when a run finishes",
+      "test": "Test"
+    }
   }
 }

--- a/src/i18n/locales/en/settings.json
+++ b/src/i18n/locales/en/settings.json
@@ -115,6 +115,12 @@
       "actionRequired": "Action required",
       "stop": "Run stopped",
       "error": "Run failed"
+    },
+    "sound": {
+      "title": "Sound",
+      "enabled": "Completion Sound",
+      "description": "Play a sound when a run finishes",
+      "test": "Test"
     }
   },
   "appearanceSettings": {

--- a/src/i18n/locales/it/settings.json
+++ b/src/i18n/locales/it/settings.json
@@ -117,10 +117,10 @@
       "error": "Esecuzione fallita"
     },
     "sound": {
-      "title": "Sound",
-      "enabled": "Completion Sound",
-      "description": "Play a sound when a run finishes",
-      "test": "Test"
+      "title": "Audio",
+      "enabled": "Suono di completamento",
+      "description": "Riproduci un suono quando un'esecuzione termina",
+      "test": "Prova"
     }
   },
   "appearanceSettings": {

--- a/src/i18n/locales/it/settings.json
+++ b/src/i18n/locales/it/settings.json
@@ -115,6 +115,12 @@
       "actionRequired": "Azione richiesta",
       "stop": "Esecuzione interrotta",
       "error": "Esecuzione fallita"
+    },
+    "sound": {
+      "title": "Sound",
+      "enabled": "Completion Sound",
+      "description": "Play a sound when a run finishes",
+      "test": "Test"
     }
   },
   "appearanceSettings": {

--- a/src/i18n/locales/ja/settings.json
+++ b/src/i18n/locales/ja/settings.json
@@ -115,6 +115,12 @@
       "actionRequired": "対応が必要",
       "stop": "実行停止",
       "error": "実行失敗"
+    },
+    "sound": {
+      "title": "Sound",
+      "enabled": "Completion Sound",
+      "description": "Play a sound when a run finishes",
+      "test": "Test"
     }
   },
   "appearanceSettings": {

--- a/src/i18n/locales/ja/settings.json
+++ b/src/i18n/locales/ja/settings.json
@@ -117,10 +117,10 @@
       "error": "実行失敗"
     },
     "sound": {
-      "title": "Sound",
-      "enabled": "Completion Sound",
-      "description": "Play a sound when a run finishes",
-      "test": "Test"
+      "title": "サウンド",
+      "enabled": "完了サウンド",
+      "description": "実行が完了したときにサウンドを再生",
+      "test": "テスト"
     }
   },
   "appearanceSettings": {

--- a/src/i18n/locales/ko/settings.json
+++ b/src/i18n/locales/ko/settings.json
@@ -117,10 +117,10 @@
       "error": "실행 실패"
     },
     "sound": {
-      "title": "Sound",
-      "enabled": "Completion Sound",
-      "description": "Play a sound when a run finishes",
-      "test": "Test"
+      "title": "사운드",
+      "enabled": "완료 알림음",
+      "description": "실행이 완료되면 알림음을 재생합니다",
+      "test": "테스트"
     }
   },
   "appearanceSettings": {

--- a/src/i18n/locales/ko/settings.json
+++ b/src/i18n/locales/ko/settings.json
@@ -115,6 +115,12 @@
       "actionRequired": "작업 필요",
       "stop": "실행 중지",
       "error": "실행 실패"
+    },
+    "sound": {
+      "title": "Sound",
+      "enabled": "Completion Sound",
+      "description": "Play a sound when a run finishes",
+      "test": "Test"
     }
   },
   "appearanceSettings": {

--- a/src/i18n/locales/ru/settings.json
+++ b/src/i18n/locales/ru/settings.json
@@ -462,28 +462,28 @@
     "runningStatus": "запущен"
   },
   "notifications": {
-    "title": "Notifications",
-    "description": "Control which notification events you receive.",
+    "title": "Уведомления",
+    "description": "Управляйте типами получаемых уведомлений.",
     "webPush": {
-      "title": "Web Push Notifications",
-      "enable": "Enable Push Notifications",
-      "disable": "Disable Push Notifications",
-      "enabled": "Push notifications are enabled",
-      "loading": "Updating...",
-      "unsupported": "Push notifications are not supported in this browser.",
-      "denied": "Push notifications are blocked. Please allow them in your browser settings."
+      "title": "Web Push уведомления",
+      "enable": "Включить Push уведомления",
+      "disable": "Отключить Push уведомления",
+      "enabled": "Push уведомления включены",
+      "loading": "Обновление...",
+      "unsupported": "Push уведомления не поддерживаются в этом браузере.",
+      "denied": "Push уведомления заблокированы. Пожалуйста, разрешите их в настройках браузера."
     },
     "events": {
-      "title": "Event Types",
-      "actionRequired": "Action required",
-      "stop": "Run stopped",
-      "error": "Run failed"
+      "title": "Типы событий",
+      "actionRequired": "Требуется действие",
+      "stop": "Выполнение остановлено",
+      "error": "Выполнение завершилось с ошибкой"
     },
     "sound": {
-      "title": "Sound",
-      "enabled": "Completion Sound",
-      "description": "Play a sound when a run finishes",
-      "test": "Test"
+      "title": "Звук",
+      "enabled": "Звук завершения",
+      "description": "Воспроизводить звук при завершении выполнения",
+      "test": "Тест"
     }
   }
 }

--- a/src/i18n/locales/ru/settings.json
+++ b/src/i18n/locales/ru/settings.json
@@ -460,5 +460,30 @@
     "installAriaLabel": "URL git-репозитория плагина",
     "tab": "вкладка",
     "runningStatus": "запущен"
+  },
+  "notifications": {
+    "title": "Notifications",
+    "description": "Control which notification events you receive.",
+    "webPush": {
+      "title": "Web Push Notifications",
+      "enable": "Enable Push Notifications",
+      "disable": "Disable Push Notifications",
+      "enabled": "Push notifications are enabled",
+      "loading": "Updating...",
+      "unsupported": "Push notifications are not supported in this browser.",
+      "denied": "Push notifications are blocked. Please allow them in your browser settings."
+    },
+    "events": {
+      "title": "Event Types",
+      "actionRequired": "Action required",
+      "stop": "Run stopped",
+      "error": "Run failed"
+    },
+    "sound": {
+      "title": "Sound",
+      "enabled": "Completion Sound",
+      "description": "Play a sound when a run finishes",
+      "test": "Test"
+    }
   }
 }

--- a/src/i18n/locales/tr/settings.json
+++ b/src/i18n/locales/tr/settings.json
@@ -117,9 +117,9 @@
       "error": "Çalıştırma başarısız"
     },
     "sound": {
-      "title": "Sound",
-      "enabled": "Completion Sound",
-      "description": "Play a sound when a run finishes",
+      "title": "Ses",
+      "enabled": "Tamamlanma Sesi",
+      "description": "Çalıştırma bittiğinde ses çal",
       "test": "Test"
     }
   },

--- a/src/i18n/locales/tr/settings.json
+++ b/src/i18n/locales/tr/settings.json
@@ -115,6 +115,12 @@
       "actionRequired": "Aksiyon gerekli",
       "stop": "Çalıştırma durduruldu",
       "error": "Çalıştırma başarısız"
+    },
+    "sound": {
+      "title": "Sound",
+      "enabled": "Completion Sound",
+      "description": "Play a sound when a run finishes",
+      "test": "Test"
     }
   },
   "appearanceSettings": {

--- a/src/i18n/locales/zh-CN/settings.json
+++ b/src/i18n/locales/zh-CN/settings.json
@@ -115,6 +115,12 @@
       "actionRequired": "需要处理",
       "stop": "运行已停止",
       "error": "运行失败"
+    },
+    "sound": {
+      "title": "声音",
+      "enabled": "完成音效",
+      "description": "运行完成时播放提示音",
+      "test": "试听"
     }
   },
   "appearanceSettings": {

--- a/src/utils/notification-sound.ts
+++ b/src/utils/notification-sound.ts
@@ -1,4 +1,5 @@
 const STORAGE_KEY = 'notificationSoundEnabled';
+let memoryFallback: boolean | undefined = undefined;
 
 /**
  * Returns whether the notification sound is enabled.
@@ -9,7 +10,7 @@ export function isNotificationSoundEnabled(): boolean {
     const value = localStorage.getItem(STORAGE_KEY);
     return value === null || value === 'true';
   } catch {
-    return true;
+    return memoryFallback !== undefined ? memoryFallback : true;
   }
 }
 
@@ -18,10 +19,11 @@ export function isNotificationSoundEnabled(): boolean {
  */
 export function setNotificationSoundEnabled(enabled: boolean): void {
   if (typeof window === 'undefined') return;
+  memoryFallback = enabled;
   try {
     localStorage.setItem(STORAGE_KEY, String(enabled));
   } catch {
-    // Restricted storage context
+    // Restricted storage context - memoryFallback still active
   }
 }
 
@@ -31,25 +33,30 @@ export function setNotificationSoundEnabled(enabled: boolean): void {
 export function playCompletionSound(): void {
   if (typeof window === 'undefined') return;
   try {
-    const ctx = new AudioContext();
-    const playTone = (frequency: number, startTime: number, duration: number) => {
-      const osc = ctx.createOscillator();
-      const gain = ctx.createGain();
-      osc.type = 'sine';
-      osc.frequency.value = frequency;
-      gain.gain.setValueAtTime(0.3, startTime);
-      gain.gain.exponentialRampToValueAtTime(0.01, startTime + duration);
-      osc.connect(gain);
-      gain.connect(ctx.destination);
-      osc.start(startTime);
-      osc.stop(startTime + duration);
-    };
-    const now = ctx.currentTime;
-    playTone(880, now, 0.12);
-    playTone(1100, now + 0.15, 0.2);
-    setTimeout(() => ctx.close(), 600);
-    console.log('[notification-sound] playing completion sound');
-  } catch (err) {
-    console.error('[notification-sound] failed to play:', err);
+    const Ctx = (window.AudioContext || (window as any).webkitAudioContext);
+    if (!Ctx) return;
+    const ctx = new Ctx();
+    const resumeIfNeeded = () =>
+      ctx.state === 'suspended' ? ctx.resume() : Promise.resolve();
+    resumeIfNeeded().then(() => {
+      const playTone = (frequency: number, startTime: number, duration: number) => {
+        const osc = ctx.createOscillator();
+        const gain = ctx.createGain();
+        osc.type = 'sine';
+        osc.frequency.value = frequency;
+        gain.gain.setValueAtTime(0.3, startTime);
+        gain.gain.exponentialRampToValueAtTime(0.01, startTime + duration);
+        osc.connect(gain);
+        gain.connect(ctx.destination);
+        osc.start(startTime);
+        osc.stop(startTime + duration);
+      };
+      const now = ctx.currentTime;
+      playTone(880, now, 0.12);
+      playTone(1100, now + 0.15, 0.2);
+      setTimeout(() => ctx.close(), 600);
+    });
+  } catch {
+    // Autoplay policy or other audio restrictions - silently ignore
   }
 }

--- a/src/utils/notification-sound.ts
+++ b/src/utils/notification-sound.ts
@@ -1,0 +1,55 @@
+const STORAGE_KEY = 'notificationSoundEnabled';
+
+/**
+ * Returns whether the notification sound is enabled.
+ */
+export function isNotificationSoundEnabled(): boolean {
+  if (typeof window === 'undefined') return false;
+  try {
+    const value = localStorage.getItem(STORAGE_KEY);
+    return value === null || value === 'true';
+  } catch {
+    return true;
+  }
+}
+
+/**
+ * Persists the notification sound preference to localStorage.
+ */
+export function setNotificationSoundEnabled(enabled: boolean): void {
+  if (typeof window === 'undefined') return;
+  try {
+    localStorage.setItem(STORAGE_KEY, String(enabled));
+  } catch {
+    // Restricted storage context
+  }
+}
+
+/**
+ * Plays a two-tone completion sound using the Web Audio API.
+ */
+export function playCompletionSound(): void {
+  if (typeof window === 'undefined') return;
+  try {
+    const ctx = new AudioContext();
+    const playTone = (frequency: number, startTime: number, duration: number) => {
+      const osc = ctx.createOscillator();
+      const gain = ctx.createGain();
+      osc.type = 'sine';
+      osc.frequency.value = frequency;
+      gain.gain.setValueAtTime(0.3, startTime);
+      gain.gain.exponentialRampToValueAtTime(0.01, startTime + duration);
+      osc.connect(gain);
+      gain.connect(ctx.destination);
+      osc.start(startTime);
+      osc.stop(startTime + duration);
+    };
+    const now = ctx.currentTime;
+    playTone(880, now, 0.12);
+    playTone(1100, now + 0.15, 0.2);
+    setTimeout(() => ctx.close(), 600);
+    console.log('[notification-sound] playing completion sound');
+  } catch (err) {
+    console.error('[notification-sound] failed to play:', err);
+  }
+}


### PR DESCRIPTION
## Summary / 摘要
- Add a short audio notification when a chat run finishes — 聊天完成时播放简短提示音
- Users can toggle the sound via the Notifications settings tab — 可在设置 → 通知中开关
- Uses Web Audio API to generate tones, no external assets required — 使用 Web Audio API 生成音效，无需外部资源
- Sound is **enabled by default** — 默认开启
- Includes a "Test sound" button for preview — 包含"试听"按钮

## Test plan / 测试
- [ ] Start a new chat session and wait for AI response to complete — should hear a two-tone sound
- [ ] Navigate to Settings → Notifications → toggle sound off — sound should stop
- [ ] Click "Test sound" button — should hear sound without starting a chat

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  - Notification sound settings to control audio alerts when runs complete
  - New sound settings card with enable/disable toggle and a Test button
  - Plays a completion sound when enabled and when testing
  - Sound preference persisted locally across sessions

* **Localization**
  - Added translations for sound settings in multiple locales (en, zh-CN, de, it, ja, ko, ru, tr)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->