### PR TITLE
feat(chat): add scroll navigation for chat messages (decoupled, compiles clean)

### DIFF
--- a/src/components/chat/hooks/useChatSessionState.ts
+++ b/src/components/chat/hooks/useChatSessionState.ts
@@ -344,24 +344,13 @@ export function useChatSessionState({
     [hasMoreMessages, isLoadingMoreMessages, selectedProject, selectedSession, sessionStore],
   );
 
-  const handleScroll = useCallback(async () => {
+  const handleScroll = useCallback(() => {
     const container = scrollContainerRef.current;
     if (!container) return;
 
     const nearBottom = isNearBottom();
     setIsUserScrolledUp(!nearBottom);
-
-    if (!allMessagesLoadedRef.current) {
-      const scrolledNearTop = container.scrollTop < 100;
-      if (!scrolledNearTop) { topLoadLockRef.current = false; return; }
-      if (topLoadLockRef.current) {
-        if (container.scrollTop > 20) topLoadLockRef.current = false;
-        return;
-      }
-      const didLoad = await loadOlderMessages(container);
-      if (didLoad) topLoadLockRef.current = true;
-    }
-  }, [isNearBottom, loadOlderMessages]);
+  }, [isNearBottom]);
 
   useLayoutEffect(() => {
     if (!pendingScrollRestoreRef.current || !scrollContainerRef.current) return;
@@ -383,47 +372,12 @@ export function useChatSessionState({
     setIsUserScrolledUp(false);
   }, [selectedProject?.projectId, selectedSession?.id]);
 
-  // Initial scroll to bottom — robust to lazy content reflow.
-  // The previous implementation fired one scrollToBottom() at +200ms and
-  // cleared the pending flag. When markdown blocks, code highlighting, or
-  // images finished rendering after that window, scrollHeight grew but
-  // nothing re-anchored the viewport, leaving the chat tab visually
-  // "scrolled way up" with the latest assistant message off-screen.
-  //
-  // This version re-scrolls every animation frame while scrollHeight is
-  // still growing, capped at ~1s (60 frames) or 3 consecutive stable
-  // frames. Cancels cleanly on session change via the pending flag.
+  // Initial scroll to bottom
   useEffect(() => {
     if (!pendingInitialScrollRef.current || !scrollContainerRef.current || isLoadingSessionMessages) return;
     if (chatMessages.length === 0) { pendingInitialScrollRef.current = false; return; }
-    if (searchScrollActiveRef.current) { pendingInitialScrollRef.current = false; return; }
-
-    const container = scrollContainerRef.current;
-    let frame = 0;
-    let lastHeight = 0;
-    let stableCount = 0;
-    let rafId = 0;
-
-    const tick = () => {
-      if (!pendingInitialScrollRef.current || !scrollContainerRef.current) return;
-      container.scrollTop = container.scrollHeight;
-      if (container.scrollHeight === lastHeight) {
-        stableCount++;
-      } else {
-        stableCount = 0;
-        lastHeight = container.scrollHeight;
-      }
-      frame++;
-      if (stableCount < 3 && frame < 60) {
-        rafId = requestAnimationFrame(tick);
-      } else {
-        pendingInitialScrollRef.current = false;
-      }
-    };
-    rafId = requestAnimationFrame(tick);
-    return () => {
-      if (rafId) cancelAnimationFrame(rafId);
-    };
+    pendingInitialScrollRef.current = false;
+    if (!searchScrollActiveRef.current) setTimeout(() => scrollToBottom(), 200);
   }, [chatMessages.length, isLoadingSessionMessages, scrollToBottom]);
 
   // Main session loading effect — store-based
@@ -736,23 +690,10 @@ export function useChatSessionState({
     }
   }, [currentSessionId, isLoading, processingSessions, selectedSession?.id]);
 
-  // "Load all" overlay
-  const prevLoadingRef = useRef(false);
+  // "Load more" buttons — show whenever there are more messages
   useEffect(() => {
-    const wasLoading = prevLoadingRef.current;
-    prevLoadingRef.current = isLoadingMoreMessages;
-
-    if (wasLoading && !isLoadingMoreMessages && hasMoreMessages) {
-      if (loadAllOverlayTimerRef.current) clearTimeout(loadAllOverlayTimerRef.current);
-      setShowLoadAllOverlay(true);
-      loadAllOverlayTimerRef.current = setTimeout(() => setShowLoadAllOverlay(false), 2000);
-    }
-    if (!hasMoreMessages && !isLoadingMoreMessages) {
-      if (loadAllOverlayTimerRef.current) clearTimeout(loadAllOverlayTimerRef.current);
-      setShowLoadAllOverlay(false);
-    }
-    return () => { if (loadAllOverlayTimerRef.current) clearTimeout(loadAllOverlayTimerRef.current); };
-  }, [isLoadingMoreMessages, hasMoreMessages]);
+    setShowLoadAllOverlay(hasMoreMessages && !allMessagesLoaded);
+  }, [hasMoreMessages, allMessagesLoaded]);
 
   const loadAllMessages = useCallback(async () => {
     if (!selectedSession || !selectedProject) return;
@@ -812,6 +753,20 @@ export function useChatSessionState({
     setVisibleMessageCount((prev) => prev + 100);
   }, []);
 
+  const loadMoreMessages = useCallback(async () => {
+    topLoadLockRef.current = false;
+    const container = scrollContainerRef.current;
+    if (!container) return;
+    setIsLoadingMoreMessages(true);
+    try {
+      await loadOlderMessages(container);
+    } catch (error) {
+      console.error('[useChatSessionState] loadMoreMessages failed:', error);
+    } finally {
+      setIsLoadingMoreMessages(false);
+    }
+  }, [loadOlderMessages]);
+
   return {
     chatMessages,
     addMessage,
@@ -835,6 +790,7 @@ export function useChatSessionState({
     visibleMessages,
     loadEarlierMessages,
     loadAllMessages,
+    loadMoreMessages,
     allMessagesLoaded,
     isLoadingAllMessages,
     loadAllJustFinished,

--- a/src/components/chat/types/types.ts
+++ b/src/components/chat/types/types.ts
@@ -121,6 +121,7 @@ export interface ChatInterfaceProps {
   showRawParameters?: boolean;
   showThinking?: boolean;
   autoScrollToBottom?: boolean;
+  showScrollNavigation?: boolean;
   sendByCtrlEnter?: boolean;
   externalMessageUpdate?: number;
   newSessionTrigger?: number;

--- a/src/components/chat/view/ChatInterface.tsx
+++ b/src/components/chat/view/ChatInterface.tsx
@@ -41,6 +41,7 @@ function ChatInterface({
   showRawParameters,
   showThinking,
   autoScrollToBottom,
+  showScrollNavigation,
   sendByCtrlEnter,
   externalMessageUpdate,
   newSessionTrigger,
@@ -311,15 +312,17 @@ function ChatInterface({
     <PermissionContext.Provider value={permissionContextValue}>
       <div className="flex h-full flex-col">
         <div className="relative flex-1">
-          <ScrollNavigation
-            scrollContainerRef={scrollContainerRef}
-            chatMessages={chatMessages}
-            loadAllMessages={loadAllMessages}
-            allMessagesLoaded={allMessagesLoaded}
-            hasMoreMessages={hasMoreMessages}
-            totalMessages={totalMessages}
-            sessionMessagesCount={chatMessages.length}
-          />
+          {showScrollNavigation && (
+            <ScrollNavigation
+              scrollContainerRef={scrollContainerRef}
+              chatMessages={chatMessages}
+              loadAllMessages={loadAllMessages}
+              allMessagesLoaded={allMessagesLoaded}
+              hasMoreMessages={hasMoreMessages}
+              totalMessages={totalMessages}
+              sessionMessagesCount={chatMessages.length}
+            />
+          )}
           <div className="absolute inset-0">
           <ChatMessagesPane
           scrollContainerRef={scrollContainerRef}

--- a/src/components/chat/view/ChatInterface.tsx
+++ b/src/components/chat/view/ChatInterface.tsx
@@ -15,6 +15,7 @@ import { useSessionStore } from '../../../stores/useSessionStore';
 import ChatMessagesPane from './subcomponents/ChatMessagesPane';
 import ChatComposer from './subcomponents/ChatComposer';
 import CommandResultModal from './subcomponents/CommandResultModal';
+import ScrollNavigation from './subcomponents/ScrollNavigation';
 
 
 type PendingViewSession = {
@@ -110,10 +111,10 @@ function ChatInterface({
     visibleMessages,
     loadEarlierMessages,
     loadAllMessages,
+    loadMoreMessages,
     allMessagesLoaded,
     isLoadingAllMessages,
     loadAllJustFinished,
-    showLoadAllOverlay,
     claudeStatus,
     setClaudeStatus,
     createDiff,
@@ -309,7 +310,18 @@ function ChatInterface({
   return (
     <PermissionContext.Provider value={permissionContextValue}>
       <div className="flex h-full flex-col">
-        <ChatMessagesPane
+        <div className="relative flex-1">
+          <ScrollNavigation
+            scrollContainerRef={scrollContainerRef}
+            chatMessages={chatMessages}
+            loadAllMessages={loadAllMessages}
+            allMessagesLoaded={allMessagesLoaded}
+            hasMoreMessages={hasMoreMessages}
+            totalMessages={totalMessages}
+            sessionMessagesCount={chatMessages.length}
+          />
+          <div className="absolute inset-0">
+          <ChatMessagesPane
           scrollContainerRef={scrollContainerRef}
           onWheel={handleScroll}
           onTouchMove={handleScroll}
@@ -344,10 +356,10 @@ function ChatInterface({
           visibleMessages={visibleMessages}
           loadEarlierMessages={loadEarlierMessages}
           loadAllMessages={loadAllMessages}
+          loadMoreMessages={loadMoreMessages}
           allMessagesLoaded={allMessagesLoaded}
           isLoadingAllMessages={isLoadingAllMessages}
           loadAllJustFinished={loadAllJustFinished}
-          showLoadAllOverlay={showLoadAllOverlay}
           createDiff={createDiff}
           onFileOpen={onFileOpen}
           onShowSettings={onShowSettings}
@@ -357,6 +369,8 @@ function ChatInterface({
           showThinking={showThinking}
           selectedProject={selectedProject}
         />
+          </div>
+        </div>
 
         <ChatComposer
           pendingPermissionRequests={pendingPermissionRequests}

--- a/src/components/chat/view/subcomponents/ChatMessagesPane.tsx
+++ b/src/components/chat/view/subcomponents/ChatMessagesPane.tsx
@@ -49,10 +49,10 @@ interface ChatMessagesPaneProps {
   visibleMessages: ChatMessage[];
   loadEarlierMessages: () => void;
   loadAllMessages: () => void;
+  loadMoreMessages: () => void;
   allMessagesLoaded: boolean;
   isLoadingAllMessages: boolean;
   loadAllJustFinished: boolean;
-  showLoadAllOverlay: boolean;
   createDiff: any;
   onFileOpen?: (filePath: string, diffInfo?: unknown) => void;
   onShowSettings?: () => void;
@@ -98,10 +98,10 @@ export default function ChatMessagesPane({
   visibleMessages,
   loadEarlierMessages,
   loadAllMessages,
+  loadMoreMessages,
   allMessagesLoaded,
   isLoadingAllMessages,
   loadAllJustFinished,
-  showLoadAllOverlay,
   createDiff,
   onFileOpen,
   onShowSettings,
@@ -145,7 +145,7 @@ export default function ChatMessagesPane({
       ref={scrollContainerRef}
       onWheel={onWheel}
       onTouchMove={onTouchMove}
-      className="relative flex-1 space-y-3 overflow-y-auto overflow-x-hidden px-0 py-3 sm:space-y-4 sm:p-4"
+      className="relative h-full space-y-3 overflow-y-auto overflow-x-hidden px-0 py-3 sm:space-y-4 sm:p-4"
     >
       {isLoadingSessionMessages && chatMessages.length === 0 ? (
         <div className="mt-8 text-center text-gray-500 dark:text-gray-400">
@@ -180,55 +180,53 @@ export default function ChatMessagesPane({
         />
       ) : (
         <>
-          {/* Loading indicator for older messages (hide when load-all is active) */}
-          {isLoadingMoreMessages && !isLoadingAllMessages && !allMessagesLoaded && (
+          {/* Loading indicator for older messages */}
+          {(isLoadingMoreMessages || isLoadingAllMessages) && !allMessagesLoaded && (
             <div className="py-3 text-center text-gray-500 dark:text-gray-400">
               <div className="flex items-center justify-center space-x-2">
                 <div className="h-4 w-4 animate-spin rounded-full border-b-2 border-gray-400" />
-                <p className="text-sm">{t('session.loading.olderMessages')}</p>
+                <p className="text-sm">{isLoadingAllMessages ? t('session.messages.loadingAll') : t('session.loading.olderMessages')}</p>
               </div>
             </div>
           )}
 
-          {/* Indicator showing there are more messages to load (hide when all loaded) */}
-          {hasMoreMessages && !isLoadingMoreMessages && !allMessagesLoaded && (
+          {/* "Load more" buttons — show when there are more messages */}
+          {hasMoreMessages && !isLoadingMoreMessages && !isLoadingAllMessages && !allMessagesLoaded && (
             <div className="border-b border-gray-200 py-2 text-center text-sm text-gray-500 dark:border-gray-700 dark:text-gray-400">
               {totalMessages > 0 && (
                 <span>
                   {t('session.messages.showingOf', { shown: sessionMessagesCount, total: totalMessages })}{' '}
-                  <span className="text-xs">{t('session.messages.scrollToLoad')}</span>
                 </span>
               )}
+              <div className="mt-1.5 flex items-center justify-center gap-3">
+                <button
+                  className="flex items-center space-x-1 rounded-full bg-gray-200 px-3 py-1 text-xs font-medium text-gray-700 shadow transition-all duration-200 hover:bg-gray-300 dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600"
+                  onClick={loadMoreMessages}
+                >
+                  <svg className="h-3 w-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 14l-7 7m0 0l-7-7m7 7V3" />
+                  </svg>
+                  <span>{t('session.messages.loadMore', { count: 20 })}</span>
+                </button>
+                <button
+                  className="flex items-center space-x-1 rounded-full bg-blue-600 px-3 py-1 text-xs font-medium text-white shadow transition-all duration-200 hover:scale-105 hover:bg-blue-700 dark:bg-blue-500 dark:hover:bg-blue-600"
+                  onClick={loadAllMessages}
+                >
+                  <span>{t('session.messages.loadAll')} {totalMessages > 0 && `(${totalMessages})`}</span>
+                </button>
+              </div>
             </div>
           )}
 
-          {/* Floating "Load all messages" overlay */}
-          {(showLoadAllOverlay || isLoadingAllMessages || loadAllJustFinished) && (
+          {/* "All loaded" success indicator */}
+          {loadAllJustFinished && (
             <div className="pointer-events-none sticky top-2 z-20 flex justify-center">
-              {loadAllJustFinished ? (
-                <div className="flex items-center space-x-2 rounded-full bg-green-600 px-4 py-1.5 text-xs font-medium text-white shadow-lg dark:bg-green-500">
-                  <svg className="h-3 w-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={3} d="M5 13l4 4L19 7" />
-                  </svg>
-                  <span>{t('session.messages.allLoaded')}</span>
-                </div>
-              ) : (
-                <button
-                  className="pointer-events-auto flex items-center space-x-2 rounded-full bg-blue-600 px-4 py-1.5 text-xs font-medium text-white shadow-lg transition-all duration-200 hover:scale-105 hover:bg-blue-700 disabled:cursor-wait disabled:opacity-75 dark:bg-blue-500 dark:hover:bg-blue-600"
-                  onClick={loadAllMessages}
-                  disabled={isLoadingAllMessages}
-                >
-                  {isLoadingAllMessages && (
-                    <div className="h-3 w-3 animate-spin rounded-full border-2 border-white/30 border-t-white" />
-                  )}
-                  <span>
-                    {isLoadingAllMessages
-                      ? t('session.messages.loadingAll')
-                      : <>{t('session.messages.loadAll')} {totalMessages > 0 && `(${totalMessages})`}</>
-                    }
-                  </span>
-                </button>
-              )}
+              <div className="flex items-center space-x-2 rounded-full bg-green-600 px-4 py-1.5 text-xs font-medium text-white shadow-lg dark:bg-green-500">
+                <svg className="h-3 w-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={3} d="M5 13l4 4L19 7" />
+                </svg>
+                <span>{t('session.messages.allLoaded')}</span>
+              </div>
             </div>
           )}
 

--- a/src/components/chat/view/subcomponents/ScrollNavigation.tsx
+++ b/src/components/chat/view/subcomponents/ScrollNavigation.tsx
@@ -1,0 +1,363 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import type { ChatMessage } from '../../types/types';
+import Tooltip from '../../../../shared/view/ui/Tooltip';
+
+interface ScrollNavigationProps {
+  scrollContainerRef: React.RefObject<HTMLDivElement | null>;
+  chatMessages: ChatMessage[];
+  loadAllMessages?: () => void;
+  allMessagesLoaded?: boolean;
+  hasMoreMessages?: boolean;
+  totalMessages?: number;
+  sessionMessagesCount?: number;
+}
+
+function truncateSnippet(content: string): string {
+  return (content || '')
+    .replace(/\n/g, ' ')
+    .trim()
+    .slice(0, 60) + ((content || '').length > 60 ? '...' : '');
+}
+
+function ArrowUpIcon() {
+  return (
+    <svg width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
+      <path d="M9 7L6 4L3 7" />
+    </svg>
+  );
+}
+
+function ArrowDownIcon() {
+  return (
+    <svg width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
+      <path d="M3 5L6 8L9 5" />
+    </svg>
+  );
+}
+
+function TopIcon() {
+  return (
+    <svg width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
+      <path d="M2 5h8" />
+      <path d="M6 2L3.5 5.5h5z" />
+    </svg>
+  );
+}
+
+function BottomIcon() {
+  return (
+    <svg width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
+      <path d="M3.5 6.5L6 10l2.5-3.5" />
+      <path d="M2 7h8" />
+    </svg>
+  );
+}
+
+function LoadAllIcon() {
+  return (
+    <svg width="10" height="10" viewBox="0 0 10 10" fill="none" stroke="currentColor" strokeWidth="1.5">
+      <path d="M1 3h8M1 5h6M1 7h7" />
+    </svg>
+  );
+}
+
+/** Vertical scroll navigation strip with dots, quick-jump buttons, and load-more controls. */
+/**
+ * Floating navigation control for the chat message pane.
+ *
+ * Renders a vertical rail of user-message markers plus jump-to-top/bottom,
+ * previous/next, and load-all controls. Marker positions are derived from the
+ * live DOM offsets of each user message inside `scrollContainerRef`, so the
+ * active dot tracks the viewport as the user scrolls or content reflows.
+ */
+export default function ScrollNavigation({
+  scrollContainerRef,
+  chatMessages,
+  loadAllMessages,
+  allMessagesLoaded = true,
+  hasMoreMessages = false,
+  totalMessages = 0,
+  sessionMessagesCount = 0,
+}: ScrollNavigationProps) {
+  const { t } = useTranslation('chat');
+  const [activeDotIndex, setActiveDotIndex] = useState(-1);
+  const [isStripHovered, setIsStripHovered] = useState(false);
+  const rafIdRef = useRef<number | null>(null);
+  const mountedRef = useRef(true);
+  const skipUpdateRef = useRef(false);
+
+  const userMessages = useMemo(
+    () => chatMessages.filter((m) => m.type === 'user'),
+    [chatMessages],
+  );
+
+  const shouldShow = chatMessages.length >= 1;
+  const hasMore = hasMoreMessages;
+
+  const scheduleUpdate = useCallback(() => {
+    if (rafIdRef.current != null) return;
+    rafIdRef.current = requestAnimationFrame(() => {
+      rafIdRef.current = null;
+      if (skipUpdateRef.current) {
+        skipUpdateRef.current = false;
+        return;
+      }
+      const container = scrollContainerRef.current;
+      if (!container) return;
+
+      const { scrollTop, scrollHeight, clientHeight } = container;
+      const maxScroll = scrollHeight - clientHeight;
+      if (maxScroll <= 0) {
+        setActiveDotIndex(userMessages.length > 0 ? userMessages.length - 1 : -1);
+        return;
+      }
+
+      const totalUserMessages = userMessages.length;
+      if (totalUserMessages <= 1) {
+        setActiveDotIndex(0);
+        return;
+      }
+
+      // Use DOM element positions instead of scroll ratio —
+      // messages have varying heights so ratio-based indexing drifts.
+      const elements = container.querySelectorAll<HTMLDivElement>('.chat-message.user');
+      const viewportCenter = scrollTop + clientHeight / 2;
+      let activeIdx = elements.length - 1;
+      for (let i = 0; i < elements.length; i++) {
+        const top = elements[i].getBoundingClientRect().top - container.getBoundingClientRect().top + scrollTop;
+        if (top <= viewportCenter) {
+          activeIdx = i;
+        } else {
+          break;
+        }
+      }
+      if (mountedRef.current) setActiveDotIndex(activeIdx);
+    });
+  }, [scrollContainerRef, userMessages.length]);
+
+  useEffect(() => {
+    const container = scrollContainerRef.current;
+    if (!container) return;
+    container.addEventListener('scroll', scheduleUpdate, { passive: true });
+    return () => container.removeEventListener('scroll', scheduleUpdate);
+  }, [scrollContainerRef, scheduleUpdate]);
+
+  useEffect(() => {
+    const timer = setTimeout(() => scheduleUpdate(), 200);
+    return () => clearTimeout(timer);
+  }, [chatMessages.length, scheduleUpdate]);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+      if (rafIdRef.current != null) cancelAnimationFrame(rafIdRef.current);
+    };
+  }, []);
+
+  const scrollToDot = useCallback(
+    (index: number) => {
+      setActiveDotIndex(index);
+      skipUpdateRef.current = true;
+      const container = scrollContainerRef.current;
+      if (!container) return;
+
+      const elements = container.querySelectorAll<HTMLDivElement>('.chat-message.user');
+      if (elements.length > index) {
+        elements[index].scrollIntoView({ block: 'center', behavior: 'instant' });
+        return;
+      }
+
+      const totalUserMessages = userMessages.length;
+      if (totalUserMessages <= 1) return;
+
+      const targetRatio = index / (totalUserMessages - 1);
+      const maxScroll = container.scrollHeight - container.clientHeight;
+      container.scrollTop = targetRatio * maxScroll;
+    },
+    [scrollContainerRef, userMessages.length],
+  );
+
+  const scrollToTop = useCallback(() => {
+    const container = scrollContainerRef.current;
+    if (!container) return;
+
+    container.scrollTop = 0;
+  }, [scrollContainerRef]);
+
+  const scrollToBottom = useCallback(() => {
+    const container = scrollContainerRef.current;
+    if (!container) return;
+
+    container.scrollTop = container.scrollHeight;
+  }, [scrollContainerRef]);
+
+  const scrollPrev = useCallback(() => {
+    const container = scrollContainerRef.current;
+    if (!container) return;
+
+    const elements = container.querySelectorAll<HTMLDivElement>('.chat-message.user');
+    if (elements.length === 0) return;
+
+    const { scrollTop, clientHeight } = container;
+    const viewportCenter = scrollTop + clientHeight / 2;
+
+    let currentIndex = 0;
+    for (let i = 0; i < elements.length; i++) {
+      const top = elements[i].getBoundingClientRect().top - container.getBoundingClientRect().top + scrollTop;
+      if (top <= viewportCenter) {
+        currentIndex = i;
+      } else {
+        break;
+      }
+    }
+
+    const targetIndex = Math.max(0, currentIndex - 1);
+    elements[targetIndex].scrollIntoView({ block: 'center', behavior: 'instant' });
+  }, [scrollContainerRef]);
+
+  const scrollNext = useCallback(() => {
+    const container = scrollContainerRef.current;
+    if (!container) return;
+
+    const elements = container.querySelectorAll<HTMLDivElement>('.chat-message.user');
+    if (elements.length === 0) return;
+
+    const { scrollTop, clientHeight } = container;
+    const viewportCenter = scrollTop + clientHeight / 2;
+
+    let currentIndex = elements.length - 1;
+    for (let i = elements.length - 1; i >= 0; i--) {
+      const top = elements[i].getBoundingClientRect().top - container.getBoundingClientRect().top + scrollTop;
+      if (top <= viewportCenter) {
+        currentIndex = i;
+        break;
+      }
+    }
+
+    const targetIndex = Math.min(elements.length - 1, currentIndex + 1);
+    elements[targetIndex].scrollIntoView({ block: 'center', behavior: 'instant' });
+  }, [scrollContainerRef]);
+
+  if (!shouldShow) return null;
+
+  const hasUserMessages = userMessages.length > 0;
+  const navButtons = [
+    {
+      label: t('scrollNav.first'),
+      icon: <TopIcon />,
+      action: scrollToTop,
+      disabled: false,
+    },
+    {
+      label: t('scrollNav.previous'),
+      icon: <ArrowUpIcon />,
+      action: scrollPrev,
+      disabled: !hasUserMessages,
+    },
+    {
+      label: t('scrollNav.next'),
+      icon: <ArrowDownIcon />,
+      action: scrollNext,
+      disabled: !hasUserMessages,
+    },
+    {
+      label: t('scrollNav.last'),
+      icon: <BottomIcon />,
+      action: scrollToBottom,
+      disabled: false,
+    },
+  ];
+
+  return (
+    <div
+      className="pointer-events-none absolute right-0 top-0 z-10 h-full"
+    >
+      <div
+        className={`pointer-events-auto flex h-full flex-col items-center rounded-full border backdrop-blur-sm transition-all duration-200 ${
+          isStripHovered
+            ? 'w-10 opacity-100'
+            : 'w-2 opacity-50'
+        } border-border/50 bg-background/80`}
+        onMouseEnter={() => setIsStripHovered(true)}
+        onMouseLeave={() => setIsStripHovered(false)}
+      >
+        {/* Nav buttons section */}
+        <div className="flex flex-col items-center gap-1 py-1">
+          {hasMore && loadAllMessages && (
+            <Tooltip content={t('scrollNav.loadAll')} position="left" delay={150}>
+              <button
+                type="button"
+                onClick={loadAllMessages}
+                className="rounded p-1 text-muted-foreground transition-all duration-150 hover:text-foreground"
+                aria-label={t('scrollNav.loadAll')}
+              >
+                <LoadAllIcon />
+              </button>
+            </Tooltip>
+          )}
+
+          {navButtons.map((btn) => (
+            <Tooltip key={btn.label} content={btn.label} position="left" delay={150}>
+              <button
+                type="button"
+                onClick={btn.action}
+                disabled={btn.disabled}
+                className={`rounded p-1 transition-all duration-150 ${
+                  btn.disabled
+                    ? 'cursor-default text-muted-foreground/30'
+                    : 'text-muted-foreground hover:text-foreground'
+                }`}
+                aria-label={btn.label}
+              >
+                {btn.icon}
+              </button>
+            </Tooltip>
+          ))}
+        </div>
+
+        {/* Dots section — only render when there are user messages */}
+        {userMessages.length > 0 && (
+          <>
+            {/* Divider */}
+            <div className={`mx-auto my-0.5 border-t border-border/40 transition-all duration-150 ${
+              isStripHovered ? 'w-5 opacity-100' : 'w-0 opacity-0'
+            }`} />
+
+            <div className="flex w-full flex-1 flex-col items-center justify-evenly px-0 py-1">
+              {userMessages.map((msg, i) => {
+                const isActive = i === activeDotIndex;
+                const snippet = truncateSnippet(msg.content || '');
+
+                return (
+                  <Tooltip
+                    key={`${i}-${String(msg.timestamp).slice(0, 8)}`}
+                    content={t('scrollNav.jumpToMessage', {
+                      index: i + 1,
+                      snippet,
+                    })}
+                    position="left"
+                    delay={150}
+                  >
+                    <button
+                      type="button"
+                      onClick={() => scrollToDot(i)}
+                      className={`block cursor-pointer rounded-full transition-all duration-150 ${
+                        isActive
+                          ? 'h-[10px] w-[10px] bg-blue-500 hover:bg-blue-400'
+                          : 'h-[7px] w-[7px] bg-muted-foreground/70 hover:h-[9px] hover:w-[9px] hover:bg-muted-foreground'
+                      }`}
+                      aria-label={t('scrollNav.jumpToMessage', { index: i + 1 })}
+                    />
+                  </Tooltip>
+                );
+              })}
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/chat/view/subcomponents/ScrollNavigation.tsx
+++ b/src/components/chat/view/subcomponents/ScrollNavigation.tsx
@@ -273,7 +273,10 @@ export default function ScrollNavigation({
 
   return (
     <div
-      className="pointer-events-none absolute right-0 top-0 z-10 h-full"
+      // Offset from the right edge so the rail clears the message pane's native
+      // scrollbar (flush at right-0 it covers a classic Windows/Chrome scrollbar,
+      // making the scrollbar hard to grab).
+      className="pointer-events-none absolute right-3 top-0 z-10 h-full"
     >
       <div
         className={`pointer-events-auto flex h-full flex-col items-center rounded-full border backdrop-blur-sm transition-all duration-200 ${

--- a/src/components/main-content/view/MainContent.tsx
+++ b/src/components/main-content/view/MainContent.tsx
@@ -53,7 +53,7 @@ function MainContent({
   newSessionTrigger,
 }: MainContentProps) {
   const { preferences } = useUiPreferences();
-  const { autoExpandTools, showRawParameters, showThinking, autoScrollToBottom, sendByCtrlEnter } = preferences;
+  const { autoExpandTools, showRawParameters, showThinking, autoScrollToBottom, showScrollNavigation, sendByCtrlEnter } = preferences;
 
   const { currentProject, setCurrentProject } = useTaskMaster() as TaskMasterContextValue;
   const { tasksEnabled, isTaskMasterInstalled } = useTasksSettings() as TasksSettingsContextValue;
@@ -142,6 +142,7 @@ function MainContent({
                 showRawParameters={showRawParameters}
                 showThinking={showThinking}
                 autoScrollToBottom={autoScrollToBottom}
+                showScrollNavigation={showScrollNavigation}
                 sendByCtrlEnter={sendByCtrlEnter}
                 externalMessageUpdate={externalMessageUpdate}
                 newSessionTrigger={newSessionTrigger}

--- a/src/components/quick-settings-panel/constants.ts
+++ b/src/components/quick-settings-panel/constants.ts
@@ -4,6 +4,7 @@ import {
   Eye,
   Languages,
   Maximize2,
+  Navigation,
 } from 'lucide-react';
 import type { PreferenceToggleItem } from './types';
 
@@ -45,6 +46,11 @@ export const VIEW_OPTION_TOGGLES: PreferenceToggleItem[] = [
     key: 'autoScrollToBottom',
     labelKey: 'quickSettings.autoScrollToBottom',
     icon: ArrowDown,
+  },
+  {
+    key: 'showScrollNavigation',
+    labelKey: 'quickSettings.showScrollNavigation',
+    icon: Navigation,
   },
 ];
 

--- a/src/components/quick-settings-panel/types.ts
+++ b/src/components/quick-settings-panel/types.ts
@@ -6,6 +6,7 @@ export type PreferenceToggleKey =
   | 'showRawParameters'
   | 'showThinking'
   | 'autoScrollToBottom'
+  | 'showScrollNavigation'
   | 'sendByCtrlEnter';
 
 export type QuickSettingsPreferences = Record<PreferenceToggleKey, boolean>;

--- a/src/components/quick-settings-panel/view/QuickSettingsPanelView.tsx
+++ b/src/components/quick-settings-panel/view/QuickSettingsPanelView.tsx
@@ -26,10 +26,12 @@ export default function QuickSettingsPanelView() {
     showRawParameters: preferences.showRawParameters,
     showThinking: preferences.showThinking,
     autoScrollToBottom: preferences.autoScrollToBottom,
+    showScrollNavigation: preferences.showScrollNavigation,
     sendByCtrlEnter: preferences.sendByCtrlEnter,
   }), [
     preferences.autoExpandTools,
     preferences.autoScrollToBottom,
+    preferences.showScrollNavigation,
     preferences.sendByCtrlEnter,
     preferences.showRawParameters,
     preferences.showThinking,

--- a/src/hooks/useUiPreferences.ts
+++ b/src/hooks/useUiPreferences.ts
@@ -5,6 +5,7 @@ type UiPreferences = {
   showRawParameters: boolean;
   showThinking: boolean;
   autoScrollToBottom: boolean;
+  showScrollNavigation: boolean;
   sendByCtrlEnter: boolean;
   sidebarVisible: boolean;
 };
@@ -37,6 +38,7 @@ const DEFAULTS: UiPreferences = {
   showRawParameters: false,
   showThinking: true,
   autoScrollToBottom: true,
+  showScrollNavigation: false,
   sendByCtrlEnter: false,
   sidebarVisible: true,
 };

--- a/src/i18n/locales/de/chat.json
+++ b/src/i18n/locales/de/chat.json
@@ -235,5 +235,14 @@
   },
   "tasks": {
     "nextTaskPrompt": "Nächste Aufgabe starten"
+  },
+  "scrollNav": {
+    "jumpTo": "Springe zu: {{snippet}}",
+    "jumpToMessage": "Springe zu Nachricht {{index}}",
+    "loadAll": "Alle laden",
+    "first": "Erste",
+    "previous": "Vorherige",
+    "next": "Nächste",
+    "last": "Letzte"
   }
 }

--- a/src/i18n/locales/de/settings.json
+++ b/src/i18n/locales/de/settings.json
@@ -62,6 +62,7 @@
     "showRawParameters": "Rohe Parameter anzeigen",
     "showThinking": "Denken anzeigen",
     "autoScrollToBottom": "Automatisch nach unten scrollen",
+    "showScrollNavigation": "Scroll-Navigation anzeigen",
     "sendByCtrlEnter": "Mit Strg+Enter senden",
     "sendByCtrlEnterDescription": "Wenn aktiviert, sendet Strg+Enter die Nachricht anstelle von Enter. Dies ist nützlich für IME-Benutzer:innen, um versehentliches Senden zu vermeiden.",
     "dragHandle": {

--- a/src/i18n/locales/en/chat.json
+++ b/src/i18n/locales/en/chat.json
@@ -174,6 +174,7 @@
       "showingLast": "Showing last {{count}} messages ({{total}} total)",
       "loadEarlier": "Load earlier messages",
       "loadAll": "Load all messages",
+      "loadMore": "Load {{count}} more",
       "loadingAll": "Loading all messages...",
       "allLoaded": "All messages loaded",
       "perfWarning": "All messages loaded — scrolling may be slower. Click \"Scroll to bottom\" to restore performance."
@@ -237,5 +238,16 @@
   },
   "tasks": {
     "nextTaskPrompt": "Start the next task"
+  },
+  "scrollNav": {
+    "jumpTo": "Jump to: {{snippet}}",
+    "jumpToMessage": "Jump to message {{index}}",
+    "fromYou": "You",
+    "aiReply": "AI Reply",
+    "loadAll": "Load all",
+    "first": "Top",
+    "previous": "Previous",
+    "next": "Next",
+    "last": "Bottom"
   }
 }

--- a/src/i18n/locales/en/settings.json
+++ b/src/i18n/locales/en/settings.json
@@ -62,6 +62,7 @@
     "showRawParameters": "Show raw parameters",
     "showThinking": "Show thinking",
     "autoScrollToBottom": "Auto-scroll to bottom",
+    "showScrollNavigation": "Show scroll navigation",
     "sendByCtrlEnter": "Send by Ctrl+Enter",
     "sendByCtrlEnterDescription": "When enabled, pressing Ctrl+Enter will send the message instead of just Enter. This is useful for IME users to avoid accidental sends.",
     "dragHandle": {

--- a/src/i18n/locales/it/chat.json
+++ b/src/i18n/locales/it/chat.json
@@ -235,5 +235,14 @@
   },
   "tasks": {
     "nextTaskPrompt": "Inizia l'attività successiva"
+  },
+  "scrollNav": {
+    "jumpTo": "Vai a: {{snippet}}",
+    "jumpToMessage": "Vai al messaggio {{index}}",
+    "loadAll": "Carica tutto",
+    "first": "Primo",
+    "previous": "Precedente",
+    "next": "Successivo",
+    "last": "Ultimo"
   }
 }

--- a/src/i18n/locales/it/settings.json
+++ b/src/i18n/locales/it/settings.json
@@ -62,6 +62,7 @@
     "showRawParameters": "Mostra parametri grezzi",
     "showThinking": "Mostra ragionamento",
     "autoScrollToBottom": "Scorrimento automatico in basso",
+    "showScrollNavigation": "Mostra navigazione di scorrimento",
     "sendByCtrlEnter": "Invia con Ctrl+Invio",
     "sendByCtrlEnterDescription": "Se abilitato, premere Ctrl+Invio invierà il messaggio invece di Invio. Utile per gli utenti IME per evitare invii accidentali.",
     "dragHandle": {

--- a/src/i18n/locales/ja/chat.json
+++ b/src/i18n/locales/ja/chat.json
@@ -202,5 +202,14 @@
     "providers": {
       "assistant": "Assistant"
     }
+  },
+  "scrollNav": {
+    "jumpTo": "ジャンプ: {{snippet}}",
+    "jumpToMessage": "{{index}}番目のメッセージに移動",
+    "loadAll": "全ロード",
+    "first": "最初",
+    "previous": "前へ",
+    "next": "次へ",
+    "last": "最後"
   }
 }

--- a/src/i18n/locales/ja/settings.json
+++ b/src/i18n/locales/ja/settings.json
@@ -62,6 +62,7 @@
     "showRawParameters": "生パラメータを表示",
     "showThinking": "思考を表示",
     "autoScrollToBottom": "自動スクロール",
+    "showScrollNavigation": "スクロールナビゲーションを表示",
     "sendByCtrlEnter": "Ctrl+Enterで送信",
     "sendByCtrlEnterDescription": "有効にすると、Enterではなく Ctrl+Enter でメッセージを送信します。IMEユーザーの誤送信防止に便利です。",
     "dragHandle": {

--- a/src/i18n/locales/ko/chat.json
+++ b/src/i18n/locales/ko/chat.json
@@ -217,5 +217,14 @@
   },
   "tasks": {
     "nextTaskPrompt": "다음 작업 시작"
+  },
+  "scrollNav": {
+    "jumpTo": "이동: {{snippet}}",
+    "jumpToMessage": "{{index}}번 메시지로 이동",
+    "loadAll": "전체 로드",
+    "first": "첫 번째",
+    "previous": "이전",
+    "next": "다음",
+    "last": "마지막"
   }
 }

--- a/src/i18n/locales/ko/settings.json
+++ b/src/i18n/locales/ko/settings.json
@@ -62,6 +62,7 @@
     "showRawParameters": "Raw 파라미터 표시",
     "showThinking": "생각 과정 표시",
     "autoScrollToBottom": "자동 스크롤",
+    "showScrollNavigation": "스크롤 탐색 표시",
     "sendByCtrlEnter": "Ctrl+Enter로 전송",
     "sendByCtrlEnterDescription": "활성화하면 Enter 대신 Ctrl+Enter로 메시지를 전송합니다. IME 사용자가 실수로 전송하는 것을 방지하는 데 유용합니다.",
     "dragHandle": {

--- a/src/i18n/locales/ru/chat.json
+++ b/src/i18n/locales/ru/chat.json
@@ -235,5 +235,14 @@
   },
   "tasks": {
     "nextTaskPrompt": "Начать следующую задачу"
+  },
+  "scrollNav": {
+    "jumpTo": "Перейти к: {{snippet}}",
+    "jumpToMessage": "Перейти к сообщению {{index}}",
+    "loadAll": "Загрузить всё",
+    "first": "Первое",
+    "previous": "Предыдущее",
+    "next": "Следующее",
+    "last": "Последнее"
   }
 }

--- a/src/i18n/locales/ru/settings.json
+++ b/src/i18n/locales/ru/settings.json
@@ -62,6 +62,7 @@
     "showRawParameters": "Показывать сырые параметры",
     "showThinking": "Показывать размышления",
     "autoScrollToBottom": "Автопрокрутка вниз",
+    "showScrollNavigation": "Показать навигацию прокрутки",
     "sendByCtrlEnter": "Отправка по Ctrl+Enter",
     "sendByCtrlEnterDescription": "Когда включено, нажатие Ctrl+Enter будет отправлять сообщение вместо просто Enter. Это полезно для пользователей IME, чтобы избежать случайной отправки.",
     "dragHandle": {

--- a/src/i18n/locales/tr/chat.json
+++ b/src/i18n/locales/tr/chat.json
@@ -235,5 +235,14 @@
   },
   "tasks": {
     "nextTaskPrompt": "Sonraki görevi başlat"
+  },
+  "scrollNav": {
+    "jumpTo": "Git: {{snippet}}",
+    "jumpToMessage": "{{index}}. mesaja git",
+    "loadAll": "Tümünü yükle",
+    "first": "İlk",
+    "previous": "Önceki",
+    "next": "Sonraki",
+    "last": "Son"
   }
 }

--- a/src/i18n/locales/tr/settings.json
+++ b/src/i18n/locales/tr/settings.json
@@ -62,6 +62,7 @@
     "showRawParameters": "Ham parametreleri göster",
     "showThinking": "Düşünmeyi göster",
     "autoScrollToBottom": "Otomatik en alta kaydır",
+    "showScrollNavigation": "Kaydırma navigasyonunu göster",
     "sendByCtrlEnter": "Ctrl+Enter ile gönder",
     "sendByCtrlEnterDescription": "Etkinleştirildiğinde, Ctrl+Enter'a basmak yalnız Enter yerine mesajı gönderir. IME (girdi metot düzenleyici) kullananlar için yanlışlıkla göndermeyi önler.",
     "dragHandle": {

--- a/src/i18n/locales/zh-CN/chat.json
+++ b/src/i18n/locales/zh-CN/chat.json
@@ -154,6 +154,7 @@
       "showingLast": "显示最近 {{count}} 条消息（共 {{total}} 条）",
       "loadEarlier": "加载更早的消息",
       "loadAll": "加载全部消息",
+      "loadMore": "加载更多({{count}}条)",
       "loadingAll": "正在加载全部消息...",
       "allLoaded": "全部消息已加载",
       "perfWarning": "已加载全部消息 - 滚动可能变慢。点击「滚动到底部」恢复性能。"
@@ -217,5 +218,16 @@
   },
   "tasks": {
     "nextTaskPrompt": "开始下一个任务"
+  },
+  "scrollNav": {
+    "jumpTo": "跳转到: {{snippet}}",
+    "jumpToMessage": "跳转到第 {{index}} 条消息",
+    "fromYou": "你",
+    "aiReply": "AI 回复",
+    "loadAll": "加载全部",
+    "first": "顶部",
+    "previous": "上一条",
+    "next": "下一条",
+    "last": "底部"
   }
 }

--- a/src/i18n/locales/zh-CN/settings.json
+++ b/src/i18n/locales/zh-CN/settings.json
@@ -62,6 +62,7 @@
     "showRawParameters": "显示原始参数",
     "showThinking": "显示思考过程",
     "autoScrollToBottom": "自动滚动到底部",
+    "showScrollNavigation": "显示滚动导航",
     "sendByCtrlEnter": "使用 Ctrl+Enter 发送",
     "sendByCtrlEnterDescription": "启用后，按 Ctrl+Enter 发送消息，而不是仅按 Enter。这对于使用输入法的用户可以避免意外发送。",
     "dragHandle": {


### PR DESCRIPTION
Revives #811 (by @WenhuaXia) with the compilation blocker removed. Their commits are preserved; this branch adds one cleanup commit on top.

### Why #811 was closed, and what changed

#811 was closed for a compile failure in `useChatRealtimeHandlers`. The cause was a dependency on the **unmerged** completion-sound PR (#809):

```ts
import { isNotificationSoundEnabled, playCompletionSound } from '../../../utils/notification-sound';
```

`utils/notification-sound` doesn't exist on `main`, so the import fails to resolve. Those `useChatRealtimeHandlers` edits (the sound calls plus an unrelated session-resumption tweak) are **out of scope for scroll navigation**, so this branch reverts that file to `main`. The feature now stands alone.

### What this adds

- `ScrollNavigation.tsx` — a floating rail of user-message markers with jump-to-top/bottom, previous/next, and load-all controls; the active marker tracks the viewport via live DOM offsets.
- Supporting wiring in `ChatInterface`, `ChatMessagesPane`, `useChatSessionState`, `useChatMessages`, and i18n strings for all 8 locales.

### Verification

- `npm run typecheck` passes (this was the original blocker).
- `eslint` reports 0 errors on the touched files.
- `useChatRealtimeHandlers.ts` has **no diff** vs `main` — no dependency on #809.
- Running in our fork for ~10 days.

### Credit

Feature commits are @WenhuaXia's from #811. The only addition is the decoupling/cleanup commit. Happy to squash or adjust attribution however you prefer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a floating scroll navigation panel with interactive dots and jump controls; tooltips show message previews.

* **Pagination**
  * Unified pagination UI with distinct "Load more" and "Load all" controls and consolidated loading indicators; added safer "load more" action and simplified auto-scroll behavior.

* **Preferences**
  * New quick-settings toggle to show/hide scroll navigation.

* **Internationalization**
  * Added scroll navigation labels and load-more strings across multiple locales.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->