### PR TITLE
fix: slash command suggestions trigger at any / in input

### DIFF
--- a/src/components/chat/hooks/useSlashCommands.ts
+++ b/src/components/chat/hooks/useSlashCommands.ts
@@ -393,7 +393,8 @@ export function useSlashCommands({
         return;
       }
 
-      const slashPattern = /^\/(\S*)$/;
+      // Match / at start of input OR after whitespace, capturing the /word up to cursor.
+      const slashPattern = /(?:^|\s)(\/\S*)$/;
       const match = textBeforeCursor.match(slashPattern);
 
       if (!match) {
@@ -401,8 +402,9 @@ export function useSlashCommands({
         return;
       }
 
-      const slashPos = 0;
-      const query = match[1];
+      // Compute actual position of / in the full input string.
+      const slashPos = match.index! + (match[0].length - match[1].length);
+      const query = match[1].slice(1); // strip leading /
 
       setSlashPosition(slashPos);
       setShowCommandMenu(true);


### PR DESCRIPTION
Small chunk from #801 (maintainer asked to split the large PR #816 into reviewable pieces).

## What
Slash command suggestions now trigger at any `/` position in the input, not only when `/` is the first character.

## Why
Typing a path or a `/` mid-message should still surface command suggestions when appropriate, matching user expectation.

## Scope
- `src/components/chat/hooks/useSlashCommands.ts` — 1 file, +5/-3

First of several small PRs splitting #816. More to follow per your request in #801.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved slash-command detection to recognize commands at the start of input and immediately following whitespace
  * Enhanced command parsing logic for better reliability across different input positions and contexts
  * Better handling of edge cases in command recognition for improved user experience

<!-- end of auto-generated comment: release notes by coderabbit.ai -->