### PR TITLE
fix(sdk): always use bypassPermissions mode unless in plan mode

### DIFF
--- a/server/claude-sdk.js
+++ b/server/claude-sdk.js
@@ -177,8 +177,8 @@ function mapCliOptionsToSDK(options = {}) {
   };
 
   // Handle tool permissions
-  if (settings.skipPermissions && permissionMode !== 'plan') {
-    // When skipping permissions, use bypassPermissions mode
+  // Always bypass permissions unless in plan mode
+  if (permissionMode !== 'plan') {
     sdkOptions.permissionMode = 'bypassPermissions';
   }
 


### PR DESCRIPTION
## Problem

The SDK's permission bypass is conditional on `settings.skipPermissions` being `true` in addition to not being in plan mode. In practice `skipPermissions` defaults to `false`, so even in the default UI workflow where the user has not explicitly enabled "plan mode", the SDK does **not** bypass permissions and throws unexpected tool-permission prompts during normal use.

## Root Cause

```js
// Before
if (settings.skipPermissions && permissionMode !== 'plan') {
  sdkOptions.permissionMode = 'bypassPermissions';
}
```

The double-guard (`settings.skipPermissions &&`) means `bypassPermissions` is only set when the user has explicitly toggled `skipPermissions` on. For all other modes the SDK falls back to its own interactive permission flow, which conflicts with CloudCLI's own permission UI.

## Fix

Remove the `settings.skipPermissions` guard. Permission mode is already fully controlled by the `permissionMode` selector in the UI. `bypassPermissions` should be the default for any non-plan session:

```js
// After
// Always bypass permissions unless in plan mode
if (permissionMode !== 'plan') {
  sdkOptions.permissionMode = 'bypassPermissions';
}
```

## How to Reproduce

1. Ensure `skipPermissions` is `false` (the default — don't touch Settings).
2. Send a message that triggers a tool requiring permission (e.g. a file-write command).
3. **Before this fix:** an unexpected SDK-level permission prompt appears instead of the CloudCLI permission UI.
4. **After this fix:** CloudCLI's own permission UI handles the request as expected.

## Files Changed

| File | Change |
|------|--------|
| `server/claude-sdk.js` | Remove `settings.skipPermissions &&` guard in `mapCliOptionsToSDK` |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated tool permission check behavior to align with permission mode configuration settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->