### PR TITLE
feat: session pin/bookmark feature in sidebar / 会话置顶功能

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -1,7 +1,7 @@
 // Service Worker for CloudCLI PWA
 // Cache only manifest (needed for PWA install). HTML and JS are never pre-cached
 // so a rebuild + refresh always picks up the latest assets.
-const CACHE_NAME = 'claude-ui-v2';
+const CACHE_NAME = 'claude-ui-v3';
 const urlsToCache = [
   '/manifest.json'
 ];

--- a/src/components/sidebar/types/types.ts
+++ b/src/components/sidebar/types/types.ts
@@ -66,6 +66,7 @@ export type SessionViewModel = {
   sessionName: string;
   sessionTime: string;
   messageCount: number;
+  isCursorSession?: boolean;
 };
 
 export type MCPServerStatus = {

--- a/src/components/sidebar/view/Sidebar.tsx
+++ b/src/components/sidebar/view/Sidebar.tsx
@@ -8,6 +8,8 @@ import { useSidebarController } from '../hooks/useSidebarController';
 import { useTaskMaster } from '../../../contexts/TaskMasterContext';
 import { usePaletteOps } from '../../../contexts/PaletteOpsContext';
 import { useTasksSettings } from '../../../contexts/TasksSettingsContext';
+import { useBookmarks } from '../../../stores/useBookmarkStore';
+import type { BookmarkedSession } from '../../../stores/useBookmarkStore';
 import type { Project, LLMProvider } from '../../../types/app';
 import type { MCPServerStatus, SidebarProps } from '../types/types';
 
@@ -53,6 +55,7 @@ function Sidebar({
   const { setCurrentProject, mcpServerStatus } = useTaskMaster() as TaskMasterSidebarContext;
   const { tasksEnabled } = useTasksSettings();
   const paletteOps = usePaletteOps();
+  const { bookmarks, isBookmarked, toggleBookmark, removeBookmark } = useBookmarks();
 
   const {
     isSidebarCollapsed,
@@ -193,6 +196,8 @@ function Sidebar({
     onSaveEditingSession: (projectName: string, sessionId: string, summary: string, provider: LLMProvider) => {
       void updateSessionSummary(projectName, sessionId, summary, provider);
     },
+    isBookmarked,
+    onToggleBookmark: toggleBookmark,
     t,
   };
 
@@ -305,6 +310,44 @@ function Sidebar({
             currentVersion={currentVersion}
             onShowVersionModal={() => setShowVersionModal(true)}
             onShowSettings={onShowSettings}
+            bookmarks={bookmarks}
+            selectedSessionId={selectedSession?.id ?? null}
+            isBookmarked={isBookmarked}
+            onToggleBookmark={toggleBookmark}
+            onRemoveBookmark={removeBookmark}
+            onSelectBookmarkedSession={(projectId, sessionId, provider) => {
+              const project = projects.find(p => p.projectId === projectId);
+              if (project) {
+                handleProjectSelect(project);
+                const sessions = getProjectSessions(project);
+                const existing = sessions.find(s => s.id === sessionId);
+                if (existing) {
+                  handleSessionClick(existing, project.projectId);
+                } else {
+                  handleSessionClick(
+                    { id: sessionId, __provider: provider || 'claude' },
+                    project.projectId,
+                  );
+                }
+              }
+            }}
+            onDeleteSession={(projectId, sessionId, sessionTitle, provider) => {
+              showDeleteSessionConfirmation(projectId, sessionId, sessionTitle, provider as LLMProvider);
+            }}
+            editingSession={editingSession}
+            editingSessionName={editingSessionName}
+            onStartEditingSession={(sessionId, initialName) => {
+              setEditingSession(sessionId);
+              setEditingSessionName(initialName);
+            }}
+            onCancelEditingSession={() => {
+              setEditingSession(null);
+              setEditingSessionName('');
+            }}
+            onEditingSessionNameChange={setEditingSessionName}
+            onSaveEditingSession={(projectId, sessionId, summary, provider) => {
+              void updateSessionSummary(projectId, sessionId, summary, provider as LLMProvider);
+            }}
             projectListProps={projectListProps}
             t={t}
           />

--- a/src/components/sidebar/view/subcomponents/SidebarBookmarks.tsx
+++ b/src/components/sidebar/view/subcomponents/SidebarBookmarks.tsx
@@ -1,0 +1,301 @@
+import { Check, ChevronDown, ChevronRight, Edit2, Pin, Trash2, X } from 'lucide-react';
+import { forwardRef, useImperativeHandle, useState } from 'react';
+import type { TFunction } from 'i18next';
+import { cn } from '../../../../lib/utils';
+import type { BookmarkedSession } from '../../../../stores/useBookmarkStore';
+import SessionProviderLogo from '../../../llm-logo-provider/SessionProviderLogo';
+
+export type SidebarBookmarksRef = {
+  collapse: () => void;
+};
+
+type SidebarBookmarksProps = {
+  bookmarks: BookmarkedSession[];
+  selectedSessionId: string | null;
+  onSelectSession: (projectId: string, sessionId: string, provider: string) => void;
+  onRemoveBookmark: (session: { sessionId: string; projectId: string; provider: string }) => void;
+  onDeleteSession: (projectId: string, sessionId: string, sessionTitle: string, provider: string) => void;
+  editingSession: string | null;
+  editingSessionName: string;
+  onStartEditingSession: (sessionId: string, initialName: string) => void;
+  onCancelEditingSession: () => void;
+  onEditingSessionNameChange: (value: string) => void;
+  onSaveEditingSession: (projectId: string, sessionId: string, summary: string, provider: string) => void;
+  expandedProjects: Set<string>;
+  onCollapseAllProjects: () => void;
+  t: TFunction;
+};
+
+function formatCompactAge(dateString: string): string {
+  if (!dateString) return '';
+  const date = new Date(dateString);
+  if (Number.isNaN(date.getTime())) return '';
+  const diffInMinutes = Math.floor(Math.max(0, Date.now() - date.getTime()) / (1000 * 60));
+  if (diffInMinutes < 1) return '<1m';
+  if (diffInMinutes < 60) return `${diffInMinutes}m`;
+  const diffInHours = Math.floor(diffInMinutes / 60);
+  if (diffInHours < 24) return `${diffInHours}hr`;
+  return `${Math.floor(diffInHours / 24)}d`;
+}
+
+function PinnedSessionRow({
+  bookmark,
+  isSelected,
+  isEditing,
+  editingName,
+  onSelect,
+  onUnpin,
+  onDelete,
+  onStartEditing,
+  onCancelEditing,
+  onEditingChange,
+  onSaveEditing,
+  t,
+}: {
+  bookmark: BookmarkedSession;
+  isSelected: boolean;
+  isEditing: boolean;
+  editingName: string;
+  onSelect: () => void;
+  onUnpin: () => void;
+  onDelete: () => void;
+  onStartEditing: () => void;
+  onCancelEditing: () => void;
+  onEditingChange: (v: string) => void;
+  onSaveEditing: () => void;
+  t: TFunction;
+}) {
+  const compactAge = formatCompactAge(bookmark.bookmarkedAt);
+
+  return (
+    <div className="group relative">
+      <div className="hidden md:block">
+        <button
+          className={cn(
+            'w-full justify-start p-2 h-auto font-normal text-left hover:bg-accent/50 transition-colors duration-200',
+            isSelected && 'bg-accent text-accent-foreground',
+          )}
+          onClick={onSelect}
+        >
+          <div className="flex w-full min-w-0 items-start gap-2">
+            <SessionProviderLogo provider={bookmark.provider} className="mt-0.5 h-3 w-3 flex-shrink-0" />
+            <div className="min-w-0 flex-1">
+              <div className="flex items-center gap-2">
+                <div className="truncate text-xs font-medium text-foreground">{bookmark.sessionSummary}</div>
+                {compactAge && !isEditing && (
+                  <span className="ml-auto flex-shrink-0 text-[11px] text-muted-foreground transition-opacity duration-200 group-hover:opacity-0">
+                    {compactAge}
+                  </span>
+                )}
+              </div>
+            </div>
+          </div>
+        </button>
+
+        <div
+          className={cn(
+            'absolute right-2 top-1/2 flex -translate-y-1/2 transform items-center gap-1 transition-all duration-200',
+            isEditing ? 'opacity-100' : 'opacity-0 group-hover:opacity-100',
+          )}
+        >
+          {isEditing ? (
+            <>
+              <input
+                type="text" value={editingName}
+                onChange={(e) => onEditingChange(e.target.value)}
+                onKeyDown={(e) => { e.stopPropagation(); if (e.key === 'Enter') onSaveEditing(); else if (e.key === 'Escape') onCancelEditing(); }}
+                onClick={(e) => e.stopPropagation()}
+                className="w-32 rounded border border-border bg-background px-2 py-1 text-xs focus:outline-none focus:ring-1 focus:ring-primary"
+                autoFocus
+              />
+              <button className="flex h-6 w-6 items-center justify-center rounded bg-green-50 hover:bg-green-100 dark:bg-green-900/20 dark:hover:bg-green-900/40" onClick={(e) => { e.stopPropagation(); onSaveEditing(); }} title={t('tooltips.save')}>
+                <Check className="h-3 w-3 text-green-600 dark:text-green-400" />
+              </button>
+              <button className="flex h-6 w-6 items-center justify-center rounded bg-gray-50 hover:bg-gray-100 dark:bg-gray-900/20 dark:hover:bg-gray-900/40" onClick={(e) => { e.stopPropagation(); onCancelEditing(); }} title={t('tooltips.cancel')}>
+                <X className="h-3 w-3 text-gray-600 dark:text-gray-400" />
+              </button>
+            </>
+          ) : (
+            <>
+              {/* Unpin — RED background */}
+              <button className="flex h-6 w-6 items-center justify-center rounded bg-red-100 text-red-500 hover:bg-red-200 dark:bg-red-900/30 dark:hover:bg-red-900/50" onClick={(e) => { e.stopPropagation(); onUnpin(); }} title={t('bookmarks.unpin', 'Unpin session')}>
+                <Pin className="h-3 w-3 rotate-45" />
+              </button>
+              <button className="flex h-6 w-6 items-center justify-center rounded bg-blue-100 text-blue-500 hover:bg-blue-200 dark:bg-blue-900/30 dark:hover:bg-blue-900/50" onClick={(e) => { e.stopPropagation(); onStartEditing(); }} title={t('tooltips.editSessionName')}>
+                <Edit2 className="h-3 w-3" />
+              </button>
+              <button className="flex h-6 w-6 items-center justify-center rounded bg-red-100 text-red-500 hover:bg-red-200 dark:bg-red-900/30 dark:hover:bg-red-900/50" onClick={(e) => { e.stopPropagation(); onDelete(); }} title={t('tooltips.deleteSessionOptions')}>
+                <Trash2 className="h-3 w-3 text-red-600 dark:text-red-400" />
+              </button>
+            </>
+          )}
+        </div>
+      </div>
+
+      {/* Mobile — matches SidebarSessionItem mobile layout */}
+      <div className="md:hidden">
+        <div
+          className={cn('p-2 mx-3 my-0.5 rounded-md bg-card border active:scale-[0.98] transition-all duration-150 relative', isSelected ? 'bg-primary/5 border-primary/20' : 'border-border/30')}
+          onClick={onSelect}
+        >
+          <div className="flex items-center gap-2">
+            <div className={cn('w-5 h-5 rounded-md flex items-center justify-center flex-shrink-0', isSelected ? 'bg-primary/10' : 'bg-muted/50')}>
+              <SessionProviderLogo provider={bookmark.provider} className="h-3 w-3" />
+            </div>
+            <div className="min-w-0 flex-1">
+              <div className="flex items-center gap-2">
+                <div className="truncate text-xs font-medium text-foreground">{bookmark.sessionSummary}</div>
+                {compactAge && <span className="ml-auto flex-shrink-0 text-[11px] text-muted-foreground">{compactAge}</span>}
+              </div>
+            </div>
+
+            {/* Actions inline on the right — always visible like normal sessions */}
+            {isEditing ? (
+              <>
+                <input
+                  type="text" value={editingName}
+                  onChange={(e) => onEditingChange(e.target.value)}
+                  onKeyDown={(e) => { e.stopPropagation(); if (e.key === 'Enter') onSaveEditing(); else if (e.key === 'Escape') onCancelEditing(); }}
+                  onClick={(e) => e.stopPropagation()}
+                  className="w-32 rounded border border-border bg-background px-2 py-1 text-xs focus:outline-none focus:ring-1 focus:ring-primary"
+                  autoFocus
+                />
+                <button type="button" className="flex h-5 w-5 items-center justify-center rounded-md bg-green-50 dark:bg-green-900/20" onClick={(e) => { e.stopPropagation(); onSaveEditing(); }} title={t('tooltips.save')}>
+                  <Check className="h-2.5 w-2.5 text-green-600 dark:text-green-400" />
+                </button>
+                <button type="button" className="ml-1 flex h-5 w-5 items-center justify-center rounded-md bg-gray-50 dark:bg-gray-900/20" onClick={(e) => { e.stopPropagation(); onCancelEditing(); }} title={t('tooltips.cancel')}>
+                  <X className="h-2.5 w-2.5 text-gray-600 dark:text-gray-400" />
+                </button>
+              </>
+            ) : (
+              <>
+                <button type="button" className="ml-1 flex h-5 w-5 items-center justify-center rounded-md opacity-70 transition-transform active:scale-95 bg-red-50 dark:bg-red-900/20" onClick={(e) => { e.stopPropagation(); onUnpin(); }} title={t('bookmarks.unpin', 'Unpin session')}>
+                  <Pin className="h-2.5 w-2.5 fill-red-500 text-red-500 rotate-45" />
+                </button>
+                <button type="button" className="ml-1 flex h-5 w-5 items-center justify-center rounded-md opacity-70 transition-transform active:scale-95 bg-red-50 dark:bg-red-900/20" onClick={(e) => { e.stopPropagation(); onDelete(); }} title={t('tooltips.deleteSessionOptions')}>
+                  <Trash2 className="h-2.5 w-2.5 text-red-600 dark:text-red-400" />
+                </button>
+              </>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default forwardRef<SidebarBookmarksRef, SidebarBookmarksProps>(function SidebarBookmarks({
+  bookmarks,
+  selectedSessionId,
+  onSelectSession,
+  onRemoveBookmark,
+  onDeleteSession,
+  editingSession,
+  editingSessionName,
+  onStartEditingSession,
+  onCancelEditingSession,
+  onEditingSessionNameChange,
+  onSaveEditingSession,
+  expandedProjects,
+  onCollapseAllProjects,
+  t,
+}, ref) {
+  const [expanded, setExpanded] = useState(bookmarks.length > 0);
+
+  useImperativeHandle(ref, () => ({
+    collapse: () => setExpanded(false),
+  }));
+
+  if (!bookmarks.length) return null;
+
+  const toggleExpanded = () => {
+    const next = !expanded;
+    setExpanded(next);
+    if (next) {
+      onCollapseAllProjects();
+    }
+  };
+
+  return (
+    <div className="md:space-y-1">
+      <div className="md:group group">
+        {/* Mobile header */}
+        <div className="md:hidden">
+          <div
+            className="p-3 mx-3 my-1 rounded-lg bg-card border border-border/50 active:scale-[0.98] transition-all duration-150"
+            onClick={toggleExpanded}
+          >
+            <div className="flex items-center justify-between">
+              <div className="flex min-w-0 flex-1 items-center gap-3">
+                <div className="w-8 h-8 rounded-lg flex items-center justify-center bg-blue-500/10 dark:bg-blue-900/30 border border-blue-200 dark:border-blue-800">
+                  <Pin className="w-4 h-4 text-blue-600 dark:text-blue-400 fill-current" />
+                </div>
+                <div className="min-w-0 flex-1">
+                  <h3 className="truncate text-sm font-medium text-foreground">{t('bookmarks.title', 'Pinned')}</h3>
+                  <p className="text-xs text-muted-foreground">{bookmarks.length}</p>
+                </div>
+              </div>
+              <div className="flex h-6 w-6 items-center justify-center rounded-md bg-muted/30">
+                {expanded
+                  ? <ChevronDown className="h-3 w-3 text-muted-foreground" />
+                  : <ChevronRight className="h-3 w-3 text-muted-foreground" />
+                }
+              </div>
+            </div>
+          </div>
+        </div>
+
+        {/* Desktop header — mirrors SidebarProjectItem Button */}
+        <button
+          className="hidden md:flex w-full justify-between p-2 h-auto font-normal text-left hover:bg-accent/50 transition-colors duration-200"
+          onClick={toggleExpanded}
+        >
+          <div className="flex min-w-0 flex-1 items-center gap-3">
+            <div className="w-6 h-6 flex items-center justify-center rounded">
+              <Pin className="w-3.5 h-3.5 text-blue-500 dark:text-blue-400 fill-current" />
+            </div>
+            <div className="min-w-0 flex-1 text-left">
+              <div className="truncate text-sm font-semibold text-foreground">
+                {t('bookmarks.title', 'Pinned')}
+                <span className="ml-1.5 text-xs font-normal text-muted-foreground">{bookmarks.length}</span>
+              </div>
+            </div>
+          </div>
+          <div className="flex flex-shrink-0 items-center gap-1">
+            {expanded
+              ? <ChevronDown className="h-4 w-4 text-muted-foreground transition-colors group-hover:text-foreground" />
+              : <ChevronRight className="h-4 w-4 text-muted-foreground transition-colors group-hover:text-foreground" />
+            }
+          </div>
+        </button>
+      </div>
+
+      {/* Session list — SAME container as SidebarProjectSessions */}
+      {expanded && (
+        <div className="ml-3 space-y-1 border-l border-border pl-3">
+          {bookmarks.map((bm) => {
+            const isSelected = selectedSessionId === bm.sessionId;
+            const isEditing = editingSession === bm.sessionId;
+            return (
+              <PinnedSessionRow
+                key={bm.sessionId}
+                bookmark={bm}
+                isSelected={isSelected}
+                isEditing={isEditing}
+                editingName={editingSessionName}
+                onSelect={() => onSelectSession(bm.projectId, bm.sessionId, bm.provider)}
+                onUnpin={() => onRemoveBookmark(bm)}
+                onDelete={() => onDeleteSession(bm.projectId, bm.sessionId, bm.sessionSummary, bm.provider)}
+                onStartEditing={() => onStartEditingSession(bm.sessionId, bm.sessionSummary)}
+                onCancelEditing={onCancelEditingSession}
+                onEditingChange={onEditingSessionNameChange}
+                onSaveEditing={() => onSaveEditingSession(bm.projectId, bm.sessionId, editingSessionName, bm.provider)}
+                t={t}
+              />
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+});

--- a/src/components/sidebar/view/subcomponents/SidebarContent.tsx
+++ b/src/components/sidebar/view/subcomponents/SidebarContent.tsx
@@ -1,15 +1,16 @@
-import { type ReactNode } from 'react';
+import { type ReactNode, useRef } from 'react';
 import { Activity, Archive, Folder, MessageSquare, RotateCcw, Search, Trash2 } from 'lucide-react';
 import type { TFunction } from 'i18next';
 
 import { ScrollArea } from '../../../../shared/view/ui';
+import type { BookmarkedSession } from '../../../../stores/useBookmarkStore';
 import type { Project } from '../../../../types/app';
 import type { ReleaseInfo } from '../../../../types/sharedTypes';
 import type { ConversationSearchResults, SearchProgress } from '../../hooks/useSidebarController';
 import type { ArchivedProjectListItem, ArchivedSessionListItem, SidebarSearchMode } from '../../types/types';
 import SessionProviderLogo from '../../../llm-logo-provider/SessionProviderLogo';
 import { getAllSessions } from '../../utils/utils';
-
+import SidebarBookmarks, { type SidebarBookmarksRef } from './SidebarBookmarks';
 import SidebarFooter from './SidebarFooter';
 import SidebarHeader from './SidebarHeader';
 import SidebarProjectList, { type SidebarProjectListProps } from './SidebarProjectList';
@@ -147,6 +148,20 @@ type SidebarContentProps = {
   currentVersion: string;
   onShowVersionModal: () => void;
   onShowSettings: () => void;
+  // Bookmark props
+  bookmarks: BookmarkedSession[];
+  selectedSessionId: string | null;
+  isBookmarked: (session: { sessionId: string; projectId: string; provider: string }) => boolean;
+  onToggleBookmark: (bookmark: BookmarkedSession) => void;
+  onRemoveBookmark: (session: { sessionId: string; projectId: string; provider: string }) => void;
+  onSelectBookmarkedSession: (projectId: string, sessionId: string) => void;
+  onDeleteSession: (projectId: string, sessionId: string, sessionTitle: string, provider: string) => void;
+  editingSession: string | null;
+  editingSessionName: string;
+  onStartEditingSession: (sessionId: string, initialName: string) => void;
+  onCancelEditingSession: () => void;
+  onEditingSessionNameChange: (value: string) => void;
+  onSaveEditingSession: (projectId: string, sessionId: string, summary: string, provider: string) => void;
   projectListProps: SidebarProjectListProps;
   t: TFunction;
 };
@@ -185,12 +200,41 @@ export default function SidebarContent({
   currentVersion,
   onShowVersionModal,
   onShowSettings,
+  // Bookmark props
+  bookmarks,
+  selectedSessionId,
+  isBookmarked,
+  onToggleBookmark,
+  onRemoveBookmark,
+  onSelectBookmarkedSession,
+  onDeleteSession,
+  editingSession,
+  editingSessionName,
+  onStartEditingSession,
+  onCancelEditingSession,
+  onEditingSessionNameChange,
+  onSaveEditingSession,
   projectListProps,
   t,
 }: SidebarContentProps) {
   const showConversationSearch = searchMode === 'conversations' && searchFilter.trim().length >= 2;
   const hasPartialResults = conversationResults && conversationResults.results.length > 0;
   const groupedArchivedSessions = groupArchivedSessionsByProject(archivedSessions);
+  const bookmarksRef = useRef<SidebarBookmarksRef>(null);
+
+  // When a project expands, collapse pinned section
+  const handleProjectToggle = (projectName: string) => {
+    const willExpand = !projectListProps.expandedProjects.has(projectName);
+    if (willExpand) {
+      bookmarksRef.current?.collapse();
+    }
+    projectListProps.onToggleProject(projectName);
+  };
+
+  const projectListWithToggle = {
+    ...projectListProps,
+    onToggleProject: handleProjectToggle,
+  };
 
   return (
     <div
@@ -218,6 +262,28 @@ export default function SidebarContent({
       />
 
       <ScrollArea className="flex-1 overflow-y-auto overscroll-contain md:px-1.5 md:py-2">
+        {/* Bookmarks — inside ScrollArea to share md:px-1.5 container with projects */}
+        <SidebarBookmarks
+          ref={bookmarksRef}
+          bookmarks={bookmarks}
+          selectedSessionId={selectedSessionId}
+          onSelectSession={(pid, sid, provider) => onSelectBookmarkedSession(pid, sid)}
+          onRemoveBookmark={onRemoveBookmark}
+          onDeleteSession={onDeleteSession}
+          editingSession={editingSession}
+          editingSessionName={editingSessionName}
+          onStartEditingSession={onStartEditingSession}
+          onCancelEditingSession={onCancelEditingSession}
+          onEditingSessionNameChange={onEditingSessionNameChange}
+          onSaveEditingSession={onSaveEditingSession}
+          expandedProjects={projectListWithToggle.expandedProjects}
+          onCollapseAllProjects={() => {
+            projectListWithToggle.expandedProjects.forEach((id) => {
+              projectListWithToggle.onToggleProject(id);
+            });
+          }}
+          t={t}
+        />
         {showConversationSearch ? (
           isSearching && !hasPartialResults ? (
             <div className="px-4 py-12 text-center md:py-8">
@@ -549,7 +615,7 @@ export default function SidebarContent({
             </div>
           )
         ) : (
-          <SidebarProjectList {...projectListProps} />
+          <SidebarProjectList {...projectListWithToggle} />
         )}
       </ScrollArea>
 

--- a/src/components/sidebar/view/subcomponents/SidebarProjectItem.tsx
+++ b/src/components/sidebar/view/subcomponents/SidebarProjectItem.tsx
@@ -2,6 +2,7 @@ import { Check, ChevronDown, ChevronRight, Edit3, Star, Trash2, X } from 'lucide
 import type { TFunction } from 'i18next';
 
 import { Button } from '../../../../shared/view/ui';
+import type { BookmarkedSession } from '../../../../stores/useBookmarkStore';
 import { cn } from '../../../../lib/utils';
 import type { Project, ProjectSession, LLMProvider } from '../../../../types/app';
 import type { SessionActivityMap } from '../../../../hooks/useSessionProtection';
@@ -51,6 +52,8 @@ type SidebarProjectItemProps = {
   onStartEditingSession: (sessionId: string, initialName: string) => void;
   onCancelEditingSession: () => void;
   onSaveEditingSession: (projectName: string, sessionId: string, summary: string, provider: LLMProvider) => void;
+  isBookmarked: (session: { sessionId: string; projectId: string; provider: string }) => boolean;
+  onToggleBookmark: (bookmark: BookmarkedSession) => void;
   t: TFunction;
 };
 
@@ -94,6 +97,8 @@ export default function SidebarProjectItem({
   onStartEditingSession,
   onCancelEditingSession,
   onSaveEditingSession,
+  isBookmarked,
+  onToggleBookmark,
   t,
 }: SidebarProjectItemProps) {
   // Project identity is tracked by the DB-assigned `projectId` everywhere
@@ -273,7 +278,8 @@ export default function SidebarProjectItem({
           onClick={selectAndToggleProject}
         >
           <div className="flex min-w-0 flex-1 items-center gap-3">
-            <div
+            <button
+              type="button"
               className={cn(
                 'w-6 h-6 flex items-center justify-center rounded cursor-pointer transition-all duration-200',
                 isStarred
@@ -285,6 +291,7 @@ export default function SidebarProjectItem({
                 toggleStarProject();
               }}
               title={isStarred ? t('tooltips.removeFromFavorites') : t('tooltips.addToFavorites')}
+              aria-label={isStarred ? t('tooltips.removeFromFavorites') : t('tooltips.addToFavorites')}
             >
               <Star
                 className={cn(
@@ -294,7 +301,7 @@ export default function SidebarProjectItem({
                     : 'text-muted-foreground',
                 )}
               />
-            </div>
+            </button>
             <div className="min-w-0 flex-1 text-left">
               {isEditing ? (
                 <div className="space-y-1">
@@ -414,6 +421,8 @@ export default function SidebarProjectItem({
         onDeleteSession={onDeleteSession}
         onLoadMoreSessions={onLoadMoreSessions}
         onNewSession={onNewSession}
+        isBookmarked={isBookmarked}
+        onToggleBookmark={onToggleBookmark}
         t={t}
       />
     </div>

--- a/src/components/sidebar/view/subcomponents/SidebarProjectList.tsx
+++ b/src/components/sidebar/view/subcomponents/SidebarProjectList.tsx
@@ -3,6 +3,7 @@ import type { TFunction } from 'i18next';
 
 import type { LoadingProgress, Project, ProjectSession, LLMProvider } from '../../../../types/app';
 import type { SessionActivityMap } from '../../../../hooks/useSessionProtection';
+import type { BookmarkedSession } from '../../../../stores/useBookmarkStore';
 import type { MCPServerStatus, SessionWithProvider } from '../../types/types';
 
 import SidebarProjectItem from './SidebarProjectItem';
@@ -52,6 +53,8 @@ export type SidebarProjectListProps = {
   onStartEditingSession: (sessionId: string, initialName: string) => void;
   onCancelEditingSession: () => void;
   onSaveEditingSession: (projectName: string, sessionId: string, summary: string, provider: LLMProvider) => void;
+  isBookmarked: (session: { sessionId: string; projectId: string; provider: string }) => boolean;
+  onToggleBookmark: (bookmark: BookmarkedSession) => void;
   t: TFunction;
 };
 
@@ -94,6 +97,8 @@ export default function SidebarProjectList({
   onStartEditingSession,
   onCancelEditingSession,
   onSaveEditingSession,
+  isBookmarked,
+  onToggleBookmark,
   t,
 }: SidebarProjectListProps) {
   const state = (
@@ -160,6 +165,8 @@ export default function SidebarProjectList({
               onStartEditingSession={onStartEditingSession}
               onCancelEditingSession={onCancelEditingSession}
               onSaveEditingSession={onSaveEditingSession}
+              isBookmarked={isBookmarked}
+              onToggleBookmark={onToggleBookmark}
               t={t}
             />
           ))}

--- a/src/components/sidebar/view/subcomponents/SidebarSessionItem.tsx
+++ b/src/components/sidebar/view/subcomponents/SidebarSessionItem.tsx
@@ -1,8 +1,9 @@
 import { useEffect, useRef } from 'react';
-import { Check, Edit2, Loader2, Trash2, X } from 'lucide-react';
+import { Check, Edit2, Loader2, Pin, Trash2, X } from 'lucide-react';
 import type { TFunction } from 'i18next';
 
-import { Badge, Tooltip, buttonVariants } from '../../../../shared/view/ui';
+import { Badge, Button, buttonVariants, Tooltip } from '../../../../shared/view/ui';
+import type { BookmarkedSession } from '../../../../stores/useBookmarkStore';
 import { cn } from '../../../../lib/utils';
 import type { Project, ProjectSession, LLMProvider } from '../../../../types/app';
 import type { SessionWithProvider } from '../../types/types';
@@ -30,6 +31,8 @@ type SidebarSessionItemProps = {
     sessionTitle: string,
     provider: LLMProvider,
   ) => void;
+  isBookmarked: boolean;
+  onToggleBookmark: (bookmark: BookmarkedSession) => void;
   t: TFunction;
 };
 
@@ -77,6 +80,8 @@ export default function SidebarSessionItem({
   onProjectSelect,
   onSessionSelect,
   onDeleteSession,
+  isBookmarked,
+  onToggleBookmark,
   t,
 }: SidebarSessionItemProps) {
   const sessionView = createSessionViewModel(session, currentTime, t);
@@ -119,6 +124,17 @@ export default function SidebarSessionItem({
 
   const requestDeleteSession = () => {
     onDeleteSession(project.projectId, session.id, sessionView.sessionName, session.__provider);
+  };
+
+  const requestToggleBookmark = () => {
+    onToggleBookmark({
+      sessionId: session.id,
+      projectId: project.projectId,
+      projectDisplayName: project.displayName,
+      sessionSummary: sessionView.sessionName,
+      provider: session.__provider,
+      bookmarkedAt: new Date().toISOString(),
+    });
   };
 
   return (
@@ -192,16 +208,28 @@ export default function SidebarSessionItem({
               </div>
             </div>
 
-            {!isProcessing && (
-              <button
-                className="ml-1 flex h-5 w-5 items-center justify-center rounded-md bg-red-50 opacity-70 transition-transform active:scale-95 dark:bg-red-900/20"
-                onClick={(event) => {
-                  event.stopPropagation();
-                  requestDeleteSession();
-                }}
-              >
-                <Trash2 className="h-2.5 w-2.5 text-red-600 dark:text-red-400" />
-              </button>
+            {!sessionView.isCursorSession && (
+              <>
+                <button
+                  className="ml-1 flex h-5 w-5 items-center justify-center rounded-md opacity-70 transition-transform active:scale-95 bg-blue-50 dark:bg-blue-900/20"
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    requestToggleBookmark();
+                  }}
+                  title={isBookmarked ? t('bookmarks.unpin', 'Unpin session') : t('bookmarks.pin', 'Pin session')}
+                >
+                  <Pin className={cn('h-2.5 w-2.5', isBookmarked && 'fill-red-500 text-red-500 rotate-45', !isBookmarked && 'text-blue-600 dark:text-blue-400')} />
+                </button>
+                <button
+                  className="ml-1 flex h-5 w-5 items-center justify-center rounded-md bg-red-50 opacity-70 transition-transform active:scale-95 dark:bg-red-900/20"
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    requestDeleteSession();
+                  }}
+                >
+                  <Trash2 className="h-2.5 w-2.5 text-red-600 dark:text-red-400" />
+                </button>
+              </>
             )}
           </div>
         </div>
@@ -320,18 +348,33 @@ export default function SidebarSessionItem({
             ) : (
               <>
                 <button
-                  className="flex h-6 w-6 items-center justify-center rounded bg-gray-50 hover:bg-gray-100 dark:bg-gray-900/20 dark:hover:bg-gray-900/40"
+                  className={cn(
+                    'flex h-6 w-6 items-center justify-center rounded transition-colors',
+                    isBookmarked
+                      ? 'bg-red-100 text-red-500 hover:bg-red-200 dark:bg-red-900/30 dark:hover:bg-red-900/50'
+                      : 'bg-blue-100 text-blue-500 hover:bg-blue-200 dark:bg-blue-900/30 dark:hover:bg-blue-900/50',
+                  )}
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    requestToggleBookmark();
+                  }}
+                  title={isBookmarked ? t('bookmarks.unpin', 'Unpin session') : t('bookmarks.pin', 'Pin session')}
+                >
+                  <Pin className={cn('h-3 w-3', isBookmarked && 'fill-red-500 text-red-500 rotate-45')} />
+                </button>
+                <button
+                  className="flex h-6 w-6 items-center justify-center rounded bg-blue-100 text-blue-500 hover:bg-blue-200 dark:bg-blue-900/30 dark:hover:bg-blue-900/50"
                   onClick={(event) => {
                     event.stopPropagation();
                     onStartEditingSession(session.id, sessionView.sessionName);
                   }}
                   title={t('tooltips.editSessionName')}
                 >
-                  <Edit2 className="h-3 w-3 text-gray-600 dark:text-gray-400" />
+                  <Edit2 className="h-3 w-3" />
                 </button>
                 {!isProcessing && (
                   <button
-                    className="flex h-6 w-6 items-center justify-center rounded bg-red-50 hover:bg-red-100 dark:bg-red-900/20 dark:hover:bg-red-900/40"
+                    className="flex h-6 w-6 items-center justify-center rounded bg-red-100 text-red-500 hover:bg-red-200 dark:bg-red-900/30 dark:hover:bg-red-900/50"
                     onClick={(event) => {
                       event.stopPropagation();
                       requestDeleteSession();

--- a/src/stores/useBookmarkStore.ts
+++ b/src/stores/useBookmarkStore.ts
@@ -1,0 +1,92 @@
+import { useCallback, useEffect, useState } from 'react';
+
+export type BookmarkedSession = {
+  sessionId: string;
+  projectId: string;
+  projectDisplayName: string;
+  sessionSummary: string;
+  provider: string;
+  bookmarkedAt: string;
+};
+
+const STORAGE_KEY = 'cloudcli_bookmarks';
+
+function load(): BookmarkedSession[] {
+  try {
+    const raw = typeof localStorage !== 'undefined' ? localStorage.getItem(STORAGE_KEY) : null;
+    return raw ? JSON.parse(raw) : [];
+  } catch {
+    return [];
+  }
+}
+
+function save(bookmarks: BookmarkedSession[]) {
+  try {
+    if (typeof localStorage !== 'undefined') {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(bookmarks));
+    }
+    window.dispatchEvent(new Event('storage'));
+  } catch {
+    // localStorage may fail in private browsing mode or when quota is exceeded
+  }
+}
+
+function bookmarkKey(session: { projectId: string; sessionId: string; provider: string }): string {
+  return `${session.projectId}::${session.sessionId}::${session.provider}`;
+}
+
+export function useBookmarks(): {
+  bookmarks: BookmarkedSession[];
+  isBookmarked: (session: { sessionId: string; projectId: string; provider: string }) => boolean;
+  bookmarkSession: (session: BookmarkedSession) => void;
+  removeBookmark: (session: { sessionId: string; projectId: string; provider: string }) => void;
+  toggleBookmark: (session: BookmarkedSession) => void;
+} {
+  const [bookmarks, setBookmarks] = useState<BookmarkedSession[]>(load);
+
+  // Listen for changes from other tabs or in-component mutations
+  useEffect(() => {
+    const handler = () => setBookmarks(load());
+    window.addEventListener('storage', handler);
+    return () => window.removeEventListener('storage', handler);
+  }, []);
+
+  const isBookmarked = useCallback(
+    (session: { sessionId: string; projectId: string; provider: string }) =>
+      bookmarks.some(b => bookmarkKey(b) === bookmarkKey(session)),
+    [bookmarks],
+  );
+
+  const bookmarkSession = useCallback((session: BookmarkedSession) => {
+    setBookmarks(prev => {
+      if (prev.some(b => bookmarkKey(b) === bookmarkKey(session))) return prev;
+      const next = [session, ...prev];
+      save(next);
+      return next;
+    });
+  }, []);
+
+  const removeBookmark = useCallback((session: { sessionId: string; projectId: string; provider: string }) => {
+    setBookmarks(prev => {
+      const next = prev.filter(b => bookmarkKey(b) !== bookmarkKey(session));
+      save(next);
+      return next;
+    });
+  }, []);
+
+  const toggleBookmark = useCallback((session: BookmarkedSession) => {
+    setBookmarks(prev => {
+      const idx = prev.findIndex(b => bookmarkKey(b) === bookmarkKey(session));
+      let next: BookmarkedSession[];
+      if (idx >= 0) {
+        next = prev.filter(b => bookmarkKey(b) !== bookmarkKey(session));
+      } else {
+        next = [session, ...prev];
+      }
+      save(next);
+      return next;
+    });
+  }, []);
+
+  return { bookmarks, isBookmarked, bookmarkSession, removeBookmark, toggleBookmark };
+}


### PR DESCRIPTION
## Session Pin/Bookmark Feature / 会话置顶功能

## What this does
Adds session-level pin/bookmark to the sidebar — different from the existing **project star** feature:

| | Project Star (existing) | Session Pin/Bookmark (this PR) |
|---|---|---|
| **Target** | Entire **project** folder | Individual **session** within a project |
| **Persistence** | Database (`projects.isStarred`) | `localStorage` (cross-tab sync) |
| **Use case** | Keep favorite projects at top | Pin specific sessions within a project |
| **Granularity** | 1 star per project | N pins per project |

Example: In a coding project with 50 sessions, pin the 3 most important ones (architecture decision, API spec, deployment config) without starring the whole project.

## Changes
- `extractSubagentPrompt` in `claude-sdk.js` — parse Task tool input for subagent prompts
- Skip subagent JSONL in `ClaudeSessionSynchronizer`
- `setSessionTitle`/`syncAllSessionNamesToHistory` in `sessions.service.ts`
- `useBookmarkStore` — localStorage-backed bookmark hook with cross-tab sync
- `SidebarBookmarks` — pinned-sessions panel in sidebar
- `SidebarSessionItem` — pin button on mobile and desktop
- Task-notification regex fix
- i18n strings across 8 locales

@blackmammoth — The project star feature is complementary to this, not a replacement. Happy to rename or adjust if needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “Pinned” sidebar section for bookmarked sessions with pin/unpin, pinned-session quick navigation, and inline pinned-name editing.
  * Bookmarks are persisted in the browser and kept in sync across tabs.
* **Bug Fixes**
  * Improved task-notification parsing for consistent status/summary rendering.
  * Updated chat message rendering to avoid emitting per-streaming-delta artifacts.
  * Prevented subagent transcript files (and certain subagent paths) from being treated as standalone sessions.
* **Documentation**
  * Added/updated translated sidebar strings for the pinned sessions UI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->