### PR TITLE
fix: commands popup hidden under UI elements (#936)

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -568,7 +568,7 @@
   }
 
   .chat-composer-shell {
-    contain: layout style paint;
+    contain: layout style;
   }
 
   .chat-message {


### PR DESCRIPTION
## Summary
- Removes `paint` from `contain` property on `.chat-composer-shell` in `src/index.css`
- `contain: paint` was creating a new stacking context that clipped the commands popup, causing it to render behind other UI elements

## Root Cause
`contain: paint` tells the browser the element's content won't overflow its bounds, which implicitly creates a new stacking context. This prevented the commands popup from appearing above sibling elements regardless of z-index.

## Fix
```css
/* before */
contain: layout style paint;

/* after */
contain: layout style;
```

## Test plan
- [ ] Type `/` in chat input → commands popup appears above all UI elements
- [ ] Click the commands button → popup renders correctly
- [ ] Verify on mobile and web interface
- [ ] Confirm regression from v1.34.0 → v1.35.0 is resolved

Closes #936

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chat composer rendering behavior by adjusting how the interface is isolated by the browser, which may help reduce visual glitches or repaint issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->