### PR TITLE
fix: recognize claude auth token env

### DIFF
--- a/server/modules/providers/list/claude/claude-auth.provider.ts
+++ b/server/modules/providers/list/claude/claude-auth.provider.ts
@@ -83,6 +83,10 @@ export class ClaudeProviderAuth implements IProviderAuth {
   private async checkCredentials(): Promise<ClaudeCredentialsStatus> {
     const missingCredentialsError = 'Claude CLI is not authenticated. Run claude /login or configure ANTHROPIC_API_KEY.';
 
+    if (process.env.ANTHROPIC_AUTH_TOKEN?.trim()) {
+      return { authenticated: true, email: 'Auth Token', method: 'api_key' };
+    }
+
     if (process.env.ANTHROPIC_API_KEY?.trim()) {
       return { authenticated: true, email: 'API Key Auth', method: 'api_key' };
     }


### PR DESCRIPTION
This PR supersedes #686.
Closes #686.

The reason for the new pr instead of #686 is, that introduced a lot of changes in the readme and package.json that was not necessary.

## Summary

Adds support for recognizing `ANTHROPIC_AUTH_TOKEN` as a valid Claude authentication signal.

## What Changed

- Updated Claude provider auth detection to check `process.env.ANTHROPIC_AUTH_TOKEN`.
- If `ANTHROPIC_AUTH_TOKEN` is present and non-empty, Claude auth now reports:
  - `authenticated: true`
  - `email: "Auth Token"`
  - `method: "api_key"`
- This check runs before the existing `ANTHROPIC_API_KEY` check.

## Why

Some Claude authentication flows provide credentials through `ANTHROPIC_AUTH_TOKEN` rather than `ANTHROPIC_API_KEY`. Without this check, the app can report Claude as unauthenticated even when a usable auth token is present in the environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added API token-based authentication support for Claude provider, providing users with an additional authentication method option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->