### PR TITLE
chore: add prism plugin

### DIFF
--- a/server/utils/plugin-loader.js
+++ b/server/utils/plugin-loader.js
@@ -1,7 +1,8 @@
 import fs from 'fs';
 import path from 'path';
 import os from 'os';
-import { spawn } from 'child_process';
+
+import { spawn } from 'cross-spawn';
 
 const PLUGINS_DIR = path.join(os.homedir(), '.claude-code-ui', 'plugins');
 const PLUGINS_CONFIG_PATH = path.join(os.homedir(), '.claude-code-ui', 'plugins.json');

--- a/src/components/plugins/view/PluginSettingsTab.tsx
+++ b/src/components/plugins/view/PluginSettingsTab.tsx
@@ -74,10 +74,10 @@ const UNOFFICIAL_PLUGIN_RECOMMENDATIONS: PluginRecommendation[] = [
     source: 'unofficial',
   },
   {
-    id: 'prism-cloudcli',
+    id: 'prism',
     translationKey: 'prismCloudCLI',
     repoUrl: PRISM_CLOUDCLI_PLUGIN_URL,
-    installedNames: ['prism-cloudcli'],
+    installedNames: ['prism'],
     icon: Activity,
     source: 'unofficial'
   }

--- a/src/components/plugins/view/PluginSettingsTab.tsx
+++ b/src/components/plugins/view/PluginSettingsTab.tsx
@@ -26,6 +26,7 @@ const STARTER_PLUGIN_URL = 'https://github.com/cloudcli-ai/cloudcli-plugin-start
 const TERMINAL_PLUGIN_URL = 'https://github.com/cloudcli-ai/cloudcli-plugin-terminal';
 const SCHEDULED_PROMPT_PLUGIN_URL = 'https://github.com/grostim/cloudcli-cron';
 const CLAUDE_WATCH_PLUGIN_URL = 'https://github.com/satsuki19980613/cloudcli-claude-watch';
+const PRISM_CLOUDCLI = 'https://github.com/jakeefr/cloudcli-plugin-prism';
 
 type PluginRecommendation = {
   id: string;
@@ -72,6 +73,14 @@ const UNOFFICIAL_PLUGIN_RECOMMENDATIONS: PluginRecommendation[] = [
     icon: Clock,
     source: 'unofficial',
   },
+  {
+    id: 'prism-cloudcli',
+    translationKey: 'prismCloudCLI',
+    repoUrl: PRISM_CLOUDCLI,
+    installedNames: ['prism-cloudcli'],
+    icon: Activity,
+    source: 'unofficial'
+  }
 ];
 
 function repoSlug(repoUrl: string) {

--- a/src/components/plugins/view/PluginSettingsTab.tsx
+++ b/src/components/plugins/view/PluginSettingsTab.tsx
@@ -26,7 +26,7 @@ const STARTER_PLUGIN_URL = 'https://github.com/cloudcli-ai/cloudcli-plugin-start
 const TERMINAL_PLUGIN_URL = 'https://github.com/cloudcli-ai/cloudcli-plugin-terminal';
 const SCHEDULED_PROMPT_PLUGIN_URL = 'https://github.com/grostim/cloudcli-cron';
 const CLAUDE_WATCH_PLUGIN_URL = 'https://github.com/satsuki19980613/cloudcli-claude-watch';
-const PRISM_CLOUDCLI = 'https://github.com/jakeefr/cloudcli-plugin-prism';
+const PRISM_CLOUDCLI_PLUGIN_URL = 'https://github.com/jakeefr/cloudcli-plugin-prism';
 
 type PluginRecommendation = {
   id: string;
@@ -76,7 +76,7 @@ const UNOFFICIAL_PLUGIN_RECOMMENDATIONS: PluginRecommendation[] = [
   {
     id: 'prism-cloudcli',
     translationKey: 'prismCloudCLI',
-    repoUrl: PRISM_CLOUDCLI,
+    repoUrl: PRISM_CLOUDCLI_PLUGIN_URL,
     installedNames: ['prism-cloudcli'],
     icon: Activity,
     source: 'unofficial'

--- a/src/i18n/locales/en/settings.json
+++ b/src/i18n/locales/en/settings.json
@@ -502,6 +502,12 @@
       "description": "Watch long-running Claude Code sessions for hangs and expose process controls.",
       "install": "Install"
     },
+    "prismCloudCLI": {
+      "name": "PRISM CloudCLI",
+      "badge": "unofficial",
+      "description": "Session intelligence for Claude Code, inside CloudCLI. See why your sessions are burning tokens without leaving the browser.",
+      "install": "Install"
+    },
     "morePlugins": "More",
     "enable": "Enable",
     "disable": "Disable",


### PR DESCRIPTION
https://github.com/jakeefr/cloudcli-plugin-prism

This pull request introduces support for a new unofficial plugin, "PRISM CloudCLI," to the plugin management UI and internationalization files. It also updates the plugin loader utility to use a more cross-platform compatible process spawning library. The most important changes are:

### Plugin Management Enhancements

* Added "PRISM CloudCLI" as an unofficial plugin recommendation in the plugin settings UI, including its metadata and icon. (`src/components/plugins/view/PluginSettingsTab.tsx`) [[1]](diffhunk://#diff-96c71d7c5d8c3dc7848f4cfee9b16ed6885940c739b431fe6eece89335e7e9cfR29) [[2]](diffhunk://#diff-96c71d7c5d8c3dc7848f4cfee9b16ed6885940c739b431fe6eece89335e7e9cfR76-R83)
* Updated the English locale settings to include the name, badge, description, and install label for "PRISM CloudCLI." (`src/i18n/locales/en/settings.json`)

### Dependency Improvements

* Replaced Node's built-in `spawn` with `cross-spawn` in the plugin loader utility to improve cross-platform compatibility when spawning child processes. (`server/utils/plugin-loader.js`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Prism CloudCLI added to unofficial plugin recommendations with name, badge, description, and install prompt.

* **Improvements**
  * Switched to a cross-platform process spawn implementation for plugin management, improving compatibility across environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->