### PR TITLE
feat: add password reset settings tab / 新增密码修改设置页

### DIFF
--- a/src/components/settings/types/types.ts
+++ b/src/components/settings/types/types.ts
@@ -3,7 +3,7 @@ import type { Dispatch, SetStateAction } from 'react';
 import type { LLMProvider } from '../../../types/app';
 import type { ProviderAuthStatus } from '../../provider-auth/types';
 
-export type SettingsMainTab = 'agents' | 'appearance' | 'git' | 'api' | 'voice' | 'tasks' | 'browser' | 'notifications' | 'plugins' | 'about';
+export type SettingsMainTab = 'agents' | 'appearance' | 'git' | 'api' | 'voice' | 'tasks' | 'browser' | 'notifications' | 'plugins' | 'password' | 'about';
 export type AgentProvider = LLMProvider;
 export type AgentCategory = 'account' | 'permissions' | 'mcp' | 'skills';
 export type ProjectSortOrder = 'name' | 'date';

--- a/src/components/settings/view/Settings.tsx
+++ b/src/components/settings/view/Settings.tsx
@@ -14,6 +14,7 @@ import BrowserUseSettingsTab from '../view/tabs/browser-use-settings/BrowserUseS
 import NotificationsSettingsTab from '../view/tabs/NotificationsSettingsTab';
 import TasksSettingsTab from '../view/tabs/tasks-settings/TasksSettingsTab';
 import PluginSettingsTab from '../../plugins/view/PluginSettingsTab';
+import PasswordSettingsTab from '../view/tabs/password-settings/PasswordSettingsTab';
 import AboutTab from '../view/tabs/AboutTab';
 import { useSettingsController } from '../hooks/useSettingsController';
 import { useWebPush } from '../../../hooks/useWebPush';
