### PR TITLE
PR1: Sidebar cleanup + default expand-all + community entry removal

### DIFF
--- a/docs/superpowers/specs/2026-06-23-claudecodeui-improvements-design.md
+++ b/docs/superpowers/specs/2026-06-23-claudecodeui-improvements-design.md
@@ -1,0 +1,306 @@
+# claudecodeui 改进设计文档
+
+- **日期**：2026-06-23
+- **作者**：黄权权 + Claude（Opus 4.7）
+- **状态**：设计已对齐 · 待 writing-plans 拆任务
+
+## 0 · 背景
+
+老板自用的 claudecodeui 实例（fork 自 siteboon/claudecodeui · 已切到 `git@github.com:invoke888/claudecodeui.git`）需要 8 条改进 + 1 项 git 仓库切换 · 服务老板个人工作流：自建 CLAUDE.md 模板库 / 隔离外部项目 / 会话命名 / 全局 CLAUDE.md 编辑 / 去除社区入口 / sidebar 体验 / 简体中文补全 / 文件查看宽度修复。
+
+## 1 · 需求与决策汇总
+
+| # | 需求 | 决策（老板已拍板） |
+|---|---|---|
+| 1 | CLAUDE.md 模板库 | DB 表 `claude_md_templates` · 设置加管理 tab · 项目向导加可选模板步骤 · **多选叠加** · 应用方式 = **写入项目根 CLAUDE.md** |
+| 2 | 隐藏 tmp 项目 + 只显示自建 | `projects` 表加 `is_user_created` 列 · UI 向导建的标 1 · jsonl 同步的标 0 · sidebar toggle 默认「只显示自建」|
+| 3 | 新建会话直接命名 | composer 顶上加**可选**名称输入框 · 留空走旧自动命名 |
+| 4 | 设置编辑 CLAUDE.md | **只全局** `~/.claude/CLAUDE.md` · 复用 Monaco code-editor · 项目级走 file-tree 手开 |
+| 5 | 去掉报告问题/加入社区 | 删 5 文件的入口（SidebarFooter / SidebarCollapsed / AboutTab 的 Star+GitHub+Discord 3 按钮 / VersionInfoSection 的 GitHub link / AuthScreenLayout 的 GitHub 链接）|
+| 6 | 会话默认全部展开 + 切换按钮 | sidebar 初始化时把所有项目 id 进 `expandedProjects` Set · 顶上加「全展开 ⇄ 全折叠」按钮 |
+| 7 | 简体中文漏译补全 | **6 个 namespace 全审**（auth/chat/codeEditor/common/settings/sidebar · 共 1193 行 + 其他硬编码英文）|
+| 8 | 文件查看宽度老变 | 根因 = ResizeObserver 自动重算 + 没持久化 · 修法 = 移除 Observer 自动逻辑 + localStorage 持久化拖动结果 + app_config 兜底 |
+| ★ | git remote 切换 | `origin` → `git@github.com:invoke888/claudecodeui.git` · 旧的 rename 成 `upstream` 保留 |
+
+## 2 · 架构总览
+
+### 2.1 系统组件
+
+- **前端**：React 18 + Vite + TypeScript · 组件位置 `src/components/`
+- **后端**：Node Express + TypeScript · `server/`
+- **数据库**：SQLite · schema 在 `server/modules/database/schema.ts` · 迁移在 `migrations.ts`
+- **i18n**：i18next · locale 文件在 `src/i18n/locales/<lang>/<namespace>.json`
+- **桌面**：Electron（不在本次改动范围）
+
+### 2.2 改动边界
+
+- **不动**：Electron 打包 / WebSocket / 认证模块 / Cursor/Gemini/OpenAI SDK 集成 / Git 面板 / MCP / Task Master / Browser Use
+- **动**：项目列表 / sidebar / settings / project-creation-wizard / chat composer / code-editor sidebar / i18n locale / 数据库 schema
+
+## 3 · 数据层
+
+### 3.1 新建表：`claude_md_templates`
+
+```sql
+CREATE TABLE IF NOT EXISTS claude_md_templates (
+  id          INTEGER PRIMARY KEY AUTOINCREMENT,
+  alias       TEXT    NOT NULL UNIQUE,           -- 模板别名(唯一)
+  content     TEXT    NOT NULL,                  -- 模板正文(Markdown)
+  enabled     INTEGER NOT NULL DEFAULT 1,        -- 启用状态 0/1
+  sort_order  INTEGER NOT NULL DEFAULT 0,        -- 多选叠加顺序
+  created_at  INTEGER NOT NULL,                  -- unix ts
+  updated_at  INTEGER NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_templates_enabled_sort
+  ON claude_md_templates(enabled, sort_order);
+```
+
+### 3.2 `projects` 表新增列
+
+```sql
+ALTER TABLE projects ADD COLUMN is_user_created INTEGER NOT NULL DEFAULT 0;
+-- 1 = UI 向导创建
+-- 0 = 外部 claude jsonl 同步进来(默认 · 历史项目都是 0)
+```
+
+历史项目升级时全部为 0 · sidebar 默认 toggle = 只显示自建 = 历史项目被隐藏 · 老板切换 toggle 到「显示全部」即可看到所有项目 · 不丢数据。
+
+### 3.3 `app_config` 表新增 key
+
+| key | 类型 | 默认 | 用途 |
+|---|---|---|---|
+| `sidebar.showOnlyUserCreated` | bool | `true` | 默认只显示 UI 创建的项目 |
+| `sidebar.defaultExpandAll` | bool | `true` | 新会话进来默认全展开 |
+| `editor.sidebar.width` | int | `280` | 文件查看 sidebar 宽度（与 localStorage 双写）|
+
+### 3.4 迁移策略
+
+- 加单条迁移到 `server/modules/database/migrations.ts` · 不改老迁移
+- 迁移必须**幂等**（跑两次不报错 · `IF NOT EXISTS` / `ADD COLUMN` 容错）
+- 升级后跑一次 typecheck + 启动 server 看日志无报错
+
+## 4 · API 层
+
+### 4.1 新增 endpoints（PR3）
+
+#### 模板 CRUD
+
+| Method | Path | Body / Query | 返回 |
+|---|---|---|---|
+| `GET` | `/api/templates` | — | `[{id, alias, enabled, sort_order, updated_at}]`（不含 content · 列表瘦身）|
+| `GET` | `/api/templates/:id` | — | `{id, alias, content, enabled, sort_order, ...}` |
+| `POST` | `/api/templates` | `{alias, content, enabled?, sort_order?}` | `{id, ...}` · alias 冲突 → 409 |
+| `PUT` | `/api/templates/:id` | 部分字段 | 更新后的对象 |
+| `DELETE` | `/api/templates/:id` | — | `204` |
+| `POST` | `/api/templates/preview` | `{template_ids: number[]}` | `{content: string}` · 按 sort_order 拼接 + `\n\n---\n\n` 分隔 |
+
+#### 全局 CLAUDE.md
+
+| Method | Path | Body | 返回 |
+|---|---|---|---|
+| `GET` | `/api/claude-md/global` | — | `{content: string, last_modified: number}` · 文件不存在返空串 |
+| `PUT` | `/api/claude-md/global` | `{content: string}` | `{last_modified: number}` |
+
+### 4.2 改造现有 endpoints（PR2 / PR3）
+
+| Endpoint | 改造 | PR |
+|---|---|---|
+| `POST /api/projects/create` | body 加 `templateIds?: number[]` + `displayName?` · 创建项目目录后按 sort_order 拼接模板写入根 CLAUDE.md · 标 `is_user_created=1` | PR2 标记列 / PR3 模板写入 |
+| `GET /api/projects` | 加 query `onlyUserCreated=true/false` · 默认读 `app_config` | PR2 |
+| `POST /api/sessions`（或现有创建会话路径）| body 加 `displayName?: string` · 不传走原自动命名 | PR2 |
+
+### 4.3 安全 / 边界
+
+- `/api/claude-md/global` 路径**写死** `~/.claude/CLAUDE.md` · 不接收用户路径参数
+- 写入前 `path.resolve` + 验证最终路径在 `os.homedir() + '/.claude/'` 内 · 越权 403
+- 模板 content 不 sanitize（纯 Markdown 文本）· 但限长 100KB
+- 创建项目时若 templateIds 包含已删除/disabled → 静默跳过 · 不报错（容错）
+- 别名 alias 限长 64 字符 · 不允许换行 / 控制字符
+
+## 5 · 前端层
+
+### 5.1 设置面板新增 2 个 tab（PR3）
+
+```
+src/components/settings/view/tabs/
+├── templates-settings/
+│   ├── TemplatesTab.tsx              ← 列表(启用开关 / 别名 / 字数 / 拖拽手柄 / 编辑 / 删除)
+│   ├── TemplateEditorDialog.tsx      ← 别名+正文编辑 · 用 code-editor Monaco
+│   └── hooks/useTemplates.ts         ← react-query 封装 CRUD
+└── claude-md-settings/
+    └── ClaudeMdTab.tsx               ← 单 Monaco 编辑器 + 保存按钮 + 最后保存时间
+```
+
+### 5.2 项目向导加可选模板步骤（PR3）
+
+```
+src/components/project-creation-wizard/components/
+└── StepTemplateSelect.tsx            ← 插入到 StepConfiguration 与 StepReview 之间
+```
+
+UI 要点：
+- 只显示 `enabled=1` 的模板
+- 勾选框 + 别名 + content 前 80 字预览
+- 「跳过 · 不应用模板」按钮（等价全不选）
+- 右侧实时预览叠加结果 · 复用 `/api/templates/preview`
+
+### 5.3 Sidebar 改造（PR1 + PR2）
+
+| 改动 | PR | 文件 |
+|---|---|---|
+| 删社区入口 | PR1 | `SidebarFooter.tsx` · `SidebarCollapsed.tsx` |
+| 默认全展开 | PR1 | `useSidebarController.ts:168-184` 初始化 expandedProjects = 所有项目 id |
+| 全展开/折叠按钮 | PR1 | Sidebar 顶上加 `<button>` · 切换 expandedProjects Set 大小 0 / N |
+| 隐藏外部项目 toggle | PR2 | 列表过滤 `if (showOnlyUserCreated && !project.is_user_created) return false` · 设置 / sidebar 顶上都暴露 |
+
+### 5.4 Composer 会话命名（PR2）
+
+```
+src/components/chat/view/composer/ComposerHeader.tsx     ← 加可折叠输入框
+src/components/chat/hooks/useChatComposerState.ts:613-645 ← 创建会话时带 displayName
+```
+
+UI 要点：
+- composer 顶上一个**可折叠**小输入框「会话名称（可选）」· 默认折叠
+- 新会话第一次发消息 · 输入框非空 → 创建时带过去 · 空 → 走自动命名
+- 已建会话不显示该输入框（重命名走现有右键菜单）
+
+### 5.5 文件查看宽度修复（PR2）
+
+```
+src/components/code-editor/hooks/useEditorSidebar.ts
+src/components/code-editor/view/EditorSidebar.tsx
+```
+
+修法：
+1. 移除 ResizeObserver 自动调宽逻辑 · 父容器变动只影响主区
+2. 拖动结束（mouseup）→ `localStorage.setItem('editor.sidebar.width', width)` + 后端 `app_config` 兜底
+3. 初次挂载从 localStorage 读 · 没有用默认 280px
+4. 最小/最大宽度约束 200 / 600 · 防误拖到 0
+
+### 5.6 删除社区入口（PR1）
+
+| # | 文件 | 操作 |
+|---|---|---|
+| 1 | `src/components/sidebar/view/subcomponents/SidebarFooter.tsx` | 删 4 处入口 + 常量 |
+| 2 | `src/components/sidebar/view/subcomponents/SidebarCollapsed.tsx` | 删常量 |
+| 3 | `src/components/settings/view/tabs/AboutTab.tsx` | 删 Star/GitHub/Discord 3 按钮（保留版本号/介绍）|
+| 4 | `src/components/settings/view/tabs/api-settings/sections/VersionInfoSection.tsx` | 删 GitHub link |
+| 5 | `src/components/auth/view/AuthScreenLayout.tsx:48` | 删 GitHub 链接 |
+
+i18n key `sidebar.actions.reportIssue` / `sidebar.actions.joinCommunity` 可以删 · 也可以留（不渲染就行）· 这里保守**保留** · 避免破坏其他 locale。
+
+### 5.7 简体中文补全（PR3）
+
+工作流：
+1. 扫描 `src/` 下所有 `.tsx/.ts` 找硬编码英文字符串（非 import / 测试 / logger）
+2. 抽到 `src/i18n/locales/zh-CN/` 6 个 namespace · key 命名 `<area>.<scope>.<name>`
+3. 同步加 key 到其他 9 个 locale · 值先复制英文 + 标 TODO（不机翻）
+4. `npm run lint` + 视觉抽查关键页面
+
+边界：
+- **保留英文**：技术术语 (PR/commit/branch/token/API) · 命令名 (claude/gemini) · 文件名
+- **必须汉化**：按钮文案 / 表单 label / 提示 / 错误消息 / 空态文案 / tooltip
+
+## 6 · git remote 切换
+
+```bash
+# 已在 design 阶段完成:
+git remote rename origin upstream
+git remote add origin git@github.com:invoke888/claudecodeui.git
+
+# 验证(已通过):
+# origin    git@github.com:invoke888/claudecodeui.git
+# upstream  https://github.com/siteboon/claudecodeui
+# ssh -T git@github.com → Hi invoke888!
+# git ls-remote origin → main HEAD 与本地一致(4712431)
+```
+
+## 7 · PR 拆分
+
+### 7.1 PR1 · 低风险快速合（预计 2-4 小时）
+
+| 任务 | 文件数 |
+|---|---|
+| git remote 切换 + 首推 design doc 到 origin | 0 code 文件 |
+| 删社区入口 (5 文件) | 5 |
+| sidebar 默认全展开 | 1 |
+| sidebar 加全展开/折叠按钮 | 1-2 + i18n |
+| i18n key 加 expandAll/collapseAll (10 locale) | 10 |
+
+**验收**：
+- `git remote -v` 显示 origin = invoke888
+- `npm run dev` 启动 · sidebar 无社区入口
+- AboutTab 无 Star/GitHub/Discord 按钮
+- 新会话默认全展开 · 点折叠全收起 / 再点全展开
+- playwright 截图：sidebar 两态 / AboutTab / 登录页
+
+### 7.2 PR2 · 中等风险（预计 4-6 小时）
+
+| 任务 | 文件数 |
+|---|---|
+| DB 迁移：`is_user_created` 列 + 3 个 app_config key | 1-2 |
+| projects API：`onlyUserCreated` query + create 时标 1 | 2-3 |
+| sidebar 加显示外部项目 toggle | 2-3 + i18n |
+| composer 加可选会话名称输入框 | 2 |
+| sessions API：body 加 displayName | 1-2 |
+| EditorSidebar 宽度持久化 + 移除 ResizeObserver 抖动 | 2 |
+
+**验收**：
+- 数据库迁移幂等
+- 老项目升级后默认隐藏 · toggle 切换可显示
+- 向导新建项目自动标 1 · sidebar 立刻可见
+- composer 名称：填了用填的 · 不填走自动名（两条 case）
+- 文件查看宽度持久化（拖动 → 切文件 → 重开 · 宽度不变）
+- 父容器 resize 不再改 sidebar 宽
+- playwright 截图
+
+### 7.3 PR3 · 大功能（预计 1-2 天）
+
+| 任务 | 文件数 |
+|---|---|
+| DB 迁移：claude_md_templates 表 | 1 |
+| 模板 API CRUD + preview + 全局 CLAUDE.md 读写 | 2 个新路由 |
+| 设置面板加 2 tab：模板管理 + 全局 CLAUDE.md | 4-6 |
+| 项目向导加 StepTemplateSelect | 1-2 |
+| 创建项目时按 templateIds 写根 CLAUDE.md | 1-2 |
+| 简体中文补全 6 namespace | 60+ locale 文件 |
+
+**验收**：
+- 模板 CRUD 全流程（建 / 编辑 / 启停 / 排序 / 删）
+- 别名唯一冲突 → 409 + toast
+- 多选叠加预览正确
+- 新项目 CLAUDE.md = 拼接结果（`\n\n---\n\n` 分隔）
+- 不选模板 → 不写 CLAUDE.md
+- 设置编辑全局 CLAUDE.md · 保存后 `cat ~/.claude/CLAUDE.md` 一致
+- 路径穿越测试 → 403
+- 简体中文页面无硬编码英文（playwright 截图：sidebar / settings / chat / composer / file-tree / 向导）
+
+## 8 · 全局 done 标准
+
+跨所有 PR：
+- ✅ `npm run typecheck` 零错误零警告（铁律 8）
+- ✅ `npm run lint` 零错误
+- ✅ `npm run build` 通过
+- ✅ playwright 真机截图 · 不靠 sim PASS
+- ✅ 数据库迁移可重入
+- ✅ 每个 PR 都有 sub-PR 描述 + verify 报告
+
+## 9 · 风险与缓解
+
+| 风险 | 缓解 |
+|---|---|
+| `is_user_created=0` 默认隐藏 → 老板第一次升级看不到所有老项目以为丢了 | toggle 默认在 sidebar 顶上**可见** · 第一次切换有 onboarding 提示「老项目默认隐藏 · 切到全部查看」|
+| 模板写入项目根 CLAUDE.md 覆盖已有内容 | 创建新项目时该文件本就不存在 · 直接写 · 若存在(同名项目)→ 报错让用户改名 |
+| 全局 CLAUDE.md 编辑覆盖老板手写的内容 | 编辑器加「最后修改时间」显示 · 保存前 confirm 「你正在覆盖 X 时刻的版本」|
+| 汉化漏译范围大 · 漏抓硬编码英文 | PR3 加扫描脚本 `grep -rn '"[A-Z][a-z]\+ [A-Z]\?[a-z]\+"' src/components/` 兜底 |
+| ResizeObserver 移除后某些场景宽度不更新 | 改完手测窗口缩放 / 移动端 viewport / split view 等场景 |
+
+## 10 · 后续阶段
+
+设计批准后：
+1. 调用 `superpowers:writing-plans` skill · 把 PR1/PR2/PR3 各自拆成可执行任务清单
+2. PR1 先执行 · 走 `superpowers:subagent-driven-development` 或我直接干（视复杂度）
+3. 每个 PR 完工走 `superpowers:verification-before-completion` + playwright 截图自验 → 报告
+4. 老板拍板 merge → 切下一个 PR

