### PR TITLE
Fix Windows browser-runtime install and Claude Code SDK spawn failures

### DIFF
--- a/server/claude-sdk.js
+++ b/server/claude-sdk.js
@@ -14,7 +14,7 @@
 
 import { query } from '@anthropic-ai/claude-agent-sdk';
 import crypto from 'crypto';
-import { promises as fs } from 'fs';
+import { promises as fs, statSync } from 'fs';
 import path from 'path';
 import os from 'os';
 import { CLAUDE_FALLBACK_MODELS } from './modules/providers/list/claude/claude-models.provider.js';
@@ -40,6 +40,14 @@ const abortedSessionIds = new Set();
 const TOOL_APPROVAL_TIMEOUT_MS = parseInt(process.env.CLAUDE_TOOL_APPROVAL_TIMEOUT_MS, 10) || 55000;
 
 const TOOLS_REQUIRING_INTERACTION = new Set(['AskUserQuestion', 'ExitPlanMode']);
+
+function isExistingDirectory(dir) {
+  try {
+    return statSync(dir).isDirectory();
+  } catch {
+    return false;
+  }
+}
 
 function createRequestId() {
   if (typeof crypto.randomUUID === 'function') {
@@ -163,9 +171,17 @@ function mapCliOptionsToSDK(options = {}) {
   // which does not reliably follow npm's shell wrappers like cross-spawn does.
   sdkOptions.pathToClaudeCodeExecutable = resolveClaudeCodeExecutablePath(process.env.CLAUDE_CLI_PATH);
 
-  // Map working directory
+  // Map working directory. The SDK spawns the Claude Code binary with this as
+  // cwd, and on Windows child_process.spawn throws ENOENT when cwd does not
+  // exist — surfaced as the misleading "native binary exists but failed to
+  // launch". Guard against a stale/missing project path: skip it and let the
+  // SDK default to the server's cwd rather than crash the run.
   if (cwd) {
-    sdkOptions.cwd = cwd;
+    if (isExistingDirectory(cwd)) {
+      sdkOptions.cwd = cwd;
+    } else {
+      console.warn(`[claude-sdk] Project directory does not exist, ignoring cwd: ${cwd}`);
+    }
   }
 
   // Map permission mode

--- a/server/modules/browser-use/browser-use.service.ts
+++ b/server/modules/browser-use/browser-use.service.ts
@@ -79,6 +79,12 @@ const DEFAULT_SETTINGS: BrowserUseSettings = {
 };
 const AGENT_OWNER_ID = 'agent';
 const PROFILE_ROOT = path.join(os.homedir(), '.cloudcli', 'browser-use', 'profiles');
+// Playwright is installed into an isolated dir with its own package.json rather
+// than the project root. Installing into the project tree forces npm to
+// reconcile every dependency (re-fetching unrelated tarballs, racing the
+// running dev server for locked node_modules dirs on Windows). An isolated
+// dir keeps the install to just playwright + playwright-core.
+const RUNTIME_ROOT = path.join(os.homedir(), '.cloudcli', 'browser-use', 'runtime');
 const MCP_SERVER_NAME = 'cloudcli-browser';
 const LEGACY_MCP_SERVER_NAMES = ['cloudcli-browser-use'];
 const RUNTIME_READINESS_CACHE_TTL_MS = 30_000;
@@ -140,6 +146,14 @@ function getSetupMessage(settings: BrowserUseSettings, readiness: RuntimeReadine
 }
 
 function getPlaywright(): any | null {
+  // Prefer the isolated runtime install; fall back to a project-level install
+  // (e.g. when playwright is a dev dependency during local development).
+  try {
+    const runtimeRequire = createRequire(path.join(RUNTIME_ROOT, 'package.json'));
+    return runtimeRequire('playwright');
+  } catch {
+    // fall through to project resolution
+  }
   try {
     return require('playwright');
   } catch {
@@ -243,14 +257,25 @@ const INSTALL_COMMAND_TIMEOUT_MS = Number.parseInt(
   10,
 );
 
-function runCommand(command: string, args: string[]): Promise<void> {
+function ensureRuntimeDir(): void {
+  fs.mkdirSync(RUNTIME_ROOT, { recursive: true });
+  const pkgPath = path.join(RUNTIME_ROOT, 'package.json');
+  if (!fs.existsSync(pkgPath)) {
+    fs.writeFileSync(
+      pkgPath,
+      `${JSON.stringify({ name: 'cloudcli-browser-runtime', private: true, version: '1.0.0' }, null, 2)}\n`,
+    );
+  }
+}
+
+function runCommand(command: string, args: string[], cwd: string): Promise<void> {
   return new Promise((resolve, reject) => {
     // On Windows, npm is `npm.cmd`. Since Node's fix for CVE-2024-27980
     // (v18.20.2 / v20.12.2+), spawning a .cmd/.bat without a shell throws
     // `spawn EINVAL`. Use a shell on Windows. Args here are static literals,
     // so there is no command-injection surface.
     const child = spawn(command, args, {
-      cwd: process.cwd(),
+      cwd,
       env: process.env,
       shell: process.platform === 'win32',
       stdio: ['ignore', 'pipe', 'pipe'],
@@ -305,16 +330,18 @@ async function installRuntime(): Promise<{ success: boolean; message: string }> 
   runtimeProbeCache = null;
   installPromise = (async () => {
     try {
+      ensureRuntimeDir();
+
       lastInstallMessage = 'Installing Playwright package...';
-      await runCommand(npmCommand, ['install', '--no-save', '--no-package-lock', 'playwright']);
+      await runCommand(npmCommand, ['install', 'playwright'], RUNTIME_ROOT);
 
       if (process.platform === 'linux') {
         lastInstallMessage = 'Installing Chromium system dependencies...';
-        await runCommand(npmCommand, ['exec', '--', 'playwright', 'install-deps', 'chromium']);
+        await runCommand(npmCommand, ['exec', '--', 'playwright', 'install-deps', 'chromium'], RUNTIME_ROOT);
       }
 
       lastInstallMessage = 'Installing Chromium runtime...';
-      await runCommand(npmCommand, ['exec', '--', 'playwright', 'install', 'chromium']);
+      await runCommand(npmCommand, ['exec', '--', 'playwright', 'install', 'chromium'], RUNTIME_ROOT);
 
       lastInstallMessage = 'Browser runtime installed.';
       return { success: true, message: lastInstallMessage };

--- a/server/modules/browser-use/browser-use.service.ts
+++ b/server/modules/browser-use/browser-use.service.ts
@@ -245,10 +245,14 @@ const INSTALL_COMMAND_TIMEOUT_MS = Number.parseInt(
 
 function runCommand(command: string, args: string[]): Promise<void> {
   return new Promise((resolve, reject) => {
+    // On Windows, npm is `npm.cmd`. Since Node's fix for CVE-2024-27980
+    // (v18.20.2 / v20.12.2+), spawning a .cmd/.bat without a shell throws
+    // `spawn EINVAL`. Use a shell on Windows. Args here are static literals,
+    // so there is no command-injection surface.
     const child = spawn(command, args, {
       cwd: process.cwd(),
       env: process.env,
-      shell: false,
+      shell: process.platform === 'win32',
       stdio: ['ignore', 'pipe', 'pipe'],
     });
     const output: string[] = [];

--- a/start-cloudcli.bat
+++ b/start-cloudcli.bat
@@ -1,0 +1,22 @@
+@echo off
+REM Launch CloudCLI standalone (server on :3001 + client on :5173).
+REM Double-click this file, or run it from a terminal. Close the window to stop.
+
+cd /d "%~dp0"
+
+REM Free port 3001 if a previous instance is still listening.
+for /f "tokens=5" %%P in ('netstat -ano ^| findstr /r /c:":3001 .*LISTENING"') do (
+    echo Stopping previous server on :3001 (PID %%P)...
+    taskkill /F /PID %%P >nul 2>&1
+)
+
+echo Starting CloudCLI...
+echo   Server: http://localhost:3001
+echo   App UI: http://localhost:5173
+echo.
+
+call npm run dev
+
+echo.
+echo Server stopped.
+pause


### PR DESCRIPTION
## What

Three Windows-only failures in the Browser runtime installer and the Claude Code SDK integration, plus a standalone launcher script.

### 1. `spawn EINVAL` when installing the Browser runtime
`server/modules/browser-use/browser-use.service.ts` spawned `npm.cmd` with `shell: false`. Since Node's fix for CVE-2024-27980 (v18.20.2 / v20.12.2+), spawning a `.cmd`/`.bat` without a shell throws `spawn EINVAL`, so **Install Runtime** failed immediately on Windows. Fix: `shell: process.platform === 'win32'` (args are static literals, no injection surface).

### 2. `ECONNRESET` / `EPERM rmdir` during Browser runtime install
After EINVAL was fixed, the installer ran `npm install` in the **project root**, forcing npm to reconcile the entire dependency tree — re-fetching unrelated tarballs (`parse-github-url` → `ECONNRESET`) and racing the running dev server for locked `node_modules` dirs (`EPERM rmdir eslint/nypm`). Fix: install Playwright into an isolated dir (`~/.cloudcli/browser-use/runtime`) with its own `package.json` and resolve it from there. Install drops to just `playwright` + `playwright-core`, no tree churn, no locks. Project `node_modules` stays a dev fallback.

### 3. `Claude Code native binary exists but failed to launch`
Misleading error — the binary is fine. When a session's project directory no longer exists on disk, `server/claude-sdk.js` passed it to the SDK as `cwd`. On Windows `child_process.spawn` throws `ENOENT` when `cwd` is invalid, which the Agent SDK reports as a binary launch failure. Fix: guard `cwd` with `statSync().isDirectory()`; if missing, log a warning and let the SDK default to the server's cwd so the run still launches.

### 4. `start-cloudcli.bat`
Standalone launcher: frees port 3001 if a previous instance lingers, then runs `npm run dev` (server :3001 + client :5173).

## Why
All three bugs make core features unusable on Windows (Node 18.20.2+ / 20.12.2+, reproduced on Node 25). They surface as cryptic errors that don't point at the real cause.

## Notes for reviewers
- Each fix is an isolated commit.
- Verified on Windows 11, Node v25.9.0: `tsc --noEmit` clean, eslint clean, and each failure mode reproduced before/after.
- The isolated-runtime install was validated end-to-end (Playwright + Chromium resolve, `chrome.exe` exists).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Windows launcher that starts the app, shows the local server/UI URLs, and keeps the console open.

* **Bug Fixes**
  * Improved handling of invalid working directories so the app falls back to a safe default instead of using a missing path.
  * Made browser/runtime setup more reliable by using an isolated install location and better Windows command handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->