### PR TITLE
feat: use montserrat as app font

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,9 @@
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <link rel="icon" type="image/png" href="/favicon.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0, user-scalable=no, viewport-fit=cover" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600;700;800&display=swap" rel="stylesheet" />
     <title>CloudCLI UI</title>
     
     <!-- PWA Manifest -->

--- a/src/index.css
+++ b/src/index.css
@@ -128,7 +128,7 @@
   
   body {
     @apply bg-background text-foreground;
-    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+    font-family: "Montserrat", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
     margin: 0;
     padding: 0;
   }


### PR DESCRIPTION
## Summary

Updates the app’s main font to Montserrat.

## What Changed

- Added Google Fonts preconnect links for `fonts.googleapis.com` and `fonts.gstatic.com`.
- Added the Montserrat stylesheet with weights `400`, `500`, `600`, `700`, and `800`.
- Updated the global `body` font stack to use Montserrat first, with the existing system sans-serif stack as fallback.

## Why

Montserrat gives the app a more consistent branded typography baseline while preserving reliable fallback behavior across modern browsers.

## Browser Support

Google Fonts serves Montserrat in modern web font formats such as WOFF2, which are supported by all modern browsers. The app also retains the existing fallback stack:

`-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated typography throughout the app to use Montserrat font for improved visual consistency
  * Optimized font loading performance through enhanced delivery methods

<!-- end of auto-generated comment: release notes by coderabbit.ai -->