### PR TITLE
fix: detect TaskMaster CLI installation on Windows

### DIFF
--- a/server/routes/taskmaster.js
+++ b/server/routes/taskmaster.js
@@ -40,8 +40,9 @@ const router = express.Router();
  */
 async function checkTaskMasterInstallation() {
     return new Promise((resolve) => {
-        // Check if task-master command is available
-        const child = spawn('which', ['task-master'], { 
+        // Check if task-master command is available ('which' is not available in cmd.exe)
+        const whichCommand = process.platform === 'win32' ? 'where' : 'which';
+        const child = spawn(whichCommand, ['task-master'], {
             stdio: ['ignore', 'pipe', 'pipe'],
             shell: true 
         });
@@ -59,6 +60,8 @@ async function checkTaskMasterInstallation() {
         
         child.on('close', (code) => {
             if (code === 0 && output.trim()) {
+                // 'where' may return multiple matches (e.g. task-master and task-master.cmd)
+                const installPath = output.trim().split(/\r?\n/)[0];
                 // TaskMaster is installed, get version
                 const versionChild = spawn('task-master', ['--version'], { 
                     stdio: ['ignore', 'pipe', 'pipe'],
@@ -74,16 +77,16 @@ async function checkTaskMasterInstallation() {
                 versionChild.on('close', (versionCode) => {
                     resolve({
                         isInstalled: true,
-                        installPath: output.trim(),
+                        installPath,
                         version: versionCode === 0 ? versionOutput.trim() : 'unknown',
                         reason: null
                     });
                 });
-                
+
                 versionChild.on('error', () => {
                     resolve({
                         isInstalled: true,
-                        installPath: output.trim(),
+                        installPath,
                         version: 'unknown',
                         reason: null
                     });


### PR DESCRIPTION
## Problem

On Windows, the TaskMaster setup screen always reports the CLI as not installed ("TaskMaster CLI not found in PATH"), even when `task-master-ai` is installed globally via npm and available on PATH.

## Cause

`checkTaskMasterInstallation()` in `server/routes/taskmaster.js` runs:

```js
const child = spawn('which', ['task-master'], { shell: true });
```

With `shell: true` on Windows, Node spawns `cmd.exe`, which has no `which` command (the Windows equivalent is `where`). The lookup therefore always exits non-zero and the endpoint returns `isInstalled: false`.

## Fix

- Use `where` on `win32` and `which` elsewhere.
- Take only the first line of the lookup output for `installPath`, since `where` can return multiple matches (e.g. `task-master` and `task-master.cmd`).

## Testing

Verified on Windows 11 with `task-master-ai@0.43.1` installed globally: the detection now resolves `isInstalled: true` with the correct install path and version. The non-Windows code path is unchanged (`which` as before).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved task-master binary detection across Windows and Unix-based platforms, ensuring more reliable installation path resolution and verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->