### PR TITLE
fix: check CLAUDE_CODE_OAUTH_TOKEN in checkCredentials()

### DIFF
--- a/server/modules/providers/list/claude/claude-auth.provider.ts
+++ b/server/modules/providers/list/claude/claude-auth.provider.ts
@@ -101,7 +101,7 @@ export class ClaudeProviderAuth implements IProviderAuth {
     }
 
     if (process.env.CLAUDE_CODE_OAUTH_TOKEN?.trim()) {
-      return { authenticated: true, email: 'CLAUDE_CODE_OAUTH_TOKEN', method: 'environment' };
+      return { authenticated: true, email: 'OAuth Token (long-lived)', method: 'environment' };
     }
 
     try {

--- a/server/modules/providers/list/claude/claude-auth.provider.ts
+++ b/server/modules/providers/list/claude/claude-auth.provider.ts
@@ -100,6 +100,10 @@ export class ClaudeProviderAuth implements IProviderAuth {
       return { authenticated: true, email: 'Configured via settings.json', method: 'api_key' };
     }
 
+    if (process.env.CLAUDE_CODE_OAUTH_TOKEN?.trim()) {
+      return { authenticated: true, email: 'CLAUDE_CODE_OAUTH_TOKEN', method: 'environment' };
+    }
+
     try {
       const credPath = path.join(os.homedir(), '.claude', '.credentials.json');
       const content = await readFile(credPath, 'utf8');

--- a/server/modules/providers/list/claude/claude-auth.provider.ts
+++ b/server/modules/providers/list/claude/claude-auth.provider.ts
@@ -104,6 +104,10 @@ export class ClaudeProviderAuth implements IProviderAuth {
       return { authenticated: true, email: 'OAuth Token (long-lived)', method: 'environment' };
     }
 
+    if (readOptionalString(settingsEnv.CLAUDE_CODE_OAUTH_TOKEN)) {
+      return { authenticated: true, email: 'OAuth Token (long-lived)', method: 'environment' };
+    }
+
     try {
       const credPath = path.join(os.homedir(), '.claude', '.credentials.json');
       const content = await readFile(credPath, 'utf8');

--- a/server/modules/providers/tests/claude-auth.test.ts
+++ b/server/modules/providers/tests/claude-auth.test.ts
@@ -1,0 +1,129 @@
+import assert from 'node:assert/strict';
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+
+import { ClaudeProviderAuth } from '@/modules/providers/list/claude/claude-auth.provider.js';
+
+// checkCredentials() is private, but unlike getStatus() it never shells out to the
+// `claude` CLI — it only reads env vars and ~/.claude files. Calling it directly
+// (TypeScript's `private` has no runtime effect) tests the priority order without
+// depending on `claude` being installed in the test environment.
+type CheckCredentialsResult = {
+  authenticated: boolean;
+  email: string | null;
+  method: string | null;
+  error?: string;
+};
+
+const checkCredentials = (auth: ClaudeProviderAuth): Promise<CheckCredentialsResult> =>
+  (auth as unknown as { checkCredentials: () => Promise<CheckCredentialsResult> }).checkCredentials();
+
+const ENV_KEYS = ['CLAUDE_CODE_OAUTH_TOKEN', 'ANTHROPIC_API_KEY', 'ANTHROPIC_AUTH_TOKEN'] as const;
+
+const withEnv = async (
+  overrides: Partial<Record<(typeof ENV_KEYS)[number], string>>,
+  fn: () => Promise<void>,
+) => {
+  const original: Partial<Record<(typeof ENV_KEYS)[number], string>> = {};
+  for (const key of ENV_KEYS) {
+    original[key] = process.env[key];
+    const value = overrides[key];
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+  try {
+    await fn();
+  } finally {
+    for (const key of ENV_KEYS) {
+      if (original[key] === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = original[key];
+      }
+    }
+  }
+};
+
+const withTempHome = async (fn: (homeDir: string) => Promise<void>) => {
+  const homeDir = await mkdtemp(path.join(os.tmpdir(), 'claude-auth-test-'));
+  const originalHome = process.env.HOME;
+  process.env.HOME = homeDir;
+  try {
+    await fn(homeDir);
+  } finally {
+    if (originalHome === undefined) {
+      delete process.env.HOME;
+    } else {
+      process.env.HOME = originalHome;
+    }
+    await rm(homeDir, { recursive: true, force: true });
+  }
+};
+
+const writeCredentialsFile = async (homeDir: string, body: unknown) => {
+  const claudeDir = path.join(homeDir, '.claude');
+  await mkdir(claudeDir, { recursive: true });
+  await writeFile(path.join(claudeDir, '.credentials.json'), JSON.stringify(body));
+};
+
+test('checkCredentials: CLAUDE_CODE_OAUTH_TOKEN set is authenticated via environment, even with a stale credentials file', async () => {
+  await withTempHome(async (homeDir) => {
+    await writeCredentialsFile(homeDir, {
+      claudeAiOauth: { accessToken: 'stale-token', expiresAt: 1_000_000_000_000 }, // long expired
+    });
+
+    await withEnv({ CLAUDE_CODE_OAUTH_TOKEN: 'test-oauth-token' }, async () => {
+      const status = await checkCredentials(new ClaudeProviderAuth());
+      assert.equal(status.authenticated, true);
+      assert.equal(status.method, 'environment');
+    });
+  });
+});
+
+test('checkCredentials: no CLAUDE_CODE_OAUTH_TOKEN, valid credentials file falls back to credentials_file', async () => {
+  await withTempHome(async (homeDir) => {
+    await writeCredentialsFile(homeDir, {
+      claudeAiOauth: { accessToken: 'valid-token', expiresAt: Date.now() + 60 * 60 * 1000 },
+      email: 'someone@example.com',
+    });
+
+    await withEnv({}, async () => {
+      const status = await checkCredentials(new ClaudeProviderAuth());
+      assert.equal(status.authenticated, true);
+      assert.equal(status.method, 'credentials_file');
+      assert.equal(status.email, 'someone@example.com');
+    });
+  });
+});
+
+test('checkCredentials: no CLAUDE_CODE_OAUTH_TOKEN, expired credentials file reports not authenticated', async () => {
+  await withTempHome(async (homeDir) => {
+    await writeCredentialsFile(homeDir, {
+      claudeAiOauth: { accessToken: 'stale-token', expiresAt: 1_000_000_000_000 },
+    });
+
+    await withEnv({}, async () => {
+      const status = await checkCredentials(new ClaudeProviderAuth());
+      assert.equal(status.authenticated, false);
+      assert.match(status.error ?? '', /expired/i);
+    });
+  });
+});
+
+test('checkCredentials: ANTHROPIC_API_KEY takes precedence over CLAUDE_CODE_OAUTH_TOKEN', async () => {
+  await withTempHome(async () => {
+    await withEnv(
+      { ANTHROPIC_API_KEY: 'test-api-key', CLAUDE_CODE_OAUTH_TOKEN: 'test-oauth-token' },
+      async () => {
+        const status = await checkCredentials(new ClaudeProviderAuth());
+        assert.equal(status.authenticated, true);
+        assert.equal(status.method, 'api_key');
+      },
+    );
+  });
+});

--- a/server/modules/providers/tests/claude-auth.test.ts
+++ b/server/modules/providers/tests/claude-auth.test.ts
@@ -71,6 +71,12 @@ const writeCredentialsFile = async (homeDir: string, body: unknown) => {
   await writeFile(path.join(claudeDir, '.credentials.json'), JSON.stringify(body));
 };
 
+const writeSettingsFile = async (homeDir: string, env: Record<string, string>) => {
+  const claudeDir = path.join(homeDir, '.claude');
+  await mkdir(claudeDir, { recursive: true });
+  await writeFile(path.join(claudeDir, 'settings.json'), JSON.stringify({ env }));
+};
+
 test('checkCredentials: CLAUDE_CODE_OAUTH_TOKEN set is authenticated via environment, even with a stale credentials file', async () => {
   await withTempHome(async (homeDir) => {
     await writeCredentialsFile(homeDir, {
@@ -78,6 +84,21 @@ test('checkCredentials: CLAUDE_CODE_OAUTH_TOKEN set is authenticated via environ
     });
 
     await withEnv({ CLAUDE_CODE_OAUTH_TOKEN: 'test-oauth-token' }, async () => {
+      const status = await checkCredentials(new ClaudeProviderAuth());
+      assert.equal(status.authenticated, true);
+      assert.equal(status.method, 'environment');
+    });
+  });
+});
+
+test('checkCredentials: CLAUDE_CODE_OAUTH_TOKEN configured via settings.json env block is authenticated via environment', async () => {
+  await withTempHome(async (homeDir) => {
+    await writeSettingsFile(homeDir, { CLAUDE_CODE_OAUTH_TOKEN: 'test-oauth-token-from-settings' });
+    await writeCredentialsFile(homeDir, {
+      claudeAiOauth: { accessToken: 'stale-token', expiresAt: 1_000_000_000_000 }, // long expired
+    });
+
+    await withEnv({}, async () => {
       const status = await checkCredentials(new ClaudeProviderAuth());
       assert.equal(status.authenticated, true);
       assert.equal(status.method, 'environment');


### PR DESCRIPTION
## Problem

`checkCredentials()` in `claude-auth.provider.ts` never checks `CLAUDE_CODE_OAUTH_TOKEN`. If
that env var is set (e.g. via `claude setup-token`, for a long-lived non-interactive
credential), it's silently ignored, and auth status falls through to reading
`~/.claude/.credentials.json` instead. Once that file's own short-lived OAuth session expires,
`getStatus()` reports "Claude login has expired" even though the app is actually still
authenticated via the token — a false negative for anyone using `CLAUDE_CODE_OAUTH_TOKEN`.

## Root cause

The priority chain in `checkCredentials()` checks `ANTHROPIC_AUTH_TOKEN`, `ANTHROPIC_API_KEY`,
and their `settings.json` equivalents, then falls straight to the credentials file — with no
step in between for `CLAUDE_CODE_OAUTH_TOKEN`.

## Fix

Added the check in the same priority slot Claude Code itself uses (per
`https://code.claude.com/docs/en/authentication`): after `ANTHROPIC_AUTH_TOKEN` /
`ANTHROPIC_API_KEY` (and their `apiKeyHelper`/settings.json equivalents), before falling back to
the credentials file. Uses `method: 'environment'`, matching the existing convention already
used by `opencode-auth.provider.ts` for the same "static credential from an env var" case
(rather than inventing a new value the frontend's `method !== 'api_key'` UI gate doesn't know
about).

## Testing

Manually verified `getStatus()` now returns `authenticated: true` when `CLAUDE_CODE_OAUTH_TOKEN`
is set even with a stale/expired `~/.claude/.credentials.json`, and confirmed the existing
fallback behavior (no token set) is unchanged. `npm run typecheck`, `npm run lint`, and
`npm run build` all pass clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for authenticating with a long-lived Claude OAuth token via an environment variable.
  * When set, the token is prioritized and authentication succeeds immediately, with the auth method and email labeled accordingly.
* **Tests**
  * Added automated coverage for token selection priority and correct behavior across environment-token, config-provided token, valid credentials-file, and expired credentials scenarios, including precedence over the API key flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->