### PR TITLE
fix(gemini): graceful fallback for stale Gemini session IDs on resume

### DIFF
--- a/server/gemini-cli.js
+++ b/server/gemini-cli.js
@@ -130,6 +130,7 @@ async function spawnGemini(command, options = {}, ws) {
     let sessionCreatedSent = false; // Track if we've already sent session-created event
     let assistantBlocks = []; // Accumulate the full response blocks including tools
     let stderrHasInvalidSession = false; // Detect stale cliSessionId errors
+    let invalidSessionStderrBuffer = []; // Hold invalid-session messages until we know if we'll retry
 
     // Use tools settings passed from frontend, or defaults
     const settings = toolsSettings || {
@@ -470,11 +471,20 @@ async function spawnGemini(command, options = {}, ws) {
                 return;
             }
 
+            const socketSessionId = typeof ws.getSessionId === 'function' ? ws.getSessionId() : (capturedSessionId || sessionId);
+
             if (errorMsg.toLowerCase().includes('invalid session identifier')) {
                 stderrHasInvalidSession = true;
             }
 
-            const socketSessionId = typeof ws.getSessionId === 'function' ? ws.getSessionId() : (capturedSessionId || sessionId);
+            // If this is an invalid-session error and a retry is possible, buffer it
+            // rather than sending immediately — it will be discarded on a successful
+            // retry, or flushed to the client if the retry also fails / won't happen.
+            if (stderrHasInvalidSession && !options._retried) {
+                invalidSessionStderrBuffer.push({ errorMsg, socketSessionId });
+                return;
+            }
+
             ws.send(createNormalizedMessage({ kind: 'error', content: errorMsg, sessionId: socketSessionId, provider: 'gemini' }));
         });
 
@@ -497,9 +507,14 @@ async function spawnGemini(command, options = {}, ws) {
                 sessionManager.addMessage(finalSessionId, 'assistant', assistantBlocks);
             }
 
-            // Suppress 'complete' when we're about to retry — the retry emits its own
+            // Suppress 'complete' (and buffered invalid-session errors) when we're
+            // about to retry — the retry emits its own events. If no retry, flush
+            // any buffered messages so the client sees the real error.
             const willRetry = code === 42 && sessionId && stderrHasInvalidSession && !options._retried;
             if (!willRetry) {
+                for (const { errorMsg, socketSessionId } of invalidSessionStderrBuffer) {
+                    ws.send(createNormalizedMessage({ kind: 'error', content: errorMsg, sessionId: socketSessionId, provider: 'gemini' }));
+                }
                 ws.send(createNormalizedMessage({ kind: 'complete', exitCode: code, isNewSession: !sessionId && !!command, sessionId: finalSessionId, provider: 'gemini' }));
             }
 

