### PR TITLE
fix: do not show model description in chat view

### DIFF
--- a/src/components/chat/view/subcomponents/ProviderSelectionEmptyState.tsx
+++ b/src/components/chat/view/subcomponents/ProviderSelectionEmptyState.tsx
@@ -277,11 +277,15 @@ export default function ProviderSelectionEmptyState({
                           >
                             <div className="min-w-0 flex-1">
                               <div className="truncate">{model.label}</div>
-                              {model.description && (
+                              {/* 
+                              // * Temporarly commented out because the description of models from claude 
+                              // * was a bit inconsistent.  Will return it back when it becomes more consistent.
+                              */}
+                              {/* {model.description && (
                                 <div className="truncate text-xs text-muted-foreground">
                                   {model.description}
                                 </div>
-                              )}
+                              )} */}
                             </div>
                             {isSelected && (
                               <Check className="ml-auto h-4 w-4 shrink-0 text-primary" />


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Removed model description display from the provider selection dialog, showing only model labels for a simplified interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->