### PR TITLE
feat: add scroll navigation for chat messages / 添加聊天消息滚动导航

### DIFF
--- a/src/components/chat/hooks/useChatMessages.ts
+++ b/src/components/chat/hooks/useChatMessages.ts
@@ -55,7 +55,7 @@ export function normalizedToChatMessages(messages: NormalizedMessage[]): ChatMes
 
         if (msg.role === 'user') {
           // Parse task notifications
-          const taskNotifRegex = /<task-notification>\s*<task-id>[^<]*<\/task-id>\s*<output-file>[^<]*<\/output-file>\s*<status>([^<]*)<\/status>\s*<summary>([^<]*)<\/summary>\s*<\/task-notification>/g;
+          const taskNotifRegex = /^<task-notification>[\s\S]*?<status>([^<]*)<\/status>[\s\S]*?<summary>([^<]*)<\/summary>[\s\S]*?<\/task-notification>$/;
           const taskNotifMatch = taskNotifRegex.exec(content);
           if (taskNotifMatch) {
             converted.push({

--- a/src/components/chat/hooks/useChatMessages.ts
+++ b/src/components/chat/hooks/useChatMessages.ts
@@ -56,7 +56,7 @@ export function normalizedToChatMessages(messages: NormalizedMessage[]): ChatMes
         if (msg.role === 'user') {
           // Parse task notifications
           const taskNotifRegex = /^<task-notification>[\s\S]*?<status>([^<]*)<\/status>[\s\S]*?<summary>([^<]*)<\/summary>[\s\S]*?<\/task-notification>$/;
-          const taskNotifMatch = taskNotifRegex.exec(content);
+          const taskNotifMatch = taskNotifRegex.exec(content.trim());
           if (taskNotifMatch) {
             converted.push({
               type: 'assistant',

--- a/src/components/chat/hooks/useChatRealtimeHandlers.ts
+++ b/src/components/chat/hooks/useChatRealtimeHandlers.ts
@@ -1,6 +1,7 @@
 import { useEffect, useRef } from 'react';
 import type { Dispatch, MutableRefObject, SetStateAction } from 'react';
 
+import { isNotificationSoundEnabled, playCompletionSound } from '../../../utils/notification-sound';
 import { usePaletteOps } from '../../../contexts/PaletteOpsContext';
 import type { PendingPermissionRequest, SessionNavigationOptions } from '../types/types';
 import type { ProjectSession, LLMProvider } from '../../../types/app';
@@ -285,6 +286,11 @@ export function useChatRealtimeHandlers({
           break;
         }
 
+        // Play completion sound if enabled
+        if (isNotificationSoundEnabled()) {
+          playCompletionSound();
+        }
+
         const actualSessionId =
           typeof msg.actualSessionId === 'string' && msg.actualSessionId.trim().length > 0
             ? msg.actualSessionId
@@ -306,9 +312,31 @@ export function useChatRealtimeHandlers({
             onNavigateToSession?.(actualSessionId, { replace: true });
             setTimeout(() => { void paletteOps.refreshProjects(); }, 500);
           }
+
+          // Refresh from server using the resolved session ID so we fetch the
+          // correct canonical JSONL history, replacing any client-side streaming
+          // echoes with committed messages.
+          void sessionStore.refreshFromServer(actualSessionId);
           break;
         }
 
+        // Clear pending session if we reached this far (complete event, not aborted)
+        const pendingSessionId = sessionStorage.getItem('pendingSessionId');
+        if (pendingSessionId && !currentSessionId) {
+          const resolvedSessionId = actualSessionId || pendingSessionId;
+          setCurrentSessionId(resolvedSessionId);
+          if (actualSessionId) {
+            onNavigateToSession?.(resolvedSessionId, { replace: true });
+          }
+          sessionStorage.removeItem('pendingSessionId');
+          setTimeout(() => { void paletteOps.refreshProjects(); }, 500);
+        }
+
+        // Refresh from server so the canonical JSONL history replaces any
+        // client-side streaming echoes with committed messages.
+        if (sid) {
+          void sessionStore.refreshFromServer(sid);
+        }
         break;
       }
 

--- a/src/components/chat/hooks/useChatSessionState.ts
+++ b/src/components/chat/hooks/useChatSessionState.ts
@@ -256,9 +256,14 @@ export function useChatSessionState({
 
   const chatMessages = useMemo(() => {
     const all = normalizedToChatMessages(storeMessages);
-    // Show pending user message when no session data exists yet (new session, pre-backend-response)
-    if (pendingUserMessage && all.length === 0) {
-      return [pendingUserMessage];
+    // Show pending user message until a user message actually appears in the store.
+    // This covers both the "no messages yet" case and the race condition where
+    // `stream_delta` (AI content) arrives in realtime before the echoed user
+    // message — without this check the pending message would disappear and the
+    // AI response would briefly appear as the first visible message.
+    const hasUserMessage = all.some((m) => m.type === 'user');
+    if (pendingUserMessage && !hasUserMessage) {
+      return [...all, pendingUserMessage];
     }
     if (viewHiddenCount > 0 && viewHiddenCount < all.length) return all.slice(0, -viewHiddenCount);
     return all;
@@ -344,24 +349,13 @@ export function useChatSessionState({
     [hasMoreMessages, isLoadingMoreMessages, selectedProject, selectedSession, sessionStore],
   );
 
-  const handleScroll = useCallback(async () => {
+  const handleScroll = useCallback(() => {
     const container = scrollContainerRef.current;
     if (!container) return;
 
     const nearBottom = isNearBottom();
     setIsUserScrolledUp(!nearBottom);
-
-    if (!allMessagesLoadedRef.current) {
-      const scrolledNearTop = container.scrollTop < 100;
-      if (!scrolledNearTop) { topLoadLockRef.current = false; return; }
-      if (topLoadLockRef.current) {
-        if (container.scrollTop > 20) topLoadLockRef.current = false;
-        return;
-      }
-      const didLoad = await loadOlderMessages(container);
-      if (didLoad) topLoadLockRef.current = true;
-    }
-  }, [isNearBottom, loadOlderMessages]);
+  }, [isNearBottom]);
 
   useLayoutEffect(() => {
     if (!pendingScrollRestoreRef.current || !scrollContainerRef.current) return;
@@ -701,23 +695,10 @@ export function useChatSessionState({
     }
   }, [currentSessionId, isLoading, processingSessions, selectedSession?.id]);
 
-  // "Load all" overlay
-  const prevLoadingRef = useRef(false);
+  // "Load more" buttons — show whenever there are more messages
   useEffect(() => {
-    const wasLoading = prevLoadingRef.current;
-    prevLoadingRef.current = isLoadingMoreMessages;
-
-    if (wasLoading && !isLoadingMoreMessages && hasMoreMessages) {
-      if (loadAllOverlayTimerRef.current) clearTimeout(loadAllOverlayTimerRef.current);
-      setShowLoadAllOverlay(true);
-      loadAllOverlayTimerRef.current = setTimeout(() => setShowLoadAllOverlay(false), 2000);
-    }
-    if (!hasMoreMessages && !isLoadingMoreMessages) {
-      if (loadAllOverlayTimerRef.current) clearTimeout(loadAllOverlayTimerRef.current);
-      setShowLoadAllOverlay(false);
-    }
-    return () => { if (loadAllOverlayTimerRef.current) clearTimeout(loadAllOverlayTimerRef.current); };
-  }, [isLoadingMoreMessages, hasMoreMessages]);
+    setShowLoadAllOverlay(hasMoreMessages && !allMessagesLoaded);
+  }, [hasMoreMessages, allMessagesLoaded]);
 
   const loadAllMessages = useCallback(async () => {
     if (!selectedSession || !selectedProject) return;
@@ -777,6 +758,20 @@ export function useChatSessionState({
     setVisibleMessageCount((prev) => prev + 100);
   }, []);
 
+  const loadMoreMessages = useCallback(async () => {
+    topLoadLockRef.current = false;
+    const container = scrollContainerRef.current;
+    if (!container) return;
+    setIsLoadingMoreMessages(true);
+    try {
+      await loadOlderMessages(container);
+    } catch (error) {
+      console.error('[useChatSessionState] loadMoreMessages failed:', error);
+    } finally {
+      setIsLoadingMoreMessages(false);
+    }
+  }, [loadOlderMessages]);
+
   return {
     chatMessages,
     addMessage,
@@ -800,6 +795,7 @@ export function useChatSessionState({
     visibleMessages,
     loadEarlierMessages,
     loadAllMessages,
+    loadMoreMessages,
     allMessagesLoaded,
     isLoadingAllMessages,
     loadAllJustFinished,

--- a/src/components/chat/view/ChatInterface.tsx
+++ b/src/components/chat/view/ChatInterface.tsx
@@ -15,6 +15,7 @@ import { useSessionStore } from '../../../stores/useSessionStore';
 import ChatMessagesPane from './subcomponents/ChatMessagesPane';
 import ChatComposer from './subcomponents/ChatComposer';
 import CommandResultModal from './subcomponents/CommandResultModal';
+import ScrollNavigation from './subcomponents/ScrollNavigation';
 
 
 type PendingViewSession = {
@@ -110,10 +111,10 @@ function ChatInterface({
     visibleMessages,
     loadEarlierMessages,
     loadAllMessages,
+    loadMoreMessages,
     allMessagesLoaded,
     isLoadingAllMessages,
     loadAllJustFinished,
-    showLoadAllOverlay,
     claudeStatus,
     setClaudeStatus,
     createDiff,
@@ -309,7 +310,18 @@ function ChatInterface({
   return (
     <PermissionContext.Provider value={permissionContextValue}>
       <div className="flex h-full flex-col">
-        <ChatMessagesPane
+        <div className="relative flex-1">
+          <ScrollNavigation
+            scrollContainerRef={scrollContainerRef}
+            chatMessages={chatMessages}
+            loadAllMessages={loadAllMessages}
+            allMessagesLoaded={allMessagesLoaded}
+            hasMoreMessages={hasMoreMessages}
+            totalMessages={totalMessages}
+            sessionMessagesCount={chatMessages.length}
+          />
+          <div className="absolute inset-0">
+          <ChatMessagesPane
           scrollContainerRef={scrollContainerRef}
           onWheel={handleScroll}
           onTouchMove={handleScroll}
@@ -344,10 +356,10 @@ function ChatInterface({
           visibleMessages={visibleMessages}
           loadEarlierMessages={loadEarlierMessages}
           loadAllMessages={loadAllMessages}
+          loadMoreMessages={loadMoreMessages}
           allMessagesLoaded={allMessagesLoaded}
           isLoadingAllMessages={isLoadingAllMessages}
           loadAllJustFinished={loadAllJustFinished}
-          showLoadAllOverlay={showLoadAllOverlay}
           createDiff={createDiff}
           onFileOpen={onFileOpen}
           onShowSettings={onShowSettings}
@@ -357,6 +369,8 @@ function ChatInterface({
           showThinking={showThinking}
           selectedProject={selectedProject}
         />
+          </div>
+        </div>
 
         <ChatComposer
           pendingPermissionRequests={pendingPermissionRequests}

--- a/src/components/chat/view/subcomponents/ChatMessagesPane.tsx
+++ b/src/components/chat/view/subcomponents/ChatMessagesPane.tsx
@@ -49,10 +49,10 @@ interface ChatMessagesPaneProps {
   visibleMessages: ChatMessage[];
   loadEarlierMessages: () => void;
   loadAllMessages: () => void;
+  loadMoreMessages: () => void;
   allMessagesLoaded: boolean;
   isLoadingAllMessages: boolean;
   loadAllJustFinished: boolean;
-  showLoadAllOverlay: boolean;
   createDiff: any;
   onFileOpen?: (filePath: string, diffInfo?: unknown) => void;
   onShowSettings?: () => void;
@@ -98,10 +98,10 @@ export default function ChatMessagesPane({
   visibleMessages,
   loadEarlierMessages,
   loadAllMessages,
+  loadMoreMessages,
   allMessagesLoaded,
   isLoadingAllMessages,
   loadAllJustFinished,
-  showLoadAllOverlay,
   createDiff,
   onFileOpen,
   onShowSettings,
@@ -145,7 +145,7 @@ export default function ChatMessagesPane({
       ref={scrollContainerRef}
       onWheel={onWheel}
       onTouchMove={onTouchMove}
-      className="relative flex-1 space-y-3 overflow-y-auto overflow-x-hidden px-0 py-3 sm:space-y-4 sm:p-4"
+      className="relative h-full space-y-3 overflow-y-auto overflow-x-hidden px-0 py-3 sm:space-y-4 sm:p-4"
     >
       {isLoadingSessionMessages && chatMessages.length === 0 ? (
         <div className="mt-8 text-center text-gray-500 dark:text-gray-400">
@@ -180,55 +180,53 @@ export default function ChatMessagesPane({
         />
       ) : (
         <>
-          {/* Loading indicator for older messages (hide when load-all is active) */}
-          {isLoadingMoreMessages && !isLoadingAllMessages && !allMessagesLoaded && (
+          {/* Loading indicator for older messages */}
+          {(isLoadingMoreMessages || isLoadingAllMessages) && !allMessagesLoaded && (
             <div className="py-3 text-center text-gray-500 dark:text-gray-400">
               <div className="flex items-center justify-center space-x-2">
                 <div className="h-4 w-4 animate-spin rounded-full border-b-2 border-gray-400" />
-                <p className="text-sm">{t('session.loading.olderMessages')}</p>
+                <p className="text-sm">{isLoadingAllMessages ? t('session.messages.loadingAll') : t('session.loading.olderMessages')}</p>
               </div>
             </div>
           )}
 
-          {/* Indicator showing there are more messages to load (hide when all loaded) */}
-          {hasMoreMessages && !isLoadingMoreMessages && !allMessagesLoaded && (
+          {/* "Load more" buttons — show when there are more messages */}
+          {hasMoreMessages && !isLoadingMoreMessages && !isLoadingAllMessages && !allMessagesLoaded && (
             <div className="border-b border-gray-200 py-2 text-center text-sm text-gray-500 dark:border-gray-700 dark:text-gray-400">
               {totalMessages > 0 && (
                 <span>
                   {t('session.messages.showingOf', { shown: sessionMessagesCount, total: totalMessages })}{' '}
-                  <span className="text-xs">{t('session.messages.scrollToLoad')}</span>
                 </span>
               )}
+              <div className="mt-1.5 flex items-center justify-center gap-3">
+                <button
+                  className="flex items-center space-x-1 rounded-full bg-gray-200 px-3 py-1 text-xs font-medium text-gray-700 shadow transition-all duration-200 hover:bg-gray-300 dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600"
+                  onClick={loadMoreMessages}
+                >
+                  <svg className="h-3 w-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 14l-7 7m0 0l-7-7m7 7V3" />
+                  </svg>
+                  <span>{t('session.messages.loadMore', { count: 20 }) || `加载更多(20条)`}</span>
+                </button>
+                <button
+                  className="flex items-center space-x-1 rounded-full bg-blue-600 px-3 py-1 text-xs font-medium text-white shadow transition-all duration-200 hover:scale-105 hover:bg-blue-700 dark:bg-blue-500 dark:hover:bg-blue-600"
+                  onClick={loadAllMessages}
+                >
+                  <span>{t('session.messages.loadAll')} {totalMessages > 0 && `(${totalMessages})`}</span>
+                </button>
+              </div>
             </div>
           )}
 
-          {/* Floating "Load all messages" overlay */}
-          {(showLoadAllOverlay || isLoadingAllMessages || loadAllJustFinished) && (
+          {/* "All loaded" success indicator */}
+          {loadAllJustFinished && (
             <div className="pointer-events-none sticky top-2 z-20 flex justify-center">
-              {loadAllJustFinished ? (
-                <div className="flex items-center space-x-2 rounded-full bg-green-600 px-4 py-1.5 text-xs font-medium text-white shadow-lg dark:bg-green-500">
-                  <svg className="h-3 w-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={3} d="M5 13l4 4L19 7" />
-                  </svg>
-                  <span>{t('session.messages.allLoaded')}</span>
-                </div>
-              ) : (
-                <button
-                  className="pointer-events-auto flex items-center space-x-2 rounded-full bg-blue-600 px-4 py-1.5 text-xs font-medium text-white shadow-lg transition-all duration-200 hover:scale-105 hover:bg-blue-700 disabled:cursor-wait disabled:opacity-75 dark:bg-blue-500 dark:hover:bg-blue-600"
-                  onClick={loadAllMessages}
-                  disabled={isLoadingAllMessages}
-                >
-                  {isLoadingAllMessages && (
-                    <div className="h-3 w-3 animate-spin rounded-full border-2 border-white/30 border-t-white" />
-                  )}
-                  <span>
-                    {isLoadingAllMessages
-                      ? t('session.messages.loadingAll')
-                      : <>{t('session.messages.loadAll')} {totalMessages > 0 && `(${totalMessages})`}</>
-                    }
-                  </span>
-                </button>
-              )}
+              <div className="flex items-center space-x-2 rounded-full bg-green-600 px-4 py-1.5 text-xs font-medium text-white shadow-lg dark:bg-green-500">
+                <svg className="h-3 w-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={3} d="M5 13l4 4L19 7" />
+                </svg>
+                <span>{t('session.messages.allLoaded')}</span>
+              </div>
             </div>
           )}
 

--- a/src/components/chat/view/subcomponents/ChatMessagesPane.tsx
+++ b/src/components/chat/view/subcomponents/ChatMessagesPane.tsx
@@ -206,7 +206,7 @@ export default function ChatMessagesPane({
                   <svg className="h-3 w-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 14l-7 7m0 0l-7-7m7 7V3" />
                   </svg>
-                  <span>{t('session.messages.loadMore', { count: 20 }) || `加载更多(20条)`}</span>
+                  <span>{t('session.messages.loadMore', { count: 20 })}</span>
                 </button>
                 <button
                   className="flex items-center space-x-1 rounded-full bg-blue-600 px-3 py-1 text-xs font-medium text-white shadow transition-all duration-200 hover:scale-105 hover:bg-blue-700 dark:bg-blue-500 dark:hover:bg-blue-600"

--- a/src/components/chat/view/subcomponents/ScrollNavigation.tsx
+++ b/src/components/chat/view/subcomponents/ScrollNavigation.tsx
@@ -105,14 +105,25 @@ export default function ScrollNavigation({
         return;
       }
 
-      const scrollRatio = scrollTop / maxScroll;
       const totalUserMessages = userMessages.length;
       if (totalUserMessages <= 1) {
         setActiveDotIndex(0);
         return;
       }
 
-      const activeIdx = Math.round(scrollRatio * (totalUserMessages - 1));
+      // Use DOM element positions instead of scroll ratio —
+      // messages have varying heights so ratio-based indexing drifts.
+      const elements = container.querySelectorAll<HTMLDivElement>('.chat-message.user');
+      const viewportCenter = scrollTop + clientHeight / 2;
+      let activeIdx = elements.length - 1;
+      for (let i = 0; i < elements.length; i++) {
+        const top = elements[i].getBoundingClientRect().top - container.getBoundingClientRect().top + scrollTop;
+        if (top <= viewportCenter) {
+          activeIdx = i;
+        } else {
+          break;
+        }
+      }
       if (mountedRef.current) setActiveDotIndex(activeIdx);
     });
   }, [scrollContainerRef, userMessages.length]);

--- a/src/components/chat/view/subcomponents/ScrollNavigation.tsx
+++ b/src/components/chat/view/subcomponents/ScrollNavigation.tsx
@@ -1,0 +1,343 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import type { ChatMessage } from '../../types/types';
+import Tooltip from '../../../../shared/view/ui/Tooltip';
+
+interface ScrollNavigationProps {
+  scrollContainerRef: React.RefObject<HTMLDivElement | null>;
+  chatMessages: ChatMessage[];
+  loadAllMessages?: () => void;
+  allMessagesLoaded?: boolean;
+  hasMoreMessages?: boolean;
+  totalMessages?: number;
+  sessionMessagesCount?: number;
+}
+
+function truncateSnippet(content: string): string {
+  return (content || '')
+    .replace(/\n/g, ' ')
+    .trim()
+    .slice(0, 60) + ((content || '').length > 60 ? '...' : '');
+}
+
+function ArrowUpIcon() {
+  return (
+    <svg width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
+      <path d="M9 7L6 4L3 7" />
+    </svg>
+  );
+}
+
+function ArrowDownIcon() {
+  return (
+    <svg width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
+      <path d="M3 5L6 8L9 5" />
+    </svg>
+  );
+}
+
+function TopIcon() {
+  return (
+    <svg width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
+      <path d="M2 5h8" />
+      <path d="M6 2L3.5 5.5h5z" />
+    </svg>
+  );
+}
+
+function BottomIcon() {
+  return (
+    <svg width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
+      <path d="M3.5 6.5L6 10l2.5-3.5" />
+      <path d="M2 7h8" />
+    </svg>
+  );
+}
+
+function LoadAllIcon() {
+  return (
+    <svg width="10" height="10" viewBox="0 0 10 10" fill="none" stroke="currentColor" strokeWidth="1.5">
+      <path d="M1 3h8M1 5h6M1 7h7" />
+    </svg>
+  );
+}
+
+/** Vertical scroll navigation strip with dots, quick-jump buttons, and load-more controls. */
+export default function ScrollNavigation({
+  scrollContainerRef,
+  chatMessages,
+  loadAllMessages,
+  allMessagesLoaded = true,
+  hasMoreMessages = false,
+  totalMessages = 0,
+  sessionMessagesCount = 0,
+}: ScrollNavigationProps) {
+  const { t } = useTranslation('chat');
+  const [activeDotIndex, setActiveDotIndex] = useState(-1);
+  const [isStripHovered, setIsStripHovered] = useState(false);
+  const rafIdRef = useRef<number | null>(null);
+  const mountedRef = useRef(true);
+  const skipUpdateRef = useRef(false);
+
+  const userMessages = useMemo(
+    () => chatMessages.filter((m) => m.type === 'user'),
+    [chatMessages],
+  );
+
+  const shouldShow = chatMessages.length >= 1;
+  const hasMore = hasMoreMessages;
+
+  const scheduleUpdate = useCallback(() => {
+    if (rafIdRef.current != null) return;
+    rafIdRef.current = requestAnimationFrame(() => {
+      rafIdRef.current = null;
+      if (skipUpdateRef.current) {
+        skipUpdateRef.current = false;
+        return;
+      }
+      const container = scrollContainerRef.current;
+      if (!container) return;
+
+      const { scrollTop, scrollHeight, clientHeight } = container;
+      const maxScroll = scrollHeight - clientHeight;
+      if (maxScroll <= 0) {
+        setActiveDotIndex(userMessages.length > 0 ? userMessages.length - 1 : -1);
+        return;
+      }
+
+      const scrollRatio = scrollTop / maxScroll;
+      const totalUserMessages = userMessages.length;
+      if (totalUserMessages <= 1) {
+        setActiveDotIndex(0);
+        return;
+      }
+
+      const activeIdx = Math.round(scrollRatio * (totalUserMessages - 1));
+      if (mountedRef.current) setActiveDotIndex(activeIdx);
+    });
+  }, [scrollContainerRef, userMessages.length]);
+
+  useEffect(() => {
+    const container = scrollContainerRef.current;
+    if (!container) return;
+    container.addEventListener('scroll', scheduleUpdate, { passive: true });
+    return () => container.removeEventListener('scroll', scheduleUpdate);
+  }, [scrollContainerRef, scheduleUpdate]);
+
+  useEffect(() => {
+    const timer = setTimeout(() => scheduleUpdate(), 200);
+    return () => clearTimeout(timer);
+  }, [chatMessages.length, scheduleUpdate]);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+      if (rafIdRef.current != null) cancelAnimationFrame(rafIdRef.current);
+    };
+  }, []);
+
+  const scrollToDot = useCallback(
+    (index: number) => {
+      setActiveDotIndex(index);
+      skipUpdateRef.current = true;
+      const container = scrollContainerRef.current;
+      if (!container) return;
+
+      const elements = container.querySelectorAll<HTMLDivElement>('.chat-message.user');
+      if (elements.length > index) {
+        elements[index].scrollIntoView({ block: 'center', behavior: 'instant' });
+        return;
+      }
+
+      const totalUserMessages = userMessages.length;
+      if (totalUserMessages <= 1) return;
+
+      const targetRatio = index / (totalUserMessages - 1);
+      const maxScroll = container.scrollHeight - container.clientHeight;
+      container.scrollTop = targetRatio * maxScroll;
+    },
+    [scrollContainerRef, userMessages.length],
+  );
+
+  const scrollToTop = useCallback(() => {
+    const container = scrollContainerRef.current;
+    if (!container) return;
+
+    container.scrollTop = 0;
+  }, [scrollContainerRef]);
+
+  const scrollToBottom = useCallback(() => {
+    const container = scrollContainerRef.current;
+    if (!container) return;
+
+    container.scrollTop = container.scrollHeight;
+  }, [scrollContainerRef]);
+
+  const scrollPrev = useCallback(() => {
+    const container = scrollContainerRef.current;
+    if (!container) return;
+
+    const elements = container.querySelectorAll<HTMLDivElement>('.chat-message.user');
+    if (elements.length === 0) return;
+
+    const { scrollTop, clientHeight } = container;
+    const viewportCenter = scrollTop + clientHeight / 2;
+
+    let currentIndex = 0;
+    for (let i = 0; i < elements.length; i++) {
+      const top = elements[i].getBoundingClientRect().top - container.getBoundingClientRect().top + scrollTop;
+      if (top <= viewportCenter) {
+        currentIndex = i;
+      } else {
+        break;
+      }
+    }
+
+    const targetIndex = Math.max(0, currentIndex - 1);
+    elements[targetIndex].scrollIntoView({ block: 'center', behavior: 'instant' });
+  }, [scrollContainerRef]);
+
+  const scrollNext = useCallback(() => {
+    const container = scrollContainerRef.current;
+    if (!container) return;
+
+    const elements = container.querySelectorAll<HTMLDivElement>('.chat-message.user');
+    if (elements.length === 0) return;
+
+    const { scrollTop, clientHeight } = container;
+    const viewportCenter = scrollTop + clientHeight / 2;
+
+    let currentIndex = elements.length - 1;
+    for (let i = elements.length - 1; i >= 0; i--) {
+      const top = elements[i].getBoundingClientRect().top - container.getBoundingClientRect().top + scrollTop;
+      if (top <= viewportCenter) {
+        currentIndex = i;
+        break;
+      }
+    }
+
+    const targetIndex = Math.min(elements.length - 1, currentIndex + 1);
+    elements[targetIndex].scrollIntoView({ block: 'center', behavior: 'instant' });
+  }, [scrollContainerRef]);
+
+  if (!shouldShow) return null;
+
+  const hasUserMessages = userMessages.length > 0;
+  const navButtons = [
+    {
+      label: t('scrollNav.first'),
+      icon: <TopIcon />,
+      action: scrollToTop,
+      disabled: false,
+    },
+    {
+      label: t('scrollNav.previous'),
+      icon: <ArrowUpIcon />,
+      action: scrollPrev,
+      disabled: !hasUserMessages,
+    },
+    {
+      label: t('scrollNav.next'),
+      icon: <ArrowDownIcon />,
+      action: scrollNext,
+      disabled: !hasUserMessages,
+    },
+    {
+      label: t('scrollNav.last'),
+      icon: <BottomIcon />,
+      action: scrollToBottom,
+      disabled: false,
+    },
+  ];
+
+  return (
+    <div
+      className="pointer-events-none absolute right-0 top-0 z-10 h-full"
+    >
+      <div
+        className={`pointer-events-auto flex h-full flex-col items-center rounded-full border backdrop-blur-sm transition-all duration-200 ${
+          isStripHovered
+            ? 'w-10 opacity-100'
+            : 'w-2 opacity-50'
+        } bg-background/80 border-border/50`}
+        onMouseEnter={() => setIsStripHovered(true)}
+        onMouseLeave={() => setIsStripHovered(false)}
+      >
+        {/* Nav buttons section */}
+        <div className="flex flex-col items-center gap-1 py-1">
+          {hasMore && loadAllMessages && (
+            <Tooltip content={t('scrollNav.loadAll')} position="left" delay={150}>
+              <button
+                type="button"
+                onClick={loadAllMessages}
+                className="rounded p-1 text-muted-foreground transition-all duration-150 hover:text-foreground"
+                aria-label={t('scrollNav.loadAll')}
+              >
+                <LoadAllIcon />
+              </button>
+            </Tooltip>
+          )}
+
+          {navButtons.map((btn) => (
+            <Tooltip key={btn.label} content={btn.label} position="left" delay={150}>
+              <button
+                type="button"
+                onClick={btn.action}
+                disabled={btn.disabled}
+                className={`rounded p-1 transition-all duration-150 ${
+                  btn.disabled
+                    ? 'text-muted-foreground/30 cursor-default'
+                    : 'text-muted-foreground hover:text-foreground'
+                }`}
+                aria-label={btn.label}
+              >
+                {btn.icon}
+              </button>
+            </Tooltip>
+          ))}
+        </div>
+
+        {/* Dots section — only render when there are user messages */}
+        {userMessages.length > 0 && (
+          <>
+            {/* Divider */}
+            <div className={`mx-auto my-0.5 border-t border-border/40 transition-all duration-150 ${
+              isStripHovered ? 'w-5 opacity-100' : 'w-0 opacity-0'
+            }`} />
+
+            <div className="flex flex-1 w-full flex-col items-center justify-evenly px-0 py-1">
+              {userMessages.map((msg, i) => {
+                const isActive = i === activeDotIndex;
+                const snippet = truncateSnippet(msg.content || '');
+
+                return (
+                  <Tooltip
+                    key={`${i}-${String(msg.timestamp).slice(0, 8)}`}
+                    content={t('scrollNav.jumpToMessage', {
+                      index: i + 1,
+                      snippet,
+                    })}
+                    position="left"
+                    delay={150}
+                  >
+                    <button
+                      type="button"
+                      onClick={() => scrollToDot(i)}
+                      className={`block cursor-pointer rounded-full transition-all duration-150 ${
+                        isActive
+                          ? 'h-[10px] w-[10px] bg-blue-500 hover:bg-blue-400'
+                          : 'h-[7px] w-[7px] bg-muted-foreground/70 hover:bg-muted-foreground hover:h-[9px] hover:w-[9px]'
+                      }`}
+                      aria-label={t('scrollNav.jumpToMessage', { index: i + 1 })}
+                    />
+                  </Tooltip>
+                );
+              })}
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/i18n/locales/de/chat.json
+++ b/src/i18n/locales/de/chat.json
@@ -235,5 +235,14 @@
   },
   "tasks": {
     "nextTaskPrompt": "Nächste Aufgabe starten"
+  },
+  "scrollNav": {
+    "jumpTo": "Springe zu: {{snippet}}",
+    "jumpToMessage": "Springe zu Nachricht {{index}}",
+    "loadAll": "Alle laden",
+    "first": "Erste",
+    "previous": "Vorherige",
+    "next": "Nächste",
+    "last": "Letzte"
   }
 }

--- a/src/i18n/locales/en/chat.json
+++ b/src/i18n/locales/en/chat.json
@@ -174,6 +174,7 @@
       "showingLast": "Showing last {{count}} messages ({{total}} total)",
       "loadEarlier": "Load earlier messages",
       "loadAll": "Load all messages",
+      "loadMore": "Load {{count}} more",
       "loadingAll": "Loading all messages...",
       "allLoaded": "All messages loaded",
       "perfWarning": "All messages loaded — scrolling may be slower. Click \"Scroll to bottom\" to restore performance."
@@ -237,5 +238,16 @@
   },
   "tasks": {
     "nextTaskPrompt": "Start the next task"
+  },
+  "scrollNav": {
+    "jumpTo": "Jump to: {{snippet}}",
+    "jumpToMessage": "Jump to message {{index}}",
+    "fromYou": "You",
+    "aiReply": "AI Reply",
+    "loadAll": "Load all",
+    "first": "Top",
+    "previous": "Previous",
+    "next": "Next",
+    "last": "Bottom"
   }
 }

--- a/src/i18n/locales/it/chat.json
+++ b/src/i18n/locales/it/chat.json
@@ -235,5 +235,14 @@
   },
   "tasks": {
     "nextTaskPrompt": "Inizia l'attività successiva"
+  },
+  "scrollNav": {
+    "jumpTo": "Vai a: {{snippet}}",
+    "jumpToMessage": "Vai al messaggio {{index}}",
+    "loadAll": "Carica tutto",
+    "first": "Primo",
+    "previous": "Precedente",
+    "next": "Successivo",
+    "last": "Ultimo"
   }
 }

--- a/src/i18n/locales/ja/chat.json
+++ b/src/i18n/locales/ja/chat.json
@@ -202,5 +202,14 @@
     "providers": {
       "assistant": "Assistant"
     }
+  },
+  "scrollNav": {
+    "jumpTo": "ジャンプ: {{snippet}}",
+    "jumpToMessage": "{{index}}番目のメッセージに移動",
+    "loadAll": "全ロード",
+    "first": "最初",
+    "previous": "前へ",
+    "next": "次へ",
+    "last": "最後"
   }
 }

--- a/src/i18n/locales/ko/chat.json
+++ b/src/i18n/locales/ko/chat.json
@@ -217,5 +217,14 @@
   },
   "tasks": {
     "nextTaskPrompt": "다음 작업 시작"
+  },
+  "scrollNav": {
+    "jumpTo": "이동: {{snippet}}",
+    "jumpToMessage": "{{index}}번 메시지로 이동",
+    "loadAll": "전체 로드",
+    "first": "첫 번째",
+    "previous": "이전",
+    "next": "다음",
+    "last": "마지막"
   }
 }

--- a/src/i18n/locales/ru/chat.json
+++ b/src/i18n/locales/ru/chat.json
@@ -235,5 +235,14 @@
   },
   "tasks": {
     "nextTaskPrompt": "Начать следующую задачу"
+  },
+  "scrollNav": {
+    "jumpTo": "Перейти к: {{snippet}}",
+    "jumpToMessage": "Перейти к сообщению {{index}}",
+    "loadAll": "Загрузить всё",
+    "first": "Первое",
+    "previous": "Предыдущее",
+    "next": "Следующее",
+    "last": "Последнее"
   }
 }

--- a/src/i18n/locales/tr/chat.json
+++ b/src/i18n/locales/tr/chat.json
@@ -235,5 +235,14 @@
   },
   "tasks": {
     "nextTaskPrompt": "Sonraki görevi başlat"
+  },
+  "scrollNav": {
+    "jumpTo": "Git: {{snippet}}",
+    "jumpToMessage": "{{index}}. mesaja git",
+    "loadAll": "Tümünü yükle",
+    "first": "İlk",
+    "previous": "Önceki",
+    "next": "Sonraki",
+    "last": "Son"
   }
 }

--- a/src/i18n/locales/zh-CN/chat.json
+++ b/src/i18n/locales/zh-CN/chat.json
@@ -154,6 +154,7 @@
       "showingLast": "显示最近 {{count}} 条消息（共 {{total}} 条）",
       "loadEarlier": "加载更早的消息",
       "loadAll": "加载全部消息",
+      "loadMore": "加载更多({{count}}条)",
       "loadingAll": "正在加载全部消息...",
       "allLoaded": "全部消息已加载",
       "perfWarning": "已加载全部消息 - 滚动可能变慢。点击「滚动到底部」恢复性能。"
@@ -217,5 +218,16 @@
   },
   "tasks": {
     "nextTaskPrompt": "开始下一个任务"
+  },
+  "scrollNav": {
+    "jumpTo": "跳转到: {{snippet}}",
+    "jumpToMessage": "跳转到第 {{index}} 条消息",
+    "fromYou": "你",
+    "aiReply": "AI 回复",
+    "loadAll": "加载全部",
+    "first": "顶部",
+    "previous": "上一条",
+    "next": "下一条",
+    "last": "底部"
   }
 }


### PR DESCRIPTION
## Summary / 摘要
- Add scroll navigation bar with dot indicators for each user message — 添加滚动导航栏，每个用户消息对应一个圆点
- Previous/Next buttons for sequential navigation — 上一条/下一条按钮顺序导航
- First/Last buttons for quick jump to start/end — 顶部/底部按钮快速跳转
- Load all button when messages are paginated — 消息分页时显示"加载全部"按钮
- Improve message loading with explicit `loadMoreMessages` callback — 改进消息加载机制
- Fix `pendingUserMessage` visibility with `hasUserMessage` check — 修复待发送消息可见性
- Add i18n strings for scroll navigation in 8 languages — 添加8种语言国际化字符串

## Test plan / 测试
- [ ] Open a long session with many user messages — scroll navigation should appear — 打开长会话应显示导航栏
- [ ] Click dots to jump between messages — 点击圆点跳转消息
- [ ] Test Previous/Next buttons — 测试顺序导航
- [ ] Test First/Last buttons — 测试快速跳转
- [ ] Verify Load All button works when paginated — 验证分页时加载全部功能
- [ ] Navigation should disappear when no user messages — 无用户消息时导航栏应隐藏

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Chat navigation strip with message jump dots, first/previous/next/last buttons, and a "load all" control
  * Exposed an explicit "Load More" action for older messages
  * Plays a completion notification sound when enabled

* **Bug Fixes**
  * Prevents pending user messages from disappearing during realtime streaming
  * Stricter task-notification parsing to reduce false positives

* **Localization**
  * Added translations for navigation and message-loading controls in multiple languages

* **UX**
  * Simplified "load all" indicators and added a concise success feedback indicator
<!-- end of auto-generated comment: release notes by coderabbit.ai -->