--- a/server/gemini-cli.js
+++ b/server/gemini-cli.js
@@ -129,6 +129,7 @@ async function spawnGemini(command, options = {}, ws) {
     let capturedSessionId = sessionId; // Track session ID throughout the process
     let sessionCreatedSent = false; // Track if we've already sent session-created event
     let assistantBlocks = []; // Accumulate the full response blocks including tools
+    let stderrHasInvalidSession = false; // Detect stale cliSessionId errors
 
     // Use tools settings passed from frontend, or defaults
     const settings = toolsSettings || {
@@ -147,9 +148,14 @@ async function spawnGemini(command, options = {}, ws) {
 
     // If we have a sessionId, we want to resume
     if (sessionId) {
-        const session = sessionManager.getSession(sessionId);
-        if (session && session.cliSessionId) {
-            args.push('--resume', session.cliSessionId);
+        if (options._resumeLatest) {
+            // Fallback: stale/mismatched cliSessionId — let Gemini pick the newest file
+            args.push('--resume', 'latest');
+        } else {
+            const session = sessionManager.getSession(sessionId);
+            if (session && session.cliSessionId) {
+                args.push('--resume', session.cliSessionId);
+            }
         }
     }
 
@@ -424,7 +430,8 @@ async function spawnGemini(command, options = {}, ws) {
                     }
 
                     const sess = sessionManager.getSession(capturedSessionId);
-                    if (sess && !sess.cliSessionId) {
+                    if (sess) {
+                        // Always refresh so stale IDs from prior Gemini runs are replaced
                         sess.cliSessionId = discoveredSessionId;
                         sessionManager.saveSession(capturedSessionId);
                     }
@@ -463,6 +470,10 @@ async function spawnGemini(command, options = {}, ws) {
                 return;
             }
 
+            if (errorMsg.toLowerCase().includes('invalid session identifier')) {
+                stderrHasInvalidSession = true;
+            }
+
             const socketSessionId = typeof ws.getSessionId === 'function' ? ws.getSessionId() : (capturedSessionId || sessionId);
             ws.send(createNormalizedMessage({ kind: 'error', content: errorMsg, sessionId: socketSessionId, provider: 'gemini' }));
         });
@@ -486,7 +497,11 @@ async function spawnGemini(command, options = {}, ws) {
                 sessionManager.addMessage(finalSessionId, 'assistant', assistantBlocks);
             }
 
-            ws.send(createNormalizedMessage({ kind: 'complete', exitCode: code, isNewSession: !sessionId && !!command, sessionId: finalSessionId, provider: 'gemini' }));
+            // Suppress 'complete' when we're about to retry — the retry emits its own
+            const willRetry = code === 42 && sessionId && stderrHasInvalidSession && !options._retried;
+            if (!willRetry) {
+                ws.send(createNormalizedMessage({ kind: 'complete', exitCode: code, isNewSession: !sessionId && !!command, sessionId: finalSessionId, provider: 'gemini' }));
+            }
 
             // Clean up temporary image files if any
             if (geminiProcess.tempImagePaths && geminiProcess.tempImagePaths.length > 0) {
@@ -501,6 +516,20 @@ async function spawnGemini(command, options = {}, ws) {
             if (code === 0) {
                 notifyTerminalState({ code });
                 resolve();
+            } else if (code === 42 && sessionId && stderrHasInvalidSession && !options._retried) {
+                // Gemini rejected --resume <id> because the stored cliSessionId is stale.
+                // Clear it and retry once with --resume latest so the newest chat file is used.
+                const staleSession = sessionManager.getSession(sessionId);
+                if (staleSession) {
+                    staleSession.cliSessionId = null;
+                    sessionManager.saveSession(sessionId);
+                }
+                try {
+                    await spawnGemini(command, { ...options, _retried: true, _resumeLatest: true }, ws);
+                    resolve();
+                } catch (retryErr) {
+                    reject(retryErr);
+                }
             } else {
                 const socketSessionId = typeof ws.getSessionId === 'function' ? ws.getSessionId() : finalSessionId;
 

--- a/server/gemini-cli.js
+++ b/server/gemini-cli.js
@@ -119,6 +119,29 @@ async function buildGeminiProcessEnv() {
     return processEnv;
 }
 
+/**
+ * Spawns a Gemini CLI process for a given command and streams its output over a WebSocket.
+ *
+ * Handles session resumption (including automatic retry when a stored cliSessionId has gone
+ * stale after a Gemini restart), tool-use permission enforcement, image attachments, and
+ * graceful fallback to `--resume latest` on exit-code 42 + "Invalid session identifier".
+ *
+ * @param {string} command - The user prompt to send to Gemini, or an empty string for a
+ *   passive resume (session reconnect with no new message).
+ * @param {object} [options={}] - Spawn options.
+ * @param {string}  [options.sessionId]      - Existing session ID to resume.
+ * @param {string}  [options.projectPath]    - Gemini metadata directory for the project.
+ * @param {string}  [options.cwd]            - Working directory for the Gemini process.
+ * @param {object}  [options.toolsSettings]  - Allowed/disallowed tools and permission flags.
+ * @param {string}  [options.permissionMode] - Permission mode passed to Gemini.
+ * @param {Array}   [options.images]         - Base-64 image attachments.
+ * @param {string}  [options.sessionSummary] - Optional summary injected into the session.
+ * @param {string}  [options.model]          - Model override; resolved via providerModelsService if omitted.
+ * @param {boolean} [options._retried]       - Internal flag — set on the automatic retry to prevent loops.
+ * @param {boolean} [options._resumeLatest]  - Internal flag — uses `--resume latest` instead of a specific ID.
+ * @param {object} ws - WebSocket-compatible writer used to stream events to the client.
+ * @returns {Promise<void>} Resolves when the Gemini process exits cleanly; rejects on unrecoverable errors.
+ */
 async function spawnGemini(command, options = {}, ws) {
     const { sessionId, projectPath, cwd, toolsSettings, permissionMode, images, sessionSummary } = options;
     const resolvedModel = await providerModelsService.resolveResumeModel(

--- a/server/modules/websocket/services/shell-websocket.service.ts
+++ b/server/modules/websocket/services/shell-websocket.service.ts
@@ -132,7 +132,13 @@ function buildShellCommand(
     }
 
     if (hasSession && resumeId) {
-      return `${command} --resume "${resumeId}"`;
+      // resumeId is the stored cliSessionId. If Gemini restarted since we last
+      // ran, that UUID is gone — fall back to latest (scoped to this project's
+      // chats dir), then to a fresh session as last resort.
+      if (os.platform() === 'win32') {
+        return `${command} --resume "${resumeId}"; if ($LASTEXITCODE -ne 0) { ${command} --resume latest }; if ($LASTEXITCODE -ne 0) { ${command} }`;
+      }
+      return `${command} --resume "${resumeId}" || ${command} --resume latest || ${command}`;
     }
     return command;
   }


### PR DESCRIPTION
## Summary

Fixes the upstream defect where Gemini CLI assigns a new internal session ID on each run, causing all subsequent resume attempts to fail with exit code 42 and \"Invalid session identifier\".

### Chat path (`server/gemini-cli.js`)
- Always refresh `cliSessionId` in the `onInit` handler instead of only writing it once, so the stored value stays current after every run
- On exit code 42 + \"Invalid session identifier\" in stderr: clear the stale `cliSessionId`, suppress the buffered error messages, and retry once with `--resume latest`
- Suppress the `complete` WebSocket event before the retry so the client doesn't receive a spurious exitCode 42 completion followed by a second stream
- Buffer \"invalid session identifier\" stderr lines instead of forwarding immediately — discarded silently on a successful retry, flushed to the client only if the retry also fails

### Terminal/PTY path (`server/modules/websocket/services/shell-websocket.service.ts`)
- The shell path built `gemini --resume "<id>"` with no fallback, leaving the terminal stuck on a stale ID
- Add a three-level fallback: `--resume <id>` → `--resume latest` → fresh session, with a PowerShell-compatible variant on Windows (mirroring how the Claude provider already handles this)

## Test plan

- [ ] Start a Gemini session, send a message, close and reopen — chat should resume without any visible error
- [ ] Open the same session in the terminal tab — should recover via `--resume latest` fallback instead of dying with exit 42
- [ ] Verify that after a successful resume the stored `cliSessionId` is updated (future restarts should also work)
- [ ] Confirm a genuine exit-code-42 (non-session reason) still surfaces an error to the UI and does not trigger a retry loop
- [ ] Verify on Windows that the PowerShell fallback chain behaves correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session resilience: CLI now detects invalid/stale sessions and automatically retries resuming to avoid repeated failures.
  * Single automatic stale-resume retry introduced to recover from transient resume errors.
  * Added fallback resume behavior: if resuming a stored session fails, the system falls back to resuming the latest session, then starts fresh.
  * More reliable session tracking: stored session identifiers are refreshed on init to reduce future resume errors.
  * Reduced noisy error emissions during automatic retry attempts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/siteboon/claudecodeui/pull/812?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->