### PR TITLE
fix: keep editor toolbar in view on long unwrapped lines

### DIFF
--- a/src/components/code-editor/view/EditorSidebar.tsx
+++ b/src/components/code-editor/view/EditorSidebar.tsx
@@ -102,7 +102,7 @@ export default function EditorSidebar({
   const useFlexLayout = editorExpanded || (fillSpace && !hasManualWidth);
 
   return (
-    <div ref={containerRef} className={`flex h-full min-w-0 flex-shrink-0 ${editorExpanded ? 'flex-1' : ''}`}>
+    <div ref={containerRef} className={`flex h-full min-w-0 ${editorExpanded ? 'flex-1' : ''}`}>
       {!editorExpanded && (
         <div
           ref={resizeHandleRef}


### PR DESCRIPTION
Opening a file with a very long unwrapped line (minified JSON, a base64 blob, that kind of thing) pushes the editor header buttons off the right edge, so preview, settings, download, save and close all disappear.

The wrapper div in EditorSidebar.tsx has both min-w-0 and flex-shrink-0 on it. Those fight each other and flex-shrink-0 wins, so the row won't shrink to its column. Once CodeMirror reports the width of the longest line, the pane grows past the space it has and takes the toolbar with it.

Removing flex-shrink-0 and keeping min-w-0 fixes it. The row shrinks to its column again and the long line scrolls sideways inside CodeMirror like it should. Short files and the normal desktop layout are unchanged.

Worth noting for repro: it shows up in the desktop side pane around 850 to 1000px wide. Under 768px the editor goes full screen and skips this row entirely, so it won't show under mobile emulation.

Closes #796

Before: 
<img width="812" height="1120" alt="before" src="https://github.com/user-attachments/assets/df72557e-b8b0-4cf9-b26f-605872a758c5" />

After:
<img width="812" height="1120" alt="after" src="https://github.com/user-attachments/assets/3bc4f713-207c-46e4-9ce4-4b390e5a292c" />