### PR TITLE
fix(chat): prevent chat interface crash on malformed AskUserQuestion payload

### DIFF
--- a/src/components/chat/tools/components/ContentRenderers/QuestionAnswerContent.test.tsx
+++ b/src/components/chat/tools/components/ContentRenderers/QuestionAnswerContent.test.tsx
@@ -32,6 +32,29 @@ test('renders without throwing when a question is missing options[]', () => {
   });
 });
 
+test('renders without throwing when a questions entry is null/non-object', () => {
+  assert.doesNotThrow(() => {
+    renderToStaticMarkup(
+      React.createElement(QuestionAnswerContent, {
+        questions: [null, 'oops', { question: 'Ok?', options: [{ label: 'A' }] }] as never,
+        answers: {},
+      }),
+    );
+  });
+});
+
+test('renders without throwing when an answer is a non-string value', () => {
+  assert.doesNotThrow(() => {
+    renderToStaticMarkup(
+      React.createElement(QuestionAnswerContent, {
+        questions: [{ question: 'Pick one?', options: [{ label: 'A' }] }],
+        // Malformed: answer is an object instead of the expected string
+        answers: { 'Pick one?': { unexpected: true } } as never,
+      }),
+    );
+  });
+});
+
 test('still renders a well-formed question + answer', () => {
   const html = renderToStaticMarkup(
     React.createElement(QuestionAnswerContent, {

--- a/src/components/chat/tools/components/ContentRenderers/QuestionAnswerContent.test.tsx
+++ b/src/components/chat/tools/components/ContentRenderers/QuestionAnswerContent.test.tsx
@@ -1,0 +1,43 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { QuestionAnswerContent } from './QuestionAnswerContent';
+
+// Regression coverage for the chat-interface crash where an AskUserQuestion
+// payload loaded from a session transcript arrives with a non-array `questions`
+// or a question missing its `options` array. Rendering must degrade gracefully
+// instead of throwing "TypeError: e.map is not a function".
+
+test('renders without throwing when questions is a non-array value', () => {
+  assert.doesNotThrow(() => {
+    renderToStaticMarkup(
+      React.createElement(QuestionAnswerContent, {
+        // Malformed: object instead of an array
+        questions: { 0: { question: 'q?', options: [{ label: 'a' }] } } as never,
+        answers: {},
+      }),
+    );
+  });
+});
+
+test('renders without throwing when a question is missing options[]', () => {
+  assert.doesNotThrow(() => {
+    renderToStaticMarkup(
+      React.createElement(QuestionAnswerContent, {
+        questions: [{ question: 'Pick one?', header: 'H' } as never],
+        answers: { 'Pick one?': 'X' },
+      }),
+    );
+  });
+});
+
+test('still renders a well-formed question + answer', () => {
+  const html = renderToStaticMarkup(
+    React.createElement(QuestionAnswerContent, {
+      questions: [{ question: 'Pick one?', header: 'H', options: [{ label: 'A' }, { label: 'B' }] }],
+      answers: { 'Pick one?': 'A' },
+    }),
+  );
+  assert.ok(html.includes('Pick one?'));
+});

--- a/src/components/chat/tools/components/ContentRenderers/QuestionAnswerContent.test.tsx
+++ b/src/components/chat/tools/components/ContentRenderers/QuestionAnswerContent.test.tsx
@@ -32,6 +32,17 @@ test('renders without throwing when a question is missing options[]', () => {
   });
 });
 
+test('renders without throwing when options[] contains malformed entries', () => {
+  assert.doesNotThrow(() => {
+    renderToStaticMarkup(
+      React.createElement(QuestionAnswerContent, {
+        questions: [{ question: 'Pick one?', options: [null, 'oops', { label: 'A' }] } as never],
+        answers: { 'Pick one?': 'A, Custom' },
+      }),
+    );
+  });
+});
+
 test('renders without throwing when a questions entry is null/non-object', () => {
   assert.doesNotThrow(() => {
     renderToStaticMarkup(

--- a/src/components/chat/tools/components/ContentRenderers/QuestionAnswerContent.tsx
+++ b/src/components/chat/tools/components/ContentRenderers/QuestionAnswerContent.tsx
@@ -15,7 +15,11 @@ export const QuestionAnswerContent: React.FC<QuestionAnswerContentProps> = ({
 }) => {
   const [expandedIdx, setExpandedIdx] = useState<number | null>(null);
 
-  if (!questions || questions.length === 0) {
+  // Tool inputs are runtime data loaded from session transcripts and may be
+  // malformed (e.g. `questions` arriving as a non-array). Guard with
+  // Array.isArray so a single bad payload can't crash the whole chat view
+  // with "e.map is not a function".
+  if (!Array.isArray(questions) || questions.length === 0) {
     return null;
   }
 
@@ -29,6 +33,9 @@ export const QuestionAnswerContent: React.FC<QuestionAnswerContentProps> = ({
         const answerLabels = answer ? answer.split(', ') : [];
         const skipped = !answer;
         const isExpanded = expandedIdx === idx;
+        // `options` is typed as an array but comes from untrusted runtime data;
+        // fall back to an empty array so `.some`/`.map` below never throw.
+        const options = Array.isArray(q.options) ? q.options : [];
 
         return (
           <div
@@ -74,7 +81,7 @@ export const QuestionAnswerContent: React.FC<QuestionAnswerContentProps> = ({
                 {!isExpanded && answerLabels.length > 0 && (
                   <div className="mt-1.5 flex flex-wrap gap-1">
                     {answerLabels.map((lbl) => {
-                      const isCustom = !q.options.some(o => o.label === lbl);
+                      const isCustom = !options.some(o => o.label === lbl);
                       return (
                         <span
                           key={lbl}
@@ -110,7 +117,7 @@ export const QuestionAnswerContent: React.FC<QuestionAnswerContentProps> = ({
             {isExpanded && (
               <div className="border-t border-gray-100 px-3 pb-2.5 pt-0.5 dark:border-gray-700/40">
                 <div className="ml-6.5 space-y-1">
-                  {q.options.map((opt) => {
+                  {options.map((opt) => {
                     const wasSelected = answerLabels.includes(opt.label);
                     return (
                       <div
@@ -148,7 +155,7 @@ export const QuestionAnswerContent: React.FC<QuestionAnswerContentProps> = ({
                     );
                   })}
 
-                  {answerLabels.filter(lbl => !q.options.some(o => o.label === lbl)).map(lbl => (
+                  {answerLabels.filter(lbl => !options.some(o => o.label === lbl)).map(lbl => (
                     <div
                       key={lbl}
                       className="flex items-start gap-2 rounded-lg border border-blue-200/60 bg-blue-50/80 px-2.5 py-1.5 text-[12px] dark:border-blue-800/40 dark:bg-blue-900/20"

--- a/src/components/chat/tools/components/ContentRenderers/QuestionAnswerContent.tsx
+++ b/src/components/chat/tools/components/ContentRenderers/QuestionAnswerContent.tsx
@@ -28,9 +28,16 @@ export const QuestionAnswerContent: React.FC<QuestionAnswerContentProps> = ({
 
   return (
     <div className={`space-y-2 ${className}`}>
-      {questions.map((q, idx) => {
+      {questions.map((rawQuestion, idx) => {
+        // Entries come from session transcripts and may be malformed; skip
+        // anything that isn't a proper question object with a string prompt.
+        if (!rawQuestion || typeof rawQuestion !== 'object' || typeof rawQuestion.question !== 'string') {
+          return null;
+        }
+        const q = rawQuestion;
         const answer = answers?.[q.question];
-        const answerLabels = answer ? answer.split(', ') : [];
+        // `answer` may be a non-string (or absent) in malformed payloads.
+        const answerLabels = typeof answer === 'string' ? answer.split(', ') : [];
         const skipped = !answer;
         const isExpanded = expandedIdx === idx;
         // `options` is typed as an array but comes from untrusted runtime data;

--- a/src/components/chat/tools/components/ContentRenderers/QuestionAnswerContent.tsx
+++ b/src/components/chat/tools/components/ContentRenderers/QuestionAnswerContent.tsx
@@ -41,8 +41,10 @@ export const QuestionAnswerContent: React.FC<QuestionAnswerContentProps> = ({
         const skipped = !answer;
         const isExpanded = expandedIdx === idx;
         // `options` is typed as an array but comes from untrusted runtime data;
-        // fall back to an empty array so `.some`/`.map` below never throw.
-        const options = Array.isArray(q.options) ? q.options : [];
+        // keep only valid entries so `.some`/`.map` below never throw.
+        const options = Array.isArray(q.options)
+          ? q.options.filter((opt) => opt && typeof opt === 'object' && typeof opt.label === 'string')
+          : [];
 
         return (
           <div


### PR DESCRIPTION
## Problem

Opening a session that contains an **AskUserQuestion** tool call can crash the entire chat interface, showing the error boundary:

> **Something went wrong** — An error occurred while loading the chat interface.
> `TypeError: e.map is not a function`

The crash happens on session load, before any user interaction.

<details>
<summary>Full error log (production build)</summary>

```
Something went wrong
An error occurred while loading the chat interface.

Error Details
TypeError: e.map is not a function
    at gse (http://localhost:3001/assets/index-BIHaviaA.js:1154:3530)
    at div
    at div
    at div
    at http://localhost:3001/assets/index-BIHaviaA.js:749:105628
    at div
    at http://localhost:3001/assets/index-BIHaviaA.js:749:104924
    at L3 (http://localhost:3001/assets/index-BIHaviaA.js:842:499)
    at div
    at yG (http://localhost:3001/assets/index-BIHaviaA.js:842:9994)
    at http://localhost:3001/assets/index-BIHaviaA.js:1154:21707
    at div
    at div
    at div
    at http://localhost:3001/assets/index-BIHaviaA.js:1157:3427
    at div
    at joe (http://localhost:3001/assets/index-BIHaviaA.js:1219:66923)
    at div
    at ile (http://localhost:3001/assets/index-BIHaviaA.js:1219:111768)
    at Bue (http://localhost:3001/assets/index-BIHaviaA.js:1340:21009)
    at que (http://localhost:3001/assets/index-BIHaviaA.js:1340:23912)
    at div
    at div
    at div
    at div
    at Hue (http://localhost:3001/assets/index-BIHaviaA.js:1340:24386)
    at div
    at div
    at dde (http://localhost:3001/assets/index-BIHaviaA.js:1340:46915)
    at zO (http://localhost:3001/assets/index-BIHaviaA.js:749:56262)
    at dT
    at Xd (http://localhost:3001/assets/vendor-react-BGZc9oRE.js:50:3440)
    at fp (http://localhost:3001/assets/vendor-react-BGZc9oRE.js:50:7052)
    at lp (http://localhost:3001/assets/vendor-react-BGZc9oRE.js:50:6433)
    at dp (http://localhost:3001/assets/vendor-react-BGZc9oRE.js:59:124)
    at EO (http://localhost:3001/assets/index-BIHaviaA.js:749:42932)
    at _O (http://localhost:3001/assets/index-BIHaviaA.js:749:45318)
    at RO (http://localhost:3001/assets/index-BIHaviaA.js:749:49037)
    at DO (http://localhost:3001/assets/index-BIHaviaA.js:749:50162)
    at TO (http://localhost:3001/assets/index-BIHaviaA.js:749:44548)
    at UR (http://localhost:3001/assets/index-BIHaviaA.js:9:10092)
    at PR (http://localhost:3001/assets/index-BIHaviaA.js:9:3286)
    at LR (http://localhost:3001/assets/index-BIHaviaA.js:9:3005)
    at x4e
```

The innermost frame `gse` is the minified `QuestionAnswerContent`; the `Bue`/`que`/`Hue`/`dde` frames above it are the chat message list / message component, and `x4e` at the bottom is the error boundary that swaps in the "Something went wrong" screen.
</details>

## Root cause

`AskUserQuestion` is registered in `toolConfigs.ts` with `defaultOpen: true`, so `QuestionAnswerContent` renders immediately when the session loads.

Inside `QuestionAnswerContent.tsx`:

- The array guard only checked truthiness: `if (!questions || questions.length === 0)`. A non-array but truthy `questions` value (e.g. an object) passes the guard, and the subsequent `questions.map(...)` throws `e.map is not a function`.
- `q.options` was passed to `.map()` / `.some()` with **no guard at all**, even though tool inputs are runtime data loaded from session transcripts and can be malformed.

Because this renders inside the chat message list, a single bad message takes down the whole chat view via the error boundary instead of degrading gracefully.

## Where the malformed data comes from (and why guard at the render layer)

The bad shape originates **upstream**, not in this component. In a real session this was reproduced from a Codex transcript where the model emitted an invalid `AskUserQuestion` tool call — the agent's own input validator rejected it:

```
InputValidationError: AskUserQuestion failed ... parameter `questions` type is expected as array but provided as string
InputValidationError: AskUserQuestion failed ... required parameter questions[0].question is missing
```

That malformed tool call is still written into the provider's transcript file, and the provider parsers forward `toolInput` to the client **verbatim** (no schema normalization for `AskUserQuestion`). So:

1. **Origin** — the model/agent produces invalid tool args. This is outside the UI's control and *will* recur; it cannot be retroactively fixed for sessions already on disk.
2. **Ingestion** — the server passes the raw `toolInput` straight through.
3. **Render** — the component assumed a valid shape and crashed.

A transcript viewer must tolerate whatever the upstream tools wrote, so guarding at the render layer is the correct contract here, not a workaround — it lets one bad historical message degrade gracefully instead of taking down the whole chat view.

A complementary, more central hardening (out of scope for this PR) would be to **normalize/validate tool inputs once at ingestion** (provider parsers / `normalizedToChatMessages`) so a malformed call renders as an "errored tool" and every renderer doesn't have to guard individually. Happy to follow up with that separately.

## Fix

Guard both `questions` and `q.options` with `Array.isArray()`, and skip malformed per-question entries:

- `if (!Array.isArray(questions) || questions.length === 0) return null;`
- skip any entry that isn't an object with a string `question`
- `const options = Array.isArray(q.options) ? q.options : [];` used for the `.map()` / `.some()` calls
- only call `.split()` on an answer when it is actually a string

A malformed payload now renders nothing for that question instead of crashing the entire interface.

## Tests

Adds `QuestionAnswerContent.test.tsx` — the **first frontend regression test** in the repo. It reproduces the crash and locks in the fix:

- `questions` arriving as a non-array value → renders without throwing
- a `questions` entry that is null/non-object → renders without throwing
- a question missing its `options[]` → renders without throwing
- a non-string `answer` value → renders without throwing
- a well-formed question + answer still renders

It follows the existing test convention (`node:test`) and uses `react-dom/server` `renderToStaticMarkup`, so **no DOM/jsdom or new test framework is required**.

Run it with:

```bash
npx tsx --test "src/components/chat/tools/components/ContentRenderers/QuestionAnswerContent.test.tsx"
```

## Verification

- `npm run typecheck` (`tsc --noEmit`) passes with no errors.
- The new tests pass (5/5); confirmed they fail on the pre-fix code with `TypeError: questions.map is not a function`, matching the reported error.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chat question-and-answer rendering so invalid or incomplete data no longer breaks the view.
  * Added safer handling for missing, malformed, or non-text answers and option lists.
  * Ensured malformed question entries are skipped cleanly instead of causing rendering issues.

* **Tests**
  * Added regression coverage for malformed input cases and confirmed valid content still renders correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->