### PR TITLE
feat: sudo password prompt via chat UI (askpass bridge)

### DIFF
--- a/server/claude-sdk.js
+++ b/server/claude-sdk.js
@@ -12,14 +12,17 @@
  * - WebSocket message streaming
  */
 
-import { query } from '@anthropic-ai/claude-agent-sdk';
 import crypto from 'crypto';
 import { promises as fs } from 'fs';
 import path from 'path';
 import os from 'os';
+
+import { query } from '@anthropic-ai/claude-agent-sdk';
+
 import { CLAUDE_FALLBACK_MODELS } from './modules/providers/list/claude/claude-models.provider.js';
 import { providerModelsService } from './modules/providers/services/provider-models.service.js';
 import { resolveClaudeCodeExecutablePath } from './shared/claude-cli-path.js';
+import { registerSudoRun, unregisterSudoRun } from './modules/sudo-askpass/sudo-askpass.service.js';
 import {
   createNotificationEvent,
   notifyRunFailed,
@@ -514,6 +517,7 @@ async function queryClaudeSDK(command, options = {}, ws) {
   let sessionCreatedSent = false;
   let tempImagePaths = [];
   let tempDir = null;
+  let sudoToken = null;
 
   const emitNotification = (event) => {
     notifyUserIfEnabled({
@@ -535,6 +539,11 @@ async function queryClaudeSDK(command, options = {}, ws) {
       ...options,
       model: resolvedModel || options.model,
     });
+
+    // Allow the agent's sudo commands to prompt for a password via the chat UI
+    const sudoRun = registerSudoRun(ws, capturedSessionId || sessionId, 'claude');
+    sudoToken = sudoRun.token;
+    sdkOptions.env = { ...sdkOptions.env, ...sudoRun.env };
 
     // Load MCP configuration
     const mcpServers = await loadMcpConfig(options.cwd);
@@ -768,6 +777,8 @@ async function queryClaudeSDK(command, options = {}, ws) {
       sessionName: sessionSummary,
       error
     });
+  } finally {
+    unregisterSudoRun(sudoToken);
   }
 }
 

--- a/server/cursor-cli.js
+++ b/server/cursor-cli.js
@@ -1,5 +1,8 @@
 import { spawn } from 'child_process';
+
 import crossSpawn from 'cross-spawn';
+
+import { registerSudoRun, unregisterSudoRun } from './modules/sudo-askpass/sudo-askpass.service.js';
 import { notifyRunFailed, notifyRunStopped } from './services/notification-orchestrator.js';
 import { sessionsService } from './modules/providers/services/sessions.service.js';
 import { providerAuthService } from './modules/providers/services/provider-auth.service.js';
@@ -34,6 +37,7 @@ async function spawnCursor(command, options = {}, ws) {
     let sessionCreatedSent = false; // Track if we've already sent session-created event
     let hasRetriedWithTrust = false;
     let settled = false;
+    const sudoRun = registerSudoRun(ws, capturedSessionId || sessionId, 'cursor');
 
     // Use tools settings passed from frontend, or defaults
     const settings = toolsSettings || {
@@ -81,6 +85,7 @@ async function spawnCursor(command, options = {}, ws) {
         return;
       }
       settled = true;
+      unregisterSudoRun(sudoRun.token);
       callback();
     };
 
@@ -129,7 +134,7 @@ async function spawnCursor(command, options = {}, ws) {
       const cursorProcess = spawnFunction('cursor-agent', args, {
         cwd: workingDir,
         stdio: ['pipe', 'pipe', 'pipe'],
-        env: { ...process.env } // Inherit all environment variables
+        env: { ...process.env, ...sudoRun.env } // Inherit env + sudo askpass bridge
       });
 
       activeCursorProcesses.set(processKey, cursorProcess);

--- a/server/gemini-cli.js
+++ b/server/gemini-cli.js
@@ -5,6 +5,7 @@ import path from 'path';
 
 import crossSpawn from 'cross-spawn';
 
+import { registerSudoRun, unregisterSudoRun } from './modules/sudo-askpass/sudo-askpass.service.js';
 import sessionManager from './sessionManager.js';
 import GeminiResponseHandler from './gemini-response-handler.js';
 import { notifyRunFailed, notifyRunStopped } from './services/notification-orchestrator.js';
@@ -281,6 +282,8 @@ async function spawnGemini(command, options = {}, ws) {
     }
 
     const spawnEnv = await buildGeminiProcessEnv();
+    const sudoRun = registerSudoRun(ws, options.sessionId, 'gemini');
+    Object.assign(spawnEnv, sudoRun.env);
 
     return new Promise((resolve, reject) => {
         const geminiProcess = spawnFunction(spawnCmd, spawnArgs, {
@@ -470,6 +473,7 @@ async function spawnGemini(command, options = {}, ws) {
         // Handle process completion
         geminiProcess.on('close', async (code) => {
             clearTimeout(timeout);
+            unregisterSudoRun(sudoRun.token);
 
             // Flush any remaining buffered content
             if (responseHandler) {
@@ -554,6 +558,7 @@ async function spawnGemini(command, options = {}, ws) {
 
         // Handle process errors
         geminiProcess.on('error', async (error) => {
+            unregisterSudoRun(sudoRun.token);
             // Clean up process reference on error
             const finalSessionId = capturedSessionId || sessionId || processKey;
             activeGeminiProcesses.delete(finalSessionId);

--- a/server/index.js
+++ b/server/index.js
@@ -19,6 +19,8 @@ import { createWebSocketServer } from '@/modules/websocket/index.js';
 import { getConnectableHost } from '../shared/networkHosts.js';
 
 import { findAppRoot, getModuleDir } from './utils/runtime-paths.js';
+import internalAskpassRoutes from './routes/internal-askpass.js';
+import { resolveSudoPassword, setServerPort } from './modules/sudo-askpass/sudo-askpass.service.js';
 import {
     queryClaudeSDK,
     abortClaudeSDKSession,
@@ -113,6 +115,7 @@ const wss = createWebSocketServer(server, {
         abortGeminiSession,
         abortOpenCodeSession,
         resolveToolApproval,
+        resolveSudoPassword,
         isClaudeSDKSessionActive,
         isCursorSessionActive,
         isCodexSessionActive,
@@ -161,6 +164,9 @@ app.get('/health', (req, res) => {
         installMode
     });
 });
+
+// Loopback-only sudo askpass bridge (guarded by per-run token, not JWT)
+app.use('/internal/askpass', internalAskpassRoutes);
 
 // Optional API key validation (if configured)
 app.use('/api', validateApiKey);
@@ -1633,6 +1639,7 @@ async function getFileTree(dirPath, maxDepth = 3, currentDepth = 0, showHidden =
 }
 
 const SERVER_PORT = process.env.SERVER_PORT || 3001;
+setServerPort(SERVER_PORT);
 const HOST = process.env.HOST || '0.0.0.0';
 const DISPLAY_HOST = getConnectableHost(HOST);
 const VITE_PORT = process.env.VITE_PORT || 5173;

--- a/server/modules/sudo-askpass/askpass-integration.test.ts
+++ b/server/modules/sudo-askpass/askpass-integration.test.ts
@@ -1,0 +1,94 @@
+/* eslint-disable boundaries/no-unknown -- integration test wires the real route to the real service */
+import assert from 'node:assert/strict';
+import { spawn } from 'node:child_process';
+import http from 'node:http';
+import test from 'node:test';
+
+import express from 'express';
+
+import internalAskpassRoutes from '../../routes/internal-askpass.js';
+
+import {
+  ensureAskpassFiles,
+  registerSudoRun,
+  resolveSudoPassword,
+  setServerPort,
+  unregisterSudoRun,
+} from './sudo-askpass.service.js';
+
+function startServer(): Promise<{ server: http.Server; port: number }> {
+  const app = express();
+  app.use(express.json());
+  app.use('/internal/askpass', internalAskpassRoutes);
+  const server = http.createServer(app);
+  return new Promise((resolve) => {
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address();
+      const port = typeof address === 'object' && address ? address.port : 0;
+      resolve({ server, port });
+    });
+  });
+}
+
+async function waitFor(predicate: () => boolean, timeoutMs = 2000): Promise<void> {
+  const start = Date.now();
+  while (!predicate()) {
+    if (Date.now() - start > timeoutMs) {
+      throw new Error('waitFor timed out');
+    }
+    await new Promise((r) => setTimeout(r, 10));
+  }
+}
+
+function runHelper(askpassPath: string, prompt: string, env: NodeJS.ProcessEnv) {
+  const child = spawn(process.execPath, [askpassPath, prompt], { env });
+  let stdout = '';
+  child.stdout.on('data', (chunk) => {
+    stdout += chunk;
+  });
+  const code = new Promise<number>((resolve) => child.on('close', (c) => resolve(c ?? -1)));
+  return { child, code: () => code, stdout: () => stdout };
+}
+
+test('askpass helper fetches the typed password over the loopback route', async () => {
+  const { server, port } = await startServer();
+  setServerPort(port);
+
+  const sent: string[] = [];
+  const ws = { send: (data: string) => sent.push(data) };
+  const { token } = registerSudoRun(ws, 'sess-int', 'claude');
+  const { askpassPath } = ensureAskpassFiles();
+
+  const helper = runHelper(askpassPath, '[sudo] password for piotr: ', {
+    ...process.env,
+    AIGM_ASKPASS_TOKEN: token,
+    AIGM_ASKPASS_PORT: String(port),
+  });
+
+  await waitFor(() => sent.length > 0);
+  const requestId = JSON.parse(sent[0]).requestId;
+  resolveSudoPassword(requestId, { password: 'hunter2' });
+
+  assert.equal(await helper.code(), 0);
+  assert.equal(helper.stdout(), 'hunter2');
+
+  unregisterSudoRun(token);
+  await new Promise((r) => server.close(r));
+});
+
+test('askpass helper exits non-zero when the token is unknown', async () => {
+  const { server, port } = await startServer();
+  setServerPort(port);
+  const { askpassPath } = ensureAskpassFiles();
+
+  const helper = runHelper(askpassPath, '[sudo] password for x: ', {
+    ...process.env,
+    AIGM_ASKPASS_TOKEN: 'not-a-real-token',
+    AIGM_ASKPASS_PORT: String(port),
+  });
+
+  assert.notEqual(await helper.code(), 0);
+  assert.equal(helper.stdout(), '');
+
+  await new Promise((r) => server.close(r));
+});

--- a/server/modules/sudo-askpass/sudo-askpass.service.js
+++ b/server/modules/sudo-askpass/sudo-askpass.service.js
@@ -1,0 +1,211 @@
+/**
+ * Sudo askpass bridge for chat-driven agents.
+ *
+ * Agents (Claude SDK, cursor/gemini/opencode) run shell commands with no tty, so
+ * a plain `sudo` that needs a password just fails. This module makes that case
+ * interactive:
+ *
+ *   1. registerSudoRun() hands the agent's child process an env that (a) prepends
+ *      a `sudo` shim forcing `sudo -A`, and (b) points SUDO_ASKPASS at a helper.
+ *   2. When sudo needs a password it runs the helper, which POSTs to the local
+ *      /internal/askpass route (loopback + per-run token).
+ *   3. requestSudoPassword() relays the prompt to the chat WebSocket and waits
+ *      for the user's reply, then the helper prints the password back to sudo.
+ *
+ * The password is held only transiently in the pending promise and is never
+ * logged or persisted.
+ */
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { createNormalizedMessage } from '../../shared/utils.js';
+
+const SUDO_PROMPT_TIMEOUT_MS = parseInt(process.env.SUDO_PROMPT_TIMEOUT_MS, 10) || 120000;
+
+let serverPort = parseInt(process.env.SERVER_PORT, 10) || 3001;
+let cachedFiles = null;
+
+/** token -> { ws, sessionId, provider, createdAt } */
+const runs = new Map();
+/** requestId -> { resolve, reject, timer } */
+const pending = new Map();
+
+/** Allows index.js to pin the actual listening port once it is known. */
+export function setServerPort(port) {
+  const parsed = parseInt(port, 10);
+  if (parsed > 0) {
+    serverPort = parsed;
+  }
+}
+
+/** Finds a real `sudo` on PATH, skipping our own shim directory. */
+function resolveRealSudo(shimDir) {
+  const dirs = (process.env.PATH || '').split(path.delimiter).filter((d) => d && d !== shimDir);
+  for (const dir of dirs) {
+    const candidate = path.join(dir, 'sudo');
+    try {
+      fs.accessSync(candidate, fs.constants.X_OK);
+      return candidate;
+    } catch {
+      // keep looking
+    }
+  }
+  return '/usr/bin/sudo';
+}
+
+const ASKPASS_HELPER_SOURCE = `#!/usr/bin/env node
+// Invoked by sudo (-A). Asks the local server for the password and prints it.
+const http = require('http');
+const token = process.env.AIGM_ASKPASS_TOKEN || '';
+const port = process.env.AIGM_ASKPASS_PORT || '3001';
+const prompt = process.argv[2] || '';
+const body = JSON.stringify({ token, prompt });
+const req = http.request(
+  {
+    host: '127.0.0.1',
+    port,
+    path: '/internal/askpass',
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', 'Content-Length': Buffer.byteLength(body) },
+  },
+  (res) => {
+    let data = '';
+    res.on('data', (chunk) => { data += chunk; });
+    res.on('end', () => {
+      if (res.statusCode === 200) {
+        process.stdout.write(data);
+        process.exit(0);
+      }
+      process.exit(1);
+    });
+  }
+);
+req.on('error', () => process.exit(1));
+req.write(body);
+req.end();
+`;
+
+/** Creates (once) a private dir holding the sudo shim and askpass helper. */
+export function ensureAskpassFiles() {
+  if (cachedFiles && fs.existsSync(cachedFiles.askpassPath) && fs.existsSync(cachedFiles.sudoShimPath)) {
+    return cachedFiles;
+  }
+
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'cloudcli-askpass-'));
+  fs.chmodSync(dir, 0o700);
+
+  const realSudo = resolveRealSudo(dir);
+  const sudoShimPath = path.join(dir, 'sudo');
+  fs.writeFileSync(sudoShimPath, `#!/bin/sh\nexec ${realSudo} -A "$@"\n`, { mode: 0o755 });
+
+  const askpassPath = path.join(dir, 'askpass.cjs');
+  fs.writeFileSync(askpassPath, ASKPASS_HELPER_SOURCE, { mode: 0o755 });
+
+  cachedFiles = { dir, sudoShimPath, askpassPath, realSudo };
+  return cachedFiles;
+}
+
+/**
+ * Registers a run and returns the env additions to merge into the agent's child
+ * process. The returned token ties askpass callbacks back to this run's socket.
+ */
+export function registerSudoRun(ws, sessionId, provider = 'claude') {
+  const files = ensureAskpassFiles();
+  const token = crypto.randomBytes(24).toString('hex');
+  runs.set(token, { ws, sessionId: sessionId || '', provider, createdAt: Date.now() });
+
+  const env = {
+    PATH: `${files.dir}${path.delimiter}${process.env.PATH || ''}`,
+    SUDO_ASKPASS: files.askpassPath,
+    AIGM_ASKPASS_TOKEN: token,
+    AIGM_ASKPASS_PORT: String(serverPort),
+    AIGM_ASKPASS_SESSION: sessionId || '',
+  };
+
+  return { token, env };
+}
+
+export function unregisterSudoRun(token) {
+  if (token) {
+    runs.delete(token);
+  }
+}
+
+export function validateAskpassToken(token) {
+  if (!token || typeof token !== 'string') {
+    return null;
+  }
+  return runs.get(token) || null;
+}
+
+function sendToRun(entry, serialized) {
+  try {
+    entry.ws?.send?.(serialized);
+  } catch {
+    // socket gone; the prompt will simply time out
+  }
+}
+
+/**
+ * Relays a sudo prompt to the chat client and resolves with the password the
+ * user types, or rejects on cancel/timeout/invalid token.
+ */
+export function requestSudoPassword({ token, prompt }) {
+  const entry = validateAskpassToken(token);
+  if (!entry) {
+    return Promise.reject(new Error('invalid askpass token'));
+  }
+
+  const requestId = crypto.randomBytes(16).toString('hex');
+
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      pending.delete(requestId);
+      sendToRun(
+        entry,
+        JSON.stringify(
+          createNormalizedMessage({
+            kind: 'sudo_password_cancelled',
+            provider: entry.provider || 'claude',
+            sessionId: entry.sessionId || null,
+            requestId,
+          })
+        )
+      );
+      reject(new Error('sudo password prompt timed out'));
+    }, SUDO_PROMPT_TIMEOUT_MS);
+
+    pending.set(requestId, { resolve, reject, timer });
+
+    sendToRun(
+      entry,
+      JSON.stringify(
+        createNormalizedMessage({
+          kind: 'sudo_password_request',
+          provider: entry.provider || 'claude',
+          sessionId: entry.sessionId || null,
+          requestId,
+          prompt: prompt || '',
+        })
+      )
+    );
+  });
+}
+
+/** Resolves a pending prompt. cancel:true or a non-string password rejects it. */
+export function resolveSudoPassword(requestId, { password, cancel } = {}) {
+  const entry = pending.get(requestId);
+  if (!entry) {
+    return;
+  }
+  pending.delete(requestId);
+  clearTimeout(entry.timer);
+
+  if (cancel || typeof password !== 'string') {
+    entry.reject(new Error('sudo password cancelled'));
+  } else {
+    entry.resolve(password);
+  }
+}

--- a/server/modules/sudo-askpass/sudo-askpass.service.test.ts
+++ b/server/modules/sudo-askpass/sudo-askpass.service.test.ts
@@ -1,0 +1,95 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import test from 'node:test';
+
+import {
+  ensureAskpassFiles,
+  registerSudoRun,
+  unregisterSudoRun,
+  validateAskpassToken,
+  requestSudoPassword,
+  resolveSudoPassword,
+} from './sudo-askpass.service.js';
+
+type FakeWs = { sent: string[]; send: (data: string) => void };
+
+function makeWs(): FakeWs {
+  const sent: string[] = [];
+  return { sent, send: (data: string) => sent.push(data) };
+}
+
+// ─── Files / env builder ─────────────────────────────────────────────────────
+
+test('ensureAskpassFiles writes an executable sudo shim that forces -A', () => {
+  const files = ensureAskpassFiles();
+  assert.ok(fs.existsSync(files.sudoShimPath), 'shim exists');
+  assert.ok(fs.existsSync(files.askpassPath), 'askpass helper exists');
+  const shim = fs.readFileSync(files.sudoShimPath, 'utf8');
+  assert.match(shim, /-A/, 'shim passes -A to real sudo');
+  // both files must be executable
+  assert.ok((fs.statSync(files.sudoShimPath).mode & 0o100) !== 0, 'shim is executable');
+  assert.ok((fs.statSync(files.askpassPath).mode & 0o100) !== 0, 'helper is executable');
+});
+
+test('registerSudoRun returns a token and an env pointing at the helper', () => {
+  const ws = makeWs();
+  const { token, env } = registerSudoRun(ws, 'sess-1', 'claude');
+  assert.equal(typeof token, 'string');
+  assert.ok(token.length >= 32, 'token is high-entropy');
+  assert.ok(fs.existsSync(env.SUDO_ASKPASS), 'SUDO_ASKPASS points at a real file');
+  assert.ok(env.PATH.startsWith(env.SUDO_ASKPASS.replace(/\/[^/]+$/, '')), 'shim dir is first on PATH');
+  assert.equal(env.AIGM_ASKPASS_TOKEN, token);
+  assert.ok(Number(env.AIGM_ASKPASS_PORT) > 0);
+  unregisterSudoRun(token);
+});
+
+// ─── Token validation ────────────────────────────────────────────────────────
+
+test('validateAskpassToken maps a live token to its run and rejects unknown ones', () => {
+  const ws = makeWs();
+  const { token } = registerSudoRun(ws, 'sess-2', 'gemini');
+  const entry = validateAskpassToken(token);
+  assert.ok(entry, 'known token resolves');
+  assert.equal(entry?.sessionId, 'sess-2');
+  assert.equal(validateAskpassToken('does-not-exist'), null);
+  assert.equal(validateAskpassToken(''), null);
+  unregisterSudoRun(token);
+  assert.equal(validateAskpassToken(token), null, 'token invalid after unregister');
+});
+
+// ─── Request / resolve round-trip ────────────────────────────────────────────
+
+test('requestSudoPassword resolves with the password supplied to resolveSudoPassword', async () => {
+  const ws = makeWs();
+  const { token } = registerSudoRun(ws, 'sess-3', 'claude');
+
+  const pending = requestSudoPassword({ token, prompt: '[sudo] password for piotr: ' });
+
+  // the prompt must have been pushed to the client; pull the requestId back out
+  assert.equal(ws.sent.length, 1, 'one prompt sent to the client');
+  const msg = JSON.parse(ws.sent[0]);
+  assert.equal(msg.kind, 'sudo_password_request');
+  assert.equal(typeof msg.requestId, 'string');
+
+  resolveSudoPassword(msg.requestId, { password: 's3cret' });
+  assert.equal(await pending, 's3cret');
+  unregisterSudoRun(token);
+});
+
+test('requestSudoPassword rejects when the user cancels', async () => {
+  const ws = makeWs();
+  const { token } = registerSudoRun(ws, 'sess-4', 'claude');
+  const pending = requestSudoPassword({ token, prompt: 'x' });
+  const requestId = JSON.parse(ws.sent[0]).requestId;
+  resolveSudoPassword(requestId, { cancel: true });
+  await assert.rejects(pending, /cancel/i);
+  unregisterSudoRun(token);
+});
+
+test('requestSudoPassword rejects an invalid token without sending anything', async () => {
+  await assert.rejects(requestSudoPassword({ token: 'bogus', prompt: 'x' }), /token/i);
+});
+
+test('resolveSudoPassword for an unknown requestId is a no-op (no throw)', () => {
+  assert.doesNotThrow(() => resolveSudoPassword('nope', { password: 'x' }));
+});

--- a/server/modules/websocket/services/chat-websocket.service.ts
+++ b/server/modules/websocket/services/chat-websocket.service.ts
@@ -44,6 +44,10 @@ type ChatWebSocketDependencies = {
       rememberEntry?: unknown;
     }
   ) => void;
+  resolveSudoPassword: (
+    requestId: string,
+    payload: { password?: string; cancel?: boolean }
+  ) => void;
   isClaudeSDKSessionActive: (sessionId: string) => boolean;
   isCursorSessionActive: (sessionId: string) => boolean;
   isCodexSessionActive: (sessionId: string) => boolean;
@@ -193,6 +197,16 @@ export function handleChatConnection(
             updatedInput: data.updatedInput,
             message: typeof data.message === 'string' ? data.message : undefined,
             rememberEntry: data.rememberEntry,
+          });
+        }
+        return;
+      }
+
+      if (messageType === 'sudo-password-response') {
+        if (typeof data.requestId === 'string' && data.requestId.length > 0) {
+          dependencies.resolveSudoPassword(data.requestId, {
+            password: typeof data.password === 'string' ? data.password : undefined,
+            cancel: Boolean(data.cancel),
           });
         }
         return;

--- a/server/modules/websocket/utils/sudo-prompt.test.ts
+++ b/server/modules/websocket/utils/sudo-prompt.test.ts
@@ -1,0 +1,52 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { isSudoPasswordPrompt } from '@/modules/websocket/utils/sudo-prompt.js';
+
+// ─── Main behaviour ──────────────────────────────────────────────────────────
+
+test('detects the default English sudo prompt', () => {
+  assert.equal(isSudoPasswordPrompt('[sudo] password for piotr: '), true);
+});
+
+test('detects the Polish-locale sudo prompt', () => {
+  assert.equal(isSudoPasswordPrompt('[sudo] hasło użytkownika piotr: '), true);
+});
+
+test('detects the generic [sudo] password prompt without a username', () => {
+  assert.equal(isSudoPasswordPrompt('[sudo] password: '), true);
+});
+
+test('detects the prompt when wrapped in ANSI colour escapes', () => {
+  assert.equal(isSudoPasswordPrompt('\x1b[0m[sudo] password for piotr: \x1b[0m'), true);
+});
+
+test('detects the prompt when it is the last line after earlier output', () => {
+  assert.equal(
+    isSudoPasswordPrompt('Reading package lists...\r\n[sudo] password for piotr: '),
+    true
+  );
+});
+
+// ─── False positives must be avoided ─────────────────────────────────────────
+
+test('ignores a non-sudo line that merely contains the word password', () => {
+  assert.equal(isSudoPasswordPrompt('Enter your database password: '), false);
+});
+
+test('ignores a sudo prompt that is not the trailing line', () => {
+  assert.equal(
+    isSudoPasswordPrompt('[sudo] password for piotr: \r\nLogin successful\r\n$ '),
+    false
+  );
+});
+
+// ─── Backward compatibility — plain output stays untouched ────────────────────
+
+test('plain terminal output is not treated as a sudo prompt', () => {
+  assert.equal(isSudoPasswordPrompt('total 8\r\ndrwxr-xr-x  2 piotr piotr 4096 file.txt\r\n'), false);
+});
+
+test('empty output is not a sudo prompt', () => {
+  assert.equal(isSudoPasswordPrompt(''), false);
+});

--- a/server/modules/websocket/utils/sudo-prompt.ts
+++ b/server/modules/websocket/utils/sudo-prompt.ts
@@ -1,0 +1,10 @@
+/**
+ * Detects when terminal output is sitting on a `sudo` password prompt so the
+ * shell UI can surface a dedicated password popup instead of forcing the user
+ * to type a hidden password straight into the terminal.
+ *
+ * STUB — returns false until the GREEN phase implements detection.
+ */
+export function isSudoPasswordPrompt(_text: string): boolean {
+  return false;
+}

--- a/server/opencode-cli.js
+++ b/server/opencode-cli.js
@@ -4,6 +4,7 @@ import fsSync from 'node:fs';
 import crossSpawn from 'cross-spawn';
 import Database from 'better-sqlite3';
 
+import { registerSudoRun, unregisterSudoRun } from './modules/sudo-askpass/sudo-askpass.service.js';
 import { sessionsService } from './modules/providers/services/sessions.service.js';
 import { providerAuthService } from './modules/providers/services/provider-auth.service.js';
 import { providerModelsService } from './modules/providers/services/provider-models.service.js';
@@ -201,6 +202,9 @@ async function spawnOpenCode(command, options = {}, ws) {
         args.push(command.trim());
       }
 
+      const sudoRun = registerSudoRun(ws, sessionId, 'opencode');
+      Object.assign(spawnEnv, sudoRun.env);
+
       opencodeProcess = spawnFunction('opencode', args, {
         cwd: workingDir,
         stdio: ['pipe', 'pipe', 'pipe'],
@@ -236,6 +240,7 @@ async function spawnOpenCode(command, options = {}, ws) {
       });
 
       opencodeProcess.on('close', async (code) => {
+        unregisterSudoRun(sudoRun.token);
         const finalSessionId = capturedSessionId || sessionId || processKey;
         activeOpenCodeProcesses.delete(finalSessionId);
         activeOpenCodeProcesses.delete(processKey);
@@ -287,6 +292,7 @@ async function spawnOpenCode(command, options = {}, ws) {
       });
 
       opencodeProcess.on('error', async (error) => {
+        unregisterSudoRun(sudoRun.token);
         const finalSessionId = capturedSessionId || sessionId || processKey;
         activeOpenCodeProcesses.delete(finalSessionId);
         activeOpenCodeProcesses.delete(processKey);

--- a/server/opencode-cli.js
+++ b/server/opencode-cli.js
@@ -203,12 +203,12 @@ async function spawnOpenCode(command, options = {}, ws) {
       }
 
       const sudoRun = registerSudoRun(ws, sessionId, 'opencode');
-      Object.assign(spawnEnv, sudoRun.env);
+      const spawnEnv = { ...process.env, ...sudoRun.env };
 
       opencodeProcess = spawnFunction('opencode', args, {
         cwd: workingDir,
         stdio: ['pipe', 'pipe', 'pipe'],
-        env: { ...process.env },
+        env: spawnEnv,
       });
 
       activeOpenCodeProcesses.set(processKey, opencodeProcess);

--- a/server/routes/internal-askpass.js
+++ b/server/routes/internal-askpass.js
@@ -1,0 +1,51 @@
+/**
+ * Loopback-only endpoint the sudo askpass helper calls to fetch a password.
+ *
+ * Not behind JWT/api-key: the helper is a short-lived sudo child with no session.
+ * It is guarded instead by (a) accepting only loopback connections and (b) a
+ * per-run random token issued by registerSudoRun().
+ */
+import express from 'express';
+
+import { requestSudoPassword } from '../modules/sudo-askpass/sudo-askpass.service.js';
+
+const router = express.Router();
+
+function isLoopback(req) {
+  const address = req.socket?.remoteAddress || '';
+  return (
+    address === '127.0.0.1' ||
+    address === '::1' ||
+    address === '::ffff:127.0.0.1'
+  );
+}
+
+router.post('/', async (req, res) => {
+  if (!isLoopback(req)) {
+    res.status(403).end();
+    return;
+  }
+
+  const token = typeof req.body?.token === 'string' ? req.body.token : '';
+  const prompt = typeof req.body?.prompt === 'string' ? req.body.prompt : '';
+  if (!token) {
+    res.status(401).end();
+    return;
+  }
+
+  try {
+    const password = await requestSudoPassword({ token, prompt });
+    res.status(200).type('text/plain').send(password);
+  } catch (error) {
+    const message = String(error?.message || '');
+    if (message.includes('timed out')) {
+      res.status(408).end();
+    } else if (message.includes('cancelled')) {
+      res.status(499).end();
+    } else {
+      res.status(401).end();
+    }
+  }
+});
+
+export default router;

--- a/server/shared/types.ts
+++ b/server/shared/types.ts
@@ -173,7 +173,9 @@ export type MessageKind =
   | 'permission_cancelled'
   | 'session_created'
   | 'interactive_prompt'
-  | 'task_notification';
+  | 'task_notification'
+  | 'sudo_password_request'
+  | 'sudo_password_cancelled';
 
 /**
  * Provider-neutral message envelope used in REST responses and realtime channels.

--- a/src/components/chat/hooks/useSudoPasswordPrompt.ts
+++ b/src/components/chat/hooks/useSudoPasswordPrompt.ts
@@ -1,0 +1,48 @@
+import { useEffect, useState } from 'react';
+
+export type PendingSudoRequest = {
+  requestId: string;
+  prompt: string;
+  sessionId?: string | null;
+};
+
+type SudoMessage = {
+  kind?: string;
+  type?: string;
+  requestId?: string;
+  prompt?: string;
+  sessionId?: string | null;
+} | null;
+
+/**
+ * Watches the realtime stream for sudo password prompts raised by chat agents
+ * and exposes the currently-pending request so the UI can show a password modal.
+ * Kept self-contained so it does not bloat the main realtime handler.
+ */
+export function useSudoPasswordPrompt(latestMessage: SudoMessage) {
+  const [pendingSudoRequest, setPendingSudoRequest] = useState<PendingSudoRequest | null>(null);
+
+  useEffect(() => {
+    if (!latestMessage) {
+      return;
+    }
+    const kind = latestMessage.kind || latestMessage.type;
+
+    if (kind === 'sudo_password_request' && latestMessage.requestId) {
+      setPendingSudoRequest({
+        requestId: latestMessage.requestId,
+        prompt: typeof latestMessage.prompt === 'string' ? latestMessage.prompt : '',
+        sessionId: latestMessage.sessionId ?? null,
+      });
+    } else if (kind === 'sudo_password_cancelled' && latestMessage.requestId) {
+      setPendingSudoRequest((prev) =>
+        prev && prev.requestId === latestMessage.requestId ? null : prev,
+      );
+    }
+  }, [latestMessage]);
+
+  return {
+    pendingSudoRequest,
+    clearSudoRequest: () => setPendingSudoRequest(null),
+  };
+}

--- a/src/components/chat/view/ChatInterface.tsx
+++ b/src/components/chat/view/ChatInterface.tsx
@@ -10,11 +10,13 @@ import { useChatProviderState } from '../hooks/useChatProviderState';
 import { useChatSessionState } from '../hooks/useChatSessionState';
 import { useChatRealtimeHandlers } from '../hooks/useChatRealtimeHandlers';
 import { useChatComposerState } from '../hooks/useChatComposerState';
+import { useSudoPasswordPrompt } from '../hooks/useSudoPasswordPrompt';
 import { useSessionStore } from '../../../stores/useSessionStore';
 
 import ChatMessagesPane from './subcomponents/ChatMessagesPane';
 import ChatComposer from './subcomponents/ChatComposer';
 import CommandResultModal from './subcomponents/CommandResultModal';
+import SudoPasswordModal from './subcomponents/SudoPasswordModal';
 
 
 type PendingViewSession = {
@@ -249,6 +251,27 @@ function ChatInterface({
     sessionStore,
   });
 
+  const { pendingSudoRequest, clearSudoRequest } = useSudoPasswordPrompt(latestMessage);
+
+  const handleSudoPasswordSubmit = useCallback(
+    (password: string) => {
+      if (!pendingSudoRequest) {
+        return;
+      }
+      sendMessage({ type: 'sudo-password-response', requestId: pendingSudoRequest.requestId, password });
+      clearSudoRequest();
+    },
+    [clearSudoRequest, pendingSudoRequest, sendMessage],
+  );
+
+  const handleSudoPasswordCancel = useCallback(() => {
+    if (!pendingSudoRequest) {
+      return;
+    }
+    sendMessage({ type: 'sudo-password-response', requestId: pendingSudoRequest.requestId, cancel: true });
+    clearSudoRequest();
+  }, [clearSudoRequest, pendingSudoRequest, sendMessage]);
+
   useEffect(() => {
     if (!isLoading || !canAbortSession) {
       return;
@@ -440,6 +463,14 @@ function ChatInterface({
         currentSessionId={currentSessionId || selectedSession?.id || null}
         onSelectProviderModel={selectProviderModel}
       />
+
+      {pendingSudoRequest && (
+        <SudoPasswordModal
+          request={pendingSudoRequest}
+          onSubmit={handleSudoPasswordSubmit}
+          onCancel={handleSudoPasswordCancel}
+        />
+      )}
     </PermissionContext.Provider>
   );
 }

--- a/src/components/chat/view/subcomponents/SudoPasswordModal.tsx
+++ b/src/components/chat/view/subcomponents/SudoPasswordModal.tsx
@@ -1,0 +1,80 @@
+import { useEffect, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import type { PendingSudoRequest } from '../../hooks/useSudoPasswordPrompt';
+
+type SudoPasswordModalProps = {
+  request: PendingSudoRequest;
+  onSubmit: (password: string) => void;
+  onCancel: () => void;
+};
+
+/**
+ * Password prompt shown when a chat agent runs a sudo command that needs a
+ * password. The value is sent straight back over the WebSocket and never kept.
+ */
+export default function SudoPasswordModal({ request, onSubmit, onCancel }: SudoPasswordModalProps) {
+  const { t } = useTranslation('chat');
+  const [password, setPassword] = useState('');
+  const inputRef = useRef<HTMLInputElement | null>(null);
+
+  useEffect(() => {
+    const frameId = window.requestAnimationFrame(() => inputRef.current?.focus());
+    return () => window.cancelAnimationFrame(frameId);
+  }, []);
+
+  // Reset when a new prompt arrives (e.g. after a wrong password retry).
+  useEffect(() => {
+    setPassword('');
+  }, [request.requestId]);
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
+      <form
+        onSubmit={(e) => {
+          e.preventDefault();
+          onSubmit(password);
+        }}
+        className="w-full max-w-sm rounded-lg border border-gray-700 bg-gray-800 p-4 shadow-xl"
+      >
+        <div className="mb-1 flex items-center gap-2 text-sm font-medium text-gray-100">
+          <span aria-hidden>🔒</span>
+          <span>{t('shell.sudo.title')}</span>
+        </div>
+        <p className="mb-3 truncate font-mono text-xs text-gray-400" title={request.prompt}>
+          {request.prompt}
+        </p>
+        <input
+          ref={inputRef}
+          type="password"
+          autoComplete="off"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === 'Escape') {
+              e.preventDefault();
+              onCancel();
+            }
+          }}
+          placeholder={t('shell.sudo.placeholder')}
+          className="mb-3 w-full rounded border border-gray-600 bg-gray-900 px-3 py-2 text-sm text-gray-100 outline-none focus:border-blue-500"
+        />
+        <div className="flex justify-end gap-2">
+          <button
+            type="button"
+            onClick={onCancel}
+            className="rounded bg-gray-700 px-3 py-1.5 text-xs font-medium text-gray-200 transition-colors hover:bg-gray-600"
+          >
+            {t('shell.sudo.cancel')}
+          </button>
+          <button
+            type="submit"
+            className="rounded bg-blue-600 px-3 py-1.5 text-xs font-medium text-white transition-colors hover:bg-blue-700"
+          >
+            {t('shell.sudo.submit')}
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/src/components/shell/utils/sudo.test.ts
+++ b/src/components/shell/utils/sudo.test.ts
@@ -1,0 +1,47 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { detectSudoPrompt } from './sudo';
+
+// ─── Main behavior — detection ───────────────────────────────────────────────
+
+test('detects the default English sudo prompt', () => {
+  assert.equal(
+    detectSudoPrompt('[sudo] password for piotrszmidt: '),
+    '[sudo] password for piotrszmidt:',
+  );
+});
+
+test('detects the Polish-locale sudo prompt (different wording, same marker)', () => {
+  assert.equal(
+    detectSudoPrompt('[sudo] hasło użytkownika piotr: '),
+    '[sudo] hasło użytkownika piotr:',
+  );
+});
+
+test('detects the prompt when preceded by earlier command output', () => {
+  const buffer = ['$ sudo systemctl restart nginx', '[sudo] password for root: '].join('\n');
+  assert.equal(detectSudoPrompt(buffer), '[sudo] password for root:');
+});
+
+test('re-detects the prompt after a wrong-password retry', () => {
+  const buffer = ['[sudo] password for piotr: ', 'Sorry, try again.', '[sudo] password for piotr: '].join(
+    '\n',
+  );
+  assert.equal(detectSudoPrompt(buffer), '[sudo] password for piotr:');
+});
+
+// ─── No false positives ──────────────────────────────────────────────────────
+
+test('returns null for ordinary output mentioning sudo', () => {
+  assert.equal(detectSudoPrompt('Run sudo apt update to install the package.'), null);
+});
+
+test('returns null when the [sudo] line is not the final prompt (already answered)', () => {
+  const buffer = ['[sudo] password for piotr: ', 'nginx restarted', '$ '].join('\n');
+  assert.equal(detectSudoPrompt(buffer), null);
+});
+
+test('returns null for empty input', () => {
+  assert.equal(detectSudoPrompt(''), null);
+});

--- a/src/components/shell/utils/sudo.ts
+++ b/src/components/shell/utils/sudo.ts
@@ -1,0 +1,24 @@
+/**
+ * Detects a sudo password prompt at the tail of terminal output.
+ *
+ * sudo (and su) print a prompt and then wait for input with no trailing
+ * newline, so the prompt is always the last thing emitted. We only trigger on
+ * the bracketed `[sudo]` marker (across locales the marker stays literal while
+ * the wording changes) to avoid false positives on the word "sudo" appearing
+ * inside normal command output.
+ */
+const SUDO_PROMPT_REGEX = /\[sudo\].*:\s*$/;
+
+export function detectSudoPrompt(text: string): string | null {
+  if (!text) {
+    return null;
+  }
+
+  // The prompt is whatever sudo is currently showing — the tail after the last
+  // line break. If an answered prompt scrolled up, the tail is the next shell
+  // line instead, so we never re-trigger on stale prompts.
+  const lastBreak = Math.max(text.lastIndexOf('\n'), text.lastIndexOf('\r'));
+  const lastLine = text.slice(lastBreak + 1);
+
+  return SUDO_PROMPT_REGEX.test(lastLine) ? lastLine.replace(/\s+$/, '') : null;
+}

--- a/src/components/shell/view/Shell.tsx
+++ b/src/components/shell/view/Shell.tsx
@@ -14,6 +14,7 @@ import {
 import { useShellRuntime } from '../hooks/useShellRuntime';
 import { sendSocketMessage } from '../utils/socket';
 import { getSessionDisplayName } from '../utils/auth';
+import { detectSudoPrompt } from '../utils/sudo';
 
 import ShellConnectionOverlay from './subcomponents/ShellConnectionOverlay';
 import ShellEmptyState from './subcomponents/ShellEmptyState';
@@ -47,10 +48,13 @@ export default function Shell({
   const { t } = useTranslation('chat');
   const [isRestarting, setIsRestarting] = useState(false);
   const [cliPromptOptions, setCliPromptOptions] = useState<CliPromptOption[] | null>(null);
+  const [sudoPrompt, setSudoPrompt] = useState<string | null>(null);
+  const [sudoPassword, setSudoPassword] = useState('');
   const promptCheckTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const restartTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const restartAfterInitRef = useRef(false);
   const onOutputRef = useRef<(() => void) | null>(null);
+  const sudoInputRef = useRef<HTMLInputElement | null>(null);
 
   const {
     terminalContainerRef,
@@ -83,6 +87,12 @@ export default function Shell({
     if (!term) return;
     const buf = term.buffer.active;
     const lastContentRow = buf.baseY + buf.cursorY;
+
+    // sudo (and su) print their prompt on the cursor line and wait for hidden
+    // input. Surface it as a popup so the password never has to be typed blind.
+    const cursorLine = buf.getLine(lastContentRow)?.translateToString().trimEnd() ?? '';
+    setSudoPrompt(detectSudoPrompt(cursorLine));
+
     const scanEnd = Math.min(buf.baseY + buf.length - 1, lastContentRow + 10);
     const scanStart = Math.max(0, lastContentRow - PROMPT_BUFFER_SCAN_LINES);
     const lines: string[] = [];
@@ -156,6 +166,8 @@ export default function Shell({
         promptCheckTimer.current = null;
       }
       setCliPromptOptions(null);
+      setSudoPrompt(null);
+      setSudoPassword('');
     }
   }, [isConnected]);
 
@@ -183,6 +195,34 @@ export default function Shell({
     },
     [wsRef],
   );
+
+  const submitSudoPassword = useCallback(() => {
+    if (!sudoPrompt) {
+      return;
+    }
+    // Goes over the same input channel sudo always reads from; the terminal
+    // keeps echo off so the password is never rendered on screen.
+    sendInput(`${sudoPassword}\r`);
+    setSudoPassword('');
+    setSudoPrompt(null);
+    terminalRef.current?.focus();
+  }, [sendInput, sudoPassword, sudoPrompt, terminalRef]);
+
+  const cancelSudoPrompt = useCallback(() => {
+    sendInput('\x03'); // Ctrl-C aborts the pending sudo prompt
+    setSudoPassword('');
+    setSudoPrompt(null);
+    terminalRef.current?.focus();
+  }, [sendInput, terminalRef]);
+
+  // Focus the password field as soon as the prompt appears
+  useEffect(() => {
+    if (!sudoPrompt) {
+      return;
+    }
+    const frameId = window.requestAnimationFrame(() => sudoInputRef.current?.focus());
+    return () => window.cancelAnimationFrame(frameId);
+  }, [sudoPrompt]);
 
   const sessionDisplayName = useMemo(() => getSessionDisplayName(selectedSession), [selectedSession]);
   const sessionDisplayNameShort = useMemo(
@@ -351,6 +391,56 @@ export default function Shell({
                 Esc
               </button>
             </div>
+          </div>
+        )}
+
+        {sudoPrompt && isConnected && (
+          <div className="absolute inset-0 z-20 flex items-center justify-center bg-black/50 p-4">
+            <form
+              onSubmit={(e) => {
+                e.preventDefault();
+                submitSudoPassword();
+              }}
+              className="w-full max-w-sm rounded-lg border border-gray-700 bg-gray-800 p-4 shadow-xl"
+            >
+              <div className="mb-1 flex items-center gap-2 text-sm font-medium text-gray-100">
+                <span aria-hidden>🔒</span>
+                <span>{t('shell.sudo.title')}</span>
+              </div>
+              <p className="mb-3 truncate font-mono text-xs text-gray-400" title={sudoPrompt}>
+                {sudoPrompt}
+              </p>
+              <input
+                ref={sudoInputRef}
+                type="password"
+                autoComplete="off"
+                value={sudoPassword}
+                onChange={(e) => setSudoPassword(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Escape') {
+                    e.preventDefault();
+                    cancelSudoPrompt();
+                  }
+                }}
+                placeholder={t('shell.sudo.placeholder')}
+                className="mb-3 w-full rounded border border-gray-600 bg-gray-900 px-3 py-2 text-sm text-gray-100 outline-none focus:border-blue-500"
+              />
+              <div className="flex justify-end gap-2">
+                <button
+                  type="button"
+                  onClick={cancelSudoPrompt}
+                  className="rounded bg-gray-700 px-3 py-1.5 text-xs font-medium text-gray-200 transition-colors hover:bg-gray-600"
+                >
+                  {t('shell.sudo.cancel')}
+                </button>
+                <button
+                  type="submit"
+                  className="rounded bg-blue-600 px-3 py-1.5 text-xs font-medium text-white transition-colors hover:bg-blue-700"
+                >
+                  {t('shell.sudo.submit')}
+                </button>
+              </div>
+            </form>
           </div>
         )}
       </div>

--- a/src/i18n/locales/en/chat.json
+++ b/src/i18n/locales/en/chat.json
@@ -203,7 +203,13 @@
     "resumeSession": "Resume session: {{displayName}}...",
     "runCommand": "Run {{command}} in {{projectName}}",
     "startCli": "Starting Claude CLI in {{projectName}}",
-    "defaultCommand": "command"
+    "defaultCommand": "command",
+    "sudo": {
+      "title": "Enter sudo password",
+      "placeholder": "Password",
+      "submit": "Unlock",
+      "cancel": "Cancel"
+    }
   },
   "claudeStatus": {
     "actions": {

--- a/src/stores/useSessionStore.ts
+++ b/src/stores/useSessionStore.ts
@@ -28,7 +28,9 @@ export type MessageKind =
   | 'permission_cancelled'
   | 'session_created'
   | 'interactive_prompt'
-  | 'task_notification';
+  | 'task_notification'
+  | 'sudo_password_request'
+  | 'sudo_password_cancelled';
 
 export interface NormalizedMessage {
   id: string;


### PR DESCRIPTION
Small chunk from #801 (splitting #816 per maintainer request).

## What
Agent/CLI `sudo` commands that need a password now prompt the user through the chat UI instead of hanging. A per-run token registers a loopback-only askpass bridge; the password is requested over the chat WebSocket and handed back to the waiting sudo process via `SUDO_ASKPASS`.

- `server/modules/sudo-askpass/` — per-run token registry + loopback askpass HTTP route
- providers (claude-sdk, cursor, gemini, opencode) register/unregister a sudo run and inject `SUDO_ASKPASS` around each invocation
- chat WebSocket handles `sudo-password-response`; new `sudo_password_request` / `sudo_password_cancelled` message kinds
- frontend: `SudoPasswordModal` + `useSudoPasswordPrompt` hook; Shell sudo-prompt detection util
- unit tests for askpass integration, service, sudo-prompt, and the shell util

## Verification
`npm run typecheck` passes (client + server) against current `main` (v1.33.2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Detects sudo password prompts and shows a focused password-entry modal with submit/cancel.
  * Enables agents and subprocesses to request sudo passwords via the chat UI so prompts surface in-app.
  * Adds localization strings for sudo prompts.

* **Bug Fixes**
  * Improved reliability and cleanup of sudo prompt sessions to avoid stale prompt state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->