### PR TITLE
fix: refresh auth token for idle WS/SSE clients, stop reconnect spam on expired sessions

### DIFF
--- a/src/components/auth/constants.ts
+++ b/src/components/auth/constants.ts
@@ -6,3 +6,12 @@ export const AUTH_ERROR_MESSAGES = {
   registrationFailed: 'Registration failed',
   networkError: 'Network error. Please try again.',
 } as const;
+
+// Server issues 7-day JWTs and only refreshes them once a request arrives
+// past the token's half-life (see server/middleware/auth.js). A tab left
+// open with no user-triggered requests (idle WS/SSE clients) would never
+// send that request and would eventually reconnect with an expired token.
+// Proactively pinging an authenticated endpoint on this interval keeps the
+// token refreshed well before that half-life, without depending on user
+// activity. Kept well under half of the 7-day lifetime (3.5 days).
+export const TOKEN_REFRESH_CHECK_INTERVAL_MS = 60 * 60 * 1000; // 1 hour

--- a/src/components/auth/context/AuthContext.tsx
+++ b/src/components/auth/context/AuthContext.tsx
@@ -144,16 +144,37 @@ export function AuthProvider({ children }: AuthProviderProps) {
   // update localStorage. Without this, this context's `token` state — and
   // anything derived from it, like WebSocketContext's reconnect URL — keeps
   // using the token captured at login/mount and never picks up a refresh.
+  //
+  // AUTH_TOKEN_REFRESHED_EVENT only reaches the tab that made the request, so
+  // it alone doesn't help *other* open tabs — each of those would otherwise
+  // keep reconnecting with their own stale in-memory token until their own
+  // proactive refresh happens to run. The `storage` event is the complement:
+  // it fires in every *other* tab (never the one that made the write) when
+  // localStorage changes, so together the two listeners keep every open tab's
+  // token state in sync regardless of which tab actually refreshed it.
   useEffect(() => {
-    const handleTokenRefreshed = (event: Event) => {
-      const refreshedToken = (event as CustomEvent<string>).detail;
+    const syncToken = (refreshedToken: string | null) => {
       if (refreshedToken) {
         setToken(refreshedToken);
       }
     };
 
+    const handleTokenRefreshed = (event: Event) => {
+      syncToken((event as CustomEvent<string>).detail);
+    };
+
+    const handleStorage = (event: StorageEvent) => {
+      if (event.key === AUTH_TOKEN_STORAGE_KEY) {
+        syncToken(event.newValue);
+      }
+    };
+
     window.addEventListener(AUTH_TOKEN_REFRESHED_EVENT, handleTokenRefreshed);
-    return () => window.removeEventListener(AUTH_TOKEN_REFRESHED_EVENT, handleTokenRefreshed);
+    window.addEventListener('storage', handleStorage);
+    return () => {
+      window.removeEventListener(AUTH_TOKEN_REFRESHED_EVENT, handleTokenRefreshed);
+      window.removeEventListener('storage', handleStorage);
+    };
   }, []);
 
   // The server only refreshes the token in response to a request made past
@@ -169,9 +190,22 @@ export function AuthProvider({ children }: AuthProviderProps) {
 
     const checkAndRefreshToken = () => {
       lastRefreshCheckRef.current = Date.now();
-      void api.auth.user().catch((caughtError: unknown) => {
-        console.error('[Auth] Background token refresh check failed:', caughtError);
-      });
+      // fetch() only rejects on network failure, never on a non-2xx status —
+      // a 401 (token invalid for a reason other than plain expiry: the
+      // server's JWT_SECRET rotated, or the user record is gone) resolves
+      // normally and would otherwise pass through unnoticed here. Since that
+      // case isn't a mere timing issue, no retry will ever succeed either, so
+      // treat it the same as a client-side-detected expiry.
+      void api.auth
+        .user()
+        .then((response) => {
+          if (response.status === 401) {
+            endExpiredSession();
+          }
+        })
+        .catch((caughtError: unknown) => {
+          console.error('[Auth] Background token refresh check failed:', caughtError);
+        });
     };
 
     const intervalId = setInterval(checkAndRefreshToken, TOKEN_REFRESH_CHECK_INTERVAL_MS);
@@ -192,7 +226,7 @@ export function AuthProvider({ children }: AuthProviderProps) {
       clearInterval(intervalId);
       document.removeEventListener('visibilitychange', handleVisibilityChange);
     };
-  }, [token]);
+  }, [endExpiredSession, token]);
 
   const login = useCallback<AuthContextValue['login']>(
     async (username, password) => {

--- a/src/components/auth/context/AuthContext.tsx
+++ b/src/components/auth/context/AuthContext.tsx
@@ -1,7 +1,7 @@
-import { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
 import { IS_PLATFORM } from '../../../constants/config';
-import { api } from '../../../utils/api';
-import { AUTH_ERROR_MESSAGES, AUTH_TOKEN_STORAGE_KEY } from '../constants';
+import { api, AUTH_TOKEN_REFRESHED_EVENT } from '../../../utils/api';
+import { AUTH_ERROR_MESSAGES, AUTH_TOKEN_STORAGE_KEY, TOKEN_REFRESH_CHECK_INTERVAL_MS } from '../constants';
 import type {
   AuthContextValue,
   AuthProviderProps,
@@ -41,10 +41,13 @@ export function AuthProvider({ children }: AuthProviderProps) {
   const [needsSetup, setNeedsSetup] = useState(false);
   const [hasCompletedOnboarding, setHasCompletedOnboarding] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [sessionExpired, setSessionExpired] = useState(false);
+  const lastRefreshCheckRef = useRef(0);
 
   const setSession = useCallback((nextUser: AuthUser, nextToken: string) => {
     setUser(nextUser);
     setToken(nextToken);
+    setSessionExpired(false);
     persistToken(nextToken);
   }, []);
 
@@ -52,6 +55,15 @@ export function AuthProvider({ children }: AuthProviderProps) {
     setUser(null);
     setToken(null);
     clearStoredToken();
+  }, []);
+
+  const endExpiredSession = useCallback(() => {
+    clearSession();
+    setSessionExpired(true);
+  }, [clearSession]);
+
+  const acknowledgeSessionExpired = useCallback(() => {
+    setSessionExpired(false);
   }, []);
 
   const checkOnboardingStatus = useCallback(async () => {
@@ -128,6 +140,60 @@ export function AuthProvider({ children }: AuthProviderProps) {
     void checkAuthStatus();
   }, [checkAuthStatus, checkOnboardingStatus]);
 
+  // Background HTTP refreshes (see applyRefreshedToken in utils/api.js) only
+  // update localStorage. Without this, this context's `token` state — and
+  // anything derived from it, like WebSocketContext's reconnect URL — keeps
+  // using the token captured at login/mount and never picks up a refresh.
+  useEffect(() => {
+    const handleTokenRefreshed = (event: Event) => {
+      const refreshedToken = (event as CustomEvent<string>).detail;
+      if (refreshedToken) {
+        setToken(refreshedToken);
+      }
+    };
+
+    window.addEventListener(AUTH_TOKEN_REFRESHED_EVENT, handleTokenRefreshed);
+    return () => window.removeEventListener(AUTH_TOKEN_REFRESHED_EVENT, handleTokenRefreshed);
+  }, []);
+
+  // The server only refreshes the token in response to a request made past
+  // its half-life (server/middleware/auth.js). A tab with an open WS/SSE
+  // connection but no other user-triggered requests would never send one,
+  // so the token silently goes stale until the WS has to reconnect — at
+  // which point it's already expired. Proactively pinging an authenticated
+  // endpoint keeps it refreshed regardless of user activity.
+  useEffect(() => {
+    if (IS_PLATFORM || !token) {
+      return;
+    }
+
+    const checkAndRefreshToken = () => {
+      lastRefreshCheckRef.current = Date.now();
+      void api.auth.user().catch((caughtError: unknown) => {
+        console.error('[Auth] Background token refresh check failed:', caughtError);
+      });
+    };
+
+    const intervalId = setInterval(checkAndRefreshToken, TOKEN_REFRESH_CHECK_INTERVAL_MS);
+
+    const handleVisibilityChange = () => {
+      if (document.visibilityState !== 'visible') {
+        return;
+      }
+      // Avoid refresh-storms from rapid tab/window focus churn.
+      if (Date.now() - lastRefreshCheckRef.current > TOKEN_REFRESH_CHECK_INTERVAL_MS / 4) {
+        checkAndRefreshToken();
+      }
+    };
+
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+
+    return () => {
+      clearInterval(intervalId);
+      document.removeEventListener('visibilitychange', handleVisibilityChange);
+    };
+  }, [token]);
+
   const login = useCallback<AuthContextValue['login']>(
     async (username, password) => {
       try {
@@ -199,12 +265,17 @@ export function AuthProvider({ children }: AuthProviderProps) {
       needsSetup,
       hasCompletedOnboarding,
       error,
+      sessionExpired,
       login,
       register,
       logout,
+      endExpiredSession,
+      acknowledgeSessionExpired,
       refreshOnboardingStatus,
     }),
     [
+      acknowledgeSessionExpired,
+      endExpiredSession,
       error,
       hasCompletedOnboarding,
       isLoading,
@@ -213,6 +284,7 @@ export function AuthProvider({ children }: AuthProviderProps) {
       needsSetup,
       refreshOnboardingStatus,
       register,
+      sessionExpired,
       token,
       user,
     ],

--- a/src/components/auth/types.ts
+++ b/src/components/auth/types.ts
@@ -39,9 +39,19 @@ export type AuthContextValue = {
   needsSetup: boolean;
   hasCompletedOnboarding: boolean;
   error: string | null;
+  /**
+   * True after `endExpiredSession` drops a session because the JWT itself
+   * expired (not a user-initiated logout). LoginForm surfaces this so the
+   * user understands why they were signed out instead of silently landing
+   * back on the login screen.
+   */
+  sessionExpired: boolean;
   login: (username: string, password: string) => Promise<AuthActionResult>;
   register: (username: string, password: string) => Promise<AuthActionResult>;
   logout: () => void;
+  /** Clears the session without pinging the (already-invalid) logout endpoint. */
+  endExpiredSession: () => void;
+  acknowledgeSessionExpired: () => void;
   refreshOnboardingStatus: () => Promise<void>;
 };
 

--- a/src/components/auth/view/LoginForm.tsx
+++ b/src/components/auth/view/LoginForm.tsx
@@ -24,7 +24,7 @@ const initialState: LoginFormState = {
  */
 export default function LoginForm() {
   const { t } = useTranslation('auth');
-  const { login } = useAuth();
+  const { login, sessionExpired, acknowledgeSessionExpired } = useAuth();
 
   const [formState, setFormState] = useState<LoginFormState>(initialState);
   const [errorMessage, setErrorMessage] = useState('');
@@ -38,6 +38,7 @@ export default function LoginForm() {
     async (event: FormEvent<HTMLFormElement>) => {
       event.preventDefault();
       setErrorMessage('');
+      acknowledgeSessionExpired();
 
       // Keep form validation local so each auth screen owns its own UI feedback.
       if (!formState.username.trim() || !formState.password) {
@@ -52,8 +53,14 @@ export default function LoginForm() {
       }
       setIsSubmitting(false);
     },
-    [formState.password, formState.username, login, t],
+    [acknowledgeSessionExpired, formState.password, formState.username, login, t],
   );
+
+  // Landing here because a background reconnect found the JWT itself expired
+  // (see endExpiredSession in AuthContext / WebSocketContext) is a distinct
+  // case from a bad-credentials error below — surface it until the user
+  // acts on it, but let a fresh submit attempt's own error take over.
+  const displayedError = errorMessage || (sessionExpired ? t('login.errors.sessionExpired') : '');
 
   return (
     <AuthScreenLayout
@@ -85,7 +92,7 @@ export default function LoginForm() {
           icon={Lock}
         />
 
-        <AuthErrorAlert errorMessage={errorMessage} />
+        <AuthErrorAlert errorMessage={displayedError} />
 
         <button
           type="submit"

--- a/src/components/file-tree/hooks/useFileTreeUpload.ts
+++ b/src/components/file-tree/hooks/useFileTreeUpload.ts
@@ -3,7 +3,7 @@ import type { DragEvent } from 'react';
 
 import { IS_PLATFORM } from '../../../constants/config';
 import type { Project } from '../../../types/app';
-import { isValidRefreshedToken } from '../../../utils/api';
+import { applyRefreshedToken } from '../../../utils/api';
 import {
   MAX_FILE_UPLOAD_COUNT,
   MAX_FILE_UPLOAD_SIZE_BYTES,
@@ -131,10 +131,7 @@ const uploadFormDataWithProgress = (
     };
 
     xhr.onload = () => {
-      const refreshedToken = xhr.getResponseHeader('X-Refreshed-Token');
-      if (isValidRefreshedToken(refreshedToken)) {
-        localStorage.setItem('auth-token', refreshedToken);
-      }
+      applyRefreshedToken(xhr.getResponseHeader('X-Refreshed-Token'));
 
       const payload = parseUploadResponse(xhr);
       if (xhr.status >= 200 && xhr.status < 300) {

--- a/src/contexts/WebSocketContext.tsx
+++ b/src/contexts/WebSocketContext.tsx
@@ -1,6 +1,7 @@
 import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
 import { useAuth } from '../components/auth/context/AuthContext';
 import { IS_PLATFORM } from '../constants/config';
+import { isTokenExpired } from '../utils/jwt';
 
 /**
  * One frame received from the chat websocket. The server guarantees every
@@ -56,36 +57,6 @@ const buildWebSocketUrl = (token: string | null) => {
   if (IS_PLATFORM) return `${protocol}//${window.location.host}/ws`; // Platform mode: Use same domain as the page (goes through proxy)
   if (!token) return null;
   return `${protocol}//${window.location.host}/ws?token=${encodeURIComponent(token)}`; // OSS mode: Use same host:port that served the page
-};
-
-// Tolerance for client/server clock skew. This check only decides whether to
-// keep retrying a WS reconnect — the server's own `jwt.verify` (which has no
-// skew allowance) is the real authority. Without this, a client clock running
-// even slightly ahead of the server could read a still-server-valid token as
-// expired and force an unwanted logout on a plain WS close.
-const TOKEN_EXPIRY_SKEW_MS = 60_000;
-
-/**
- * Reads the `exp` claim out of a JWT without verifying its signature — this
- * only needs to detect "this token cannot possibly still be valid" so the
- * reconnect loop can stop, not to authenticate anything. The server remains
- * the sole source of truth for verification.
- */
-const isTokenExpired = (token: string | null): boolean => {
-  if (!token) return true;
-
-  const payloadSegment = token.split('.')[1];
-  if (!payloadSegment) return true;
-
-  try {
-    const normalized = payloadSegment.replace(/-/g, '+').replace(/_/g, '/');
-    const padded = normalized.padEnd(normalized.length + ((4 - (normalized.length % 4)) % 4), '=');
-    const payload = JSON.parse(atob(padded)) as { exp?: number };
-    return typeof payload.exp !== 'number' || Date.now() >= payload.exp * 1000 + TOKEN_EXPIRY_SKEW_MS;
-  } catch {
-    // Unreadable token shape — treat as expired rather than retrying forever.
-    return true;
-  }
 };
 
 const useWebSocketProviderState = (): WebSocketContextType => {

--- a/src/contexts/WebSocketContext.tsx
+++ b/src/contexts/WebSocketContext.tsx
@@ -58,6 +58,13 @@ const buildWebSocketUrl = (token: string | null) => {
   return `${protocol}//${window.location.host}/ws?token=${encodeURIComponent(token)}`; // OSS mode: Use same host:port that served the page
 };
 
+// Tolerance for client/server clock skew. This check only decides whether to
+// keep retrying a WS reconnect — the server's own `jwt.verify` (which has no
+// skew allowance) is the real authority. Without this, a client clock running
+// even slightly ahead of the server could read a still-server-valid token as
+// expired and force an unwanted logout on a plain WS close.
+const TOKEN_EXPIRY_SKEW_MS = 60_000;
+
 /**
  * Reads the `exp` claim out of a JWT without verifying its signature — this
  * only needs to detect "this token cannot possibly still be valid" so the
@@ -74,7 +81,7 @@ const isTokenExpired = (token: string | null): boolean => {
     const normalized = payloadSegment.replace(/-/g, '+').replace(/_/g, '/');
     const padded = normalized.padEnd(normalized.length + ((4 - (normalized.length % 4)) % 4), '=');
     const payload = JSON.parse(atob(padded)) as { exp?: number };
-    return typeof payload.exp !== 'number' || Date.now() >= payload.exp * 1000;
+    return typeof payload.exp !== 'number' || Date.now() >= payload.exp * 1000 + TOKEN_EXPIRY_SKEW_MS;
   } catch {
     // Unreadable token shape — treat as expired rather than retrying forever.
     return true;

--- a/src/contexts/WebSocketContext.tsx
+++ b/src/contexts/WebSocketContext.tsx
@@ -58,6 +58,29 @@ const buildWebSocketUrl = (token: string | null) => {
   return `${protocol}//${window.location.host}/ws?token=${encodeURIComponent(token)}`; // OSS mode: Use same host:port that served the page
 };
 
+/**
+ * Reads the `exp` claim out of a JWT without verifying its signature — this
+ * only needs to detect "this token cannot possibly still be valid" so the
+ * reconnect loop can stop, not to authenticate anything. The server remains
+ * the sole source of truth for verification.
+ */
+const isTokenExpired = (token: string | null): boolean => {
+  if (!token) return true;
+
+  const payloadSegment = token.split('.')[1];
+  if (!payloadSegment) return true;
+
+  try {
+    const normalized = payloadSegment.replace(/-/g, '+').replace(/_/g, '/');
+    const padded = normalized.padEnd(normalized.length + ((4 - (normalized.length % 4)) % 4), '=');
+    const payload = JSON.parse(atob(padded)) as { exp?: number };
+    return typeof payload.exp !== 'number' || Date.now() >= payload.exp * 1000;
+  } catch {
+    // Unreadable token shape — treat as expired rather than retrying forever.
+    return true;
+  }
+};
+
 const useWebSocketProviderState = (): WebSocketContextType => {
   const wsRef = useRef<WebSocket | null>(null);
   const unmountedRef = useRef(false); // Track if component is unmounted
@@ -71,7 +94,7 @@ const useWebSocketProviderState = (): WebSocketContextType => {
   const [latestMessage, setLatestMessage] = useState<ServerEvent | null>(null);
   const [isConnected, setIsConnected] = useState(false);
   const reconnectTimeoutRef = useRef<NodeJS.Timeout | null>(null);
-  const { token } = useAuth();
+  const { token, endExpiredSession } = useAuth();
 
   const dispatch = useCallback((event: ServerEvent) => {
     for (const listener of listenersRef.current) {
@@ -135,6 +158,18 @@ const useWebSocketProviderState = (): WebSocketContextType => {
         setIsConnected(false);
         wsRef.current = null;
 
+        // A closed connection with an already-expired token can never
+        // succeed — the server rejects it at the handshake every time. Retrying
+        // that on a 3s loop forever is exactly the reconnect-spam issue #754
+        // describes (thousands of failed attempts/hour against a token that
+        // went stale days earlier). Stop and drop the session instead of
+        // retrying so the user sees a login screen rather than a silently
+        // spinning connection indicator.
+        if (isTokenExpired(token)) {
+          endExpiredSession();
+          return;
+        }
+
         // Attempt to reconnect after 3 seconds
         reconnectTimeoutRef.current = setTimeout(() => {
           if (unmountedRef.current) return; // Prevent reconnection if unmounted
@@ -149,7 +184,7 @@ const useWebSocketProviderState = (): WebSocketContextType => {
     } catch (error) {
       console.error('Error creating WebSocket connection:', error);
     }
-  }, [token, dispatch]); // everytime token changes, we reconnect
+  }, [token, dispatch, endExpiredSession]); // everytime token changes, we reconnect
 
   const sendMessage = useCallback((message: unknown) => {
     const socket = wsRef.current;

--- a/src/contexts/WebSocketContext.tsx
+++ b/src/contexts/WebSocketContext.tsx
@@ -63,6 +63,13 @@ const useWebSocketProviderState = (): WebSocketContextType => {
   const wsRef = useRef<WebSocket | null>(null);
   const unmountedRef = useRef(false); // Track if component is unmounted
   const hasConnectedRef = useRef(false); // Track if we've ever connected (to detect reconnects)
+  // Identifies which `connect()` call a given socket belongs to. WebSocket's
+  // close handshake is asynchronous, so when a token change (or unmount)
+  // triggers cleanup on the old socket and immediately opens a new one, the
+  // *old* socket's onclose can still fire later — with its own closure's
+  // (now stale) token. Bumped on every new connection attempt and on
+  // cleanup/unmount so a stale onclose can recognize it's no longer current.
+  const connectionGenerationRef = useRef(0);
   /**
    * Listener registry for the subscribe API. A ref (not state) because the
    * set must be readable synchronously inside `onmessage` and never trigger
@@ -94,6 +101,7 @@ const useWebSocketProviderState = (): WebSocketContextType => {
 
     return () => {
       unmountedRef.current = true;
+      connectionGenerationRef.current += 1;
       if (reconnectTimeoutRef.current) {
         clearTimeout(reconnectTimeoutRef.current);
       }
@@ -111,6 +119,7 @@ const useWebSocketProviderState = (): WebSocketContextType => {
 
       if (!wsUrl) return console.warn('No authentication token found for WebSocket connection');
 
+      const connectionGeneration = ++connectionGenerationRef.current;
       const websocket = new WebSocket(wsUrl);
 
       websocket.onopen = () => {
@@ -133,6 +142,16 @@ const useWebSocketProviderState = (): WebSocketContextType => {
       };
 
       websocket.onclose = () => {
+        // This socket may already be superseded by a newer connection (see
+        // connectionGenerationRef above) — e.g. a token refresh triggered a
+        // reconnect while this socket's close handshake was still in
+        // flight. Acting on that here (dropping the session, or scheduling
+        // a redundant reconnect) could kill a perfectly healthy new
+        // connection over this socket's now-stale token.
+        if (connectionGenerationRef.current !== connectionGeneration) {
+          return;
+        }
+
         setIsConnected(false);
         wsRef.current = null;
 

--- a/src/i18n/locales/en/auth.json
+++ b/src/i18n/locales/en/auth.json
@@ -9,7 +9,8 @@
     "errors": {
       "invalidCredentials": "Invalid username or password",
       "requiredFields": "Please fill in all fields",
-      "networkError": "Network error. Please try again."
+      "networkError": "Network error. Please try again.",
+      "sessionExpired": "Your session expired. Please sign in again."
     },
     "placeholders": {
       "username": "Enter your username",

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -11,6 +11,25 @@ export const isValidRefreshedToken = (token) =>
   typeof token === 'string' &&
   /^[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+$/.test(token);
 
+// Fired on `window` whenever a refreshed token is persisted, so contexts
+// holding their own copy of the token (e.g. AuthContext's React state) can
+// stay in sync with localStorage instead of silently going stale. Without
+// this, background refreshes update localStorage but any consumer reading
+// the token from React state (rather than localStorage on every use) keeps
+// reconnecting with the original, eventually-expired token.
+export const AUTH_TOKEN_REFRESHED_EVENT = 'cloudcli:auth-token-refreshed';
+
+/**
+ * @param {unknown} token
+ */
+export const applyRefreshedToken = (token) => {
+  if (!isValidRefreshedToken(token)) {
+    return;
+  }
+  localStorage.setItem('auth-token', token);
+  window.dispatchEvent(new CustomEvent(AUTH_TOKEN_REFRESHED_EVENT, { detail: token }));
+};
+
 // Utility function for authenticated API calls
 export const authenticatedFetch = (url, options = {}) => {
   const token = localStorage.getItem('auth-token');
@@ -33,10 +52,7 @@ export const authenticatedFetch = (url, options = {}) => {
       ...options.headers,
     },
   }).then((response) => {
-    const refreshedToken = response.headers.get('X-Refreshed-Token');
-    if (isValidRefreshedToken(refreshedToken)) {
-      localStorage.setItem('auth-token', refreshedToken);
-    }
+    applyRefreshedToken(response.headers.get('X-Refreshed-Token'));
     return response;
   });
 };

--- a/src/utils/jwt.test.ts
+++ b/src/utils/jwt.test.ts
@@ -39,6 +39,15 @@ test('isTokenExpired: a token missing the exp claim is treated as expired', () =
   assert.equal(isTokenExpired(token), true);
 });
 
+test('isTokenExpired: a non-finite exp claim (e.g. 1e309 parses to Infinity) is treated as expired', () => {
+  // JSON.stringify(Infinity) collapses to "null", which wouldn't reproduce this
+  // case — the payload segment has to contain the raw "1e309" numeric literal,
+  // matching how a malformed/adversarial token would actually be shaped.
+  const encode = (value: string) => Buffer.from(value).toString('base64url');
+  const token = `${encode('{"alg":"HS256"}')}.${encode('{"exp":1e309}')}.signature`;
+  assert.equal(isTokenExpired(token), true);
+});
+
 test('isTokenExpired: a malformed token (unreadable payload) is treated as expired', () => {
   assert.equal(isTokenExpired('not-a-jwt'), true);
   assert.equal(isTokenExpired('only.two-segments'), true);

--- a/src/utils/jwt.test.ts
+++ b/src/utils/jwt.test.ts
@@ -1,0 +1,50 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { isTokenExpired, TOKEN_EXPIRY_SKEW_MS } from './jwt';
+
+// Builds a JWT-shaped string (header.payload.signature, base64url segments) without
+// needing a real signing library — isTokenExpired() never verifies the signature,
+// it only decodes the payload, so the header/signature segments are placeholders.
+const makeToken = (payload: unknown) => {
+  const encode = (value: unknown) =>
+    Buffer.from(JSON.stringify(value)).toString('base64url');
+  return `${encode({ alg: 'HS256', typ: 'JWT' })}.${encode(payload)}.signature`;
+};
+
+test('isTokenExpired: a token with a future exp is not expired', () => {
+  const token = makeToken({ exp: Math.floor(Date.now() / 1000) + 600 }); // 10 min from now
+  assert.equal(isTokenExpired(token), false);
+});
+
+test('isTokenExpired: a token expired well past the skew tolerance is expired', () => {
+  const token = makeToken({ exp: Math.floor(Date.now() / 1000) - 600 }); // 10 min ago
+  assert.equal(isTokenExpired(token), true);
+});
+
+test('isTokenExpired: a token expired within the clock-skew tolerance is not treated as expired', () => {
+  const skewSeconds = TOKEN_EXPIRY_SKEW_MS / 1000;
+  const token = makeToken({ exp: Math.floor(Date.now() / 1000) - Math.floor(skewSeconds / 2) });
+  assert.equal(isTokenExpired(token), false);
+});
+
+test('isTokenExpired: a token expired just past the clock-skew tolerance is expired', () => {
+  const skewSeconds = TOKEN_EXPIRY_SKEW_MS / 1000;
+  const token = makeToken({ exp: Math.floor(Date.now() / 1000) - skewSeconds - 5 });
+  assert.equal(isTokenExpired(token), true);
+});
+
+test('isTokenExpired: a token missing the exp claim is treated as expired', () => {
+  const token = makeToken({ userId: 1, username: 'someone' });
+  assert.equal(isTokenExpired(token), true);
+});
+
+test('isTokenExpired: a malformed token (unreadable payload) is treated as expired', () => {
+  assert.equal(isTokenExpired('not-a-jwt'), true);
+  assert.equal(isTokenExpired('only.two-segments'), true);
+  assert.equal(isTokenExpired('header.not-valid-base64url-json.sig'), true);
+});
+
+test('isTokenExpired: a null token is treated as expired', () => {
+  assert.equal(isTokenExpired(null), true);
+});

--- a/src/utils/jwt.ts
+++ b/src/utils/jwt.ts
@@ -21,7 +21,11 @@ export const isTokenExpired = (token: string | null): boolean => {
     const normalized = payloadSegment.replace(/-/g, '+').replace(/_/g, '/');
     const padded = normalized.padEnd(normalized.length + ((4 - (normalized.length % 4)) % 4), '=');
     const payload = JSON.parse(atob(padded)) as { exp?: number };
-    return typeof payload.exp !== 'number' || Date.now() >= payload.exp * 1000 + TOKEN_EXPIRY_SKEW_MS;
+    const { exp } = payload;
+    // Number.isFinite on top of typeof — `typeof Infinity === 'number'` is true
+    // in JS, so a malformed exp like 1e309 (parses to Infinity) would otherwise
+    // pass this check and never be treated as expired.
+    return typeof exp !== 'number' || !Number.isFinite(exp) || Date.now() >= exp * 1000 + TOKEN_EXPIRY_SKEW_MS;
   } catch {
     // Unreadable token shape — treat as expired rather than retrying forever.
     return true;

--- a/src/utils/jwt.ts
+++ b/src/utils/jwt.ts
@@ -1,0 +1,29 @@
+// Tolerance for client/server clock skew. This check only decides whether to
+// keep retrying a WS reconnect — the server's own `jwt.verify` (which has no
+// skew allowance) is the real authority. Without this, a client clock running
+// even slightly ahead of the server could read a still-server-valid token as
+// expired and force an unwanted logout on a plain WS close.
+export const TOKEN_EXPIRY_SKEW_MS = 60_000;
+
+/**
+ * Reads the `exp` claim out of a JWT without verifying its signature — this
+ * only needs to detect "this token cannot possibly still be valid" so a
+ * reconnect loop can stop, not to authenticate anything. The server remains
+ * the sole source of truth for verification.
+ */
+export const isTokenExpired = (token: string | null): boolean => {
+  if (!token) return true;
+
+  const payloadSegment = token.split('.')[1];
+  if (!payloadSegment) return true;
+
+  try {
+    const normalized = payloadSegment.replace(/-/g, '+').replace(/_/g, '/');
+    const padded = normalized.padEnd(normalized.length + ((4 - (normalized.length % 4)) % 4), '=');
+    const payload = JSON.parse(atob(padded)) as { exp?: number };
+    return typeof payload.exp !== 'number' || Date.now() >= payload.exp * 1000 + TOKEN_EXPIRY_SKEW_MS;
+  } catch {
+    // Unreadable token shape — treat as expired rather than retrying forever.
+    return true;
+  }
+};


### PR DESCRIPTION
## Problem

Users who leave a CloudCLI tab open with an active WebSocket (and/or SSE) connection eventually
see a flood of failed reconnect attempts once their session JWT expires — even though the tab
was never actively closed. Closes #754.

## Root cause

Two independent gaps, not one:

1. The server only refreshes a token (`X-Refreshed-Token` response header, in
   `server/middleware/auth.js`) in response to an HTTP request made past the token's half-life.
   A tab with just an open WebSocket and no other user-triggered HTTP calls never sends one, so
   the token silently goes stale until the WS has to reconnect — at which point it's already
   expired.
2. Background refreshes (via `X-Refreshed-Token`) only ever updated `localStorage`.
   `AuthContext`'s in-memory `token` state — which `WebSocketContext` reads to build its
   reconnect URL — was never resynced, so even a tab that *did* get a fresh token via an HTTP
   call kept reconnecting its WebSocket with the original, now-stale token. This also explains a
   symptom some users report as "one tab authenticated, another not": each tab's WS reconnect
   logic was pinned to whatever token happened to be in memory at that tab's last mount.

On top of that, once the token genuinely expired, the WebSocket reconnect loop retried every 3s
forever against a token that could never succeed, which is what produces the failure flood.

## Fix

- `AuthContext` proactively pings an authenticated endpoint (`/api/auth/user` — no new endpoint
  needed, it already triggers the server's existing half-life refresh logic) on an hourly
  interval and on tab visibility change, so idle-but-open tabs stay refreshed without depending
  on user activity.
- `api.js`'s refreshed-token handling now also dispatches a `window` event so `AuthContext`'s
  `token` state stays in sync with `localStorage` instead of going stale after the initial
  mount.
- `WebSocketContext` stops its reconnect loop and drops the session (instead of retrying every
  3s forever) once the token it holds is actually expired — with a 60s clock-skew allowance, so
  a client clock running slightly ahead of the server doesn't trigger a false-positive logout.
  `LoginForm` surfaces a "session expired" message for this case instead of a silent redirect.

## Testing

Verified against a live isolated instance of this server (separate DB/port, real JWT secret):
confirmed `X-Refreshed-Token` only appears on requests past the token's half-life as expected,
and that the WS handshake accepts a valid-but-past-half-life token but rejects a genuinely
expired one — matching what the new client-side expiry check assumes. `npm run typecheck`,
`npm run lint`, and `npm run build` all pass clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added session-expired handling to authentication, including a “session expired” login message and acknowledgement support.
  * Improved token refresh synchronization across the app and tabs, with proactive background checks.
* **Bug Fixes**
  * Prevented endless WebSocket reconnect loops when the session token is expired.
  * Ensured file-tree uploads apply refreshed tokens consistently.
  * Centralized refreshed-token validation and persistence.
* **Tests**
  * Added unit tests for JWT expiry detection, including skew and malformed-token cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->