### PR TITLE
fix(claude-sdk): use close() instead of interrupt() to terminate child process on abort

### DIFF
--- a/server/claude-sdk.js
+++ b/server/claude-sdk.js
@@ -807,8 +807,11 @@ async function abortClaudeSDKSession(sessionId) {
     // terminal complete (the abort handler sends the aborted one).
     abortedSessionIds.add(sessionId);
 
-    // Call interrupt() on the query instance
-    await session.instance.interrupt();
+    // Use close() instead of interrupt() to forcefully terminate the
+    // underlying Claude Code child process. interrupt() only stops the
+    // current model turn — the child process may keep running and
+    // streaming output, making the UI stop button appear broken.
+    session.instance.close();
 
     // Update session status
     session.status = 'aborted';


### PR DESCRIPTION
## Problem

When the user clicks the STOP (ESC) button or presses Escape to abort a running Claude Code session, the UI shows the session as stopped (processing flags cleared), but the Claude Code child process continues running and streaming messages to the chat.

## Root Cause

`abortClaudeSDKSession` in `server/claude-sdk.js` calls `session.instance.interrupt()`, which per the SDK types only stops the **current model turn** — it does not terminate the underlying child process. The child process may continue executing tool calls and streaming output.

From the SDK type definitions (`sdk.d.ts`):

| Method | Behavior |
|--------|----------|
| `interrupt()` | "Interrupt the current query execution. The query will stop processing **the current turn** and return control to the caller." |
| `close()` | "Close the query and **terminate the underlying process**. This forcefully ends the query, cleaning up all resources including the CLI subprocess. **Use this when you need to abort a query that is still running.**" |

## Fix

Replace `interrupt()` with `close()` in `abortClaudeSDKSession`. This forcefully terminates the child process, which is the correct behavior for a user-initiated abort.

**Change:** 1 line in `server/claude-sdk.js`

All stop entry points (ESC key, STOP button, ActivityIndicator stop) share the same call chain, so a single fix covers all of them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the AI SDK session cancellation behavior to use a more reliable abort mechanism, preventing occasional duplicate “completion” events after stopping an active session.
  * This improves stability when users interrupt or cancel AI runs, ensuring the session lifecycle ends cleanly without extra terminal updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->