### PR TITLE
feat: accept a one-time auth token from the URL (?token=) for tunnel/proxy setups

### DIFF
--- a/src/bootstrap-url-token.js
+++ b/src/bootstrap-url-token.js
@@ -1,0 +1,15 @@
+// Accept a one-time auth token handed in via the URL (?token=…) for reverse-proxy / tunnel / automation
+// setups where access is already gated upstream (e.g. an ssh -L tunnel). Store it the same way a login
+// does (localStorage['auth-token']), then strip it from the URL so it isn't left in history or shared
+// links. Gated on no existing token; the backend already issues/verifies these JWTs (see /api/auth/*).
+try {
+  const u = new URL(window.location.href);
+  const t = u.searchParams.get('token');
+  if (t && !localStorage.getItem('auth-token')) {
+    localStorage.setItem('auth-token', t);
+    u.searchParams.delete('token');
+    window.history.replaceState({}, '', u.pathname + u.search + u.hash);
+  }
+} catch (e) {
+  /* non-fatal: never block app boot over a malformed URL */
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,3 +1,4 @@
+import './bootstrap-url-token.js'
 import React from 'react'
 import ReactDOM from 'react-dom/client'
 import App from './App.tsx'


### PR DESCRIPTION
## Problem

The web UI authenticates purely from `localStorage['auth-token']`, which is only ever set after a manual login/register in the browser (`src/utils/api.js`). For deployments where access is **already gated upstream** — a reverse proxy, or an `ssh -L` tunnel to a remote box — there's no way to pre-authenticate: every fresh deployment forces a manual login even though reaching the page already required authenticating to the tunnel/proxy.

Concretely, we provision ephemeral dev boxes, run `cloudcli` bound to `127.0.0.1`, and forward it to the user's machine over `ssh -L`. The ssh tunnel is the real security boundary, but the user still has to hand-log-in to the CloudCLI account on every new box.

## Change

On boot, accept a token passed via the URL and persist it as `auth-token`, then strip it from the URL. The frontend already has the `auth-token` key, and the backend already issues/verifies these JWTs (`/api/auth/register` and `/api/auth/login` return one) — this just wires the bootstrap path, as the very first import in `src/main.jsx` so it runs before anything reads the token.

```js
// src/bootstrap-url-token.js
try {
  const u = new URL(window.location.href);
  const t = u.searchParams.get('token');
  if (t && !localStorage.getItem('auth-token')) {
    localStorage.setItem('auth-token', t);
    u.searchParams.delete('token');
    window.history.replaceState({}, '', u.pathname + u.search + u.hash);
  }
} catch (e) { /* non-fatal */ }
```

It's gated on no existing token and strips the token from the URL after storing it (so it isn't left in history or shared links). Happy to gate it behind an opt-in env (e.g. `ALLOW_URL_TOKEN=true`) if you'd prefer it off by default.

## Why not platform mode

`VITE_IS_PLATFORM=true` bypasses the JWT check in the backend (`middleware/auth.js`), but the published frontend still renders the login screen (it doesn't read `isPlatform`), so platform mode alone doesn't help self-hosted/tunnel users. A URL-token bootstrap is the smallest change that does.

## Note

I wasn't able to run the frontend build locally to smoke-test, so please double-check placement; the change is additive and self-contained.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * URL tokens are now automatically extracted during app startup and stored locally if no existing token is present. Token parameters are removed from the URL for a cleaner interface, with error handling to ensure startup stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->