### PR TITLE
fix: include exitCode on Codex completion events

### DIFF
--- a/server/modules/providers/list/codex/codex-sessions.provider.ts
+++ b/server/modules/providers/list/codex/codex-sessions.provider.ts
@@ -492,6 +492,7 @@ export class CodexSessionsProvider implements IProviderSessions {
         timestamp: ts,
         provider: PROVIDER,
         kind: 'complete',
+        exitCode: 0,
       })];
     }
     if (raw.type === 'turn_failed') {

--- a/server/openai-codex.js
+++ b/server/openai-codex.js
@@ -245,6 +245,7 @@ export async function queryCodex(command, options = {}, ws) {
   let capturedSessionId = sessionId;
   let sessionCreatedSent = false;
   let terminalFailure = null;
+  let wasAborted = false;
   const abortController = new AbortController();
 
   try {
@@ -311,11 +312,13 @@ export async function queryCodex(command, options = {}, ws) {
 
       // Check if session was aborted
       if (abortController.signal.aborted) {
+        wasAborted = true;
         break;
       }
       if (capturedSessionId) {
         const session = activeCodexSessions.get(capturedSessionId);
         if (session?.status === 'aborted') {
+          wasAborted = true;
           break;
         }
       }
@@ -353,9 +356,10 @@ export async function queryCodex(command, options = {}, ws) {
     }
 
     // Send completion event
-    if (!terminalFailure) {
+    if (!terminalFailure && !wasAborted) {
       sendMessage(ws, createNormalizedMessage({
         kind: 'complete',
+        exitCode: 0,
         actualSessionId: capturedSessionId || thread.id || sessionId || null,
         sessionId: capturedSessionId || sessionId || null,
         provider: 'codex'
@@ -371,7 +375,7 @@ export async function queryCodex(command, options = {}, ws) {
 
   } catch (error) {
     const session = capturedSessionId ? activeCodexSessions.get(capturedSessionId) : null;
-    const wasAborted =
+    wasAborted = wasAborted ||
       session?.status === 'aborted' ||
       error?.name === 'AbortError' ||
       String(error?.message || '').toLowerCase().includes('aborted');
@@ -402,7 +406,7 @@ export async function queryCodex(command, options = {}, ws) {
     if (capturedSessionId) {
       const session = activeCodexSessions.get(capturedSessionId);
       if (session) {
-        session.status = session.status === 'aborted' ? 'aborted' : 'completed';
+        session.status = wasAborted || session.status === 'aborted' ? 'aborted' : 'completed';
       }
     }
   }


### PR DESCRIPTION
## Summary
- Add an explicit `exitCode: 0` to successful Codex `complete` events.
- Keep aborted Codex streams out of the normal success completion path.
- Add `exitCode: 0` to Codex `turn_complete` provider normalization so live and history paths agree.
- Keep the existing `actualSessionId`, `sessionId`, and provider fields unchanged for successful completions.

## Context
Codex was the only provider sending the final successful `complete` event without an explicit success exit code. This is the server-side version of the session finalization problem discussed in #614 and CoderLuii/HolyClaude#19.

This supersedes #614. Current `main` already handles session replacement through `actualSessionId`; this PR makes the provider lifecycle payload consistent at the source.

Abort handling stays separate from success handling. The abort request path already sends an aborted `complete` payload for client cleanup, so `queryCodex` now avoids sending a second normal success completion after an aborted stream.

## Testing
- `node --check server/openai-codex.js`
- `git diff --check`
- `npm ci` completed; npm audit reported 38 existing advisories
- `npm run typecheck`
- `npm run build` passed with existing CSS/chunk/Browserslist warnings
- Compiled `CodexSessionsProvider` `turn_complete` normalization check returned `kind: complete` with `exitCode: 0`

Not live-tested: live Codex abort against the upstream service.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved completion event handling so “complete” messages are only sent when runs finish normally.
  * Added an explicit exit code (`0`) to completion payloads to make stream termination clearer.

* **Chores**
  * Enhanced abort detection so sessions are consistently marked as aborted when an abort occurs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->