### PR TITLE
fix(chat): re-anchor initial scroll across lazy content reflow

### DIFF
--- a/src/components/chat/hooks/useChatSessionState.ts
+++ b/src/components/chat/hooks/useChatSessionState.ts
@@ -383,12 +383,47 @@ export function useChatSessionState({
     setIsUserScrolledUp(false);
   }, [selectedProject?.projectId, selectedSession?.id]);
 
-  // Initial scroll to bottom
+  // Initial scroll to bottom — robust to lazy content reflow.
+  // The previous implementation fired one scrollToBottom() at +200ms and
+  // cleared the pending flag. When markdown blocks, code highlighting, or
+  // images finished rendering after that window, scrollHeight grew but
+  // nothing re-anchored the viewport, leaving the chat tab visually
+  // "scrolled way up" with the latest assistant message off-screen.
+  //
+  // This version re-scrolls every animation frame while scrollHeight is
+  // still growing, capped at ~1s (60 frames) or 3 consecutive stable
+  // frames. Cancels cleanly on session change via the pending flag.
   useEffect(() => {
     if (!pendingInitialScrollRef.current || !scrollContainerRef.current || isLoadingSessionMessages) return;
     if (chatMessages.length === 0) { pendingInitialScrollRef.current = false; return; }
-    pendingInitialScrollRef.current = false;
-    if (!searchScrollActiveRef.current) setTimeout(() => scrollToBottom(), 200);
+    if (searchScrollActiveRef.current) { pendingInitialScrollRef.current = false; return; }
+
+    const container = scrollContainerRef.current;
+    let frame = 0;
+    let lastHeight = 0;
+    let stableCount = 0;
+    let rafId = 0;
+
+    const tick = () => {
+      if (!pendingInitialScrollRef.current || !scrollContainerRef.current) return;
+      container.scrollTop = container.scrollHeight;
+      if (container.scrollHeight === lastHeight) {
+        stableCount++;
+      } else {
+        stableCount = 0;
+        lastHeight = container.scrollHeight;
+      }
+      frame++;
+      if (stableCount < 3 && frame < 60) {
+        rafId = requestAnimationFrame(tick);
+      } else {
+        pendingInitialScrollRef.current = false;
+      }
+    };
+    rafId = requestAnimationFrame(tick);
+    return () => {
+      if (rafId) cancelAnimationFrame(rafId);
+    };
   }, [chatMessages.length, isLoadingSessionMessages, scrollToBottom]);
 
   // Main session loading effect — store-based


### PR DESCRIPTION
Revives #788 (by @ShockStruck), which was closed pending a reproduction. Here is a detailed one.

### The bug

When a session is opened, `useChatSessionState` does a single `scrollToBottom()` at `+200ms`, then clears the pending flag. If content finishes rendering **after** that 200ms window — syntax-highlighted code blocks, markdown tables, or images that load asynchronously — `scrollHeight` keeps growing but nothing re-anchors the viewport. The chat opens "scrolled up", with the latest assistant message off-screen below.

### Reproduction

1. Open a session whose **last** screenful contains content that lays out asynchronously after mount. Easiest triggers, in order of reliability:
   - several inline images (they reserve no height until decoded), or
   - multiple large fenced code blocks (syntax highlighting reflows after first paint), or
   - long markdown tables.
2. From a different session (or a fresh reload), switch into that session so it mounts from scratch.
3. **Observed:** the view lands partway up the conversation; you must manually scroll down to see the latest message.
4. The effect is intermittent on fast machines and consistent when the late-rendering content is tall — it is a race against the fixed 200ms timer.

To make it deterministic: throttle to "Slow 3G" in devtools and open a session ending in a few images — the 200ms scroll fires long before the images decode, so the view stays pinned near the top.

### The fix

Replace the one-shot 200ms timeout with a `requestAnimationFrame` loop that re-scrolls to bottom while `scrollHeight` is still growing, stopping after 3 consecutive stable frames or ~1s (60 frames), and cancelling cleanly on session change.

- No behavior change for sessions whose layout is already stable at the first frame (loop exits after 3 stable frames immediately).
- Bounded (≤60 frames), so no busy-loop risk.
- `npm run typecheck` and `eslint` pass.
- Running in our fork for ~10 days.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced chat message scrolling behavior during initial load to reliably display the latest messages as content renders. This improvement prevents users from missing new content due to timing delays and provides a more consistent experience when opening conversations, loading message batches, or scrolling through chat history.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->