### PR TITLE
fix(chat): prevent normalizeInlineCodeFences from breaking adjacent fenced code blocks

### DIFF
--- a/src/components/chat/utils/chatFormatting.ts
+++ b/src/components/chat/utils/chatFormatting.ts
@@ -11,7 +11,7 @@ export function decodeHtmlEntities(text: string) {
 export function normalizeInlineCodeFences(text: string) {
   if (!text || typeof text !== 'string') return text;
   try {
-    return text.replace(/```\s*([^\n\r]+?)\s*```/g, '`$1`');
+    return text.replace(/```[ \t]*([^\n\r]+?)[ \t]*```/g, '`$1`');
   } catch {
     return text;
   }


### PR DESCRIPTION
## Problem

The `normalizeInlineCodeFences` function in `chatFormatting.ts` uses a regex that can span across adjacent fenced code blocks, corrupting the markdown output.

### Root Cause

The regex `/```\s*([^\n\r]+?)\s*```/g` uses `\s` which matches newline characters (`\n`, `\r`). When two fenced code blocks appear next to each other, the regex matches across block boundaries:

```
```           ← closing fence of first block
                    ← empty line (matched by \s*)
### Title          ← matched by ([^\n\r]+?)
                    ← empty line (matched by \s*)
```bash        ← opening fence of second block (matched by final ```)
```

This causes the closing fence of the first block and the opening fence of the second block to be consumed, merging the two blocks and corrupting the markdown.

### Example

**Input:**
```markdown
### Step 3: Set permissions

```bash
chmod +x script1.sh
chmod +x script2.sh
```

### Step 4: Configure pm2

```bash
pm2 stop cloudcli-ui
pm2 delete cloudcli-ui
```
```

**Before (broken):**
```markdown
### Step 3: Set permissions

```bash
chmod +x script1.sh
chmod +x script2.sh
`### Step 4: Configure pm2`bash
pm2 stop cloudcli-ui
pm2 delete cloudcli-ui
```
```

**After (fixed):** Renders correctly as two separate code blocks.

### Fix

Change `\s*` to `[ \t]*` so the regex only matches spaces and tabs within the same line, preventing cross-block matching:

```diff
- return text.replace(/```\s*([^\n\r]+?)\s*```/g, '`$1`');
+ return text.replace(/```[ \t]*([^\n\r]+?)[ \t]*```/g, '`$1`');
```

The original purpose of converting single-line triple-backtick fences to inline code (e.g., ```` ```text``` ```` → ```` `text` ````) is preserved.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved inline code formatting in chat messages to ensure proper handling of code fences with more precise whitespace processing for better display consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->