### PR TITLE
feat(abort): persist partial streamed response to history on Stop Generation

### DIFF
--- a/server/claude-sdk.js
+++ b/server/claude-sdk.js
@@ -790,6 +790,10 @@ async function appendInterruptedAssistantEntry(sessionId, cwd, partialText) {
   let parentUuid = null;
   let detectedModel = 'claude-sonnet-4-6';
   let detectedGitBranch = '';
+  // Safety assumption: interrupt() is called only after this function returns,
+  // so the SDK subprocess cannot write new entries between our read and append.
+  // If that invariant ever changes, replace with an atomic tempfile+rename write
+  // or an explicit file lock to avoid TOCTOU issues.
   try {
     const raw = await fs.readFile(jsonlPath, 'utf8');
     const lines = raw.split('\n').filter(Boolean);

--- a/server/claude-sdk.js
+++ b/server/claude-sdk.js
@@ -233,14 +233,15 @@ function mapCliOptionsToSDK(options = {}) {
  * @param {Array<string>} tempImagePaths - Temp image file paths for cleanup
  * @param {string} tempDir - Temp directory for cleanup
  */
-function addSession(sessionId, queryInstance, tempImagePaths = [], tempDir = null, writer = null) {
+function addSession(sessionId, queryInstance, tempImagePaths = [], tempDir = null, writer = null, cwd = null) {
   activeSessions.set(sessionId, {
     instance: queryInstance,
     startTime: Date.now(),
     status: 'active',
     tempImagePaths,
     tempDir,
-    writer
+    writer,
+    cwd
   });
 }
 
@@ -669,7 +670,7 @@ async function queryClaudeSDK(command, options = {}, ws) {
 
     // Track the query instance for abort capability
     if (capturedSessionId) {
-      addSession(capturedSessionId, queryInstance, tempImagePaths, tempDir, ws);
+      addSession(capturedSessionId, queryInstance, tempImagePaths, tempDir, ws, options.cwd || null);
     }
 
     // Process streaming messages
@@ -679,7 +680,7 @@ async function queryClaudeSDK(command, options = {}, ws) {
       if (message.session_id && !capturedSessionId) {
 
         capturedSessionId = message.session_id;
-        addSession(capturedSessionId, queryInstance, tempImagePaths, tempDir, ws);
+        addSession(capturedSessionId, queryInstance, tempImagePaths, tempDir, ws, options.cwd || null);
 
         // Set session ID on writer
         if (ws.setSessionId && typeof ws.setSessionId === 'function') {
@@ -765,11 +766,110 @@ async function queryClaudeSDK(command, options = {}, ws) {
 }
 
 /**
+ * Encode an absolute working directory the same way the Claude Agent SDK
+ * does when naming its per-project storage folder under ~/.claude/projects/.
+ */
+function encodeProjectDir(cwd) {
+  if (!cwd) return '';
+  return cwd.replace(/\//g, '-');
+}
+
+/**
+ * Append a synthetic assistant entry capturing the partial streamed response
+ * to the SDK's JSONL session history file so Claude sees its interrupted reply
+ * on the next turn.
+ */
+async function appendInterruptedAssistantEntry(sessionId, cwd, partialText) {
+  if (!sessionId || !cwd || typeof partialText !== 'string') return false;
+  const trimmed = partialText.trim();
+  if (!trimmed) return false;
+
+  const projectDir = path.join(os.homedir(), '.claude', 'projects', encodeProjectDir(cwd));
+  const jsonlPath = path.join(projectDir, `${sessionId}.jsonl`);
+
+  let parentUuid = null;
+  let detectedModel = 'claude-sonnet-4-6';
+  let detectedGitBranch = '';
+  try {
+    const raw = await fs.readFile(jsonlPath, 'utf8');
+    const lines = raw.split('\n').filter(Boolean);
+    if (lines.length === 0) return false;
+    const last = JSON.parse(lines[lines.length - 1]);
+    parentUuid = last.uuid || null;
+    if (last.message && last.message.model) detectedModel = last.message.model;
+    if (last.gitBranch) detectedGitBranch = last.gitBranch;
+
+    const lastMsg = last.message || {};
+    if (
+      last.type === 'assistant' &&
+      Array.isArray(lastMsg.content) &&
+      lastMsg.content.some(
+        (b) => b && b.type === 'text' && typeof b.text === 'string' && b.text.includes('[generation interrupted]')
+      )
+    ) {
+      return false;
+    }
+  } catch (err) {
+    if (err && err.code === 'ENOENT') return false;
+    console.warn(`Could not read JSONL for partial-response append (${jsonlPath}):`, err.message);
+    return false;
+  }
+
+  const uuid = (typeof crypto.randomUUID === 'function')
+    ? crypto.randomUUID()
+    : crypto.randomBytes(16).toString('hex');
+
+  const entry = {
+    parentUuid,
+    isSidechain: false,
+    message: {
+      model: detectedModel,
+      id: `msg_interrupted_${uuid.replace(/-/g, '').slice(0, 24)}`,
+      type: 'message',
+      role: 'assistant',
+      content: [
+        {
+          type: 'text',
+          text: `${trimmed}\n\n[generation interrupted]`
+        }
+      ],
+      stop_reason: 'end_turn',
+      stop_sequence: null,
+      usage: {
+        input_tokens: 0,
+        cache_creation_input_tokens: 0,
+        cache_read_input_tokens: 0,
+        output_tokens: 0
+      }
+    },
+    type: 'assistant',
+    uuid,
+    timestamp: new Date().toISOString(),
+    userType: 'external',
+    entrypoint: 'sdk-ts',
+    cwd,
+    sessionId,
+    version: '2.1.118',
+    gitBranch: detectedGitBranch
+  };
+
+  try {
+    await fs.appendFile(jsonlPath, JSON.stringify(entry) + '\n', 'utf8');
+    console.log(`Persisted interrupted assistant partial (${trimmed.length} chars) to ${jsonlPath}`);
+    return true;
+  } catch (err) {
+    console.warn(`Failed to append interrupted assistant entry to ${jsonlPath}:`, err.message);
+    return false;
+  }
+}
+
+/**
  * Aborts an active SDK session
  * @param {string} sessionId - Session identifier
+ * @param {string} [partialResponse] - Partial assistant text captured by the UI
  * @returns {boolean} True if session was aborted, false if not found
  */
-async function abortClaudeSDKSession(sessionId) {
+async function abortClaudeSDKSession(sessionId, partialResponse = '') {
   const session = getSession(sessionId);
 
   if (!session) {
@@ -779,6 +879,15 @@ async function abortClaudeSDKSession(sessionId) {
 
   try {
     console.log(`Aborting SDK session: ${sessionId}`);
+
+    // Persist partial response BEFORE interrupting.
+    if (partialResponse && typeof partialResponse === 'string' && partialResponse.trim()) {
+      try {
+        await appendInterruptedAssistantEntry(sessionId, session.cwd, partialResponse);
+      } catch (writeError) {
+        console.warn('Failed to persist partial response on abort:', writeError?.message || writeError);
+      }
+    }
 
     // Call interrupt() on the query instance
     await session.instance.interrupt();

--- a/server/modules/websocket/services/chat-websocket.service.ts
+++ b/server/modules/websocket/services/chat-websocket.service.ts
@@ -30,7 +30,7 @@ type ChatWebSocketDependencies = {
   queryCodex: (command: string, options: unknown, writer: WebSocketWriter) => Promise<unknown>;
   spawnGemini: (command: string, options: unknown, writer: WebSocketWriter) => Promise<unknown>;
   spawnOpenCode: (command: string, options: unknown, writer: WebSocketWriter) => Promise<unknown>;
-  abortClaudeSDKSession: (sessionId: string) => Promise<boolean>;
+  abortClaudeSDKSession: (sessionId: string, partialResponse?: string) => Promise<boolean>;
   abortCursorSession: (sessionId: string) => boolean;
   abortCodexSession: (sessionId: string) => boolean;
   abortGeminiSession: (sessionId: string) => boolean;
@@ -170,7 +170,7 @@ export function handleChatConnection(
         } else if (provider === 'opencode') {
           success = dependencies.abortOpenCodeSession(sessionId);
         } else {
-          success = await dependencies.abortClaudeSDKSession(sessionId);
+          success = await dependencies.abortClaudeSDKSession(sessionId, typeof data.partialResponse === 'string' ? data.partialResponse : '');
         }
 
         writer.send(

--- a/src/components/chat/hooks/useChatComposerState.ts
+++ b/src/components/chat/hooks/useChatComposerState.ts
@@ -6,6 +6,7 @@ import type {
   FormEvent,
   KeyboardEvent,
   MouseEvent,
+  MutableRefObject,
   SetStateAction,
   TouchEvent,
 } from 'react';
@@ -60,6 +61,7 @@ interface UseChatComposerStateArgs {
   setClaudeStatus: (status: { text: string; tokens: number; can_interrupt: boolean } | null) => void;
   setIsUserScrolledUp: (isScrolledUp: boolean) => void;
   setPendingPermissionRequests: Dispatch<SetStateAction<PendingPermissionRequest[]>>;
+  accumulatedStreamRef?: MutableRefObject<string>;
 }
 
 interface MentionableFile {
@@ -191,6 +193,7 @@ export function useChatComposerState({
   setClaudeStatus,
   setIsUserScrolledUp,
   setPendingPermissionRequests,
+  accumulatedStreamRef,
 }: UseChatComposerStateArgs) {
   const [input, setInput] = useState(() => {
     if (typeof window !== 'undefined' && selectedProject) {
@@ -954,12 +957,23 @@ export function useChatComposerState({
       return;
     }
 
+    // Optimistically clear loading state immediately.
+    setIsLoading(false);
+    setCanAbortSession(false);
+    setClaudeStatus(null);
+
+    const partialResponse =
+      accumulatedStreamRef && typeof accumulatedStreamRef.current === 'string'
+        ? accumulatedStreamRef.current
+        : '';
+
     sendMessage({
       type: 'abort-session',
       sessionId: targetSessionId,
       provider,
+      partialResponse,
     });
-  }, [canAbortSession, currentSessionId, provider, selectedSession?.id, sendMessage]);
+  }, [accumulatedStreamRef, canAbortSession, currentSessionId, provider, selectedSession?.id, sendMessage, setIsLoading, setCanAbortSession, setClaudeStatus]);
 
   const handleGrantToolPermission = useCallback(
     (suggestion: { entry: string; toolName: string }) => {


### PR DESCRIPTION
## Problem

When the user clicks **Stop Generation** mid-response, Claude's entire partial reply is silently discarded. On the next message Claude has no memory of what it had already generated and starts from scratch, causing context loss and repetition.

## Root Cause

`abortClaudeSDKSession` calls `session.instance.interrupt()` without recording anything. The streamed text was visible on screen but never written to the SDK's JSONL history file at `~/.claude/projects/<encoded-cwd>/<sessionId>.jsonl`.

## Fix

1. **Track `cwd` per session** — `addSession` now stores the working directory so the abort path can locate the correct history file.
2. **`encodeProjectDir(cwd)`** — mirrors the SDK's own directory naming logic (`/` → `-`).
3. **`appendInterruptedAssistantEntry(sessionId, cwd, partialText)`** — writes a synthetic `assistant` entry with the partial text and `[generation interrupted]` suffix to the JSONL file _before_ calling `interrupt()`. Idempotent: if the last entry already contains `[generation interrupted]` it skips the write.
4. **UI captures partial text** — `useChatComposerState` reads accumulated streamed text via `accumulatedStreamRef` and sends it in the `abort-session` WebSocket message. Also optimistically clears `isLoading` / `claudeStatus` on abort so the UI doesn't stay stuck in a processing state.
5. **WebSocket service** — threads `partialResponse` from the message through to `abortClaudeSDKSession`.

## How to Reproduce

1. Send a long prompt (e.g. "write me a detailed 1000-word essay on X").
2. While Claude is streaming, click **Stop Generation** after a few sentences have appeared.
3. **Before this fix:** send any follow-up message — Claude has no memory of the interrupted reply.
4. **After this fix:** send any follow-up message — Claude sees its own partial reply in history (marked `[generation interrupted]`) and can continue or acknowledge it naturally.

## Files Changed

| File | Change |
|------|--------|
| `server/claude-sdk.js` | Track `cwd` in sessions; add `encodeProjectDir`, `appendInterruptedAssistantEntry`; update `abortClaudeSDKSession` |
| `server/modules/websocket/services/chat-websocket.service.ts` | Pass `partialResponse` from WS message to SDK abort |
| `src/components/chat/hooks/useChatComposerState.ts` | Capture streamed text; send with abort; optimistic UI clear |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Partial response preservation: assistant output is saved when a session is aborted so interrupted generations are retained.

* **Improvements**
  * Enhanced per-session state tracking for more consistent session context.
  * Faster abort UX: UI loading/abort indicators clear immediately when aborting, improving responsiveness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->