### PR TITLE
fix(chat): persist thinking mode selection

### DIFF
--- a/src/components/chat/hooks/useChatComposerState.ts
+++ b/src/components/chat/hooks/useChatComposerState.ts
@@ -143,6 +143,21 @@ const createFakeSubmitEvent = () => {
   return { preventDefault: () => undefined } as unknown as FormEvent<HTMLFormElement>;
 };
 
+const THINKING_MODE_STORAGE_KEY = 'chat-thinking-mode';
+
+const getInitialThinkingMode = () => {
+  if (typeof window === 'undefined') {
+    return 'none';
+  }
+
+  const savedMode = safeLocalStorage.getItem(THINKING_MODE_STORAGE_KEY);
+  if (!savedMode) {
+    return 'none';
+  }
+
+  return thinkingModes.some((mode) => mode.id === savedMode) ? savedMode : 'none';
+};
+
 const getNotificationSessionSummary = (
   selectedSession: ProjectSession | null,
   fallbackInput: string,
@@ -204,7 +219,7 @@ export function useChatComposerState({
   const [uploadingImages, setUploadingImages] = useState<Map<string, number>>(new Map());
   const [imageErrors, setImageErrors] = useState<Map<string, string>>(new Map());
   const [isTextareaExpanded, setIsTextareaExpanded] = useState(false);
-  const [thinkingMode, setThinkingMode] = useState('none');
+  const [thinkingMode, setThinkingMode] = useState(getInitialThinkingMode);
   const [commandModalPayload, setCommandModalPayload] = useState<CommandModalPayload | null>(null);
 
   const textareaRef = useRef<HTMLTextAreaElement>(null);
@@ -749,7 +764,6 @@ export function useChatComposerState({
       setUploadingImages(new Map());
       setImageErrors(new Map());
       setIsTextareaExpanded(false);
-      setThinkingMode('none');
 
       if (textareaRef.current) {
         textareaRef.current.style.height = 'auto';
@@ -794,6 +808,10 @@ export function useChatComposerState({
   useEffect(() => {
     inputValueRef.current = input;
   }, [input]);
+
+  useEffect(() => {
+    safeLocalStorage.setItem(THINKING_MODE_STORAGE_KEY, thinkingMode);
+  }, [thinkingMode]);
 
   useEffect(() => {
     if (!selectedProjectId) {

--- a/src/components/chat/hooks/useChatComposerState.ts
+++ b/src/components/chat/hooks/useChatComposerState.ts
@@ -579,7 +579,7 @@ export function useChatComposerState({
 
       let messageContent = currentInput;
       const selectedThinkingMode = thinkingModes.find((mode: { id: string; prefix?: string }) => mode.id === thinkingMode);
-      if (selectedThinkingMode && selectedThinkingMode.prefix) {
+      if (provider === 'claude' && selectedThinkingMode && selectedThinkingMode.prefix) {
         messageContent = `${selectedThinkingMode.prefix}: ${currentInput}`;
       }
 


### PR DESCRIPTION
Closes PR #618 

Initialize the composer thinking mode from localStorage so reloads keep the user's selected mode instead of falling back to Standard.

Keeps the chosen mode after sending because the selector behaves like a preference, not a one-shot modifier for a single prompt.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The chat composer now persists your selected thinking mode across messages and sessions, so your preference is retained automatically.
* **Bug Fixes**
  * Thinking-mode prefixes are applied only for the Claude provider as intended.
  * Sending a message no longer resets the chosen thinking mode, preserving it between sends.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->