### PR TITLE
fix(shell): prioritize user npm binaries

### DIFF
--- a/server/modules/websocket/services/shell-websocket.service.ts
+++ b/server/modules/websocket/services/shell-websocket.service.ts
@@ -171,6 +171,62 @@ function buildShellCommand(
   return command;
 }
 
+function readEnvValue(env: NodeJS.ProcessEnv, key: string): string | undefined {
+  const resolvedKey = Object.keys(env).find((envKey) => envKey.toLowerCase() === key.toLowerCase());
+  return resolvedKey ? env[resolvedKey] : undefined;
+}
+
+function getPathEnvKey(env: NodeJS.ProcessEnv): string {
+  return Object.keys(env).find((key) => key.toLowerCase() === 'path') || 'PATH';
+}
+
+function prioritizeUserNpmGlobalBin(env: NodeJS.ProcessEnv): { key: string; value: string | undefined } {
+  const pathKey = getPathEnvKey(env);
+  const currentPath = env[pathKey];
+  if (!currentPath) {
+    return { key: pathKey, value: currentPath };
+  }
+
+  const delimiter = path.delimiter;
+  const pathEntries = currentPath.split(delimiter).filter(Boolean);
+  const npmPrefix = readEnvValue(env, 'npm_config_prefix');
+  const appData = readEnvValue(env, 'APPDATA');
+  const candidates = [
+    npmPrefix || '',
+    npmPrefix ? path.join(npmPrefix, 'bin') : '',
+    appData ? path.join(appData, 'npm') : '',
+    path.join(os.homedir(), 'AppData', 'Roaming', 'npm'),
+    path.join(os.homedir(), '.npm-global', 'bin'),
+  ].filter(Boolean);
+
+  const normalizedPathEntries = pathEntries.map((entry) => os.platform() === 'win32' ? entry.toLowerCase() : entry);
+  const preferredEntries = candidates.filter((candidate, index) => {
+    const normalizedCandidate = os.platform() === 'win32' ? candidate.toLowerCase() : candidate;
+    return (
+      candidates.indexOf(candidate) === index &&
+      normalizedPathEntries.includes(normalizedCandidate)
+    );
+  });
+
+  if (preferredEntries.length === 0) {
+    return { key: pathKey, value: currentPath };
+  }
+
+  const normalizedPreferredEntries = preferredEntries.map((entry) =>
+    os.platform() === 'win32' ? entry.toLowerCase() : entry
+  );
+
+  const value = [
+    ...preferredEntries,
+    ...pathEntries.filter((entry) => {
+      const normalizedEntry = os.platform() === 'win32' ? entry.toLowerCase() : entry;
+      return !normalizedPreferredEntries.includes(normalizedEntry);
+    }),
+  ].join(delimiter);
+
+  return { key: pathKey, value };
+}
+
 /**
  * Handles websocket connections used by the standalone shell terminal UI.
  */
@@ -284,6 +340,7 @@ export function handleShellConnection(
           os.platform() === 'win32' ? ['-Command', shellCommand] : ['-c', shellCommand];
         const termCols = readNumber(data.cols, 80);
         const termRows = readNumber(data.rows, 24);
+        const prioritizedPath = prioritizeUserNpmGlobalBin(process.env);
 
         shellProcess = pty.spawn(shell, shellArgs, {
           name: 'xterm-256color',
@@ -292,6 +349,7 @@ export function handleShellConnection(
           cwd: resolvedProjectPath,
           env: {
             ...process.env,
+            [prioritizedPath.key]: prioritizedPath.value,
             TERM: 'xterm-256color',
             COLORTERM: 'truecolor',
             FORCE_COLOR: '3',


### PR DESCRIPTION
## Summary

Prioritize user-installed npm global binaries when starting interactive shell sessions.

## Why

Interactive terminals inherit the server process environment. In packaged or hosted environments, that `PATH` can place bundled or system-level binaries before tools installed globally by the user.

As a result, commands such as provider CLIs may resolve to an older or unintended executable even though the user has installed a newer version globally through npm.

The shell should behave like the user’s normal terminal and prefer their existing global npm installation paths.

## What Changed

- Detect the environment’s actual `PATH` key case-insensitively.
- Read environment variables case-insensitively for Windows compatibility.
- Identify common user npm global binary locations:
  - `npm_config_prefix`
  - `<npm_config_prefix>/bin`
  - `%APPDATA%\npm`
  - `~/AppData/Roaming/npm`
  - `~/.npm-global/bin`
- Move matching locations to the beginning of `PATH`.
- Preserve the order of all remaining `PATH` entries.
- Avoid inserting directories that are not already present in `PATH`.
- Pass the prioritized `PATH` only to the spawned shell process without mutating `process.env`.

## Behavior

Before:

```text
bundled binaries -> system binaries -> user npm binaries
```

After:

```text
user npm binaries -> bundled binaries -> system binaries
```

If no recognized npm global directory exists in `PATH`, the original value remains unchanged.

## Platform Considerations

Environment variable names and path comparisons are handled case-insensitively on Windows. The implementation uses the platform path delimiter, so Unix-style colon-separated and Windows-style semicolon-separated paths are both supported.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced npm global binary resolution in the shell environment with improved PATH handling across different platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->