### PR TITLE
Pass Windows-essential env vars to plugin subprocesses

### DIFF
--- a/server/utils/plugin-process-manager.js
+++ b/server/utils/plugin-process-manager.js
@@ -8,6 +8,41 @@ const runningPlugins = new Map();
 const startingPlugins = new Map();
 
 /**
+ * Build the environment handed to a plugin server subprocess.
+ *
+ * Intentionally minimal: only non-secret essentials, never the host's full
+ * environment. On Windows a handful of system variables are required for any
+ * child to bootstrap (Node itself, and any Python or CLI a plugin shells out
+ * to). Without APPDATA a `pip install --user` tool cannot locate its
+ * site-packages and fails to import; SystemRoot, PATHEXT and TEMP are needed to
+ * resolve system DLLs, executable extensions and a temp directory. None of
+ * these carry secrets, so the ones that are set get passed straight through.
+ */
+function buildPluginEnv(name) {
+  const env = {
+    PATH: process.env.PATH,
+    HOME: process.env.HOME,
+    NODE_ENV: process.env.NODE_ENV || 'production',
+    PLUGIN_NAME: name,
+  };
+
+  if (process.platform === 'win32') {
+    const WINDOWS_ESSENTIALS = [
+      'SystemRoot', 'windir', 'SystemDrive',
+      'USERPROFILE', 'APPDATA', 'LOCALAPPDATA',
+      'TEMP', 'TMP', 'PATHEXT',
+    ];
+    for (const key of WINDOWS_ESSENTIALS) {
+      if (process.env[key] !== undefined) {
+        env[key] = process.env[key];
+      }
+    }
+  }
+
+  return env;
+}
+
+/**
  * Start a plugin's server subprocess.
  * The plugin's server entry must print a JSON line with { ready: true, port: <number> }
  * to stdout within 10 seconds.
@@ -26,15 +61,9 @@ export function startPluginServer(name, pluginDir, serverEntry) {
 
     const serverPath = path.join(pluginDir, serverEntry);
 
-    // Restricted env — only essentials, no host secrets
     const pluginProcess = spawn('node', [serverPath], {
       cwd: pluginDir,
-      env: {
-        PATH: process.env.PATH,
-        HOME: process.env.HOME,
-        NODE_ENV: process.env.NODE_ENV || 'production',
-        PLUGIN_NAME: name,
-      },
+      env: buildPluginEnv(name),
       stdio: ['ignore', 'pipe', 'pipe'],
     });
 


### PR DESCRIPTION
### What

Plugin server subprocesses are spawned with a minimal env (`PATH`, `HOME`, `NODE_ENV`, `PLUGIN_NAME`). On Windows that omits system variables that child processes rely on to start up.

I ran into this with a plugin of mine that shells out to a Python CLI installed via `pip install --user`. The CLI's `.exe` launches, but Python can't import its own package because `APPDATA` is missing, so it can't locate the per-user `site-packages`. It surfaces to the user as a generic `RPC error 400` from the plugin tab. `SystemRoot`, `PATHEXT` and `TEMP` cause similar failures for other tools.

### Change

On `win32` only, pass through a small allowlist of non-secret system variables when they are set:

`SystemRoot`, `windir`, `SystemDrive`, `USERPROFILE`, `APPDATA`, `LOCALAPPDATA`, `TEMP`, `TMP`, `PATHEXT`

The env stays an explicit allowlist, no host secrets are added, and there is no behavior change on macOS or Linux.

### Notes

I also worked around this on the plugin side (re-deriving these before spawning the child), but it really belongs in the host so every Windows plugin gets it for free. I didn't see existing tests for `plugin-process-manager.js`. Happy to add one if you point me at the runner you prefer.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved plugin server initialization with centralized environment variable configuration and enhanced cross-platform compatibility, particularly for Windows systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->