--- a/src/components/auth/view/AuthScreenLayout.tsx
+++ b/src/components/auth/view/AuthScreenLayout.tsx
@@ -1,6 +1,5 @@
 import type { ReactNode } from 'react';
 import { MessageSquare } from 'lucide-react';
-import { IS_PLATFORM } from '../../../constants/config';
 
 type AuthScreenLayoutProps = {
   title: string;
@@ -38,22 +37,6 @@ export default function AuthScreenLayout({
           <div className="text-center">
             <p className="text-sm text-muted-foreground">{footerText}</p>
           </div>
-
-          {!IS_PLATFORM && (
-            <div className="flex items-center justify-center gap-1.5 pt-2">
-              <svg className="h-3.5 w-3.5 text-muted-foreground/50" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
-                <path d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z" />
-              </svg>
-              <a
-                href="https://github.com/siteboon/claudecodeui"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="text-xs text-muted-foreground/50 transition-colors hover:text-muted-foreground"
-              >
-                CloudCLI is open source
-              </a>
-            </div>
-          )}
         </div>
       </div>
     </div>

--- a/src/components/settings/view/tabs/AboutTab.tsx
+++ b/src/components/settings/view/tabs/AboutTab.tsx
@@ -1,35 +1,10 @@
-import { ExternalLink, MessageSquare, Star } from 'lucide-react';
+import { MessageSquare } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
-import { IS_PLATFORM } from '../../../../constants/config';
 import { useVersionCheck } from '../../../../hooks/useVersionCheck';
-import PremiumFeatureCard from '../PremiumFeatureCard';
-import { Cloud, Users } from 'lucide-react';
-
-const GITHUB_REPO_URL = 'https://github.com/siteboon/claudecodeui';
-const DISCORD_URL = 'https://discord.gg/buxwujPNRE';
-const DOCS_URL = 'https://cloudcli.ai/docs/plugin-overview';
-const CLOUDCLI_URL = 'https://cloudcli.ai';
-
-function GitHubIcon({ className }: { className?: string }) {
-  return (
-    <svg className={className} fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
-      <path d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z" />
-    </svg>
-  );
-}
-
-function DiscordIcon({ className }: { className?: string }) {
-  return (
-    <svg className={className} fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
-      <path d="M20.317 4.37a19.791 19.791 0 0 0-4.885-1.515.074.074 0 0 0-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 0 0-5.487 0 12.64 12.64 0 0 0-.617-1.25.077.077 0 0 0-.079-.037A19.736 19.736 0 0 0 3.677 4.37a.07.07 0 0 0-.032.027C.533 9.046-.32 13.58.099 18.057a.082.082 0 0 0 .031.057 19.9 19.9 0 0 0 5.993 3.03.078.078 0 0 0 .084-.028c.462-.63.874-1.295 1.226-1.994a.076.076 0 0 0-.041-.106 13.107 13.107 0 0 1-1.872-.892.077.077 0 0 1-.008-.128 10.2 10.2 0 0 0 .372-.292.074.074 0 0 1 .077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 0 1 .078.01c.12.098.246.198.373.292a.077.077 0 0 1-.006.127 12.299 12.299 0 0 1-1.873.892.077.077 0 0 0-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.028 19.839 19.839 0 0 0 6.002-3.03.077.077 0 0 0 .032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 0 0-.031-.03zM8.02 15.33c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.956-2.419 2.157-2.419 1.21 0 2.176 1.095 2.157 2.42 0 1.333-.956 2.418-2.157 2.418zm7.975 0c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.955-2.419 2.157-2.419 1.21 0 2.176 1.095 2.157 2.42 0 1.333-.946 2.418-2.157 2.418z" />
-    </svg>
-  );
-}
 
 export default function AboutTab() {
   const { t } = useTranslation('settings');
-  const { updateAvailable, latestVersion, currentVersion, releaseInfo } = useVersionCheck('siteboon', 'claudecodeui');
-  const releasesUrl = releaseInfo?.htmlUrl || `${GITHUB_REPO_URL}/releases`;
+  const { updateAvailable, latestVersion, currentVersion } = useVersionCheck('siteboon', 'claudecodeui');
 
   return (
     <div className="space-y-6">
@@ -41,119 +16,20 @@ export default function AboutTab() {
         <div>
           <div className="flex items-center gap-2">
             <span className="text-base font-semibold text-foreground">CloudCLI</span>
-            <a
-              href={releasesUrl}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="rounded-full bg-muted px-2 py-0.5 text-[11px] font-medium text-muted-foreground transition-colors hover:text-foreground"
-            >
+            <span className="rounded-full bg-muted px-2 py-0.5 text-[11px] font-medium text-muted-foreground">
               v{currentVersion}
-            </a>
+            </span>
             {updateAvailable && latestVersion && (
-              <a
-                href={releasesUrl}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="flex items-center gap-1 rounded-full bg-green-500/10 px-2 py-0.5 text-[10px] font-medium text-green-600 transition-colors hover:bg-green-500/20 dark:text-green-400"
-              >
+              <span className="rounded-full bg-green-500/10 px-2 py-0.5 text-[10px] font-medium text-green-600 dark:text-green-400">
                 {t('apiKeys.version.updateAvailable', { version: latestVersion })}
-                <ExternalLink className="h-2.5 w-2.5" />
-              </a>
+              </span>
             )}
           </div>
           <p className="mt-0.5 text-sm text-muted-foreground">
-            Open-source AI coding assistant interface
+            AI coding assistant interface
           </p>
         </div>
       </div>
-
-      {/* Star on GitHub button */}
-      <a
-        href={GITHUB_REPO_URL}
-        target="_blank"
-        rel="noopener noreferrer"
-        className="inline-flex items-center gap-2 rounded-lg border border-border/60 bg-background px-3.5 py-2 text-sm font-medium text-muted-foreground transition-colors hover:bg-muted/50 hover:text-foreground"
-      >
-        <GitHubIcon className="h-4 w-4" />
-        <Star className="h-3.5 w-3.5" />
-        <span>Star on GitHub</span>
-      </a>
-
-      {/* Links */}
-      <div className="flex flex-wrap gap-4 text-sm">
-        <a
-          href={GITHUB_REPO_URL}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="flex items-center gap-1.5 text-muted-foreground transition-colors hover:text-foreground"
-        >
-          <GitHubIcon className="h-4 w-4" />
-          GitHub
-        </a>
-        <a
-          href={DISCORD_URL}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="flex items-center gap-1.5 text-muted-foreground transition-colors hover:text-foreground"
-        >
-          <DiscordIcon className="h-4 w-4" />
-          Discord
-        </a>
-        <a
-          href={DOCS_URL}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="flex items-center gap-1.5 text-muted-foreground transition-colors hover:text-foreground"
-        >
-          <ExternalLink className="h-3.5 w-3.5" />
-          Docs
-        </a>
-        <a
-          href={CLOUDCLI_URL}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="flex items-center gap-1.5 text-muted-foreground transition-colors hover:text-foreground"
-        >
-          <ExternalLink className="h-3.5 w-3.5" />
-          cloudcli.ai
-        </a>
-      </div>
-
-      {/* Hosted CTA (OSS mode only) */}
-      {!IS_PLATFORM && (
-        <div className="rounded-xl border border-primary/10 bg-primary/5 p-4">
-          <h4 className="text-sm font-medium text-foreground">Try CloudCLI Hosted</h4>
-          <p className="mt-1 text-xs text-muted-foreground">
-            Team collaboration, shared MCP configs, settings sync across environments, and managed infrastructure.
-          </p>
-          <a
-            href={CLOUDCLI_URL}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="mt-2 inline-flex items-center gap-1 text-xs font-medium text-primary transition-colors hover:underline"
-          >
-            Learn more
-            <ExternalLink className="h-3 w-3" />
-          </a>
-        </div>
-      )}
-
-      {/* Premium feature placeholders (OSS mode only) */}
-      {!IS_PLATFORM && (
-        <div className="space-y-4 border-t border-border/50 pt-6">
-          <h3 className="text-sm font-medium text-foreground">CloudCLI Pro Features</h3>
-          <PremiumFeatureCard
-            icon={<Cloud className="h-5 w-5" />}
-            title="Sync Settings"
-            description="Keep your preferences, MCP configs, and theme in sync across all your environments."
-          />
-          <PremiumFeatureCard
-            icon={<Users className="h-5 w-5" />}
-            title="Team Management"
-            description="Multiple users, role-based access, and shared projects for your team."
-          />
-        </div>
-      )}
 
       {/* License */}
       <div className="border-t border-border/50 pt-4">

--- a/src/components/settings/view/tabs/api-settings/sections/VersionInfoSection.tsx
+++ b/src/components/settings/view/tabs/api-settings/sections/VersionInfoSection.tsx
@@ -1,50 +1,22 @@
-import { ExternalLink, Star, MessageSquare } from 'lucide-react';
+import { MessageSquare } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
-import { IS_PLATFORM } from '../../../../../../constants/config';
-import type { ReleaseInfo } from '../../../../../../types/sharedTypes';
-
-const GITHUB_REPO_URL = 'https://github.com/siteboon/claudecodeui';
-const DISCORD_URL = 'https://discord.gg/buxwujPNRE';
-const DOCS_URL = 'https://cloudcli.ai/docs/plugin-overview';
-const CLOUDCLI_URL = 'https://cloudcli.ai';
-
-function GitHubIcon({ className }: { className?: string }) {
-  return (
-    <svg className={className} fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
-      <path d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z" />
-    </svg>
-  );
-}
-
-function DiscordIcon({ className }: { className?: string }) {
-  return (
-    <svg className={className} fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
-      <path d="M20.317 4.37a19.791 19.791 0 0 0-4.885-1.515.074.074 0 0 0-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 0 0-5.487 0 12.64 12.64 0 0 0-.617-1.25.077.077 0 0 0-.079-.037A19.736 19.736 0 0 0 3.677 4.37a.07.07 0 0 0-.032.027C.533 9.046-.32 13.58.099 18.057a.082.082 0 0 0 .031.057 19.9 19.9 0 0 0 5.993 3.03.078.078 0 0 0 .084-.028c.462-.63.874-1.295 1.226-1.994a.076.076 0 0 0-.041-.106 13.107 13.107 0 0 1-1.872-.892.077.077 0 0 1-.008-.128 10.2 10.2 0 0 0 .372-.292.074.074 0 0 1 .077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 0 1 .078.01c.12.098.246.198.373.292a.077.077 0 0 1-.006.127 12.299 12.299 0 0 1-1.873.892.077.077 0 0 0-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.028 19.839 19.839 0 0 0 6.002-3.03.077.077 0 0 0 .032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 0 0-.031-.03zM8.02 15.33c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.956-2.419 2.157-2.419 1.21 0 2.176 1.095 2.157 2.42 0 1.333-.956 2.418-2.157 2.418zm7.975 0c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.955-2.419 2.157-2.419 1.21 0 2.176 1.095 2.157 2.42 0 1.333-.946 2.418-2.157 2.418z" />
-    </svg>
-  );
-}
 
 type VersionInfoSectionProps = {
   currentVersion: string;
   updateAvailable: boolean;
   latestVersion: string | null;
-  releaseInfo: ReleaseInfo | null;
 };
 
 export default function VersionInfoSection({
   currentVersion,
   updateAvailable,
   latestVersion,
-  releaseInfo,
 }: VersionInfoSectionProps) {
   const { t } = useTranslation('settings');
-  const releasesUrl = releaseInfo?.htmlUrl || `${GITHUB_REPO_URL}/releases`;
 
   return (
     <div className="border-t border-border/50 pt-6">
-      {/* About CloudCLI */}
       <div className="space-y-4">
-        {/* Logo + name + version */}
         <div className="flex items-center gap-3">
           <div className="flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-lg bg-primary/90 shadow-sm">
             <MessageSquare className="h-4.5 w-4.5 text-primary-foreground" />
@@ -52,102 +24,20 @@ export default function VersionInfoSection({
           <div>
             <div className="flex items-center gap-2">
               <span className="text-sm font-semibold text-foreground">CloudCLI</span>
-              <a
-                href={releasesUrl}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="rounded-full bg-muted px-2 py-0.5 text-[10px] font-medium text-muted-foreground transition-colors hover:text-foreground"
-              >
+              <span className="rounded-full bg-muted px-2 py-0.5 text-[10px] font-medium text-muted-foreground">
                 v{currentVersion}
-              </a>
+              </span>
               {updateAvailable && latestVersion && (
-                <a
-                  href={releasesUrl}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="flex items-center gap-1 rounded-full bg-green-500/10 px-2 py-0.5 text-[10px] font-medium text-green-600 transition-colors hover:bg-green-500/20 dark:text-green-400"
-                >
+                <span className="rounded-full bg-green-500/10 px-2 py-0.5 text-[10px] font-medium text-green-600 dark:text-green-400">
                   {t('apiKeys.version.updateAvailable', { version: latestVersion })}
-                  <ExternalLink className="h-2.5 w-2.5" />
-                </a>
+                </span>
               )}
             </div>
             <p className="mt-0.5 text-xs text-muted-foreground">
-              Open-source AI coding assistant interface
+              AI coding assistant interface
             </p>
           </div>
         </div>
-
-        {/* Star on GitHub button */}
-        <a
-          href={GITHUB_REPO_URL}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="inline-flex items-center gap-2 rounded-lg border border-border/60 bg-background px-3 py-1.5 text-xs font-medium text-muted-foreground transition-colors hover:bg-muted/50 hover:text-foreground"
-        >
-          <GitHubIcon className="h-4 w-4" />
-          <Star className="h-3.5 w-3.5" />
-          <span>Star on GitHub</span>
-        </a>
-
-        {/* Links */}
-        <div className="flex flex-wrap gap-3 text-xs">
-          <a
-            href={GITHUB_REPO_URL}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="flex items-center gap-1 text-muted-foreground transition-colors hover:text-foreground"
-          >
-            <GitHubIcon className="h-3.5 w-3.5" />
-            GitHub
-          </a>
-          <a
-            href={DISCORD_URL}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="flex items-center gap-1 text-muted-foreground transition-colors hover:text-foreground"
-          >
-            <DiscordIcon className="h-3.5 w-3.5" />
-            Discord
-          </a>
-          <a
-            href={DOCS_URL}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="flex items-center gap-1 text-muted-foreground transition-colors hover:text-foreground"
-          >
-            <ExternalLink className="h-3 w-3" />
-            Docs
-          </a>
-          <a
-            href={CLOUDCLI_URL}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="flex items-center gap-1 text-muted-foreground transition-colors hover:text-foreground"
-          >
-            <ExternalLink className="h-3 w-3" />
-            cloudcli.ai
-          </a>
-        </div>
-
-        {/* Hosted CTA (OSS mode only) */}
-        {!IS_PLATFORM && (
-          <div className="rounded-xl border border-primary/10 bg-primary/5 p-4">
-            <h4 className="text-sm font-medium text-foreground">Try CloudCLI Hosted</h4>
-            <p className="mt-1 text-xs text-muted-foreground">
-              Team collaboration, shared MCP configs, settings sync across environments, and managed infrastructure.
-            </p>
-            <a
-              href={CLOUDCLI_URL}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="mt-2 inline-flex items-center gap-1 text-xs font-medium text-primary transition-colors hover:underline"
-            >
-              Learn more
-              <ExternalLink className="h-3 w-3" />
-            </a>
-          </div>
-        )}
       </div>
     </div>
   );

--- a/src/components/sidebar/hooks/useSidebarController.ts
+++ b/src/components/sidebar/hooks/useSidebarController.ts
@@ -147,6 +147,7 @@ export function useSidebarController({
   const starToggleSequenceByProjectRef = useRef<Map<string, number>>(new Map());
   const migrationStartedRef = useRef(false);
   const onRefreshRef = useRef(onRefresh);
+  const hasInitializedExpansionRef = useRef(false);
 
   const isSidebarCollapsed = !isMobile && !sidebarVisible;
   const activeSessionIds = useMemo(() => new Set(activeSessions.keys()), [activeSessions]);
@@ -182,6 +183,17 @@ export function useSidebarController({
       return next;
     });
   }, [selectedProject?.projectId]);
+
+  useEffect(() => {
+    if (hasInitializedExpansionRef.current) {
+      return;
+    }
+    if (isLoading || projects.length === 0) {
+      return;
+    }
+    hasInitializedExpansionRef.current = true;
+    setExpandedProjects(new Set(projects.map((project) => project.projectId)));
+  }, [projects, isLoading]);
 
   useEffect(() => {
     if (projects.length > 0 && !isLoading) {
@@ -432,12 +444,22 @@ export function useSidebarController({
   // `projectId` as their identifier after the migration.
   const toggleProject = useCallback((projectId: string) => {
     setExpandedProjects((prev) => {
-      const next = new Set<string>();
-      if (!prev.has(projectId)) {
+      const next = new Set(prev);
+      if (next.has(projectId)) {
+        next.delete(projectId);
+      } else {
         next.add(projectId);
       }
       return next;
     });
+  }, []);
+
+  const expandAllProjects = useCallback(() => {
+    setExpandedProjects(new Set(projects.map((project) => project.projectId)));
+  }, [projects]);
+
+  const collapseAllProjects = useCallback(() => {
+    setExpandedProjects(new Set());
   }, []);
 
   const handleSessionClick = useCallback(
@@ -616,6 +638,11 @@ export function useSidebarController({
   const filteredProjects = useMemo(
     () => filterProjects(searchMode === 'running' ? runningProjects : sortedProjects, debouncedSearchQuery),
     [debouncedSearchQuery, runningProjects, searchMode, sortedProjects],
+  );
+
+  const isAllExpanded = useMemo(
+    () => projects.length > 0 && projects.every((project) => expandedProjects.has(project.projectId)),
+    [projects, expandedProjects],
   );
 
   const filteredArchivedSessions = useMemo(() => {
@@ -951,6 +978,9 @@ export function useSidebarController({
     archivedSessionsCount: archivedProjects.length + archivedSessions.length,
     isArchivedSessionsLoading,
     toggleProject,
+    expandAllProjects,
+    collapseAllProjects,
+    isAllExpanded,
     handleSessionClick,
     toggleStarProject,
     isProjectStarred,

--- a/src/components/sidebar/view/Sidebar.tsx
+++ b/src/components/sidebar/view/Sidebar.tsx
@@ -82,6 +82,9 @@ function Sidebar({
     archivedSessionsCount,
     isArchivedSessionsLoading,
     toggleProject,
+    expandAllProjects,
+    collapseAllProjects,
+    isAllExpanded,
     handleSessionClick,
     toggleStarProject,
     isProjectStarred,
@@ -295,6 +298,9 @@ function Sidebar({
             isRefreshing={isRefreshing}
             onCreateProject={() => setShowNewProject(true)}
             onCollapseSidebar={handleCollapseSidebar}
+            isAllExpanded={isAllExpanded}
+            onExpandAll={expandAllProjects}
+            onCollapseAll={collapseAllProjects}
             updateAvailable={updateAvailable}
             releaseInfo={releaseInfo}
             latestVersion={latestVersion}

--- a/src/components/sidebar/view/subcomponents/SidebarCollapsed.tsx
+++ b/src/components/sidebar/view/subcomponents/SidebarCollapsed.tsx
@@ -1,16 +1,5 @@
-import { Settings, Sparkles, PanelLeftOpen, Bug } from 'lucide-react';
+import { Settings, Sparkles, PanelLeftOpen } from 'lucide-react';
 import type { TFunction } from 'i18next';
-
-const DISCORD_INVITE_URL = 'https://discord.gg/buxwujPNRE';
-const GITHUB_ISSUES_URL = 'https://github.com/siteboon/claudecodeui/issues/new';
-
-function DiscordIcon({ className }: { className?: string }) {
-  return (
-    <svg className={className} fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
-      <path d="M20.317 4.37a19.791 19.791 0 0 0-4.885-1.515.074.074 0 0 0-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 0 0-5.487 0 12.64 12.64 0 0 0-.617-1.25.077.077 0 0 0-.079-.037A19.736 19.736 0 0 0 3.677 4.37a.07.07 0 0 0-.032.027C.533 9.046-.32 13.58.099 18.057a.082.082 0 0 0 .031.057 19.9 19.9 0 0 0 5.993 3.03.078.078 0 0 0 .084-.028c.462-.63.874-1.295 1.226-1.994a.076.076 0 0 0-.041-.106 13.107 13.107 0 0 1-1.872-.892.077.077 0 0 1-.008-.128 10.2 10.2 0 0 0 .372-.292.074.074 0 0 1 .077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 0 1 .078.01c.12.098.246.198.373.292a.077.077 0 0 1-.006.127 12.299 12.299 0 0 1-1.873.892.077.077 0 0 0-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.028 19.839 19.839 0 0 0 6.002-3.03.077.077 0 0 0 .032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 0 0-.031-.03zM8.02 15.33c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.956-2.419 2.157-2.419 1.21 0 2.176 1.095 2.157 2.42 0 1.333-.956 2.418-2.157 2.418zm7.975 0c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.955-2.419 2.157-2.419 1.21 0 2.176 1.095 2.157 2.42 0 1.333-.946 2.418-2.157 2.418z" />
-    </svg>
-  );
-}
 
 type SidebarCollapsedProps = {
   onExpand: () => void;
@@ -50,30 +39,6 @@ export default function SidebarCollapsed({
       >
         <Settings className="h-4 w-4 text-muted-foreground transition-colors group-hover:text-foreground" />
       </button>
-
-      {/* Report Issue */}
-      <a
-        href={GITHUB_ISSUES_URL}
-        target="_blank"
-        rel="noopener noreferrer"
-        className="group flex h-8 w-8 items-center justify-center rounded-lg transition-colors hover:bg-accent/80"
-        aria-label={t('actions.reportIssue')}
-        title={t('actions.reportIssue')}
-      >
-        <Bug className="h-4 w-4 text-muted-foreground transition-colors group-hover:text-foreground" />
-      </a>
-
-      {/* Discord */}
-      <a
-        href={DISCORD_INVITE_URL}
-        target="_blank"
-        rel="noopener noreferrer"
-        className="group flex h-8 w-8 items-center justify-center rounded-lg transition-colors hover:bg-accent/80"
-        aria-label={t('actions.joinCommunity')}
-        title={t('actions.joinCommunity')}
-      >
-        <DiscordIcon className="h-4 w-4 text-muted-foreground transition-colors group-hover:text-foreground" />
-      </a>
 
       {/* Update indicator */}
       {updateAvailable && (

--- a/src/components/sidebar/view/subcomponents/SidebarContent.tsx
+++ b/src/components/sidebar/view/subcomponents/SidebarContent.tsx
@@ -140,6 +140,9 @@ type SidebarContentProps = {
   isRefreshing: boolean;
   onCreateProject: () => void;
   onCollapseSidebar: () => void;
+  isAllExpanded: boolean;
+  onExpandAll: () => void;
+  onCollapseAll: () => void;
   updateAvailable: boolean;
   releaseInfo: ReleaseInfo | null;
   latestVersion: string | null;
@@ -177,6 +180,9 @@ export default function SidebarContent({
   isRefreshing,
   onCreateProject,
   onCollapseSidebar,
+  isAllExpanded,
+  onExpandAll,
+  onCollapseAll,
   updateAvailable,
   releaseInfo,
   latestVersion,
@@ -212,6 +218,9 @@ export default function SidebarContent({
         isRefreshing={isRefreshing}
         onCreateProject={onCreateProject}
         onCollapseSidebar={onCollapseSidebar}
+        isAllExpanded={isAllExpanded}
+        onExpandAll={onExpandAll}
+        onCollapseAll={onCollapseAll}
         t={t}
       />
 

--- a/src/components/sidebar/view/subcomponents/SidebarFooter.tsx
+++ b/src/components/sidebar/view/subcomponents/SidebarFooter.tsx
@@ -1,20 +1,7 @@
-import { Settings, ArrowUpCircle, Bug } from 'lucide-react';
+import { Settings, ArrowUpCircle } from 'lucide-react';
 import type { TFunction } from 'i18next';
 import { IS_PLATFORM } from '../../../../constants/config';
 import type { ReleaseInfo } from '../../../../types/sharedTypes';
-
-const GITHUB_ISSUES_URL = 'https://github.com/siteboon/claudecodeui/issues/new';
-const GITHUB_REPO_URL = 'https://github.com/siteboon/claudecodeui';
-
-const DISCORD_INVITE_URL = 'https://discord.gg/buxwujPNRE';
-
-function DiscordIcon({ className }: { className?: string }) {
-  return (
-    <svg className={className} fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
-      <path d="M20.317 4.37a19.791 19.791 0 0 0-4.885-1.515.074.074 0 0 0-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 0 0-5.487 0 12.64 12.64 0 0 0-.617-1.25.077.077 0 0 0-.079-.037A19.736 19.736 0 0 0 3.677 4.37a.07.07 0 0 0-.032.027C.533 9.046-.32 13.58.099 18.057a.082.082 0 0 0 .031.057 19.9 19.9 0 0 0 5.993 3.03.078.078 0 0 0 .084-.028c.462-.63.874-1.295 1.226-1.994a.076.076 0 0 0-.041-.106 13.107 13.107 0 0 1-1.872-.892.077.077 0 0 1-.008-.128 10.2 10.2 0 0 0 .372-.292.074.074 0 0 1 .077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 0 1 .078.01c.12.098.246.198.373.292a.077.077 0 0 1-.006.127 12.299 12.299 0 0 1-1.873.892.077.077 0 0 0-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.028 19.839 19.839 0 0 0 6.002-3.03.077.077 0 0 0 .032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 0 0-.031-.03zM8.02 15.33c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.956-2.419 2.157-2.419 1.21 0 2.176 1.095 2.157 2.42 0 1.333-.956 2.418-2.157 2.418zm7.975 0c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.955-2.419 2.157-2.419 1.21 0 2.176 1.095 2.157 2.42 0 1.333-.946 2.418-2.157 2.418z" />
-    </svg>
-  );
-}
 
 type SidebarFooterProps = {
   updateAvailable: boolean;
@@ -85,34 +72,7 @@ export default function SidebarFooter({
         </>
       )}
 
-      {/* Community + Settings */}
       <div className="nav-divider" />
-
-      {/* Desktop Report Issue */}
-      <div className="hidden px-2 pt-1.5 md:block">
-        <a
-          href={GITHUB_ISSUES_URL}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="flex w-full items-center gap-2 rounded-lg px-2.5 py-1.5 text-muted-foreground transition-colors hover:bg-accent/60 hover:text-foreground"
-        >
-          <Bug className="h-3.5 w-3.5" />
-          <span className="text-sm">{t('actions.reportIssue')}</span>
-        </a>
-      </div>
-
-      {/* Desktop Discord */}
-      <div className="hidden px-2 md:block">
-        <a
-          href={DISCORD_INVITE_URL}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="flex w-full items-center gap-2 rounded-lg px-2.5 py-1.5 text-muted-foreground transition-colors hover:bg-accent/60 hover:text-foreground"
-        >
-          <DiscordIcon className="h-3.5 w-3.5" />
-          <span className="text-sm">{t('actions.joinCommunity')}</span>
-        </a>
-      </div>
 
       {/* Desktop settings */}
       <div className="hidden px-2 py-1.5 md:block">
@@ -128,49 +88,14 @@ export default function SidebarFooter({
       {/* Desktop version brand line (OSS mode only) */}
       {!IS_PLATFORM && (
         <div className="hidden px-3 py-2 text-center md:block">
-          <a
-            href={GITHUB_REPO_URL}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="text-[10px] text-muted-foreground/40 transition-colors hover:text-muted-foreground"
-          >
-            CloudCLI v{currentVersion} – {t('branding.openSource')}
-          </a>
+          <span className="text-[10px] text-muted-foreground/40">
+            CloudCLI v{currentVersion}
+          </span>
         </div>
       )}
 
-      {/* Mobile Report Issue */}
-      <div className="px-3 pt-3 md:hidden">
-        <a
-          href={GITHUB_ISSUES_URL}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="flex h-10 w-full items-center gap-3 rounded-xl bg-muted/40 px-3.5 transition-all hover:bg-muted/60 active:scale-[0.98]"
-        >
-          <div className="flex h-7 w-7 items-center justify-center rounded-lg bg-background/80">
-            <Bug className="h-4 w-4 text-muted-foreground" />
-          </div>
-          <span className="text-sm font-medium text-foreground">{t('actions.reportIssue')}</span>
-        </a>
-      </div>
-
-      {/* Mobile Discord */}
-      <div className="px-3 pt-2 md:hidden">
-        <a
-          href={DISCORD_INVITE_URL}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="flex h-10 w-full items-center gap-3 rounded-xl bg-muted/40 px-3.5 transition-all hover:bg-muted/60 active:scale-[0.98]"
-        >
-          <div className="flex h-7 w-7 items-center justify-center rounded-lg bg-background/80">
-            <DiscordIcon className="h-4 w-4 text-muted-foreground" />
-          </div>
-          <span className="text-sm font-medium text-foreground">{t('actions.joinCommunity')}</span>
-        </a>
-      </div>
-
       {/* Mobile settings */}
-      <div className="px-3 pb-3 pt-2 md:hidden">
+      <div className="px-3 pb-3 pt-3 md:hidden">
         <button
           className="flex h-10 w-full items-center gap-3 rounded-xl bg-muted/40 px-3.5 transition-all hover:bg-muted/60 active:scale-[0.98]"
           onClick={onShowSettings}

--- a/src/components/sidebar/view/subcomponents/SidebarHeader.tsx
+++ b/src/components/sidebar/view/subcomponents/SidebarHeader.tsx
@@ -1,4 +1,4 @@
-import { Activity, Archive, Folder, FolderPlus, MessageSquare, Plus, RefreshCw, Search, X, PanelLeftClose } from 'lucide-react';
+import { Activity, Archive, ChevronsDownUp, ChevronsUpDown, Folder, FolderPlus, MessageSquare, Plus, RefreshCw, Search, X, PanelLeftClose } from 'lucide-react';
 import type { TFunction } from 'i18next';
 
 import { Button, Input, Tooltip } from '../../../../shared/view/ui';
@@ -28,6 +28,9 @@ type SidebarHeaderProps = {
   isRefreshing: boolean;
   onCreateProject: () => void;
   onCollapseSidebar: () => void;
+  isAllExpanded: boolean;
+  onExpandAll: () => void;
+  onCollapseAll: () => void;
   t: TFunction;
 };
 
@@ -48,8 +51,14 @@ export default function SidebarHeader({
   isRefreshing,
   onCreateProject,
   onCollapseSidebar,
+  isAllExpanded,
+  onExpandAll,
+  onCollapseAll,
   t,
 }: SidebarHeaderProps) {
+  const expandToggleLabel = isAllExpanded ? t('actions.collapseAll') : t('actions.expandAll');
+  const expandToggleHandler = isAllExpanded ? onCollapseAll : onExpandAll;
+  const showExpandToggle = projectsCount > 0;
   const showSearchTools = (projectsCount > 0 || runningSessionsCount > 0 || archivedSessionsCount > 0 || isArchivedSessionsLoading) && !isLoading;
   const searchPlaceholder = searchMode === 'conversations'
     ? t('search.conversationsPlaceholder')
@@ -106,6 +115,22 @@ export default function SidebarHeader({
                 }`}
               />
             </Button>
+            {showExpandToggle && (
+              <Button
+                variant="ghost"
+                size="sm"
+                className="h-7 w-7 rounded-lg p-0 text-muted-foreground hover:bg-accent/80 hover:text-foreground"
+                onClick={expandToggleHandler}
+                title={expandToggleLabel}
+                aria-label={expandToggleLabel}
+              >
+                {isAllExpanded ? (
+                  <ChevronsDownUp className="h-3.5 w-3.5" />
+                ) : (
+                  <ChevronsUpDown className="h-3.5 w-3.5" />
+                )}
+              </Button>
+            )}
             <Button
               variant="ghost"
               size="sm"
@@ -261,6 +286,20 @@ export default function SidebarHeader({
             >
               <RefreshCw className={`h-4 w-4 text-muted-foreground ${isRefreshing ? 'animate-spin' : ''}`} />
             </button>
+            {showExpandToggle && (
+              <button
+                className="flex h-8 w-8 items-center justify-center rounded-lg bg-muted/50 transition-all active:scale-95"
+                onClick={expandToggleHandler}
+                aria-label={expandToggleLabel}
+                title={expandToggleLabel}
+              >
+                {isAllExpanded ? (
+                  <ChevronsDownUp className="h-4 w-4 text-muted-foreground" />
+                ) : (
+                  <ChevronsUpDown className="h-4 w-4 text-muted-foreground" />
+                )}
+              </button>
+            )}
             <button
               className="flex h-8 w-8 items-center justify-center rounded-lg bg-primary/90 text-primary-foreground transition-all active:scale-95"
               onClick={onCreateProject}


### PR DESCRIPTION
## Summary

自用部署清理 sidebar 体验 · 第一波三连之一(PR1/PR2/PR3 stacked)。本 PR 风险最低 · 纯 UI 删改 + 局部 hook 逻辑调整。

### 改动 (7 commits)

| commit | 内容 |
|---|---|
| `998b508` | sidebar 默认全展开 (useRef 守门首次加载) + toggleProject 从 accordion 改 multi-toggle |
| `5cbe14a` | SidebarHeader 加全展开/折叠切换按钮 (ChevronsUpDown ⇄ ChevronsDownUp) · desktop + mobile · i18n 已有 key |
| `7517bfa` | SidebarFooter 删 Report Issue / Discord / "Open Source" 跳 GitHub 的版本号链接 |
| `2105cbc` | SidebarCollapsed 删 Bug / Discord 两个外链按钮 |
| `05e35bd` | About tab 删 Star on GitHub + GitHub/Discord/Docs/cloudcli.ai 4 link + Hosted CTA + Pro Features 占位 |
| `e5eb866` | VersionInfoSection 同步清理 (注:该组件似无 importer · commit 内已标记 · 待你拍板是否整删) |
| `5174e28` | AuthScreenLayout 删 "CloudCLI is open source" GitHub 链接 |

### 设计文档

参见 main 分支 `docs/superpowers/specs/2026-06-23-claudecodeui-improvements-design.md` 和 `docs/superpowers/plans/2026-06-23-pr1-sidebar-cleanup.md`。

### Test plan

- [x] `npm run typecheck` 0 errors (每 commit 后跑一遍)
- [x] `npm run build` 成功
- [x] `npm run lint` 仅剩 warning + 2 pre-existing server import errors(与本 PR 无关)
- [x] playwright 截图登录页 · 确认 "CloudCLI is open source" GitHub 链接已删
- [ ] **需要你登录验收的部分** (无测试账号 · 无法 playwright 自验):
  - sidebar 默认全展开 + 全展开/折叠按钮切换
  - SidebarFooter / SidebarCollapsed 不再显示 Report / Discord
  - 设置 → About tab 只剩版本号 + License
  - 单项目折叠不影响其他项目 (toggleProject 改 multi-toggle)

### Open Questions

1. VersionInfoSection.tsx 似无 importer · 是否整删?
2. useVersionCheck 还指向 siteboon/claudecodeui · 是否要改成 invoke888 fork?

🤖 Generated with Claude Code (Opus 4.7)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added expand/collapse all projects controls to the sidebar header.
  * Projects now automatically expand on initial load.

* **UI Improvements**
  * Version information now displays as a non-clickable badge instead of a link.
  * Simplified About tab with updated messaging.

* **Removed**
  * Community links (GitHub, Discord, Report Issue) from sidebar and settings.
  * Open-source branding references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->