### PR TITLE
fix: prevent stale codex processing banner

### DIFF
--- a/server/openai-codex.js
+++ b/server/openai-codex.js
@@ -279,6 +279,16 @@ export async function queryCodex(command, options = {}, ws) {
         startedAt: new Date().toISOString()
       });
     };
+    const markSessionFinished = (id) => {
+      if (!id) {
+        return;
+      }
+
+      const session = activeCodexSessions.get(id);
+      if (session && session.status !== 'aborted') {
+        session.status = 'completed';
+      }
+    };
 
     // Existing sessions can be tracked immediately; new sessions are tracked after thread.started.
     if (capturedSessionId) {
@@ -324,6 +334,10 @@ export async function queryCodex(command, options = {}, ws) {
         continue;
       }
 
+      if (event.type === 'turn.completed' || event.type === 'turn.failed') {
+        markSessionFinished(capturedSessionId || sessionId);
+      }
+
       const transformed = transformCodexEvent(event);
 
       // Normalize the transformed event into NormalizedMessage(s) via adapter
@@ -354,6 +368,8 @@ export async function queryCodex(command, options = {}, ws) {
 
     // Send completion event
     if (!terminalFailure) {
+      markSessionFinished(capturedSessionId || sessionId);
+
       sendMessage(ws, createNormalizedMessage({
         kind: 'complete',
         actualSessionId: capturedSessionId || thread.id || sessionId || null,

--- a/src/components/chat/hooks/useChatRealtimeHandlers.ts
+++ b/src/components/chat/hooks/useChatRealtimeHandlers.ts
@@ -98,6 +98,7 @@ export function useChatRealtimeHandlers({
 }: UseChatRealtimeHandlersArgs) {
   const paletteOps = usePaletteOps();
   const lastProcessedMessageRef = useRef<LatestChatMessage | null>(null);
+  const terminalSessionIdsRef = useRef<Set<string>>(new Set());
 
   useEffect(() => {
     if (!latestMessage) return;
@@ -151,6 +152,17 @@ export function useChatRealtimeHandlers({
           const isCurrentSession =
             statusSessionId === currentSessionId || (selectedSession && statusSessionId === selectedSession.id);
 
+          if (msg.isProcessing && terminalSessionIdsRef.current.has(statusSessionId)) {
+            onSessionInactive?.(statusSessionId);
+            onSessionNotProcessing?.(statusSessionId);
+            if (isCurrentSession) {
+              setIsLoading(false);
+              setCanAbortSession(false);
+              setClaudeStatus(null);
+            }
+            return;
+          }
+
           if (msg.isProcessing) {
             onSessionActive?.(statusSessionId);
             onSessionProcessing?.(statusSessionId);
@@ -179,6 +191,10 @@ export function useChatRealtimeHandlers({
     /* ---------------------------------------------------------------- */
 
     const sid = msg.sessionId || activeViewSessionId;
+
+    if (sid && msg.kind === 'session_created') {
+      terminalSessionIdsRef.current.delete(sid);
+    }
 
     // --- Streaming: buffer for performance ---
     if (msg.kind === 'stream_delta') {
@@ -258,6 +274,10 @@ export function useChatRealtimeHandlers({
       }
 
       case 'complete': {
+        if (sid) {
+          terminalSessionIdsRef.current.add(sid);
+        }
+
         // Flush any remaining streaming state
         if (streamTimerRef.current) {
           clearTimeout(streamTimerRef.current);
@@ -313,6 +333,10 @@ export function useChatRealtimeHandlers({
       }
 
       case 'error': {
+        if (sid) {
+          terminalSessionIdsRef.current.add(sid);
+        }
+
         setIsLoading(false);
         setCanAbortSession(false);
         setClaudeStatus(null);

--- a/src/components/chat/hooks/useChatSessionState.ts
+++ b/src/components/chat/hooks/useChatSessionState.ts
@@ -131,6 +131,8 @@ export function useChatSessionState({
   const pendingInitialScrollRef = useRef(true);
   const messagesOffsetRef = useRef(0);
   const scrollPositionRef = useRef({ height: 0, top: 0 });
+  const previousProcessingSessionsRef = useRef<Set<string> | null>(null);
+  const previousProcessingSessionViewIdRef = useRef<string | null>(null);
   const loadAllFinishedTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const loadAllOverlayTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const lastLoadedSessionKeyRef = useRef<string | null>(null);
@@ -693,9 +695,17 @@ export function useChatSessionState({
 
   useEffect(() => {
     const activeViewSessionId = selectedSession?.id || currentSessionId;
+    const previousProcessingSessions = previousProcessingSessionsRef.current;
+    const previousProcessingSessionViewId = previousProcessingSessionViewIdRef.current;
+    previousProcessingSessionsRef.current = processingSessions ?? null;
+    previousProcessingSessionViewIdRef.current = activeViewSessionId ?? null;
+
     if (!activeViewSessionId || !processingSessions) return;
+
+    const activeViewSessionChanged = previousProcessingSessionViewId !== activeViewSessionId;
+    const wasProcessing = previousProcessingSessions?.has(activeViewSessionId) ?? false;
     const shouldBeProcessing = processingSessions.has(activeViewSessionId);
-    if (shouldBeProcessing && !isLoading) {
+    if (shouldBeProcessing && (!wasProcessing || activeViewSessionChanged) && !isLoading) {
       setIsLoading(true);
       setCanAbortSession(true);
     }


### PR DESCRIPTION
## Summary

Fixes a Codex-only race where the processing banner can reappear 1-2 seconds
after a response has already completed.

Codex can emit a terminal turn event and clear the composer banner while a
nearby session-status check or parent processing-state update still believes the
session is running. When the response includes a delayed remote image, the image
load/reflow creates enough time for that stale state to reassert the banner even
though there is no active processing.

## Reproduction

Reproduces with Codex using:

Reply with exactly the following Markdown, no code fence, no explanation:

Start

`![scroll reflow test](https://picsum.photos/seed/pr788-scroll/1600/1400)`

BOTTOM_SENTINEL_PR_788

Did not reproduce with:

hi

Also did not reproduce with Claude in the reported testing.

## What Changed

- Mark Codex sessions as completed as soon as terminal SDK turn events arrive.
- Ignore stale `session-status` messages that report processing after the
  frontend has already seen a terminal event for that session.
- Only restore local loading from global `processingSessions` when the viewed
  session newly enters processing, rather than from stale mirrored state.

## Why

The banner state is driven by multiple lifecycle paths: local loading state,
global processing-session state, websocket session-status checks, and Codex
terminal events. The previous behavior allowed late status/protection updates to
win after completion. This change makes terminal completion authoritative for
the completed session while preserving the ability to show the banner when a
different session is genuinely still processing.

## Validation

- Staged ESLint passed through commit hooks.
- `npm run typecheck` passed before packaging.