### PR TITLE
fix: validate X-Refreshed-Token before storing it as the auth token

### DIFF
--- a/src/components/file-tree/hooks/useFileTreeUpload.ts
+++ b/src/components/file-tree/hooks/useFileTreeUpload.ts
@@ -3,6 +3,7 @@ import type { DragEvent } from 'react';
 
 import { IS_PLATFORM } from '../../../constants/config';
 import type { Project } from '../../../types/app';
+import { isValidRefreshedToken } from '../../../utils/api';
 import {
   MAX_FILE_UPLOAD_COUNT,
   MAX_FILE_UPLOAD_SIZE_BYTES,
@@ -131,7 +132,7 @@ const uploadFormDataWithProgress = (
 
     xhr.onload = () => {
       const refreshedToken = xhr.getResponseHeader('X-Refreshed-Token');
-      if (refreshedToken) {
+      if (isValidRefreshedToken(refreshedToken)) {
         localStorage.setItem('auth-token', refreshedToken);
       }
 

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -1,5 +1,16 @@
 import { IS_PLATFORM } from "../constants/config";
 
+// Only accept a refreshed token that has this app's issued JWT shape
+// (three base64url segments). An attacker-injected/malformed header value
+// must never overwrite the stored auth token.
+/**
+ * @param {unknown} token
+ * @returns {token is string}
+ */
+export const isValidRefreshedToken = (token) =>
+  typeof token === 'string' &&
+  /^[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+$/.test(token);
+
 // Utility function for authenticated API calls
 export const authenticatedFetch = (url, options = {}) => {
   const token = localStorage.getItem('auth-token');
@@ -23,10 +34,7 @@ export const authenticatedFetch = (url, options = {}) => {
     },
   }).then((response) => {
     const refreshedToken = response.headers.get('X-Refreshed-Token');
-    // Only accept a refreshed token that has this app's issued JWT shape
-    // (three base64url segments). An attacker-injected/malformed header value
-    // must never overwrite the stored auth token.
-    if (refreshedToken && /^[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+$/.test(refreshedToken)) {
+    if (isValidRefreshedToken(refreshedToken)) {
       localStorage.setItem('auth-token', refreshedToken);
     }
     return response;

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -23,7 +23,10 @@ export const authenticatedFetch = (url, options = {}) => {
     },
   }).then((response) => {
     const refreshedToken = response.headers.get('X-Refreshed-Token');
-    if (refreshedToken) {
+    // Only accept a refreshed token that has this app's issued JWT shape
+    // (three base64url segments). An attacker-injected/malformed header value
+    // must never overwrite the stored auth token.
+    if (refreshedToken && /^[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+$/.test(refreshedToken)) {
       localStorage.setItem('auth-token', refreshedToken);
     }
     return response;


### PR DESCRIPTION
`authenticatedFetch` writes whatever comes back in the `X-Refreshed-Token` header straight into `localStorage['auth-token']` with only a truthy check. A malformed or injected value silently replaces a valid token, and every request after that goes out with a broken credential until you clear storage.

This just gates the write on the value looking like one a system JWTs (three base64url segments). Legit refreshes are unaffected.

Fixes #970


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated refreshed authentication handling so the app saves new auth tokens only when the response header contains a correctly formatted, JWT-like token.
  * Applied the same validation to file upload flows, preventing malformed refreshed-token headers from overwriting the currently stored token.

* **Security**
  * Reduces the risk of invalid or unexpected refreshed token values being persisted, improving overall authentication reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->