### PR TITLE
fix(codex): resolve session model override by app session id

### DIFF
--- a/server/openai-codex.js
+++ b/server/openai-codex.js
@@ -14,10 +14,12 @@
  */
 
 import { Codex } from '@openai/codex-sdk';
-import { notifyRunFailed, notifyRunStopped } from './services/notification-orchestrator.js';
+
+import { sessionsDb } from './modules/database/repositories/sessions.db.js';
 import { sessionsService } from './modules/providers/services/sessions.service.js';
 import { providerAuthService } from './modules/providers/services/provider-auth.service.js';
 import { providerModelsService } from './modules/providers/services/provider-models.service.js';
+import { notifyRunFailed, notifyRunStopped } from './services/notification-orchestrator.js';
 import { createCompleteMessage, createNormalizedMessage } from './shared/utils.js';
 
 const activeCodexSessions = new Map();
@@ -214,6 +216,24 @@ function mapPermissionModeToCodexOptions(permissionMode) {
   }
 }
 
+export function resolveCodexModelSessionId(sessionId) {
+  if (!sessionId?.trim()) {
+    return sessionId;
+  }
+
+  const appSession = sessionsDb.getSessionById(sessionId);
+  if (appSession?.provider === 'codex') {
+    return appSession.session_id;
+  }
+
+  const providerSession = sessionsDb.getSessionByProviderSessionId(sessionId);
+  if (providerSession?.provider === 'codex') {
+    return providerSession.session_id;
+  }
+
+  return sessionId;
+}
+
 /**
  * Execute a Codex query with streaming
  * @param {string} command - The prompt to send
@@ -231,9 +251,10 @@ export async function queryCodex(command, options = {}, ws) {
     permissionMode = 'default'
   } = options;
 
+  const modelSessionId = resolveCodexModelSessionId(sessionId);
   const resolvedModel = await providerModelsService.resolveResumeModel(
     'codex',
-    sessionId,
+    modelSessionId,
     model,
   );
 


### PR DESCRIPTION
## What

Selecting a Codex model (via `/models`) does not take effect on subsequent, resumed turns — the session keeps using the default model.

## Why

The per-session model override is persisted keyed on the stable app `session_id`, but on a resumed turn `queryCodex` calls `resolveResumeModel` with the Codex provider/thread id (which `codex.resumeThread` needs). Once Codex announces its own thread id, the app id and the provider id diverge, so the override is looked up under the wrong id, is never found, and the turn falls back to the default/requested model.

## Fix

Normalize the lookup id to the app `session_id` (using the existing `sessionsDb` provider↔app mapping) before calling `resolveResumeModel`. `codex.resumeThread` still receives the original provider thread id, so resume behavior is unchanged, and there is no effect when no override exists.

Single backend file: `server/openai-codex.js`.

## How to reproduce

1. Open a Codex session and send a message (this creates the Codex thread).
2. Run `/models` and pick a non-default model.
3. Send another message.
4. The turn still uses the default model — e.g. `turn_context.model` in the Codex rollout under `~/.codex/sessions/...` (or the server logs) shows the default rather than the selected model.

After the fix, step 4 uses the selected model.

## Testing

- `npm run lint`, `npm run typecheck`, and `npm run build` all pass.
- Verified end-to-end: after selecting a model, the resumed turn's `turn_context.model` matches the selection.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Codex session continuation so resumed conversations use the correct linked session when available.
  * Fixed cases where a session could fail to resume properly after switching or referencing a different session identifier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->