### PR TITLE
Support Codex custom provider authentication

### DIFF
--- a/server/modules/providers/list/codex/codex-auth.provider.ts
+++ b/server/modules/providers/list/codex/codex-auth.provider.ts
@@ -1,19 +1,9 @@
-import { readFile } from 'node:fs/promises';
-import os from 'node:os';
-import path from 'node:path';
-
 import spawn from 'cross-spawn';
 
 import type { IProviderAuth } from '@/shared/interfaces.js';
 import type { ProviderAuthStatus } from '@/shared/types.js';
-import { readObjectRecord, readOptionalString } from '@/shared/utils.js';
 
-type CodexCredentialsStatus = {
-  authenticated: boolean;
-  email: string | null;
-  method: string | null;
-  error?: string;
-};
+import { resolveCodexCredentials } from './codex-credentials.js';
 
 export class CodexProviderAuth implements IProviderAuth {
   /**
@@ -33,7 +23,7 @@ export class CodexProviderAuth implements IProviderAuth {
    */
   async getStatus(): Promise<ProviderAuthStatus> {
     const installed = this.checkInstalled();
-    const credentials = await this.checkCredentials();
+    const credentials = await resolveCodexCredentials();
 
     return {
       installed,
@@ -43,58 +33,5 @@ export class CodexProviderAuth implements IProviderAuth {
       method: credentials.method,
       error: credentials.authenticated ? undefined : credentials.error || 'Not authenticated',
     };
-  }
-
-  /**
-   * Reads Codex auth.json and checks OAuth tokens or an API key fallback.
-   */
-  private async checkCredentials(): Promise<CodexCredentialsStatus> {
-    try {
-      const authPath = path.join(os.homedir(), '.codex', 'auth.json');
-      const content = await readFile(authPath, 'utf8');
-      const auth = readObjectRecord(JSON.parse(content)) ?? {};
-      const tokens = readObjectRecord(auth.tokens) ?? {};
-      const idToken = readOptionalString(tokens.id_token);
-      const accessToken = readOptionalString(tokens.access_token);
-
-      if (idToken || accessToken) {
-        return {
-          authenticated: true,
-          email: idToken ? this.readEmailFromIdToken(idToken) : 'Authenticated',
-          method: 'credentials_file',
-        };
-      }
-
-      if (readOptionalString(auth.OPENAI_API_KEY)) {
-        return { authenticated: true, email: 'API Key Auth', method: 'api_key' };
-      }
-
-      return { authenticated: false, email: null, method: null, error: 'No valid tokens found' };
-    } catch (error) {
-      const code = (error as NodeJS.ErrnoException).code;
-      return {
-        authenticated: false,
-        email: null,
-        method: null,
-        error: code === 'ENOENT' ? 'Codex not configured' : error instanceof Error ? error.message : 'Failed to read Codex auth',
-      };
-    }
-  }
-
-  /**
-   * Extracts the user email from a Codex id_token when a readable JWT payload exists.
-   */
-  private readEmailFromIdToken(idToken: string): string {
-    try {
-      const parts = idToken.split('.');
-      if (parts.length >= 2) {
-        const payload = readObjectRecord(JSON.parse(Buffer.from(parts[1], 'base64url').toString('utf8')));
-        return readOptionalString(payload?.email) ?? readOptionalString(payload?.user) ?? 'Authenticated';
-      }
-    } catch {
-      // Fall back to a generic authenticated marker if the token payload is not readable.
-    }
-
-    return 'Authenticated';
   }
 }

--- a/server/modules/providers/list/codex/codex-credentials.ts
+++ b/server/modules/providers/list/codex/codex-credentials.ts
@@ -1,0 +1,222 @@
+import { readFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+import TOML from '@iarna/toml';
+
+import { readObjectRecord, readOptionalString } from '@/shared/utils.js';
+
+export type CodexCredentialsStatus = {
+  authenticated: boolean;
+  email: string | null;
+  method: string | null;
+  error?: string;
+  env?: Record<string, string>;
+};
+
+type EnvFile = Record<string, string>;
+
+const resolveCodexHome = (): string => (
+  readOptionalString(process.env.CODEX_HOME) ?? path.join(os.homedir(), '.codex')
+);
+
+const parseEnvLine = (rawLine: string): [string, string] | null => {
+  const trimmedLine = rawLine.trim();
+  if (!trimmedLine || trimmedLine.startsWith('#')) {
+    return null;
+  }
+
+  const line = trimmedLine.startsWith('export ')
+    ? trimmedLine.slice('export '.length).trimStart()
+    : trimmedLine;
+  const separatorIndex = line.indexOf('=');
+  if (separatorIndex <= 0) {
+    return null;
+  }
+
+  const key = line.slice(0, separatorIndex).trim();
+  let value = line.slice(separatorIndex + 1).trim();
+  if (
+    (value.startsWith('"') && value.endsWith('"'))
+    || (value.startsWith("'") && value.endsWith("'"))
+  ) {
+    value = value.slice(1, -1);
+  }
+
+  return key ? [key, value] : null;
+};
+
+const readEnvFile = async (envPath: string): Promise<EnvFile> => {
+  const content = await readFile(envPath, 'utf8');
+  const values: EnvFile = {};
+
+  for (const line of content.split('\n')) {
+    const entry = parseEnvLine(line);
+    if (entry) {
+      values[entry[0]] = entry[1];
+    }
+  }
+
+  return values;
+};
+
+const readEmailFromIdToken = (idToken: string): string => {
+  try {
+    const parts = idToken.split('.');
+    if (parts.length >= 2) {
+      const payload = readObjectRecord(JSON.parse(Buffer.from(parts[1], 'base64url').toString('utf8')));
+      return readOptionalString(payload?.email) ?? readOptionalString(payload?.user) ?? 'Authenticated';
+    }
+  } catch {
+    // Fall back to a generic authenticated marker if the token payload is not readable.
+  }
+
+  return 'Authenticated';
+};
+
+const readOfficialCredentials = async (codexHome: string): Promise<CodexCredentialsStatus | null> => {
+  try {
+    const authPath = path.join(codexHome, 'auth.json');
+    const content = await readFile(authPath, 'utf8');
+    const auth = readObjectRecord(JSON.parse(content)) ?? {};
+    const tokens = readObjectRecord(auth.tokens) ?? {};
+    const idToken = readOptionalString(tokens.id_token);
+    const accessToken = readOptionalString(tokens.access_token);
+
+    if (idToken || accessToken) {
+      return {
+        authenticated: true,
+        email: idToken ? readEmailFromIdToken(idToken) : 'Authenticated',
+        method: 'credentials_file',
+      };
+    }
+
+    if (readOptionalString(auth.OPENAI_API_KEY)) {
+      return { authenticated: true, email: 'API Key Auth', method: 'api_key' };
+    }
+
+    return { authenticated: false, email: null, method: null, error: 'No valid tokens found' };
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (code === 'ENOENT') {
+      return null;
+    }
+
+    return {
+      authenticated: false,
+      email: null,
+      method: null,
+      error: error instanceof Error ? error.message : 'Failed to read Codex auth',
+    };
+  }
+};
+
+const readCustomProviderCredentials = async (codexHome: string): Promise<CodexCredentialsStatus> => {
+  let config: Record<string, unknown>;
+  try {
+    const rawConfig = await readFile(path.join(codexHome, 'config.toml'), 'utf8');
+    config = readObjectRecord(TOML.parse(rawConfig)) ?? {};
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    return {
+      authenticated: false,
+      email: null,
+      method: null,
+      error: code === 'ENOENT' ? 'Codex not configured' : error instanceof Error ? error.message : 'Failed to read Codex config',
+    };
+  }
+
+  const providerName = readOptionalString(config.model_provider);
+  if (!providerName) {
+    return { authenticated: false, email: null, method: null, error: 'Codex model_provider missing' };
+  }
+
+  const providers = readObjectRecord(config.model_providers) ?? {};
+  const provider = readObjectRecord(providers[providerName]);
+  const envKey = readOptionalString(provider?.env_key);
+  if (!envKey) {
+    return {
+      authenticated: false,
+      email: null,
+      method: null,
+      error: `Codex provider ${providerName} env_key missing`,
+    };
+  }
+
+  const processEnvValue = readOptionalString(process.env[envKey]);
+  if (processEnvValue) {
+    return {
+      authenticated: true,
+      email: `${providerName} custom provider`,
+      method: 'custom_provider_env',
+      env: { [envKey]: processEnvValue },
+    };
+  }
+
+  try {
+    const envFile = await readEnvFile(path.join(codexHome, '.env'));
+    const envFileValue = readOptionalString(envFile[envKey]);
+    if (envFileValue) {
+      return {
+        authenticated: true,
+        email: `${providerName} custom provider`,
+        method: 'custom_provider_env_file',
+        env: { [envKey]: envFileValue },
+      };
+    }
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (code !== 'ENOENT') {
+      return {
+        authenticated: false,
+        email: null,
+        method: null,
+        error: error instanceof Error ? error.message : 'Failed to read Codex .env',
+      };
+    }
+  }
+
+  return {
+    authenticated: false,
+    email: null,
+    method: null,
+    error: `Codex provider credential ${envKey} missing`,
+  };
+};
+
+export async function resolveCodexCredentials(): Promise<CodexCredentialsStatus> {
+  const codexHome = resolveCodexHome();
+  const officialCredentials = await readOfficialCredentials(codexHome);
+  if (officialCredentials?.authenticated) {
+    return officialCredentials;
+  }
+
+  const customProviderCredentials = await readCustomProviderCredentials(codexHome);
+  if (customProviderCredentials.authenticated) {
+    return customProviderCredentials;
+  }
+
+  if (customProviderCredentials.error !== 'Codex not configured') {
+    return customProviderCredentials;
+  }
+
+  return officialCredentials ?? customProviderCredentials;
+}
+
+export function buildCodexCliEnvironment(credentials: CodexCredentialsStatus): Record<string, string> | undefined {
+  if (!credentials.env || Object.keys(credentials.env).length === 0) {
+    return undefined;
+  }
+
+  const env: Record<string, string> = {};
+  for (const [key, value] of Object.entries(process.env)) {
+    if (value !== undefined) {
+      env[key] = value;
+    }
+  }
+
+  return {
+    ...env,
+    ...credentials.env,
+  };
+}

--- a/server/modules/providers/tests/codex-credentials.test.ts
+++ b/server/modules/providers/tests/codex-credentials.test.ts
@@ -1,0 +1,126 @@
+import assert from 'node:assert/strict';
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+
+import {
+  buildCodexCliEnvironment,
+  resolveCodexCredentials,
+} from '@/modules/providers/list/codex/codex-credentials.js';
+
+const TEST_ENV_KEY = 'CLOUDCLI_CODEX_TEST_API_KEY';
+
+const withCodexHome = async (runTest: (codexHome: string) => Promise<void>): Promise<void> => {
+  const previousCodexHome = process.env.CODEX_HOME;
+  const previousTestEnvValue = process.env[TEST_ENV_KEY];
+  const tempRoot = await mkdtemp(path.join(os.tmpdir(), 'codex-credentials-'));
+
+  process.env.CODEX_HOME = tempRoot;
+  delete process.env[TEST_ENV_KEY];
+
+  try {
+    await runTest(tempRoot);
+  } finally {
+    if (previousCodexHome === undefined) {
+      delete process.env.CODEX_HOME;
+    } else {
+      process.env.CODEX_HOME = previousCodexHome;
+    }
+
+    if (previousTestEnvValue === undefined) {
+      delete process.env[TEST_ENV_KEY];
+    } else {
+      process.env[TEST_ENV_KEY] = previousTestEnvValue;
+    }
+
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+};
+
+const writeCustomProviderConfig = async (codexHome: string): Promise<void> => {
+  await mkdir(codexHome, { recursive: true });
+  await writeFile(
+    path.join(codexHome, 'config.toml'),
+    [
+      'model = "custom-model"',
+      'model_provider = "custom_provider"',
+      '',
+      '[model_providers.custom_provider]',
+      'name = "Custom Provider"',
+      'base_url = "https://example.com/v1"',
+      `env_key = "${TEST_ENV_KEY}"`,
+      'wire_api = "responses"',
+      '',
+    ].join('\n'),
+    'utf8',
+  );
+};
+
+test('Codex credentials resolver preserves official auth.json API key login', { concurrency: false }, async () => {
+  await withCodexHome(async (codexHome) => {
+    await writeFile(
+      path.join(codexHome, 'auth.json'),
+      JSON.stringify({ OPENAI_API_KEY: 'official-key' }),
+      'utf8',
+    );
+
+    const credentials = await resolveCodexCredentials();
+
+    assert.equal(credentials.authenticated, true);
+    assert.equal(credentials.method, 'api_key');
+    assert.equal(credentials.email, 'API Key Auth');
+    assert.equal(credentials.env, undefined);
+  });
+});
+
+test('Codex credentials resolver recognizes custom provider credentials from process env', { concurrency: false }, async () => {
+  await withCodexHome(async (codexHome) => {
+    await writeCustomProviderConfig(codexHome);
+    process.env[TEST_ENV_KEY] = 'process-secret';
+
+    const credentials = await resolveCodexCredentials();
+
+    assert.equal(credentials.authenticated, true);
+    assert.equal(credentials.method, 'custom_provider_env');
+    assert.equal(credentials.email, 'custom_provider custom provider');
+    assert.deepEqual(credentials.env, { [TEST_ENV_KEY]: 'process-secret' });
+  });
+});
+
+test('Codex credentials resolver reads custom provider credentials from CODEX_HOME .env', { concurrency: false }, async () => {
+  await withCodexHome(async (codexHome) => {
+    await writeCustomProviderConfig(codexHome);
+    await writeFile(
+      path.join(codexHome, '.env'),
+      [
+        '# unrelated values should be ignored',
+        'OTHER_KEY=unused',
+        `export ${TEST_ENV_KEY}="env-file-secret"`,
+        '',
+      ].join('\n'),
+      'utf8',
+    );
+
+    const credentials = await resolveCodexCredentials();
+    const cliEnvironment = buildCodexCliEnvironment(credentials);
+
+    assert.equal(credentials.authenticated, true);
+    assert.equal(credentials.method, 'custom_provider_env_file');
+    assert.deepEqual(credentials.env, { [TEST_ENV_KEY]: 'env-file-secret' });
+    assert.equal(process.env[TEST_ENV_KEY], undefined);
+    assert.equal(cliEnvironment?.[TEST_ENV_KEY], 'env-file-secret');
+  });
+});
+
+test('Codex credentials resolver reports missing custom provider env key value', { concurrency: false }, async () => {
+  await withCodexHome(async (codexHome) => {
+    await writeCustomProviderConfig(codexHome);
+
+    const credentials = await resolveCodexCredentials();
+
+    assert.equal(credentials.authenticated, false);
+    assert.equal(credentials.method, null);
+    assert.equal(credentials.error, `Codex provider credential ${TEST_ENV_KEY} missing`);
+  });
+});

--- a/server/openai-codex.js
+++ b/server/openai-codex.js
@@ -20,6 +20,7 @@ import { notifyRunFailed, notifyRunStopped } from './services/notification-orche
 import { sessionsService } from './modules/providers/services/sessions.service.js';
 import { providerAuthService } from './modules/providers/services/provider-auth.service.js';
 import { providerModelsService } from './modules/providers/services/provider-models.service.js';
+import { buildCodexCliEnvironment, resolveCodexCredentials } from './modules/providers/list/codex/codex-credentials.js';
 import { createCompleteMessage, createNormalizedMessage } from './shared/utils.js';
 
 const activeCodexSessions = new Map();
@@ -257,7 +258,9 @@ export async function queryCodex(command, options = {}, ws) {
   const abortController = new AbortController();
 
   try {
-    codex = new Codex();
+    const codexCredentials = await resolveCodexCredentials();
+    const codexEnvironment = buildCodexCliEnvironment(codexCredentials);
+    codex = codexEnvironment ? new Codex({ env: codexEnvironment }) : new Codex();
 
     const threadOptions = {
       workingDirectory,


### PR DESCRIPTION
## Summary

- Add a shared Codex credential resolver that preserves existing `auth.json` OAuth/API-key behavior.
- Recognize Codex custom providers configured in `config.toml` via `model_provider` and provider `env_key`.
- Resolve the provider credential from the CloudCLI process environment first, then from `CODEX_HOME/.env`, and pass it only to the Codex CLI environment for execution.
- Use the same resolver for Codex auth status and Codex SDK execution.

## Tests

- `npm run typecheck`
- `npm run build:server && node --test dist-server/server/modules/providers/tests/codex-credentials.test.js`
- `npx eslint server/modules/providers/list/codex/codex-auth.provider.ts server/modules/providers/list/codex/codex-credentials.ts server/modules/providers/tests/codex-credentials.test.ts server/openai-codex.js`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved Codex authentication detection, including support for official credentials and custom providers.
  * Added support for credentials from environment variables and Codex `.env` files.
  * Codex CLI requests now use detected credentials automatically when available.
  * Added clearer authentication status and error reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->