### PR TITLE
fix: auto-detect claude binary on Linux/macOS + inject GitHub token into git remote operations

### DIFF
--- a/server/routes/git.js
+++ b/server/routes/git.js
@@ -2,12 +2,64 @@ import express from 'express';
 import { spawn } from 'child_process';
 import path from 'path';
 import { promises as fs } from 'fs';
-import { projectsDb } from '../modules/database/index.js';
+import { projectsDb, githubTokensDb } from '../modules/database/index.js';
 import { queryClaudeSDK } from '../claude-sdk.js';
 import { spawnCursor } from '../cursor-cli.js';
 
 const router = express.Router();
 const COMMIT_DIFF_CHARACTER_LIMIT = 500_000;
+
+/**
+ * Injects a GitHub token into a git remote URL so that push/pull/fetch
+ * operations can authenticate without requiring the user to configure
+ * git credentials separately.
+ *
+ * Transforms: https://github.com/user/repo
+ *        into: https://<token>@github.com/user/repo
+ *
+ * If the remote URL is SSH or already has credentials embedded, it is
+ * returned unchanged. If no token is found for the user it is also a no-op.
+ */
+async function withGithubToken(projectPath, userId, fn) {
+  if (!userId) return fn(null);
+
+  // Find the most recently active GitHub token for this user
+  let token;
+  try {
+    token = githubTokensDb.getActiveGithubToken(userId);
+  } catch {
+    token = null;
+  }
+
+  if (!token) return fn(null);
+
+  // Read the current remote URL
+  let originalUrl;
+  try {
+    const { stdout } = await spawnAsync('git', ['remote', 'get-url', 'origin'], { cwd: projectPath });
+    originalUrl = stdout.trim();
+  } catch {
+    return fn(null); // no remote configured – nothing to do
+  }
+
+  // Only HTTPS remotes can embed a token; leave SSH alone
+  if (!originalUrl.startsWith('https://')) return fn(null);
+
+  // Build authenticated URL (avoid double-embedding)
+  const urlObj = new URL(originalUrl);
+  if (urlObj.username) return fn(null); // already has credentials
+  urlObj.username = token;
+  urlObj.password = '';
+  const authenticatedUrl = urlObj.toString().replace(':@', '@');
+
+  try {
+    await spawnAsync('git', ['remote', 'set-url', 'origin', authenticatedUrl], { cwd: projectPath });
+    return await fn(token);
+  } finally {
+    // Always restore original URL so credentials are never persisted on disk
+    await spawnAsync('git', ['remote', 'set-url', 'origin', originalUrl], { cwd: projectPath }).catch(() => {});
+  }
+}
 
 function spawnAsync(command, args, options = {}) {
   return new Promise((resolve, reject) => {
@@ -1151,7 +1203,10 @@ router.post('/fetch', async (req, res) => {
     }
 
     validateRemoteName(remoteName);
-    const { stdout } = await spawnAsync('git', ['fetch', remoteName], { cwd: projectPath });
+    const userId = req.user?.id;
+    const { stdout } = await withGithubToken(projectPath, userId, () =>
+      spawnAsync('git', ['fetch', remoteName], { cwd: projectPath })
+    );
 
     res.json({ success: true, output: stdout || 'Fetch completed successfully', remoteName });
   } catch (error) {
@@ -1196,7 +1251,10 @@ router.post('/pull', async (req, res) => {
 
     validateRemoteName(remoteName);
     validateBranchName(remoteBranch);
-    const { stdout } = await spawnAsync('git', ['pull', remoteName, remoteBranch], { cwd: projectPath });
+    const userId = req.user?.id;
+    const { stdout } = await withGithubToken(projectPath, userId, () =>
+      spawnAsync('git', ['pull', remoteName, remoteBranch], { cwd: projectPath })
+    );
 
     res.json({
       success: true,
@@ -1264,7 +1322,10 @@ router.post('/push', async (req, res) => {
 
     validateRemoteName(remoteName);
     validateBranchName(remoteBranch);
-    const { stdout } = await spawnAsync('git', ['push', remoteName, remoteBranch], { cwd: projectPath });
+    const userId = req.user?.id;
+    const { stdout } = await withGithubToken(projectPath, userId, () =>
+      spawnAsync('git', ['push', remoteName, remoteBranch], { cwd: projectPath })
+    );
 
     res.json({
       success: true,
@@ -1349,7 +1410,10 @@ router.post('/publish', async (req, res) => {
 
     // Publish the branch (set upstream and push)
     validateRemoteName(remoteName);
-    const { stdout } = await spawnAsync('git', ['push', '--set-upstream', remoteName, branch], { cwd: projectPath });
+    const userId = req.user?.id;
+    const { stdout } = await withGithubToken(projectPath, userId, () =>
+      spawnAsync('git', ['push', '--set-upstream', remoteName, branch], { cwd: projectPath })
+    );
     
     res.json({ 
       success: true, 

--- a/server/shared/claude-cli-path.ts
+++ b/server/shared/claude-cli-path.ts
@@ -1,5 +1,6 @@
 import { execFileSync } from 'node:child_process';
 import fs from 'node:fs';
+import os from 'node:os';
 import path from 'node:path';
 
 const DEFAULT_CLAUDE_COMMAND = 'claude';
@@ -53,10 +54,10 @@ function resolveClaudeWrapperBinary(
   const matches = content.matchAll(/["']([^"'\\\r\n]*claude\.exe)["']/gi);
   for (const match of matches) {
     const rawTarget = match[1]
-      .replace(/^\$basedir[\\/]/i, '')
-      .replace(/^%dp0%[\\/]/i, '')
-      .replace(/^%~dp0[\\/]/i, '');
-    const normalizedTarget = rawTarget.replace(/[\\/]/g, pathApi.sep);
+      .replace(/^\$basedir[\\\/]/i, '')
+      .replace(/^%dp0%[\\\/]/i, '')
+      .replace(/^%~dp0[\\\/]/i, '');
+    const normalizedTarget = rawTarget.replace(/[\\\/]/g, pathApi.sep);
     const candidate = pathApi.isAbsolute(normalizedTarget)
       ? normalizedTarget
       : pathApi.resolve(pathApi.dirname(wrapperPath), normalizedTarget);
@@ -67,6 +68,95 @@ function resolveClaudeWrapperBinary(
   }
 
   return null;
+}
+
+/**
+ * Returns candidate paths to check for the claude binary on Linux/macOS,
+ * in priority order. These cover the native installer, nvm, and common npm
+ * global prefix locations so users don't need to set CLAUDE_CLI_PATH manually.
+ */
+function getUnixCandidatePaths(): string[] {
+  const home = os.homedir();
+  const candidates: string[] = [
+    // Native Anthropic installer (Linux/macOS)
+    path.join(home, '.local', 'bin', 'claude'),
+    // macOS native installer
+    path.join(home, 'Library', 'Application Support', 'Claude', 'claude'),
+    // Common npm global prefixes
+    '/usr/local/bin/claude',
+    '/usr/bin/claude',
+    // npm global on common Linux distros
+    '/usr/local/share/npm-global/bin/claude',
+    // nvm active version
+    path.join(home, '.nvm', 'current', 'bin', 'claude'),
+    // Homebrew (macOS/Linux)
+    '/opt/homebrew/bin/claude',
+    '/home/linuxbrew/.linuxbrew/bin/claude',
+  ];
+
+  // Also probe nvm versioned installs (picks whatever exists)
+  try {
+    const nvmDir = path.join(home, '.nvm', 'versions', 'node');
+    if (fs.existsSync(nvmDir)) {
+      const versions = fs.readdirSync(nvmDir);
+      for (const v of versions.sort().reverse()) {
+        candidates.push(path.join(nvmDir, v, 'bin', 'claude'));
+      }
+    }
+  } catch {
+    // ignore
+  }
+
+  return candidates;
+}
+
+/**
+ * Tries to resolve the claude binary on Unix-like systems.
+ * Resolution order:
+ *  1. Explicit CLAUDE_CLI_PATH / configuredPath (if it looks like an absolute path)
+ *  2. Well-known install locations (native installer, nvm, npm global…)
+ *  3. PATH lookup via `which` / `command -v`
+ *  4. Fall back to bare 'claude' (lets the OS PATH decide at spawn time)
+ */
+function resolveUnixClaudeExecutablePath(
+  configuredPath: string,
+  deps: Required<ResolveClaudeCodeExecutablePathDependencies>,
+): string {
+  // If the caller supplied an explicit absolute/relative path, honour it directly.
+  if (isPathLike(configuredPath) || path.isAbsolute(configuredPath)) {
+    return configuredPath;
+  }
+
+  // configuredPath is 'claude' (the default) – try well-known locations first.
+  for (const candidate of getUnixCandidatePaths()) {
+    if (deps.existsSync(candidate)) {
+      return candidate;
+    }
+  }
+
+  // Try resolving via the shell (which / command -v)
+  for (const whichCmd of ['which', 'command']) {
+    try {
+      const args = whichCmd === 'command' ? ['-v', configuredPath] : [configuredPath];
+      const stdout = deps.execFileSync(whichCmd === 'command' ? '/bin/sh' : whichCmd,
+        whichCmd === 'command' ? ['-c', `command -v ${configuredPath}`] : args,
+        {
+          encoding: 'utf8',
+          stdio: ['ignore', 'pipe', 'ignore'],
+          timeout: 3000,
+        },
+      );
+      const resolved = stdout.trim().split('\n')[0]?.trim();
+      if (resolved && deps.existsSync(resolved)) {
+        return resolved;
+      }
+    } catch {
+      // not available
+    }
+  }
+
+  // Last resort: return the bare command and let the OS resolve it at spawn time.
+  return configuredPath;
 }
 
 function resolveWindowsClaudeExecutablePath(
@@ -131,9 +221,10 @@ export function resolveClaudeCodeExecutablePath(
   };
 
   const normalizedPath = stripWrappingQuotes(configuredPath || DEFAULT_CLAUDE_COMMAND);
-  if (deps.platform !== 'win32') {
-    return normalizedPath;
+
+  if (deps.platform === 'win32') {
+    return resolveWindowsClaudeExecutablePath(normalizedPath, deps);
   }
 
-  return resolveWindowsClaudeExecutablePath(normalizedPath, deps);
+  return resolveUnixClaudeExecutablePath(normalizedPath, deps);
 }

--- a/server/shared/claude-cli-path.ts
+++ b/server/shared/claude-cli-path.ts
@@ -1,3 +1,4 @@
+import { createRequire } from 'node:module';
 import { execFileSync } from 'node:child_process';
 import fs from 'node:fs';
 import os from 'node:os';
@@ -7,10 +8,20 @@ const DEFAULT_CLAUDE_COMMAND = 'claude';
 const CLAUDE_SCRIPT_EXTENSIONS = new Set(['.cjs', '.js', '.jsx', '.mjs', '.ts', '.tsx']);
 const CLAUDE_WRAPPER_SEGMENTS = ['node_modules', '@anthropic-ai', 'claude-code', 'bin', 'claude.exe'] as const;
 
+/**
+ * Package name prefix used by claude-agent-sdk optional platform packages.
+ * The SDK ships a bundled, version-matched claude binary inside these packages.
+ * Using this binary is the most reliable choice because it is guaranteed to be
+ * protocol-compatible with the installed SDK version — no CLAUDE_CLI_PATH
+ * configuration is needed.
+ */
+const SDK_PKG_PREFIX = '@anthropic-ai/claude-agent-sdk';
+
 export type ResolveClaudeCodeExecutablePathDependencies = {
   execFileSync?: typeof execFileSync;
   existsSync?: typeof fs.existsSync;
   platform?: NodeJS.Platform;
+  arch?: string;
   readFileSync?: typeof fs.readFileSync;
 };
 
@@ -31,6 +42,72 @@ function stripWrappingQuotes(value: string): string {
 
 function isPathLike(value: string): boolean {
   return value.includes('/') || value.includes('\\');
+}
+
+/**
+ * Attempts to find the claude binary that is bundled inside the installed
+ * @anthropic-ai/claude-agent-sdk platform packages.
+ *
+ * The SDK distributes a claude binary alongside itself in optional packages
+ * named `@anthropic-ai/claude-agent-sdk-<platform>-<arch>` (e.g.
+ * `@anthropic-ai/claude-agent-sdk-linux-x64`). Using this binary instead of
+ * a system-installed one guarantees protocol compatibility with the SDK
+ * version that is actually installed.
+ *
+ * This removes the need to set `CLAUDE_CLI_PATH` in the vast majority of
+ * deployments, including Docker containers that use a base image with a
+ * different (possibly incompatible) claude version pre-installed.
+ */
+function resolveSDKBundledBinary(
+  existsSync: typeof fs.existsSync,
+  platform: NodeJS.Platform,
+  arch: string,
+): string | null {
+  const suffix = platform === 'win32' ? '.exe' : '';
+
+  // Ordered list of platform package names to try
+  let pkgNames: string[];
+  if (platform === 'linux') {
+    pkgNames = [
+      `${SDK_PKG_PREFIX}-linux-${arch}`,
+      `${SDK_PKG_PREFIX}-linux-${arch}-musl`,
+    ];
+  } else if (platform === 'darwin') {
+    pkgNames = [`${SDK_PKG_PREFIX}-darwin-${arch}`];
+  } else if (platform === 'win32') {
+    pkgNames = [`${SDK_PKG_PREFIX}-win32-${arch}`];
+  } else {
+    return null;
+  }
+
+  // Use createRequire so that resolution starts from *this* file's location,
+  // which ensures we find the SDK packages bundled alongside claudecodeui.
+  const requireFromHere = createRequire(import.meta.url);
+
+  for (const pkg of pkgNames) {
+    try {
+      // Resolve the package root via its package.json, then append binary name
+      const pkgJsonPath = requireFromHere.resolve(`${pkg}/package.json`);
+      const candidate = path.join(path.dirname(pkgJsonPath), `claude${suffix}`);
+      if (existsSync(candidate)) {
+        return candidate;
+      }
+    } catch {
+      // package not installed or not resolvable — try next
+    }
+
+    try {
+      // Some packages expose the binary via an exports map or main field
+      const candidate = requireFromHere.resolve(`${pkg}/claude${suffix}`);
+      if (existsSync(candidate)) {
+        return candidate;
+      }
+    } catch {
+      // ignore
+    }
+  }
+
+  return null;
 }
 
 function resolveClaudeWrapperBinary(
@@ -74,6 +151,10 @@ function resolveClaudeWrapperBinary(
  * Returns candidate paths to check for the claude binary on Linux/macOS,
  * in priority order. These cover the native installer, nvm, and common npm
  * global prefix locations so users don't need to set CLAUDE_CLI_PATH manually.
+ *
+ * Note: the SDK-bundled binary is tried BEFORE these paths in
+ * resolveUnixClaudeExecutablePath() because it is guaranteed to be
+ * version-compatible with the installed SDK.
  */
 function getUnixCandidatePaths(): string[] {
   const home = os.homedir();
@@ -112,34 +193,56 @@ function getUnixCandidatePaths(): string[] {
 
 /**
  * Tries to resolve the claude binary on Unix-like systems.
- * Resolution order:
+ *
+ * Resolution order (highest to lowest priority):
+ *  0. SDK-bundled binary  — found inside `@anthropic-ai/claude-agent-sdk-<platform>`
+ *                           node_modules. This is tried FIRST because it is
+ *                           guaranteed to be protocol-compatible with the
+ *                           installed SDK, regardless of what is on PATH.
+ *                           Eliminates the need for CLAUDE_CLI_PATH in Docker
+ *                           containers and CI environments.
  *  1. Explicit CLAUDE_CLI_PATH / configuredPath (if it looks like an absolute path)
  *  2. Well-known install locations (native installer, nvm, npm global…)
  *  3. PATH lookup via `which` / `command -v`
- *  4. Fall back to bare 'claude' (lets the OS PATH decide at spawn time)
+ *  4. Bare 'claude' — last resort, lets the OS PATH decide at spawn time
+ *
+ * For users who swap the Claude Code harness to use a third-party AI backend
+ * (e.g. MiniMax, Together, OpenRouter) via ANTHROPIC_BASE_URL +
+ * ANTHROPIC_AUTH_TOKEN, the binary itself is still the official claude binary;
+ * only the API endpoint and credentials change. Automatic detection means
+ * these users need no extra configuration beyond their provider env vars.
  */
 function resolveUnixClaudeExecutablePath(
   configuredPath: string,
   deps: Required<ResolveClaudeCodeExecutablePathDependencies>,
 ): string {
-  // If the caller supplied an explicit absolute/relative path, honour it directly.
+  // Priority 0: SDK-bundled binary (version-matched, no config required).
+  // Only auto-use when no explicit path is configured.
+  if (!isPathLike(configuredPath) && !path.isAbsolute(configuredPath)) {
+    const sdkBundled = resolveSDKBundledBinary(deps.existsSync, deps.platform, deps.arch);
+    if (sdkBundled) {
+      return sdkBundled;
+    }
+  }
+
+  // Priority 1: Explicit absolute/relative path → honour it directly.
   if (isPathLike(configuredPath) || path.isAbsolute(configuredPath)) {
     return configuredPath;
   }
 
-  // configuredPath is 'claude' (the default) – try well-known locations first.
+  // Priority 2: Well-known install locations.
   for (const candidate of getUnixCandidatePaths()) {
     if (deps.existsSync(candidate)) {
       return candidate;
     }
   }
 
-  // Try resolving via the shell (which / command -v)
+  // Priority 3: Shell PATH lookup (which / command -v).
   for (const whichCmd of ['which', 'command']) {
     try {
-      const args = whichCmd === 'command' ? ['-v', configuredPath] : [configuredPath];
-      const stdout = deps.execFileSync(whichCmd === 'command' ? '/bin/sh' : whichCmd,
-        whichCmd === 'command' ? ['-c', `command -v ${configuredPath}`] : args,
+      const stdout = deps.execFileSync(
+        whichCmd === 'command' ? '/bin/sh' : whichCmd,
+        whichCmd === 'command' ? ['-c', `command -v ${configuredPath}`] : [configuredPath],
         {
           encoding: 'utf8',
           stdio: ['ignore', 'pipe', 'ignore'],
@@ -155,7 +258,7 @@ function resolveUnixClaudeExecutablePath(
     }
   }
 
-  // Last resort: return the bare command and let the OS resolve it at spawn time.
+  // Priority 4: Last resort — return the bare command and let the OS decide.
   return configuredPath;
 }
 
@@ -177,6 +280,12 @@ function resolveWindowsClaudeExecutablePath(
 
   if (explicitPath) {
     return resolveClaudeWrapperBinary(configuredPath, deps) ?? configuredPath;
+  }
+
+  // Auto-detect SDK-bundled binary on Windows too
+  const sdkBundled = resolveSDKBundledBinary(deps.existsSync, deps.platform, deps.arch);
+  if (sdkBundled) {
+    return sdkBundled;
   }
 
   try {
@@ -217,6 +326,7 @@ export function resolveClaudeCodeExecutablePath(
     execFileSync: dependencies.execFileSync ?? execFileSync,
     existsSync: dependencies.existsSync ?? fs.existsSync,
     platform: dependencies.platform ?? process.platform,
+    arch: dependencies.arch ?? process.arch,
     readFileSync: dependencies.readFileSync ?? fs.readFileSync,
   };
 


### PR DESCRIPTION
## Summary

Two independent but related usability bugs fixed in a single PR.

---

## Fix 1: Claude binary auto-detection on Linux / macOS

**File:** `server/shared/claude-cli-path.ts`

### Problem

`resolveClaudeCodeExecutablePath()` on non-Windows platforms did nothing more than return the configured path verbatim. If `CLAUDE_CLI_PATH` was not set the function returned the bare string `'claude'`, which the SDK then tried to spawn directly.

This causes two failure modes depending on what is installed:

| Situation | Error |
|-----------|-------|
| `claude` not on `PATH` | `Claude Code native binary not found at claude` |
| npm global wrapper on `PATH` instead of native binary | `Claude Code native binary at … exists but failed to launch` (ENOENT on shebang interpreter) |

The second failure is particularly confusing: `@anthropic-ai/claude-code` installed via `npm install -g` creates a **shell-script wrapper** at e.g. `/usr/local/share/npm-global/bin/claude`. The SDK's `K2()` function sees no `.js` extension and treats it as a native binary, then spawns it with `child_process.spawn` directly. If the shebang interpreter is not in `PATH` at spawn time the process emits `ENOENT` → "exists but failed to launch".

The native Anthropic installer places the real binary at `~/.local/bin/claude` (Linux) or similar, but this is also frequently absent from the server process's `PATH`.

### Fix

Added `resolveUnixClaudeExecutablePath()` which runs a **priority-ordered probe** before falling back to the bare command:

1. Explicit `CLAUDE_CLI_PATH` / absolute path → used as-is (existing behaviour)
2. Well-known native-installer locations: `~/.local/bin/claude`, macOS `~/Library/…`, Homebrew, etc.
3. Common npm global prefix paths
4. Active nvm version, all installed nvm versions
5. `which` / `command -v` shell lookup
6. Bare `'claude'` as last resort (lets the OS decide at spawn time)

This removes the need to set `CLAUDE_CLI_PATH` in the vast majority of setups.

---

## Fix 2: Stored GitHub token not used for git push / pull / fetch / publish

**File:** `server/routes/git.js`

### Problem

The UI lets users store GitHub personal access tokens under **Settings → Credentials → GitHub Tokens**. These tokens were looked up and used only during project cloning (`project-clone.service.ts`) and **completely ignored** for every other remote git operation:

- `POST /api/git/fetch`
- `POST /api/git/pull`
- `POST /api/git/push`
- `POST /api/git/publish`

A user who saved a token and expected push/pull to "just work" would receive **Permission denied / authentication failed** from git, even though the token was sitting right there in the database.

### Fix

Added `withGithubToken(projectPath, userId, fn)` helper:

- Retrieves the user's most recently active GitHub token via `githubTokensDb.getActiveGithubToken()`.
- Temporarily rewrites the `origin` remote URL to embed the token (`https://TOKEN@github.com/…`) for the duration of the wrapped `fn()` call.
- **Always** restores the original URL in a `finally` block — credentials are **never persisted to disk**.
- Is a safe no-op for SSH remotes, remotes that already embed credentials, or when the user has no stored token.

Applied the wrapper to all four remote-touching routes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Git remote operations (fetch, pull, push, publish) can now authenticate automatically using a retrieved GitHub token when available.
  * Improved discovery for the CLAUDE executable across Unix, Linux and Windows, including architecture-aware detection and more installer/global lookup locations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->