### PR TITLE
fix: add Codex provider complete fields

### DIFF
--- a/server/modules/providers/list/codex/codex-sessions.provider.ts
+++ b/server/modules/providers/list/codex/codex-sessions.provider.ts
@@ -492,6 +492,9 @@ export class CodexSessionsProvider implements IProviderSessions {
         timestamp: ts,
         provider: PROVIDER,
         kind: 'complete',
+        exitCode: 0,
+        success: true,
+        aborted: false,
       })];
     }
     if (raw.type === 'turn_failed') {

--- a/server/modules/providers/tests/codex-sessions.test.ts
+++ b/server/modules/providers/tests/codex-sessions.test.ts
@@ -1,0 +1,22 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { CodexSessionsProvider } from '@/modules/providers/list/codex/codex-sessions.provider.js';
+
+test('Codex sessions provider marks turn_complete as a successful completion', () => {
+  const provider = new CodexSessionsProvider();
+
+  const normalized = provider.normalizeMessage({
+    type: 'turn_complete',
+    uuid: 'codex-turn-complete-1',
+    timestamp: '2026-07-03T14:00:00.000Z',
+  }, 'codex-session-1');
+
+  assert.equal(normalized.length, 1);
+  assert.equal(normalized[0]?.kind, 'complete');
+  assert.equal(normalized[0]?.provider, 'codex');
+  assert.equal(normalized[0]?.sessionId, 'codex-session-1');
+  assert.equal(normalized[0]?.exitCode, 0);
+  assert.equal(normalized[0]?.success, true);
+  assert.equal(normalized[0]?.aborted, false);
+});


### PR DESCRIPTION
## Summary
- Add explicit `exitCode: 0`, `success: true`, and `aborted: false` fields to Codex `turn_complete` normalization.
- Keep provider-normalized Codex completions aligned with the existing complete-message contract.
- Add focused `node:test` coverage for the `turn_complete` path.

## Why
`server/modules/providers/list/codex/codex-sessions.provider.ts` mapped `raw.type === 'turn_complete'` to a bare `kind: 'complete'` event.

That can leave downstream completion handling without the success fields it expects. This PR makes the terminal provider event explicit and consistent.

## Validation
- Codex sessions tests: 12 passed
- `npm run typecheck`
- `npm run build`
- `npm run lint` passes with existing warnings
- Full server suite on Windows with Node 24: both the PR branch and exact upstream `fd424f3` baseline report 449 passed, 7 failed, 1 skipped. Six failures match in both runs. Each run also hit one different concurrency-sensitive runner/timing failure.

Not tested: live Codex chat run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Completion messages now consistently include success-related details, such as exit status and whether the run was aborted.
  * Improved message normalization so finished sessions return clearer, more complete results.
  * Completed sessions now reliably report successful completion when they finish normally.

* **Tests**
  * Added coverage to verify completed session messages are mapped with the expected final status fields.
  * Added validation for session identifiers and completion status values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
