### PR TITLE
fix(projects): stop "delete all data" projects from resurrecting after reload

### DIFF
--- a/server/modules/database/migrations.ts
+++ b/server/modules/database/migrations.ts
@@ -126,6 +126,8 @@ const rebuildProjectsTableWithPrimaryKeySchema = (db: Database): void => {
     addColumnToTableIfNotExists(db, 'projects', columnNames, 'custom_project_name', 'TEXT DEFAULT NULL');
     addColumnToTableIfNotExists(db, 'projects', columnNames, 'isStarred', 'BOOLEAN DEFAULT 0');
     addColumnToTableIfNotExists(db, 'projects', columnNames, 'isArchived', 'BOOLEAN DEFAULT 0');
+    addColumnToTableIfNotExists(db, 'projects', columnNames, 'isDeleted', 'BOOLEAN DEFAULT 0');
+    addColumnToTableIfNotExists(db, 'projects', columnNames, 'deleted_at', 'TIMESTAMP DEFAULT NULL');
     db.exec(`
       UPDATE projects
       SET project_id = ${SQLITE_UUID_SQL}
@@ -170,7 +172,9 @@ const rebuildProjectsTableWithPrimaryKeySchema = (db: Database): void => {
         project_path TEXT NOT NULL UNIQUE,
         custom_project_name TEXT DEFAULT NULL,
         isStarred BOOLEAN DEFAULT 0,
-        isArchived BOOLEAN DEFAULT 0
+        isArchived BOOLEAN DEFAULT 0,
+        isDeleted BOOLEAN DEFAULT 0,
+        deleted_at TIMESTAMP DEFAULT NULL
       )
     `);
     db.exec(`

--- a/server/modules/database/repositories/projects.db.ts
+++ b/server/modules/database/repositories/projects.db.ts
@@ -34,8 +34,11 @@ export const projectsDb = {
         const normalizedProjectPath = normalizeProjectPath(projectPath);
         const normalizedProjectName = normalizeProjectDisplayName(normalizedProjectPath, customProjectName);
         const attemptedId = randomUUID();
+        // Explicit user actions (reactivateArchived) revive an archived OR force-deleted
+        // (tombstoned) row. The background synchronizer passes false and instead relies on the
+        // tombstone guard in `sessionsDb.createSession`, so it must not revive here.
         const conflictClause = reactivateArchived
-            ? 'DO UPDATE SET isArchived = 0 WHERE projects.isArchived = 1'
+            ? 'DO UPDATE SET isArchived = 0, isDeleted = 0, deleted_at = NULL WHERE projects.isArchived = 1 OR projects.isDeleted = 1'
             : 'DO NOTHING';
         const row = db.prepare(`
         INSERT INTO projects (project_id, project_path, custom_project_name, isArchived)
@@ -105,21 +108,65 @@ export const projectsDb = {
         return db.prepare(`
             SELECT project_id, project_path, custom_project_name, isStarred, isArchived
             FROM projects
-            WHERE isArchived = 0
+            WHERE isArchived = 0 AND isDeleted = 0
         `).all() as ProjectRepositoryRow[];
     },
 
     /**
      * Archived rows are queried separately so archive-focused UIs can present
      * hidden workspaces without reintroducing them into the active sidebar list.
+     * Force-deleted (tombstoned) rows are excluded from both lists.
      */
     getArchivedProjectPaths(): ProjectRepositoryRow[] {
         const db = getConnection();
         return db.prepare(`
             SELECT project_id, project_path, custom_project_name, isStarred, isArchived
             FROM projects
-            WHERE isArchived = 1
+            WHERE isArchived = 1 AND isDeleted = 0
         `).all() as ProjectRepositoryRow[];
+    },
+
+    /**
+     * Force-delete tombstone: keep the `projects` row but hide it and record when it was
+     * deleted. The synchronizer consults this (via `getDeletedAtByPath`) so a stale transcript
+     * left on disk by ANY provider cannot recreate the project on the next scan. A genuinely new
+     * session (activity after `deleted_at`) or an explicit user re-create clears the tombstone.
+     */
+    markProjectDeletedById(projectId: string): void {
+        const db = getConnection();
+        db.prepare(`
+            UPDATE projects
+            SET isDeleted = 1, deleted_at = CURRENT_TIMESTAMP
+            WHERE project_id = ?
+        `).run(projectId);
+    },
+
+    /**
+     * Returns the tombstone `deleted_at` for a path when the row is force-deleted, else null.
+     */
+    getDeletedAtByPath(projectPath: string): string | null {
+        const db = getConnection();
+        const normalizedProjectPath = normalizeProjectPath(projectPath);
+        const row = db.prepare(`
+            SELECT deleted_at
+            FROM projects
+            WHERE project_path = ? AND isDeleted = 1
+        `).get(normalizedProjectPath) as { deleted_at: string | null } | undefined;
+
+        return row?.deleted_at ?? null;
+    },
+
+    /**
+     * Clears the force-delete tombstone for a path (row becomes active again).
+     */
+    clearProjectDeletedByPath(projectPath: string): void {
+        const db = getConnection();
+        const normalizedProjectPath = normalizeProjectPath(projectPath);
+        db.prepare(`
+            UPDATE projects
+            SET isDeleted = 0, deleted_at = NULL
+            WHERE project_path = ?
+        `).run(normalizedProjectPath);
     },
 
     getCustomProjectName(projectPath: string): string | null {

--- a/server/modules/database/repositories/projects.db.ts
+++ b/server/modules/database/repositories/projects.db.ts
@@ -16,17 +16,31 @@ function normalizeProjectDisplayName(projectPath: string, customProjectName: str
 }
 
 export const projectsDb = {
-    createProjectPath(projectPath: string, customProjectName: string | null = null): CreateProjectPathResult {
+    /**
+     * Ensures a `projects` row exists for `projectPath` and returns the outcome.
+     *
+     * `reactivateArchived` (default `true`) controls what happens when the path already exists
+     * but is archived: explicit user actions (creating a project, starting a session) reactivate it,
+     * but the background session synchronizer must pass `false`. Otherwise any passive re-scan that
+     * re-touches a transcript would silently un-archive a project the user deliberately hid.
+     */
+    createProjectPath(
+        projectPath: string,
+        customProjectName: string | null = null,
+        options: { reactivateArchived?: boolean } = {},
+    ): CreateProjectPathResult {
+        const { reactivateArchived = true } = options;
         const db = getConnection();
         const normalizedProjectPath = normalizeProjectPath(projectPath);
         const normalizedProjectName = normalizeProjectDisplayName(normalizedProjectPath, customProjectName);
         const attemptedId = randomUUID();
+        const conflictClause = reactivateArchived
+            ? 'DO UPDATE SET isArchived = 0 WHERE projects.isArchived = 1'
+            : 'DO NOTHING';
         const row = db.prepare(`
         INSERT INTO projects (project_id, project_path, custom_project_name, isArchived)
             VALUES (?, ?, ?, 0)
-            ON CONFLICT(project_path) DO UPDATE SET
-            isArchived = 0
-            WHERE projects.isArchived = 1
+            ON CONFLICT(project_path) ${conflictClause}
             RETURNING project_id, project_path, custom_project_name, isStarred, isArchived
         `).get(attemptedId, normalizedProjectPath, normalizedProjectName) as ProjectRepositoryRow | undefined;
 

--- a/server/modules/database/repositories/projects.db.ts
+++ b/server/modules/database/repositories/projects.db.ts
@@ -2,7 +2,7 @@ import { randomUUID } from 'node:crypto';
 import path from 'node:path';
 
 import { getConnection } from '@/modules/database/connection.js';
-import type { CreateProjectPathResult, ProjectRepositoryRow } from '@/shared/types.js';
+import type { CreateProjectPathOptions, CreateProjectPathResult, ProjectRepositoryRow } from '@/shared/types.js';
 import { normalizeProjectPath } from '@/shared/utils.js';
 
 function normalizeProjectDisplayName(projectPath: string, customProjectName: string | null): string {
@@ -27,7 +27,7 @@ export const projectsDb = {
     createProjectPath(
         projectPath: string,
         customProjectName: string | null = null,
-        options: { reactivateArchived?: boolean } = {},
+        options: CreateProjectPathOptions = {},
     ): CreateProjectPathResult {
         const { reactivateArchived = true } = options;
         const db = getConnection();
@@ -53,7 +53,7 @@ export const projectsDb = {
 
         const existingProject = projectsDb.getProjectPath(normalizedProjectPath);
         return {
-            outcome: 'active_conflict',
+            outcome: existingProject?.isArchived ? 'archived_conflict' : 'active_conflict',
             project: existingProject,
         };
     },

--- a/server/modules/database/repositories/sessions.db.ts
+++ b/server/modules/database/repositories/sessions.db.ts
@@ -82,8 +82,10 @@ export const sessionsDb = {
     const normalizedProjectPath = normalizeProjectPathForProvider(provider, projectPath);
 
     // First, ensure the project path is recorded in the projects table,
-    // since it's a foreign key in the sessions table.
-    projectsDb.createProjectPath(normalizedProjectPath);
+    // since it's a foreign key in the sessions table. This runs from the
+    // background synchronizer/watcher, so it must NOT reactivate a project the
+    // user archived — only explicit user actions (createAppSession/createProject) do.
+    projectsDb.createProjectPath(normalizedProjectPath, null, { reactivateArchived: false });
 
     const existing = db
       .prepare(

--- a/server/modules/database/repositories/sessions.db.ts
+++ b/server/modules/database/repositories/sessions.db.ts
@@ -81,10 +81,28 @@ export const sessionsDb = {
     const updatedAtValue = normalizeTimestamp(updatedAt);
     const normalizedProjectPath = normalizeProjectPathForProvider(provider, projectPath);
 
-    // First, ensure the project path is recorded in the projects table,
-    // since it's a foreign key in the sessions table. This runs from the
-    // background synchronizer/watcher, so it must NOT reactivate a project the
-    // user archived — only explicit user actions (createAppSession/createProject) do.
+    // Tombstone guard (all providers). If the user force-deleted this project, a transcript that
+    // survived on disk — e.g. a Codex/Gemini/Cursor/OpenCode session whose `jsonl_path` was still
+    // NULL, so it was not removed by the delete — must NOT recreate the project on the next scan.
+    // Only genuinely new activity (after the deletion) revives it; a stale leftover is skipped.
+    const deletedAt = projectsDb.getDeletedAtByPath(normalizedProjectPath);
+    if (deletedAt !== null) {
+      const activityValue = updatedAtValue ?? createdAtValue;
+      const deletedAtIso = normalizeTimestamp(deletedAt);
+      const revives =
+        Boolean(activityValue) &&
+        Boolean(deletedAtIso) &&
+        new Date(activityValue as string).getTime() > new Date(deletedAtIso as string).getTime();
+      if (!revives) {
+        return '';
+      }
+      // The path is being used again after deletion → lift the tombstone and index normally.
+      projectsDb.clearProjectDeletedByPath(normalizedProjectPath);
+    }
+
+    // Ensure the project path is recorded in the projects table, since it's a foreign key in the
+    // sessions table. This runs from the background synchronizer/watcher, so it must NOT reactivate
+    // a project the user archived — only explicit user actions (createAppSession/createProject) do.
     projectsDb.createProjectPath(normalizedProjectPath, null, { reactivateArchived: false });
 
     const existing = db

--- a/server/modules/database/schema.ts
+++ b/server/modules/database/schema.ts
@@ -92,7 +92,9 @@ CREATE TABLE IF NOT EXISTS projects (
     project_path TEXT NOT NULL UNIQUE,
     custom_project_name TEXT DEFAULT NULL,
     isStarred BOOLEAN DEFAULT 0,
-    isArchived BOOLEAN DEFAULT 0
+    isArchived BOOLEAN DEFAULT 0,
+    isDeleted BOOLEAN DEFAULT 0,
+    deleted_at TIMESTAMP DEFAULT NULL
 );
 `;
 

--- a/server/modules/database/tests/projects.db.integration.test.ts
+++ b/server/modules/database/tests/projects.db.integration.test.ts
@@ -70,3 +70,21 @@ test('projectsDb.createProjectPath returns active_conflict for active duplicates
     assert.equal(conflict.project?.isArchived, 0);
   });
 });
+
+test('projectsDb.createProjectPath returns archived_conflict and stays archived when reactivateArchived is false', async () => {
+  await withIsolatedDatabase(() => {
+    const initial = projectsDb.createProjectPath('/workspace/archived-project');
+    assert.equal(initial.outcome, 'created');
+    assert.ok(initial.project);
+
+    projectsDb.updateProjectIsArchived('/workspace/archived-project', true);
+
+    const conflict = projectsDb.createProjectPath('/workspace/archived-project', null, {
+      reactivateArchived: false,
+    });
+    assert.equal(conflict.outcome, 'archived_conflict');
+    assert.ok(conflict.project);
+    assert.equal(conflict.project?.project_id, initial.project?.project_id);
+    assert.equal(conflict.project?.isArchived, 1);
+  });
+});

--- a/server/modules/projects/services/project-delete.service.ts
+++ b/server/modules/projects/services/project-delete.service.ts
@@ -102,9 +102,15 @@ async function deleteClaudeProjectDir(projectPath: string): Promise<void> {
 /**
  * - **Soft delete** (`force` false): set `isArchived` on the `projects` row (hide from the active list; DB only).
  * - **Force** (`force` true): delete each session row's `jsonl_path` file (when set), remove the whole Claude
- *   transcript directory for the path (covers app-created sessions whose `jsonl_path` is still `NULL`), then
- *   remove the session rows and the `projects` row. Removing the on-disk transcripts is what stops the
- *   synchronizer from recreating ("resurrecting") the project on the next project-list load.
+ *   transcript directory for the path, remove the session rows, and **tombstone** the `projects` row
+ *   (`isDeleted = 1`) instead of hard-deleting it.
+ *
+ * Why a tombstone rather than a row delete: only Claude stores transcripts in a per-cwd directory we can
+ * remove. Cursor/Codex/Gemini/OpenCode keep them in flat/hashed/shared-DB layouts keyed by the cwd inside
+ * each file, so an app-created session whose `jsonl_path` was still `NULL` can leave a transcript we cannot
+ * locate. The tombstone makes `sessionsDb.createSession` skip re-creating the project from such a stale
+ * leftover on the next scan (for every provider), while genuinely new activity or an explicit re-create
+ * lifts it. This is what stops the project from "resurrecting" on the next project-list load.
  */
 export async function deleteOrArchiveProject(projectId: string, force: boolean): Promise<void> {
   const row = projectsDb.getProjectById(projectId);
@@ -123,7 +129,7 @@ export async function deleteOrArchiveProject(projectId: string, force: boolean):
   await deleteSessionJsonlFilesForProjectPath(row.project_path);
   await deleteClaudeProjectDir(row.project_path);
   sessionsDb.deleteSessionsByProjectPath(row.project_path);
-  projectsDb.deleteProjectById(projectId);
+  projectsDb.markProjectDeletedById(projectId);
 }
 
 /**

--- a/server/modules/projects/services/project-delete.service.ts
+++ b/server/modules/projects/services/project-delete.service.ts
@@ -1,8 +1,14 @@
 import { promises as fs } from 'node:fs';
+import os from 'node:os';
 import path from 'node:path';
 
 import { projectsDb, sessionsDb } from '@/modules/database/index.js';
 import { AppError } from '@/shared/utils.js';
+
+// Resolved lazily (not memoized at module load) so it always reflects the current home directory.
+function claudeProjectsRoot(): string {
+  return path.join(os.homedir(), '.claude', 'projects');
+}
 
 function uniqueJsonlPathsFromSessions(
   sessions: Array<{ jsonl_path: string | null }>,
@@ -51,9 +57,53 @@ export async function deleteSessionJsonlFilesForProjectPath(projectPath: string)
 }
 
 /**
+ * Resolves the Claude transcript directory for a project path.
+ *
+ * Claude stores session files under `~/.claude/projects/<encoded-cwd>/`, where the
+ * encoding replaces every character that is not `[a-zA-Z0-9-]` with `-` (mirrors the
+ * conventional lookup in `server/index.js`). Returns `null` when the resolved path would
+ * escape the Claude projects root, so a malformed `project_path` can never delete outside it.
+ */
+function resolveClaudeProjectDir(projectPath: string): string | null {
+  const root = claudeProjectsRoot();
+  const encoded = projectPath.replace(/[^a-zA-Z0-9-]/g, '-');
+  const projectDir = path.join(root, encoded);
+  const relative = path.relative(root, projectDir);
+  if (relative === '' || relative.startsWith('..') || path.isAbsolute(relative)) {
+    return null;
+  }
+  return projectDir;
+}
+
+/**
+ * Removes the entire Claude transcript directory for a project path.
+ *
+ * `deleteSessionJsonlFilesForProjectPath` only removes files recorded in `sessions.jsonl_path`,
+ * so app-created sessions (whose `jsonl_path` is `NULL` until the synchronizer indexes them)
+ * leave their transcript on disk. The next `synchronizeSessions()` re-discovers that file and
+ * recreates the project, so a "delete all data" request appears to do nothing after a reload.
+ * Removing the directory fulfils the documented behaviour and stops the resurrection.
+ */
+async function deleteClaudeProjectDir(projectPath: string): Promise<void> {
+  const projectDir = resolveClaudeProjectDir(projectPath);
+  if (!projectDir) {
+    console.warn(`[project-delete] Refusing to remove out-of-root Claude dir for path: ${projectPath}`);
+    return;
+  }
+
+  try {
+    await fs.rm(projectDir, { recursive: true, force: true });
+  } catch (error) {
+    console.warn(`[project-delete] Failed to remove ${projectDir}:`, (error as Error).message);
+  }
+}
+
+/**
  * - **Soft delete** (`force` false): set `isArchived` on the `projects` row (hide from the active list; DB only).
- * - **Force** (`force` true): for each session row for that `project_path`, delete the file at `jsonl_path`
- *   (when set), then remove session rows and the `projects` row.
+ * - **Force** (`force` true): delete each session row's `jsonl_path` file (when set), remove the whole Claude
+ *   transcript directory for the path (covers app-created sessions whose `jsonl_path` is still `NULL`), then
+ *   remove the session rows and the `projects` row. Removing the on-disk transcripts is what stops the
+ *   synchronizer from recreating ("resurrecting") the project on the next project-list load.
  */
 export async function deleteOrArchiveProject(projectId: string, force: boolean): Promise<void> {
   const row = projectsDb.getProjectById(projectId);
@@ -70,6 +120,7 @@ export async function deleteOrArchiveProject(projectId: string, force: boolean):
   }
 
   await deleteSessionJsonlFilesForProjectPath(row.project_path);
+  await deleteClaudeProjectDir(row.project_path);
   sessionsDb.deleteSessionsByProjectPath(row.project_path);
   projectsDb.deleteProjectById(projectId);
 }

--- a/server/modules/projects/services/project-delete.service.ts
+++ b/server/modules/projects/services/project-delete.service.ts
@@ -83,19 +83,20 @@ function resolveClaudeProjectDir(projectPath: string): string | null {
  * leave their transcript on disk. The next `synchronizeSessions()` re-discovers that file and
  * recreates the project, so a "delete all data" request appears to do nothing after a reload.
  * Removing the directory fulfils the documented behaviour and stops the resurrection.
+ *
+ * Errors are intentionally NOT swallowed: `fs.rm` with `force: true` already ignores a missing
+ * directory, so anything it still throws (e.g. a permission error) means transcripts survived on
+ * disk. Propagating it aborts `deleteOrArchiveProject` before the DB rows are removed, so the
+ * caller sees a failure instead of a "deleted" project that resurrects on the next reload.
  */
 async function deleteClaudeProjectDir(projectPath: string): Promise<void> {
   const projectDir = resolveClaudeProjectDir(projectPath);
   if (!projectDir) {
-    console.warn(`[project-delete] Refusing to remove out-of-root Claude dir for path: ${projectPath}`);
+    console.warn('[project-delete] Refusing to remove out-of-root Claude dir');
     return;
   }
 
-  try {
-    await fs.rm(projectDir, { recursive: true, force: true });
-  } catch (error) {
-    console.warn(`[project-delete] Failed to remove ${projectDir}:`, (error as Error).message);
-  }
+  await fs.rm(projectDir, { recursive: true, force: true });
 }
 
 /**

--- a/server/modules/projects/services/project-management.service.ts
+++ b/server/modules/projects/services/project-management.service.ts
@@ -112,7 +112,10 @@ export async function createProject(
   const normalizedCustomName = resolveDisplayName(input.customName ?? null, resolvedProjectPath);
   const persistedProject = dependencies.persistProjectPath(resolvedProjectPath, normalizedCustomName);
 
-  if (persistedProject.outcome === 'active_conflict') {
+  // `createProject` uses the default reactivation, so an archived path resolves to
+  // `reactivated_archived`; `archived_conflict` is only reachable when a caller opts out.
+  // Both conflict outcomes mean an existing row blocked a fresh insert, so treat them alike.
+  if (persistedProject.outcome === 'active_conflict' || persistedProject.outcome === 'archived_conflict') {
     throw new AppError('Project path already exists and is active', {
       code: 'PROJECT_ALREADY_EXISTS',
       statusCode: 409,

--- a/server/modules/projects/tests/project-delete.service.test.ts
+++ b/server/modules/projects/tests/project-delete.service.test.ts
@@ -96,6 +96,51 @@ test('force delete never removes files outside the Claude projects root', async 
   });
 });
 
+const OLD_ACTIVITY = '2020-01-01T00:00:00.000Z';
+const FUTURE_ACTIVITY = '2999-01-01T00:00:00.000Z';
+
+test('force delete tombstones the project so a STALE non-claude transcript cannot resurrect it', async () => {
+  await withEnv(async () => {
+    // A Codex session: its transcript lives outside ~/.claude, so directory removal can't reach it.
+    sessionsDb.createSession('codex-1', 'codex', PROJECT_CWD, undefined, OLD_ACTIVITY, OLD_ACTIVITY, '/elsewhere/codex-1.jsonl');
+    const projectId = projectsDb.getProjectPaths()[0].project_id;
+
+    await deleteOrArchiveProject(projectId, true);
+    assert.equal(projectsDb.getProjectPaths().length, 0, 'gone right after delete');
+
+    // The next scan re-discovers the same stale transcript (activity predates the deletion).
+    const sid = sessionsDb.createSession('codex-1', 'codex', PROJECT_CWD, undefined, OLD_ACTIVITY, OLD_ACTIVITY, '/elsewhere/codex-1.jsonl');
+    assert.equal(sid, '', 'stale leftover of a deleted project must not be indexed');
+    assert.equal(projectsDb.getProjectPaths().length, 0, 'BUG: non-claude project resurrected from stale transcript');
+  });
+});
+
+test('genuinely NEW activity after a force delete revives the project (tombstone lifted)', async () => {
+  await withEnv(async () => {
+    sessionsDb.createSession('codex-1', 'codex', PROJECT_CWD, undefined, OLD_ACTIVITY, OLD_ACTIVITY, '/elsewhere/codex-1.jsonl');
+    const projectId = projectsDb.getProjectPaths()[0].project_id;
+    await deleteOrArchiveProject(projectId, true);
+    assert.equal(projectsDb.getProjectPaths().length, 0);
+
+    // A session whose activity is AFTER the deletion means the user is using the path again.
+    const sid = sessionsDb.createSession('codex-2', 'codex', PROJECT_CWD, undefined, FUTURE_ACTIVITY, FUTURE_ACTIVITY, '/elsewhere/codex-2.jsonl');
+    assert.notEqual(sid, '', 'new session is indexed');
+    assert.equal(projectsDb.getProjectPaths().length, 1, 'project revived by genuinely new activity');
+  });
+});
+
+test('explicit createAppSession on a force-deleted path revives it', async () => {
+  await withEnv(async () => {
+    sessionsDb.createSession('codex-1', 'codex', PROJECT_CWD, undefined, OLD_ACTIVITY, OLD_ACTIVITY, '/elsewhere/codex-1.jsonl');
+    const projectId = projectsDb.getProjectPaths()[0].project_id;
+    await deleteOrArchiveProject(projectId, true);
+    assert.equal(projectsDb.getProjectPaths().length, 0);
+
+    sessionsDb.createAppSession('app-1', 'codex', PROJECT_CWD);
+    assert.equal(projectsDb.getProjectPaths().length, 1, 'explicit user action lifts the tombstone');
+  });
+});
+
 test('re-indexing a transcript does NOT un-archive a project the user archived', async () => {
   await withEnv(async (home) => {
     const jsonlPath = await writeTranscript(home);

--- a/server/modules/projects/tests/project-delete.service.test.ts
+++ b/server/modules/projects/tests/project-delete.service.test.ts
@@ -1,0 +1,116 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, rm, mkdir, writeFile } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+
+import { closeConnection, initializeDatabase, projectsDb, sessionsDb } from '@/modules/database/index.js';
+import { ClaudeSessionSynchronizer } from '@/modules/providers/index.js';
+import { deleteOrArchiveProject } from '@/modules/projects/services/project-delete.service.js';
+
+const PROJECT_CWD = '/Users/tester/dev/adoring-driscoll';
+const SESSION_ID = '11111111-2222-3333-4444-555555555555';
+
+async function withEnv(runTest: (home: string) => Promise<void>): Promise<void> {
+  const prevDb = process.env.DATABASE_PATH;
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), 'project-delete-'));
+  const fakeHome = path.join(tempDir, 'home');
+  const origHomedir = os.homedir;
+  (os as unknown as { homedir: () => string }).homedir = () => fakeHome;
+
+  closeConnection();
+  process.env.DATABASE_PATH = path.join(tempDir, 'auth.db');
+  await initializeDatabase();
+  try {
+    await runTest(fakeHome);
+  } finally {
+    (os as unknown as { homedir: () => string }).homedir = origHomedir;
+    closeConnection();
+    if (prevDb === undefined) delete process.env.DATABASE_PATH;
+    else process.env.DATABASE_PATH = prevDb;
+    await rm(tempDir, { recursive: true, force: true });
+  }
+}
+
+function claudeProjectDir(home: string): string {
+  const encoded = PROJECT_CWD.replace(/[^a-zA-Z0-9-]/g, '-');
+  return path.join(home, '.claude', 'projects', encoded);
+}
+
+async function writeTranscript(home: string): Promise<string> {
+  const dir = claudeProjectDir(home);
+  await mkdir(dir, { recursive: true });
+  const jsonlPath = path.join(dir, `${SESSION_ID}.jsonl`);
+  await writeFile(
+    jsonlPath,
+    JSON.stringify({ sessionId: SESSION_ID, cwd: PROJECT_CWD, type: 'user' }) + '\n',
+    'utf8',
+  );
+  return jsonlPath;
+}
+
+test('force delete of a synchronizer-indexed project stays deleted after a re-sync', async () => {
+  await withEnv(async (home) => {
+    const jsonlPath = await writeTranscript(home);
+    await new ClaudeSessionSynchronizer().synchronizeFile(jsonlPath);
+
+    const projectId = projectsDb.getProjectPaths()[0].project_id;
+    await deleteOrArchiveProject(projectId, true);
+
+    await new ClaudeSessionSynchronizer().synchronize(undefined); // simulate reload -> GET /api/projects
+    assert.equal(projectsDb.getProjectPaths().length, 0, 'project should stay deleted');
+  });
+});
+
+test('force delete removes the transcript of an app-created session (jsonl_path NULL) so it cannot resurrect', async () => {
+  await withEnv(async (home) => {
+    const jsonlPath = await writeTranscript(home);
+    // App registers the session up-front with a NULL jsonl_path (user starts a conversation in the UI).
+    sessionsDb.createAppSession(SESSION_ID, 'claude', PROJECT_CWD);
+
+    const projectId = projectsDb.getProjectPaths()[0].project_id;
+    await deleteOrArchiveProject(projectId, true);
+
+    // The on-disk transcript (and its directory) must be gone, not just the DB rows.
+    assert.equal(existsSync(jsonlPath), false, 'transcript file should be deleted');
+    assert.equal(existsSync(claudeProjectDir(home)), false, 'project transcript dir should be deleted');
+
+    // A reload re-runs the synchronizer; with the files gone the project must not come back.
+    await new ClaudeSessionSynchronizer().synchronize(undefined);
+    assert.equal(projectsDb.getProjectPaths().length, 0, 'project must not resurrect after reload');
+  });
+});
+
+test('force delete never removes files outside the Claude projects root', async () => {
+  await withEnv(async (home) => {
+    // A malformed/relative project_path must not let directory removal escape the root.
+    const outside = path.join(home, 'precious');
+    await mkdir(outside, { recursive: true });
+    await writeFile(path.join(outside, 'keep.txt'), 'keep', 'utf8');
+
+    const created = projectsDb.createProjectPath('../../../precious');
+    await deleteOrArchiveProject(created.project!.project_id, true);
+
+    assert.equal(existsSync(path.join(outside, 'keep.txt')), true, 'unrelated files must be preserved');
+  });
+});
+
+test('re-indexing a transcript does NOT un-archive a project the user archived', async () => {
+  await withEnv(async (home) => {
+    const jsonlPath = await writeTranscript(home);
+    await new ClaudeSessionSynchronizer().synchronizeFile(jsonlPath);
+
+    const projectId = projectsDb.getProjectPaths()[0].project_id;
+    // Archive (soft delete).
+    await deleteOrArchiveProject(projectId, false);
+    assert.equal(projectsDb.getProjectPaths().length, 0, 'archived project hidden from active list');
+
+    // The file watcher re-indexes the still-present transcript (a `change` event)...
+    await new ClaudeSessionSynchronizer().synchronizeFile(jsonlPath);
+
+    // ...but the project must remain archived, not silently reappear.
+    assert.equal(projectsDb.getProjectPaths().length, 0, 'still hidden after re-index');
+    assert.equal(projectsDb.getArchivedProjectPaths().length, 1, 'still archived after re-index');
+  });
+});

--- a/server/modules/providers/index.ts
+++ b/server/modules/providers/index.ts
@@ -4,3 +4,5 @@ export { providerMcpService } from './services/mcp.service.js';
 
 export { initializeSessionsWatcher } from './services/sessions-watcher.service.js';
 export { closeSessionsWatcher } from './services/sessions-watcher.service.js';
+
+export { ClaudeSessionSynchronizer } from './list/claude/claude-session-synchronizer.provider.js';

--- a/server/shared/types.ts
+++ b/server/shared/types.ts
@@ -543,13 +543,28 @@ export type ProjectRepositoryRow = {
  * Result category returned by `projectsDb.createProjectPath`.
  *
  * `created` means a fresh row was inserted, `reactivated_archived` means an
- * existing archived path was accepted and updated, and `active_conflict` means
- * an already-active path blocked project creation.
+ * existing archived path was accepted and updated, `active_conflict` means an
+ * already-active path blocked project creation, and `archived_conflict` means an
+ * archived path already exists but was left archived (only possible when the
+ * caller opts out of reactivation via `reactivateArchived: false`).
  */
 export type CreateProjectPathOutcome =
   | 'created'
   | 'reactivated_archived'
-  | 'active_conflict';
+  | 'active_conflict'
+  | 'archived_conflict';
+
+/**
+ * Options for `projectsDb.createProjectPath`.
+ *
+ * `reactivateArchived` (default `true`) controls whether an existing archived
+ * path is un-archived on conflict. Explicit user actions leave it `true`; the
+ * background session synchronizer passes `false` so a passive re-scan can never
+ * silently reactivate a project the user archived.
+ */
+export type CreateProjectPathOptions = {
+  reactivateArchived?: boolean;
+};
 
 /**
  * Structured result returned by project-path upsert operations.


### PR DESCRIPTION
## Problem

Deleting a project with **"Delete all data" (`force=true`)** appears to do nothing after a page reload — the "deleted" project comes back. Archiving can also silently reverse itself.

### Root cause (reproduced with a test)

`deleteOrArchiveProject(force=true)` → `deleteSessionJsonlFilesForProjectPath` only unlinks files recorded in `sessions.jsonl_path`. But sessions started from the app UI are registered by `createAppSession` with **`jsonl_path = NULL`**, so the real transcript at `~/.claude/projects/<encoded-cwd>/<id>.jsonl` is never removed.

The project list is rebuilt from disk on every `GET /api/projects`: `synchronizeSessions()` → `ClaudeSessionSynchronizer.synchronize()` re-discovers the leftover transcript → `createSession()` → `createProjectPath()` **recreates the project**. The route's own doc comment says it should "remove all `*.jsonl` under the Claude project dir", but the implementation didn't.

Separately, `createProjectPath`'s `ON CONFLICT ... SET isArchived = 0` reactivates an archived project on **any** transcript re-touch (e.g. a file-watcher `change` event), so archiving doesn't reliably stick either.

## Fix

- **`project-delete.service`**: on force delete, remove the whole Claude transcript directory for the project path (encoded the same way as `server/index.js`), guarded so a malformed `project_path` can never delete outside `~/.claude/projects`. `fs.rm` errors are **not** swallowed — `force: true` already ignores a missing dir, so a remaining throw means transcripts survived; propagating it aborts the delete before the DB rows are removed, so we never report success (and resurrect) on a failed cleanup.
- **`projects.db.createProjectPath`**: add `reactivateArchived` (default `true`, via a named `CreateProjectPathOptions` type). The background synchronizer passes `false`, so a passive re-scan can no longer un-archive a project the user archived. When an archived row is left archived, the outcome is reported as the new `archived_conflict` (instead of mislabeling it `active_conflict`).
- **providers barrel**: export `ClaudeSessionSynchronizer` for tests.

## Tests

New `project-delete.service.test.ts` (4 cases) + a `createProjectPath` `archived_conflict` outcome test, all green:
1. force delete of a synchronizer-indexed project stays deleted after a re-sync
2. force delete removes an **app-created (null `jsonl_path`)** transcript so it cannot resurrect ← the reported bug
3. force delete never removes files outside the Claude projects root (path-traversal safety)
4. re-indexing a transcript does **not** un-archive an archived project

`npm run typecheck`, eslint, and the projects/database test suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Archived projects are now protected against unintended background reactivation when sessions are created.
  * Force-deleting a project now removes its associated Claude transcript directory to reduce the chance of deleted content reappearing later.

* **Bug Fixes**
  * Project-path conflicts now distinguish between active vs archived matches, leading to more consistent “already exists” behavior.
  * Soft-deleted (tombstoned) project paths won’t be recreated unless there’s genuinely new activity after deletion.
  * Re-indexing transcripts no longer restores projects that were intentionally archived.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->