### PR TITLE
fix(server): return a clear "restart required" error on missing DB schema

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -1507,6 +1507,30 @@ app.use((err, req, res, next) => {
     });
   }
 
+  // Surface "missing schema" failures explicitly instead of as a generic 500.
+  // A "no such table/column" SQLite error almost always means the on-disk
+  // package was updated (new schema/migrations) but the running server process
+  // was not restarted, so initializeDatabase() never ran for the new schema.
+  // Without this, DB-backed actions (delete/archive/rename a session or
+  // project) fail silently and look like nothing happened.
+  const isMissingSchemaError =
+    err &&
+    typeof err.message === 'string' &&
+    (err.code === 'SQLITE_ERROR' || err.name === 'SqliteError') &&
+    /no such (table|column)/i.test(err.message);
+
+  if (isMissingSchemaError) {
+    console.error('Database schema missing or outdated (restart required):', err.message);
+    return res.status(503).json({
+      success: false,
+      error: {
+        code: 'SCHEMA_NOT_INITIALIZED',
+        message:
+          'The database schema is missing or out of date. This usually means CloudCLI was updated but the server was not restarted. Please restart the server to apply the latest schema.',
+      },
+    });
+  }
+
   console.error(err);
 
   return res.status(500).json({


### PR DESCRIPTION
## Problem

When a DB-backed request hits a SQLite `no such table` / `no such column` error, the global error handler in `server/index.js` returns a generic `500 INTERNAL_ERROR`.

This occurs in a very common real-world situation: the package is updated on disk (new schema / migrations in `initializeDatabase()`), but the **running server process is not restarted**. Because the new schema is only applied at startup, the long-lived old process keeps running against a DB that lacks the new tables (`projects`, `sessions`, …). DB-backed actions — deleting/archiving/renaming a session or project — then throw `no such table: sessions` and **fail silently from the user's point of view** (the trash icon appears to do nothing).

Sidebar listings still work because they're read from disk (`~/.claude/projects/*/*.jsonl`), which makes the failure even more confusing: items are visible but can't be mutated.

## Fix

In the global error handler, detect this specific class of error (`SQLITE_ERROR` / `SqliteError` with a `no such table|column` message) and return a `503` with code `SCHEMA_NOT_INITIALIZED` and an actionable message asking the user to restart the server, instead of burying it in a generic 500.

No behavior change for any other error.

## Notes

- This is a defensive, fail-loud safety net. A complementary change (detecting the running-server-vs-frontend version skew and showing a "restart required" banner) is a good follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for uninitialized database schemas. The server now detects schema-related failures and returns a clear HTTP 503 response with guidance to restart the server for proper initialization, replacing generic error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->