### PR TITLE
feat(file-viewer): preview media files (PDF/video/audio/image) inline instead of "binary file"

### DIFF
--- a/src/components/code-editor/hooks/useCodeEditorDocument.ts
+++ b/src/components/code-editor/hooks/useCodeEditorDocument.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useState } from 'react';
 import { api } from '../../../utils/api';
 import type { CodeEditorFile } from '../types/types';
 import { isBinaryFile } from '../utils/binaryFile';
+import { getPreviewKind } from '../utils/previewableFile';
 
 type UseCodeEditorDocumentParams = {
   file: CodeEditorFile;
@@ -23,6 +24,9 @@ export const useCodeEditorDocument = ({ file, projectPath }: UseCodeEditorDocume
   const [saveSuccess, setSaveSuccess] = useState(false);
   const [saveError, setSaveError] = useState<string | null>(null);
   const [isBinary, setIsBinary] = useState(false);
+  // Some binaries (images, PDFs, audio, video) can be rendered natively, so the
+  // editor shows an inline preview instead of the generic binary placeholder.
+  const previewKind = getPreviewKind(file.name);
   // `fileProjectId` is the DB primary key passed down from the editor sidebar;
   // the fallback to `projectPath` preserves older callers that didn't yet
   // propagate the identifier.
@@ -37,6 +41,13 @@ export const useCodeEditorDocument = ({ file, projectPath }: UseCodeEditorDocume
       try {
         setLoading(true);
         setIsBinary(false);
+
+        // Natively previewable media (image/pdf/audio/video) is rendered by
+        // CodeEditorMediaPreview, so there is nothing to read as text here.
+        if (getPreviewKind(file.name)) {
+          setLoading(false);
+          return;
+        }
 
         // Check if file is binary by extension
         if (isBinaryFile(file.name)) {
@@ -134,6 +145,8 @@ export const useCodeEditorDocument = ({ file, projectPath }: UseCodeEditorDocume
     saveSuccess,
     saveError,
     isBinary,
+    previewKind,
+    fileProjectId,
     handleSave,
     handleDownload,
   };

--- a/src/components/code-editor/hooks/useCodeEditorDocument.ts
+++ b/src/components/code-editor/hooks/useCodeEditorDocument.ts
@@ -44,13 +44,17 @@ export const useCodeEditorDocument = ({ file, projectPath }: UseCodeEditorDocume
 
         // Natively previewable media (image/pdf/audio/video) is rendered by
         // CodeEditorMediaPreview, so there is nothing to read as text here.
+        // Clear any buffer left over from a previously opened text file so a
+        // stray save can't write stale content over the binary file.
         if (getPreviewKind(file.name)) {
+          setContent('');
           setLoading(false);
           return;
         }
 
         // Check if file is binary by extension
         if (isBinaryFile(file.name)) {
+          setContent('');
           setIsBinary(true);
           setLoading(false);
           return;
@@ -87,6 +91,12 @@ export const useCodeEditorDocument = ({ file, projectPath }: UseCodeEditorDocume
   }, [file.diffInfo, file.name, fileDiffNewString, fileDiffOldString, fileName, filePath, fileProjectId]);
 
   const handleSave = useCallback(async () => {
+    // Preview-only and binary files have no editable text buffer; never write
+    // them back (e.g. via Cmd/Ctrl+S) or we'd corrupt the file on disk.
+    if (previewKind || isBinaryFile(fileName)) {
+      return;
+    }
+
     setSaving(true);
     setSaveError(null);
 
@@ -120,7 +130,7 @@ export const useCodeEditorDocument = ({ file, projectPath }: UseCodeEditorDocume
     } finally {
       setSaving(false);
     }
-  }, [content, filePath, fileProjectId]);
+  }, [content, filePath, fileProjectId, previewKind, fileName]);
 
   const handleDownload = useCallback(() => {
     const blob = new Blob([content], { type: 'text/plain' });

--- a/src/components/code-editor/utils/previewableFile.ts
+++ b/src/components/code-editor/utils/previewableFile.ts
@@ -5,27 +5,59 @@
 
 export type PreviewKind = 'image' | 'pdf' | 'video' | 'audio';
 
-// Formats browsers can decode in <img>.
-const IMAGE_EXTENSIONS = new Set([
-  'png', 'jpg', 'jpeg', 'gif', 'svg', 'webp', 'ico', 'bmp', 'avif', 'apng',
-]);
+// Single source of truth: every extension the browser can preview, mapped to the
+// MIME type we apply when the server response has a missing/generic Content-Type.
+// The preview kind is derived from the MIME type so the two never drift apart.
+// Formats browsers generally can't play (avi, mkv, flv, wmv) are intentionally
+// absent and keep the binary fallback.
+const EXTENSION_MIME: Record<string, string> = {
+  // Images
+  png: 'image/png',
+  jpg: 'image/jpeg',
+  jpeg: 'image/jpeg',
+  gif: 'image/gif',
+  svg: 'image/svg+xml',
+  webp: 'image/webp',
+  ico: 'image/x-icon',
+  bmp: 'image/bmp',
+  avif: 'image/avif',
+  apng: 'image/apng',
+  // PDF
+  pdf: 'application/pdf',
+  // Video
+  mp4: 'video/mp4',
+  webm: 'video/webm',
+  ogv: 'video/ogg',
+  mov: 'video/quicktime',
+  m4v: 'video/x-m4v',
+  // Audio
+  mp3: 'audio/mpeg',
+  wav: 'audio/wav',
+  m4a: 'audio/mp4',
+  aac: 'audio/aac',
+  flac: 'audio/flac',
+  opus: 'audio/opus',
+  oga: 'audio/ogg',
+  ogg: 'audio/ogg',
+  weba: 'audio/webm',
+};
 
-const PDF_EXTENSIONS = new Set(['pdf']);
+const extensionOf = (filename: string): string => filename.split('.').pop()?.toLowerCase() ?? '';
 
-// Container/codec combos broadly playable in <video>. Intentionally excludes
-// formats browsers generally can't play (avi, mkv, flv, wmv).
-const VIDEO_EXTENSIONS = new Set(['mp4', 'webm', 'ogv', 'mov', 'm4v']);
-
-// Formats broadly playable in <audio>.
-const AUDIO_EXTENSIONS = new Set([
-  'mp3', 'wav', 'm4a', 'aac', 'flac', 'opus', 'oga', 'ogg', 'weba',
-]);
-
-export const getPreviewKind = (filename: string): PreviewKind | null => {
-  const ext = filename.split('.').pop()?.toLowerCase() ?? '';
-  if (IMAGE_EXTENSIONS.has(ext)) return 'image';
-  if (PDF_EXTENSIONS.has(ext)) return 'pdf';
-  if (VIDEO_EXTENSIONS.has(ext)) return 'video';
-  if (AUDIO_EXTENSIONS.has(ext)) return 'audio';
+const kindForMime = (mime: string): PreviewKind | null => {
+  if (mime === 'application/pdf') return 'pdf';
+  if (mime.startsWith('image/')) return 'image';
+  if (mime.startsWith('video/')) return 'video';
+  if (mime.startsWith('audio/')) return 'audio';
   return null;
 };
+
+export const getPreviewKind = (filename: string): PreviewKind | null => {
+  const mime = EXTENSION_MIME[extensionOf(filename)];
+  return mime ? kindForMime(mime) : null;
+};
+
+// MIME type to fall back to when the server returns no/generic Content-Type.
+// Returns undefined for non-previewable extensions.
+export const getPreviewMimeType = (filename: string): string | undefined =>
+  EXTENSION_MIME[extensionOf(filename)];

--- a/src/components/code-editor/utils/previewableFile.ts
+++ b/src/components/code-editor/utils/previewableFile.ts
@@ -1,0 +1,31 @@
+// Some binary files can't be edited as text, but the browser can still render
+// them natively (images, PDFs, audio, video). For those we show an inline
+// preview instead of the generic "binary file" placeholder. Anything not listed
+// here (zip, exe, avi, mkv, fonts, ...) falls through to the binary message.
+
+export type PreviewKind = 'image' | 'pdf' | 'video' | 'audio';
+
+// Formats browsers can decode in <img>.
+const IMAGE_EXTENSIONS = new Set([
+  'png', 'jpg', 'jpeg', 'gif', 'svg', 'webp', 'ico', 'bmp', 'avif', 'apng',
+]);
+
+const PDF_EXTENSIONS = new Set(['pdf']);
+
+// Container/codec combos broadly playable in <video>. Intentionally excludes
+// formats browsers generally can't play (avi, mkv, flv, wmv).
+const VIDEO_EXTENSIONS = new Set(['mp4', 'webm', 'ogv', 'mov', 'm4v']);
+
+// Formats broadly playable in <audio>.
+const AUDIO_EXTENSIONS = new Set([
+  'mp3', 'wav', 'm4a', 'aac', 'flac', 'opus', 'oga', 'ogg', 'weba',
+]);
+
+export const getPreviewKind = (filename: string): PreviewKind | null => {
+  const ext = filename.split('.').pop()?.toLowerCase() ?? '';
+  if (IMAGE_EXTENSIONS.has(ext)) return 'image';
+  if (PDF_EXTENSIONS.has(ext)) return 'pdf';
+  if (VIDEO_EXTENSIONS.has(ext)) return 'video';
+  if (AUDIO_EXTENSIONS.has(ext)) return 'audio';
+  return null;
+};

--- a/src/components/code-editor/view/CodeEditor.tsx
+++ b/src/components/code-editor/view/CodeEditor.tsx
@@ -16,6 +16,7 @@ import CodeEditorHeader from './subcomponents/CodeEditorHeader';
 import CodeEditorLoadingState from './subcomponents/CodeEditorLoadingState';
 import CodeEditorSurface from './subcomponents/CodeEditorSurface';
 import CodeEditorBinaryFile from './subcomponents/CodeEditorBinaryFile';
+import CodeEditorMediaPreview from './subcomponents/CodeEditorMediaPreview';
 
 type CodeEditorProps = {
   file: CodeEditorFile;
@@ -58,6 +59,8 @@ export default function CodeEditor({
     saveSuccess,
     saveError,
     isBinary,
+    previewKind,
+    fileProjectId,
     handleSave,
     handleDownload,
   } = useCodeEditorDocument({
@@ -158,6 +161,30 @@ export default function CodeEditor({
         isDarkMode={isDarkMode}
         isSidebar={isSidebar}
         loadingText={t('loading', { fileName: file.name })}
+      />
+    );
+  }
+
+  // Natively previewable media (image/pdf/audio/video) is rendered inline
+  // instead of showing the generic "cannot be displayed" placeholder.
+  if (previewKind) {
+    return (
+      <CodeEditorMediaPreview
+        file={file}
+        kind={previewKind}
+        projectId={fileProjectId}
+        isSidebar={isSidebar}
+        isFullscreen={isFullscreen}
+        onClose={onClose}
+        onToggleFullscreen={() => setIsFullscreen((previous) => !previous)}
+        labels={{
+          loading: t('filePreview.loading', 'Loading preview...'),
+          error: t('filePreview.error', 'Unable to display this file.'),
+          openInNewTab: t('filePreview.openInNewTab', 'Open in new tab'),
+          fullscreen: t('actions.fullscreen', 'Fullscreen'),
+          exitFullscreen: t('actions.exitFullscreen', 'Exit fullscreen'),
+          close: t('actions.close', 'Close'),
+        }}
       />
     );
   }

--- a/src/components/code-editor/view/subcomponents/CodeEditorMediaPreview.tsx
+++ b/src/components/code-editor/view/subcomponents/CodeEditorMediaPreview.tsx
@@ -103,6 +103,16 @@ export default function CodeEditorMediaPreview({
 
         const typed = outType && outType !== blob.type ? new Blob([blob], { type: outType }) : blob;
         objectUrl = URL.createObjectURL(typed);
+
+        // The cleanup may have already run (deps changed during an await), in
+        // which case it revoked nothing because objectUrl was still null. Don't
+        // publish a URL the cleanup will never revoke — drop it ourselves.
+        if (controller.signal.aborted) {
+          URL.revokeObjectURL(objectUrl);
+          objectUrl = null;
+          return;
+        }
+
         setUrl(objectUrl);
         setLoadedKey(sourceKey);
       } catch (loadError: unknown) {

--- a/src/components/code-editor/view/subcomponents/CodeEditorMediaPreview.tsx
+++ b/src/components/code-editor/view/subcomponents/CodeEditorMediaPreview.tsx
@@ -1,0 +1,230 @@
+import { useEffect, useState } from 'react';
+import { authenticatedFetch } from '../../../../utils/api';
+import type { CodeEditorFile } from '../../types/types';
+import type { PreviewKind } from '../../utils/previewableFile';
+
+type CodeEditorMediaPreviewProps = {
+  file: CodeEditorFile;
+  kind: PreviewKind;
+  // DB projectId used to build the raw-content URL; falls back to projectPath
+  // for older callers, mirroring useCodeEditorDocument.
+  projectId?: string;
+  isSidebar: boolean;
+  isFullscreen: boolean;
+  onClose: () => void;
+  onToggleFullscreen: () => void;
+  labels: {
+    loading: string;
+    error: string;
+    openInNewTab: string;
+    fullscreen: string;
+    exitFullscreen: string;
+    close: string;
+  };
+};
+
+// MIME type forced onto the blob per kind so the browser picks the right viewer
+// even when the server response was generic (e.g. application/octet-stream).
+const FALLBACK_MIME: Record<PreviewKind, string> = {
+  image: 'application/octet-stream',
+  pdf: 'application/pdf',
+  video: 'video/mp4',
+  audio: 'audio/mpeg',
+};
+
+export default function CodeEditorMediaPreview({
+  file,
+  kind,
+  projectId,
+  isSidebar,
+  isFullscreen,
+  onClose,
+  onToggleFullscreen,
+  labels,
+}: CodeEditorMediaPreviewProps) {
+  const [url, setUrl] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (!projectId) {
+      setError(labels.error);
+      setLoading(false);
+      return;
+    }
+
+    let objectUrl: string | null = null;
+    const controller = new AbortController();
+
+    const loadMedia = async () => {
+      try {
+        setLoading(true);
+        setError(null);
+        setUrl(null);
+
+        // The content endpoint requires the auth header, so we fetch the bytes
+        // ourselves and hand the media element a blob URL instead of a bare src.
+        // Fetching a blob (rather than streaming) also lets <video>/<audio> seek.
+        const contentUrl = `/api/projects/${projectId}/files/content?path=${encodeURIComponent(file.path)}`;
+        const response = await authenticatedFetch(contentUrl, { signal: controller.signal });
+
+        if (!response.ok) {
+          throw new Error(`Request failed with status ${response.status}`);
+        }
+
+        const blob = await response.blob();
+        const typed = blob.type ? blob : new Blob([blob], { type: FALLBACK_MIME[kind] });
+        objectUrl = URL.createObjectURL(typed);
+        setUrl(objectUrl);
+      } catch (loadError: unknown) {
+        if (loadError instanceof Error && loadError.name === 'AbortError') {
+          return;
+        }
+        console.error('Error loading preview:', loadError);
+        setError(labels.error);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    loadMedia();
+
+    return () => {
+      controller.abort();
+      if (objectUrl) {
+        URL.revokeObjectURL(objectUrl);
+      }
+    };
+  }, [file.path, projectId, kind, labels.error]);
+
+  const renderMedia = () => {
+    if (!url) return null;
+    switch (kind) {
+      case 'image':
+        return (
+          <img
+            src={url}
+            alt={file.name}
+            className="max-h-full max-w-full object-contain"
+          />
+        );
+      case 'pdf':
+        return <iframe src={url} title={file.name} className="h-full w-full border-0 bg-white" />;
+      case 'video':
+        return (
+          <video src={url} controls className="max-h-full max-w-full" autoPlay={false}>
+            {labels.error}
+          </video>
+        );
+      case 'audio':
+        return (
+          <div className="flex w-full max-w-xl flex-col items-center gap-4 px-6">
+            <p className="max-w-full truncate text-sm text-muted-foreground">{file.name}</p>
+            <audio src={url} controls className="w-full">
+              {labels.error}
+            </audio>
+          </div>
+        );
+      default:
+        return null;
+    }
+  };
+
+  const previewBody = (
+    <div className="relative flex h-full w-full flex-col items-center justify-center bg-muted/30 p-2">
+      {loading && (
+        <div className="text-sm text-muted-foreground">{labels.loading}</div>
+      )}
+
+      {!loading && url && renderMedia()}
+
+      {!loading && !url && (
+        <div className="flex flex-col items-center gap-3 p-8 text-center text-muted-foreground">
+          <p className="text-sm">{error || labels.error}</p>
+          <p className="break-all text-xs">{file.path}</p>
+        </div>
+      )}
+    </div>
+  );
+
+  const headerActions = (
+    <div className="flex shrink-0 items-center gap-0.5">
+      {url && (
+        <a
+          href={url}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="flex items-center justify-center rounded-md p-1.5 text-gray-600 hover:bg-gray-100 hover:text-gray-900 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-white"
+          title={labels.openInNewTab}
+        >
+          <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
+          </svg>
+        </a>
+      )}
+      {!isSidebar && (
+        <button
+          type="button"
+          onClick={onToggleFullscreen}
+          className="flex items-center justify-center rounded-md p-1.5 text-gray-600 hover:bg-gray-100 hover:text-gray-900 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-white"
+          title={isFullscreen ? labels.exitFullscreen : labels.fullscreen}
+        >
+          {isFullscreen ? (
+            <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 9V4.5M9 9H4.5M9 9L3.5 3.5M9 15v4.5M9 15H4.5M9 15l-5.5 5.5M15 9h4.5M15 9V4.5M15 9l5.5-5.5M15 15h4.5M15 15v4.5m0-4.5l5.5 5.5" />
+            </svg>
+          ) : (
+            <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 8V4m0 0h4M4 4l5 5m11-1V4m0 0h-4m4 0l-5 5M4 16v4m0 0h4m-4 0l5-5m11 5l-5-5m5 5v-4m0 4h-4" />
+            </svg>
+          )}
+        </button>
+      )}
+      <button
+        type="button"
+        onClick={onClose}
+        className="flex items-center justify-center rounded-md p-1.5 text-gray-600 hover:bg-gray-100 hover:text-gray-900 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-white"
+        title={labels.close}
+      >
+        <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+        </svg>
+      </button>
+    </div>
+  );
+
+  const header = (
+    <div className="flex flex-shrink-0 items-center justify-between border-b border-border px-3 py-1.5">
+      <div className="flex min-w-0 flex-1 items-center gap-2">
+        <h3 className="truncate text-sm font-medium text-gray-900 dark:text-white">{file.name}</h3>
+      </div>
+      {headerActions}
+    </div>
+  );
+
+  if (isSidebar) {
+    return (
+      <div className="flex h-full w-full flex-col bg-background">
+        {header}
+        {previewBody}
+      </div>
+    );
+  }
+
+  const containerClassName = isFullscreen
+    ? 'fixed inset-0 z-[9999] bg-background flex flex-col'
+    : 'fixed inset-0 z-[9999] md:bg-black/50 md:flex md:items-center md:justify-center md:p-4';
+
+  const innerClassName = isFullscreen
+    ? 'bg-background flex flex-col w-full h-full'
+    : 'bg-background shadow-2xl flex flex-col w-full h-full md:rounded-lg md:shadow-2xl md:w-full md:max-w-6xl md:h-[80vh] md:max-h-[80vh]';
+
+  return (
+    <div className={containerClassName}>
+      <div className={innerClassName}>
+        {header}
+        {previewBody}
+      </div>
+    </div>
+  );
+}

--- a/src/components/code-editor/view/subcomponents/CodeEditorMediaPreview.tsx
+++ b/src/components/code-editor/view/subcomponents/CodeEditorMediaPreview.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import { authenticatedFetch } from '../../../../utils/api';
 import type { CodeEditorFile } from '../../types/types';
-import type { PreviewKind } from '../../utils/previewableFile';
+import { getPreviewMimeType, type PreviewKind } from '../../utils/previewableFile';
 
 type CodeEditorMediaPreviewProps = {
   file: CodeEditorFile;
@@ -23,13 +23,14 @@ type CodeEditorMediaPreviewProps = {
   };
 };
 
-// MIME type forced onto the blob per kind so the browser picks the right viewer
-// even when the server response was generic (e.g. application/octet-stream).
-const FALLBACK_MIME: Record<PreviewKind, string> = {
-  image: 'application/octet-stream',
-  pdf: 'application/pdf',
-  video: 'video/mp4',
-  audio: 'audio/mpeg',
+// Reject a "PDF" whose bytes aren't actually a PDF before handing it to the
+// same-origin iframe, so a mislabeled HTML/SVG file can't run in the app origin.
+const PDF_HEADER_SCAN_BYTES = 1024;
+
+const looksLikePdf = async (blob: Blob): Promise<boolean> => {
+  const header = await blob.slice(0, PDF_HEADER_SCAN_BYTES).arrayBuffer();
+  // PDFs must contain the "%PDF-" marker at the very start of the file.
+  return new TextDecoder('latin1').decode(header).includes('%PDF-');
 };
 
 export default function CodeEditorMediaPreview({
@@ -73,7 +74,27 @@ export default function CodeEditorMediaPreview({
         }
 
         const blob = await response.blob();
-        const typed = blob.type ? blob : new Blob([blob], { type: FALLBACK_MIME[kind] });
+
+        // Pick the MIME type to expose to the browser. Preserve a valid
+        // Content-Type from the server, but supply an extension-specific
+        // default when it is missing or generic (application/octet-stream),
+        // otherwise formats like webm/ogg/flac/svg won't render.
+        const fallbackMime = getPreviewMimeType(file.name);
+        const isGenericType = !blob.type || blob.type === 'application/octet-stream';
+        let outType = isGenericType ? (fallbackMime ?? blob.type) : blob.type;
+
+        if (kind === 'pdf') {
+          // The PDF renders in a same-origin <iframe>, so verify the bytes are
+          // really a PDF and pin the type to application/pdf. That forces the
+          // browser's PDF handler and prevents a mislabeled HTML/SVG file from
+          // executing scripts in the app's origin.
+          if (!(await looksLikePdf(blob))) {
+            throw new Error('File is not a valid PDF');
+          }
+          outType = 'application/pdf';
+        }
+
+        const typed = outType && outType !== blob.type ? new Blob([blob], { type: outType }) : blob;
         objectUrl = URL.createObjectURL(typed);
         setUrl(objectUrl);
       } catch (loadError: unknown) {
@@ -109,6 +130,10 @@ export default function CodeEditorMediaPreview({
           />
         );
       case 'pdf':
+        // Not sandboxed on purpose: the browser's built-in PDF viewer refuses to
+        // load inside a sandboxed frame (any `sandbox` value yields a broken
+        // viewer). Script execution is instead prevented upstream by validating
+        // the PDF magic bytes and pinning the blob's MIME type to application/pdf.
         return <iframe src={url} title={file.name} className="h-full w-full border-0 bg-white" />;
       case 'video':
         return (

--- a/src/components/code-editor/view/subcomponents/CodeEditorMediaPreview.tsx
+++ b/src/components/code-editor/view/subcomponents/CodeEditorMediaPreview.tsx
@@ -46,9 +46,16 @@ export default function CodeEditorMediaPreview({
   const [url, setUrl] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
+  // Identifies which file the current `url` was loaded for. Rendering is gated on
+  // this so a blob from a previously-opened file can never show under the new
+  // file (the editor reuses this component instance across files).
+  const [loadedKey, setLoadedKey] = useState<string | null>(null);
+  const sourceKey = `${projectId ?? ''}:${file.path}:${kind}`;
 
   useEffect(() => {
     if (!projectId) {
+      setUrl(null);
+      setLoadedKey(null);
       setError(labels.error);
       setLoading(false);
       return;
@@ -97,6 +104,7 @@ export default function CodeEditorMediaPreview({
         const typed = outType && outType !== blob.type ? new Blob([blob], { type: outType }) : blob;
         objectUrl = URL.createObjectURL(typed);
         setUrl(objectUrl);
+        setLoadedKey(sourceKey);
       } catch (loadError: unknown) {
         if (loadError instanceof Error && loadError.name === 'AbortError') {
           return;
@@ -116,15 +124,19 @@ export default function CodeEditorMediaPreview({
         URL.revokeObjectURL(objectUrl);
       }
     };
-  }, [file.path, projectId, kind, labels.error]);
+  }, [file.path, file.name, projectId, kind, sourceKey, labels.error]);
+
+  // Only expose the blob once it matches the file currently being shown, so a
+  // stale URL from the previous file is never rendered during a switch.
+  const currentUrl = url && loadedKey === sourceKey ? url : null;
 
   const renderMedia = () => {
-    if (!url) return null;
+    if (!currentUrl) return null;
     switch (kind) {
       case 'image':
         return (
           <img
-            src={url}
+            src={currentUrl}
             alt={file.name}
             className="max-h-full max-w-full object-contain"
           />
@@ -134,10 +146,10 @@ export default function CodeEditorMediaPreview({
         // load inside a sandboxed frame (any `sandbox` value yields a broken
         // viewer). Script execution is instead prevented upstream by validating
         // the PDF magic bytes and pinning the blob's MIME type to application/pdf.
-        return <iframe src={url} title={file.name} className="h-full w-full border-0 bg-white" />;
+        return <iframe src={currentUrl} title={file.name} className="h-full w-full border-0 bg-white" />;
       case 'video':
         return (
-          <video src={url} controls className="max-h-full max-w-full" autoPlay={false}>
+          <video src={currentUrl} controls className="max-h-full max-w-full" autoPlay={false}>
             {labels.error}
           </video>
         );
@@ -145,7 +157,7 @@ export default function CodeEditorMediaPreview({
         return (
           <div className="flex w-full max-w-xl flex-col items-center gap-4 px-6">
             <p className="max-w-full truncate text-sm text-muted-foreground">{file.name}</p>
-            <audio src={url} controls className="w-full">
+            <audio src={currentUrl} controls className="w-full">
               {labels.error}
             </audio>
           </div>
@@ -161,9 +173,9 @@ export default function CodeEditorMediaPreview({
         <div className="text-sm text-muted-foreground">{labels.loading}</div>
       )}
 
-      {!loading && url && renderMedia()}
+      {!loading && currentUrl && renderMedia()}
 
-      {!loading && !url && (
+      {!loading && !currentUrl && (
         <div className="flex flex-col items-center gap-3 p-8 text-center text-muted-foreground">
           <p className="text-sm">{error || labels.error}</p>
           <p className="break-all text-xs">{file.path}</p>
@@ -174,9 +186,9 @@ export default function CodeEditorMediaPreview({
 
   const headerActions = (
     <div className="flex shrink-0 items-center gap-0.5">
-      {url && (
+      {currentUrl && (
         <a
-          href={url}
+          href={currentUrl}
           target="_blank"
           rel="noopener noreferrer"
           className="flex items-center justify-center rounded-md p-1.5 text-gray-600 hover:bg-gray-100 hover:text-gray-900 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-white"

--- a/src/i18n/locales/en/codeEditor.json
+++ b/src/i18n/locales/en/codeEditor.json
@@ -32,5 +32,10 @@
   "binaryFile": {
     "title": "Binary File",
     "message": "The file \"{{fileName}}\" cannot be displayed in the text editor because it is a binary file."
+  },
+  "filePreview": {
+    "loading": "Loading preview...",
+    "error": "Unable to display this file.",
+    "openInNewTab": "Open in new tab"
   }
 }


### PR DESCRIPTION
## Summary

A lot of files that the browser can render perfectly well — **PDFs, videos, audio, and images** — currently can't be previewed in the UI. Opening one from the **Files** tab shows the generic placeholder:

> **Binary File** — The file "report.pdf" cannot be displayed in the text editor because it is a binary file.

This PR makes the file viewer render those files **inline** with the right native element, so you can read a PDF, watch a clip, or listen to an audio file without leaving the app or downloading it. Files the browser genuinely can't display (zip, exe, avi, mkv, fonts, …) still show the existing "binary file" message.

| Kind | Extensions | Rendered as |
| --- | --- | --- |
| Image | png, jpg, jpeg, gif, svg, webp, ico, bmp, avif, apng | `<img>` |
| PDF | pdf | `<iframe>` (browser PDF viewer) |
| Video | mp4, webm, ogv, mov, m4v | `<video controls>` |
| Audio | mp3, wav, m4a, aac, flac, opus, oga, ogg, weba | `<audio controls>` |

## Before / After

| Before — "Binary File" | After — rendered inline |
| --- | --- |
| ![before](https://raw.githubusercontent.com/iamgeo92/claudecodeui/pr-assets/screenshot-before.png) | ![after](https://raw.githubusercontent.com/iamgeo92/claudecodeui/pr-assets/screenshot-after-all-formats.png) |

Per-format previews:

| PDF | Video | Audio |
| --- | --- | --- |
| ![pdf](https://raw.githubusercontent.com/iamgeo92/claudecodeui/pr-assets/verify-pdf.png) | ![video](https://raw.githubusercontent.com/iamgeo92/claudecodeui/pr-assets/verify-video.png) | ![audio](https://raw.githubusercontent.com/iamgeo92/claudecodeui/pr-assets/verify-audio.png) |

## What changed

The backend already streams file bytes with the correct MIME type from `GET /api/projects/:projectId/files/content` (`mime.lookup` returns `application/pdf`, `video/webm`, `audio/wav`, …), so **this is a frontend-only change** — no API changes and no new dependencies.

A new `getPreviewKind(filename)` classifies a file as `image | pdf | video | audio | null`. When the editor sees a non-null kind, it renders a new `CodeEditorMediaPreview` component instead of the binary placeholder. The component:

- Fetches the bytes through the existing authenticated content endpoint (`authenticatedFetch`), the same pattern `ImageViewer` uses, so the token is sent. Fetching a `Blob` (rather than pointing an element at the raw URL) also lets `<video>`/`<audio>` seek and carries auth that a bare `src` can't.
- Renders the right element for the kind (`<img>` / `<iframe>` / `<video controls>` / `<audio controls>`) from a `blob:` object URL.
- Reuses the editor's existing sidebar / modal / fullscreen chrome plus loading, error, and "open in new tab" states, and revokes the object URL on unmount.

### Files (5 changed, ~306 lines)

| File | Change |
| --- | --- |
| `src/components/code-editor/utils/previewableFile.ts` | **New** — `getPreviewKind()` + extension sets |
| `src/components/code-editor/view/subcomponents/CodeEditorMediaPreview.tsx` | **New** — inline media preview component |
| `src/components/code-editor/hooks/useCodeEditorDocument.ts` | Expose `previewKind` + `fileProjectId`; skip text load for media |
| `src/components/code-editor/view/CodeEditor.tsx` | Render the media-preview branch before the binary branch |
| `src/i18n/locales/en/codeEditor.json` | Add `filePreview` i18n strings |

## Why this approach

- **No new dependencies.** Uses the browser's built-in viewers/decoders. The backend already serves these files with correct MIME types.
- **Allow-list, not guesswork.** Only formats browsers reliably render are previewed; everything else keeps the existing safe fallback. Non-playable media (avi, mkv, flv, wmv) is intentionally excluded.
- **Consistent with the existing pattern.** Mirrors how `ImageViewer` fetches and displays bytes, and reuses the binary-file view's responsive layout.
- **Covers every entry point.** The branch lives in the editor (where the binary message was), so files preview no matter how they're opened.

## Testing

- `npm run build:client` ✅ · `npx tsc --noEmit` ✅ · `npx eslint` ✅ (no new errors)
- Manual / Playwright E2E against the running app: PDF renders in an `<iframe>`, video in a `<video>` player, audio in an `<audio>` player, image via the existing viewer; a non-previewable binary still shows the "binary file" message.

## Notes for reviewers

- Rendering relies on the browser's native viewers/decoders. PDFs use the built-in PDF viewer (all modern desktop browsers + Chromium "new" headless).
- Locale strings were added to `en` only; other locales fall back to the inline English defaults passed to `t(key, default)`.
- Images opened from the file tree still use the existing `ImageViewer` modal; the new component additionally covers images if one reaches the editor directly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added native inline previews for supported media types (images, PDFs, videos, audio) inside the code editor, with loading/error UI and an “open in new tab” action.
  * Includes preview fullscreen support (outside the sidebar) and a close control.

* **Bug Fixes**
  * Improved preview flow to skip unnecessary text/binary handling for previewable files.
  * Prevents saving preview-only/binary content back to disk.
  * Enhances reliability with request cancellation, safe object-URL cleanup, and basic PDF validation.

* **Documentation**
  * Added English localization for preview loading, error states, and “open in new tab.”
<!-- end of auto-generated comment: release notes by coderabbit.ai -->