@@ -214,6 +215,8 @@ function Settings({ isOpen, onClose, projects = [], initialTab = 'agents' }: Set
               {activeTab === 'voice' && <VoiceSettingsTab />}
 
               {activeTab === 'plugins' && <PluginSettingsTab />}
+
+              {activeTab === 'password' && <PasswordSettingsTab />}
 
               {activeTab === 'about' && <AboutTab />}
             </div>

--- a/src/components/settings/view/SettingsMainTabs.tsx
+++ b/src/components/settings/view/SettingsMainTabs.tsx
@@ -1,4 +1,4 @@
-import { GitBranch, Info, Key, Puzzle } from 'lucide-react';
+import { GitBranch, Info, Key, Lock, Puzzle } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import type { SettingsMainTab } from '../types/types';
 
@@ -22,6 +22,7 @@ const TAB_CONFIG: MainTabConfig[] = [
   { id: 'tasks', labelKey: 'mainTabs.tasks' },
   { id: 'notifications', labelKey: 'mainTabs.notifications' },
   { id: 'plugins', labelKey: 'mainTabs.plugins', icon: Puzzle },
+  { id: 'password', labelKey: 'mainTabs.password', icon: Lock },
   { id: 'about', labelKey: 'mainTabs.about', icon: Info },
 ];
 

--- a/src/components/settings/view/SettingsSidebar.tsx
+++ b/src/components/settings/view/SettingsSidebar.tsx
@@ -1,4 +1,4 @@
-import { Bell, Bot, GitBranch, Info, Key, ListChecks, Mic, MonitorPlay, Palette, Puzzle } from 'lucide-react';
+import { Bell, Bot, GitBranch, Info, Key, ListChecks, Lock, Mic, MonitorPlay, Palette, Puzzle } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 
 import { cn } from '../../../lib/utils';
@@ -26,6 +26,7 @@ const NAV_ITEMS: NavItem[] = [
   { id: 'browser', labelKey: 'mainTabs.browser', icon: MonitorPlay },
   { id: 'plugins', labelKey: 'mainTabs.plugins', icon: Puzzle },
   { id: 'notifications', labelKey: 'mainTabs.notifications', icon: Bell },
+  { id: 'password', labelKey: 'mainTabs.password', icon: Lock },
   { id: 'about', labelKey: 'mainTabs.about', icon: Info },
 ];
 

--- a/src/components/settings/view/tabs/password-settings/PasswordSettingsTab.tsx
+++ b/src/components/settings/view/tabs/password-settings/PasswordSettingsTab.tsx
@@ -1,0 +1,177 @@
+import { AlertCircle, Check, Loader2 } from 'lucide-react';
+import { useCallback, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { api } from '../../../../../utils/api';
+import { Button, Input } from '../../../../../shared/view/ui';
+import SettingsCard from '../../SettingsCard';
+import SettingsSection from '../../SettingsSection';
+
+type Status = 'idle' | 'saving' | 'success' | 'error';
+
+export default function PasswordSettingsTab() {
+  const { t } = useTranslation('settings');
+
+  const [oldPassword, setOldPassword] = useState('');
+  const [newPassword, setNewPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
+  const [status, setStatus] = useState<Status>('idle');
+  const [errorMessage, setErrorMessage] = useState('');
+
+  const handleChangePassword = useCallback(async () => {
+    setErrorMessage('');
+
+    // Prevent duplicate requests while one is in flight
+    if (status === 'saving') return;
+
+    if (!oldPassword || !newPassword || !confirmPassword) {
+      setStatus('error');
+      setErrorMessage(t('password.error.fillAllFields'));
+      return;
+    }
+
+    if (newPassword.length < 6) {
+      setStatus('error');
+      setErrorMessage(t('password.error.minLength'));
+      return;
+    }
+
+    if (newPassword !== confirmPassword) {
+      setStatus('error');
+      setErrorMessage(t('password.error.notMatch'));
+      return;
+    }
+
+    if (oldPassword === newPassword) {
+      setStatus('error');
+      setErrorMessage(t('password.error.sameAsOld'));
+      return;
+    }
+
+    setStatus('saving');
+
+    try {
+      const result = await (api.auth as any).changePassword(oldPassword, newPassword);
+      if (result.success) {
+        setStatus('success');
+        setOldPassword('');
+        setNewPassword('');
+        setConfirmPassword('');
+      } else {
+        setStatus('error');
+        setErrorMessage(result.error || t('password.error.failed'));
+      }
+    } catch (err: any) {
+      setStatus('error');
+      const msg = err.response?.data?.error || err.message || t('password.error.failed');
+      if (msg === 'Current password is incorrect') {
+        setErrorMessage(t('password.error.incorrectOld'));
+      } else {
+        setErrorMessage(msg);
+      }
+    }
+  }, [oldPassword, newPassword, confirmPassword, t]);
+
+  const canSave = oldPassword && newPassword && confirmPassword && status !== 'saving';
+
+  return (
+    <div className="space-y-8">
+      <SettingsSection
+        title={t('password.title')}
+        description={t('password.description')}
+      >
+        <SettingsCard className="p-4">
+          <div className="space-y-4">
+            {/* Current password */}
+            <div>
+              <label
+                htmlFor="settings-password-old"
+                className="mb-2 block text-sm font-medium text-foreground"
+              >
+                {t('password.currentPassword')}
+              </label>
+              <Input
+                id="settings-password-old"
+                type="password"
+                value={oldPassword}
+                onChange={(e) => setOldPassword(e.target.value)}
+                placeholder={t('password.currentPasswordPlaceholder')}
+                disabled={status === 'saving'}
+                className="w-full"
+              />
+            </div>
+
+            {/* New password */}
+            <div>
+              <label
+                htmlFor="settings-password-new"
+                className="mb-2 block text-sm font-medium text-foreground"
+              >
+                {t('password.newPassword')}
+              </label>
+              <Input
+                id="settings-password-new"
+                type="password"
+                value={newPassword}
+                onChange={(e) => setNewPassword(e.target.value)}
+                placeholder={t('password.newPasswordPlaceholder')}
+                disabled={status === 'saving'}
+                className="w-full"
+              />
+              <p className="mt-1 text-xs text-muted-foreground">
+                {t('password.minLengthHelp', { min: 6 })}
+              </p>
+            </div>
+
+            {/* Confirm new password */}
+            <div>
+              <label
+                htmlFor="settings-password-confirm"
+                className="mb-2 block text-sm font-medium text-foreground"
+              >
+                {t('password.confirmPassword')}
+              </label>
+              <Input
+                id="settings-password-confirm"
+                type="password"
+                value={confirmPassword}
+                onChange={(e) => setConfirmPassword(e.target.value)}
+                placeholder={t('password.confirmPasswordPlaceholder')}
+                disabled={status === 'saving'}
+                className="w-full"
+              />
+            </div>
+
+            {/* Error message */}
+            {status === 'error' && errorMessage && (
+              <div className="flex items-start gap-2 rounded-md bg-red-50 px-3 py-2 text-sm text-red-600 dark:bg-red-950 dark:text-red-400">
+                <AlertCircle className="mt-0.5 h-4 w-4 flex-shrink-0" />
+                <span>{errorMessage}</span>
+              </div>
+            )}
+
+            {/* Actions */}
+            <div className="flex items-center gap-2">
+              <Button onClick={handleChangePassword} disabled={!canSave}>
+                {status === 'saving' ? (
+                  <>
+                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                    {t('password.saving')}
+                  </>
+                ) : (
+                  t('password.saveChanges')
+                )}
+              </Button>
+
+              {status === 'success' && (
+                <div className="flex items-center gap-2 text-sm text-green-600 dark:text-green-400">
+                  <Check className="h-4 w-4" />
+                  {t('password.success')}
+                </div>
+              )}
+            </div>
+          </div>
+        </SettingsCard>
+      </SettingsSection>
+    </div>
+  );
+}

--- a/src/i18n/locales/en/settings.json
+++ b/src/i18n/locales/en/settings.json
@@ -112,7 +112,8 @@
     "browser": "Browser",
     "notifications": "Notifications",
     "plugins": "Plugins",
-    "about": "About"
+    "about": "About",
+    "password": "Password"
   },
   "notifications": {
     "title": "Notifications",
@@ -580,5 +581,27 @@
     "installAriaLabel": "Plugin git repository URL",
     "tab": "tab",
     "runningStatus": "running"
+  },
+  "password": {
+    "title": "Change Password",
+    "description": "Update your account password to keep your CloudCLI instance secure.",
+    "currentPassword": "Current Password",
+    "currentPasswordPlaceholder": "Enter your current password",
+    "newPassword": "New Password",
+    "newPasswordPlaceholder": "Enter your new password",
+    "minLengthHelp": "Password must be at least 8 characters",
+    "confirmPassword": "Confirm New Password",
+    "confirmPasswordPlaceholder": "Re-enter your new password",
+    "saveChanges": "Save Changes",
+    "saving": "Saving...",
+    "success": "Password updated successfully.",
+    "error": {
+      "fillAllFields": "Please fill in all fields.",
+      "incorrectOld": "Current password is incorrect.",
+      "minLength": "Password must be at least 8 characters.",
+      "notMatch": "Passwords do not match.",
+      "sameAsOld": "New password must be different from the current one.",
+      "failed": "Failed to update password."
+    }
   }
 }

--- a/src/i18n/locales/zh-CN/settings.json
+++ b/src/i18n/locales/zh-CN/settings.json
@@ -112,7 +112,8 @@
     "browser": "浏览器",
     "notifications": "通知",
     "plugins": "插件",
-    "about": "关于"
+    "about": "关于",
+    "password": "密码"
   },
   "notifications": {
     "title": "通知",
@@ -568,5 +569,27 @@
     "installAriaLabel": "插件 git 仓库 URL",
     "tab": "标签",
     "runningStatus": "运行中"
+  },
+  "password": {
+    "title": "修改密码",
+    "description": "更新账号密码以保障 CloudCLI 实例安全。",
+    "currentPassword": "当前密码",
+    "currentPasswordPlaceholder": "请输入当前密码",
+    "newPassword": "新密码",
+    "newPasswordPlaceholder": "请输入新密码",
+    "minLengthHelp": "密码至少 8 个字符",
+    "confirmPassword": "确认新密码",
+    "confirmPasswordPlaceholder": "请再次输入新密码",
+    "saveChanges": "保存更改",
+    "saving": "保存中...",
+    "success": "密码更新成功。",
+    "error": {
+      "fillAllFields": "请填写所有字段。",
+      "incorrectOld": "当前密码不正确。",
+      "minLength": "密码至少 8 个字符。",
+      "notMatch": "两次密码不一致。",
+      "sameAsOld": "新密码不能与当前密码相同。",
+      "failed": "密码更新失败。"
+    }
   }
 }


### PR DESCRIPTION
## feat: add password reset settings tab / 新增密码修改设置页

Add a dedicated Password Settings tab in CloudCLI settings UI, allowing users to change their authentication password directly from the web interface.

**新增内容：**
- PasswordSettingsTab 组件（旧密码→新密码→确认→提交）
- SettingsSidebar 新增 Lock 图标入口
- SettingsMainTabs 路由注册
- 全量 10 个 locale 的 settings.json 翻译

**Files changed:**
- src/components/settings/view/tabs/password-settings/PasswordSettingsTab.tsx (new)
- src/components/settings/view/SettingsSidebar.tsx
- src/components/settings/view/Settings.tsx
- src/components/settings/view/SettingsMainTabs.tsx
- src/components/settings/types/types.ts
- src/i18n/locales/*/settings.json (10 files)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a **Password** tab to Settings, selectable from both the main tab bar and the sidebar/navigation.
  * Introduced a password change view with current/new/confirm inputs, client-side validation, and guided save states (saving, success, error).
* **Localization**
  * Added/extended password-related Settings translations across supported languages, including tab labels, field text, validation/error messages, and success/failure copy.
  * Added/extended browser-settings text in supported locales.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->