### PR TITLE
Remove web shell tab and fix chat activity overlap

### DIFF
--- a/src/components/chat/view/subcomponents/ChatComposer.test.tsx
+++ b/src/components/chat/view/subcomponents/ChatComposer.test.tsx
@@ -1,0 +1,13 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+const sourcePath = fileURLToPath(new URL('./ChatComposer.tsx', import.meta.url));
+
+test('activity indicator participates in composer layout instead of overlaying messages', () => {
+  const source = readFileSync(sourcePath, 'utf8');
+
+  assert.doesNotMatch(source, /pointer-events-none\s+absolute\s+bottom-full/);
+  assert.match(source, /ActivityIndicator/);
+});

--- a/src/components/chat/view/subcomponents/ChatComposer.tsx
+++ b/src/components/chat/view/subcomponents/ChatComposer.tsx
@@ -202,7 +202,7 @@ export default function ChatComposer({
   return (
     <div className="chat-composer-shell relative flex-shrink-0 px-2 pb-2 pt-0 sm:px-4 sm:pb-4 md:px-4 md:pb-6">
       {!hasPendingPermissions && (
-        <div className="pointer-events-none absolute bottom-full left-1/2 z-10 w-[calc(100%-1rem)] max-w-[54.25rem] -translate-x-1/2 translate-y-px bg-transparent sm:w-[calc(100%-2rem)]">
+        <div className="pointer-events-none mx-auto w-full max-w-[54.25rem] translate-y-px bg-transparent">
           <ActivityIndicator activity={activity} onAbort={onAbortSession} isInputFocused={isInputFocused} />
         </div>
       )}

--- a/src/components/command-palette/CommandPalette.test.ts
+++ b/src/components/command-palette/CommandPalette.test.ts
@@ -1,0 +1,12 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+const sourcePath = fileURLToPath(new URL('./CommandPalette.tsx', import.meta.url));
+
+test('command palette does not expose shell navigation', () => {
+  const source = readFileSync(sourcePath, 'utf8');
+
+  assert.doesNotMatch(source, /id:\s*'shell'|Go to Shell|shell terminal console/);
+});

--- a/src/components/command-palette/CommandPalette.tsx
+++ b/src/components/command-palette/CommandPalette.tsx
@@ -58,7 +58,6 @@ type CommandPaletteProps = {
 const NAV_TABS: Array<{ id: AppTab; label: string; keywords: string }> = [
   { id: 'chat', label: 'Go to Chat', keywords: 'chat messages conversation' },
   { id: 'files', label: 'Go to Files', keywords: 'files file tree explorer' },
-  { id: 'shell', label: 'Go to Shell', keywords: 'shell terminal console' },
   { id: 'git', label: 'Go to Git', keywords: 'git diff branches' },
   { id: 'tasks', label: 'Go to Tasks', keywords: 'tasks taskmaster' },
 ];

--- a/src/components/main-content/view/MainContent.tsx
+++ b/src/components/main-content/view/MainContent.tsx
@@ -2,7 +2,6 @@ import React, { useCallback, useEffect, useState } from 'react';
 
 import ChatInterface from '../../chat/view/ChatInterface';
 import FileTree from '../../file-tree/view/FileTree';
-import StandaloneShell from '../../standalone-shell/view/StandaloneShell';
 import GitPanel from '../../git-panel/view/GitPanel';
 import PluginTabContent from '../../plugins/view/PluginTabContent';
 import { BrowserUsePanel } from '../../browser-use';
@@ -183,17 +182,6 @@ function MainContent({
           {activeTab === 'files' && (
             <div className="h-full overflow-hidden">
               <FileTree selectedProject={selectedProject} onFileOpen={handleFileOpen} />
-            </div>
-          )}
-
-          {activeTab === 'shell' && (
-            <div className="h-full w-full overflow-hidden">
-              <StandaloneShell
-                project={selectedProject}
-                session={selectedSession}
-                showHeader={false}
-                isActive={activeTab === 'shell'}
-              />
             </div>
           )}
 

--- a/src/components/main-content/view/subcomponents/MainContentTabSwitcher.test.tsx
+++ b/src/components/main-content/view/subcomponents/MainContentTabSwitcher.test.tsx
@@ -1,0 +1,12 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+const sourcePath = fileURLToPath(new URL('./MainContentTabSwitcher.tsx', import.meta.url));
+
+test('main content tab switcher does not expose the web shell tab', () => {
+  const source = readFileSync(sourcePath, 'utf8');
+
+  assert.doesNotMatch(source, /id:\s*'shell'|tabs\.shell|Terminal/);
+});

--- a/src/components/main-content/view/subcomponents/MainContentTabSwitcher.tsx
+++ b/src/components/main-content/view/subcomponents/MainContentTabSwitcher.tsx
@@ -1,4 +1,4 @@
-import { MessageSquare, Terminal, Folder, GitBranch, ClipboardCheck, MonitorPlay, type LucideIcon } from 'lucide-react';
+import { MessageSquare, Folder, GitBranch, ClipboardCheck, MonitorPlay, type LucideIcon } from 'lucide-react';
 import type { Dispatch, SetStateAction } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -33,7 +33,6 @@ type TabDefinition = BuiltInTab | PluginTab;
 
 const BASE_TABS: BuiltInTab[] = [
   { kind: 'builtin', id: 'chat',  labelKey: 'tabs.chat',  icon: MessageSquare },
-  { kind: 'builtin', id: 'shell', labelKey: 'tabs.shell', icon: Terminal },
   { kind: 'builtin', id: 'files', labelKey: 'tabs.files', icon: Folder },
   { kind: 'builtin', id: 'git',   labelKey: 'tabs.git',   icon: GitBranch },
 ];

--- a/src/hooks/useProjectsState.ts
+++ b/src/hooks/useProjectsState.ts
@@ -324,7 +324,7 @@ const removeSessionFromProject = (project: Project, sessionIdToDelete: string): 
   return updatedProject;
 };
 
-const VALID_TABS: Set<string> = new Set(['chat', 'files', 'shell', 'git', 'tasks', 'browser']);
+const VALID_TABS: Set<string> = new Set(['chat', 'files', 'git', 'tasks', 'browser']);
 
 const isValidTab = (tab: string): tab is AppTab => {
   return VALID_TABS.has(tab) || tab.startsWith('plugin:');

--- a/src/i18n/config.js
+++ b/src/i18n/config.js
@@ -96,6 +96,8 @@ import zhTWTasks from './locales/zh-TW/tasks.json';
 // Import supported languages configuration
 import { languages } from './languages.js';
 
+const DEFAULT_LANGUAGE = 'zh-CN';
+
 // Get saved language preference from localStorage
 const getSavedLanguage = () => {
   try {
@@ -104,9 +106,9 @@ const getSavedLanguage = () => {
     if (saved && languages.some(lang => lang.value === saved)) {
       return saved;
     }
-    return 'en';
+    return DEFAULT_LANGUAGE;
   } catch {
-    return 'en';
+    return DEFAULT_LANGUAGE;
   }
 };
 

--- a/src/i18n/config.test.js
+++ b/src/i18n/config.test.js
@@ -1,0 +1,13 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+const sourcePath = fileURLToPath(new URL('./config.js', import.meta.url));
+
+test('defaults the interface language to Simplified Chinese when no saved language exists', () => {
+  const source = readFileSync(sourcePath, 'utf8');
+
+  assert.match(source, /const DEFAULT_LANGUAGE = 'zh-CN';/);
+  assert.doesNotMatch(source, /return 'en';\s*\}\s*catch/);
+});

--- a/src/types/app.ts
+++ b/src/types/app.ts
@@ -17,7 +17,7 @@ export type ProviderModelsCacheInfo = {
   source: 'memory' | 'disk' | 'fresh';
 };
 
-export type AppTab = 'chat' | 'files' | 'shell' | 'git' | 'tasks' | 'browser' | `plugin:${string}`;
+export type AppTab = 'chat' | 'files' | 'git' | 'tasks' | 'browser' | `plugin:${string}`;
 
 export interface ProjectSession {
   id: string;


### PR DESCRIPTION
## Summary
- Remove the built-in Shell tab from the main CloudCLI web navigation and command palette.
- Treat persisted `activeTab=shell` as invalid so old clients fall back to the default tab.
- Keep the chat activity/Stop strip in normal composer layout flow so it no longer overlays the last conversation messages.
- Default the interface language to Simplified Chinese when no valid saved language preference exists.

Fixes #952.

## Verification
- `node --import tsx --test src/i18n/config.test.js src/components/chat/view/subcomponents/ChatComposer.test.tsx src/components/main-content/view/subcomponents/MainContentTabSwitcher.test.tsx src/components/command-palette/CommandPalette.test.ts`
- `npm run typecheck`
- `npm run lint` (passes with existing warnings)
- `npm run build` (passes with existing Vite CSS/chunk warnings)