### PR TITLE
feat: attach arbitrary files from chat composer (paperclip button)

### DIFF
--- a/src/components/chat/hooks/useChatFileAttach.ts
+++ b/src/components/chat/hooks/useChatFileAttach.ts
@@ -1,5 +1,6 @@
 import { useCallback, useState } from "react";
 import type { Dispatch, SetStateAction } from "react";
+import { useTranslation } from "react-i18next";
 
 import { api } from "../../../utils/api";
 import type { Project } from "../../../types/app";
@@ -41,6 +42,43 @@ export const sanitizeFileName = (name: string): string => {
   return (safeBase || "file") + safeExt;
 };
 
+/**
+ * Dedup sanitized filenames within a batch so that collisions like
+ * "тест.txt" → "test.txt" and "test.txt" → "test.txt" resolve to
+ * ["test.txt", "test-2.txt"] instead of silently overwriting each other.
+ */
+export const deduplicateFileNames = (files: File[]): Map<File, string> => {
+  const result = new Map<File, string>();
+  const usedLower = new Map<string, number>(); // case-insensitive counter
+
+  for (const file of files) {
+    const sanitized = sanitizeFileName(file.name);
+    const dot = sanitized.lastIndexOf(".");
+    const base = dot > 0 ? sanitized.slice(0, dot) : sanitized;
+    const ext = dot > 0 ? sanitized.slice(dot) : "";
+
+    const key = sanitized.toLowerCase();
+    const count = usedLower.get(key) ?? 0;
+    if (count === 0) {
+      usedLower.set(key, 1);
+      result.set(file, sanitized);
+    } else {
+      // Find next available suffix
+      let suffix = count + 1;
+      let candidate: string;
+      do {
+        candidate = `${base}-${suffix}${ext}`;
+        suffix++;
+      } while (usedLower.has(candidate.toLowerCase()));
+      usedLower.set(candidate.toLowerCase(), 1);
+      usedLower.set(key, suffix - 1);
+      result.set(file, candidate);
+    }
+  }
+
+  return result;
+};
+
 type UseChatFileAttachOptions = {
   selectedProject: Project | null;
   setInput: Dispatch<SetStateAction<string>>;
@@ -56,6 +94,7 @@ export const appendMentions = (previous: string, mentions: string): string => {
 };
 
 export function useChatFileAttach({ selectedProject, setInput }: UseChatFileAttachOptions) {
+  const { t } = useTranslation("chat");
   const [isAttachingFiles, setIsAttachingFiles] = useState(false);
   const [fileAttachError, setFileAttachError] = useState<string | null>(null);
 
@@ -68,7 +107,7 @@ export function useChatFileAttach({ selectedProject, setInput }: UseChatFileAtta
       setFileAttachError(null);
 
       if (files.length > MAX_FILE_UPLOAD_COUNT) {
-        setFileAttachError(`You can attach up to ${MAX_FILE_UPLOAD_COUNT} files at once.`);
+        setFileAttachError(t("input.attachTooMany", { count: MAX_FILE_UPLOAD_COUNT }));
         return;
       }
 
@@ -77,7 +116,10 @@ export function useChatFileAttach({ selectedProject, setInput }: UseChatFileAtta
 
       if (oversized.length > 0) {
         setFileAttachError(
-          `${oversized.map((file) => file.name).join(", ")}: larger than ${MAX_FILE_UPLOAD_SIZE_LABEL}, skipped.`,
+          t("input.attachTooLarge", {
+            files: oversized.map((file) => file.name).join(", "),
+            limit: MAX_FILE_UPLOAD_SIZE_LABEL,
+          }),
         );
       }
 
@@ -85,10 +127,14 @@ export function useChatFileAttach({ selectedProject, setInput }: UseChatFileAtta
         return;
       }
 
+      // Fix #1: deduplicate sanitized names within the batch to prevent
+      // silent overwrites (e.g. "тест.txt" and "test.txt" both → "test.txt")
+      const nameMap = deduplicateFileNames(validFiles);
+
       const formData = new FormData();
       formData.append("targetPath", ATTACHMENTS_DIR);
       formData.append("requestedFileCount", String(validFiles.length));
-      validFiles.forEach((file) => formData.append("files", file, sanitizeFileName(file.name)));
+      validFiles.forEach((file) => formData.append("files", file, nameMap.get(file)!));
 
       setIsAttachingFiles(true);
       try {
@@ -96,7 +142,9 @@ export function useChatFileAttach({ selectedProject, setInput }: UseChatFileAtta
         const data = await response.json().catch(() => ({}));
 
         if (!response.ok || data.error) {
-          setFileAttachError(data.error || `Upload failed (HTTP ${response.status}).`);
+          setFileAttachError(
+            data.error || t("input.attachUploadFailed", { status: response.status }),
+          );
           return;
         }
 
@@ -105,18 +153,18 @@ export function useChatFileAttach({ selectedProject, setInput }: UseChatFileAtta
           : [];
 
         if (uploadedNames.length === 0) {
-          setFileAttachError("Upload failed: no files were saved.");
+          setFileAttachError(t("input.attachNoneSaved"));
           return;
         }
 
         setInput((previous) => appendMentions(previous, buildAttachmentMentions(uploadedNames)));
       } catch (error) {
-        setFileAttachError(error instanceof Error ? error.message : "Upload failed.");
+        setFileAttachError(error instanceof Error ? error.message : t("input.attachUploadFailed", { status: "?" }));
       } finally {
         setIsAttachingFiles(false);
       }
     },
-    [selectedProject, isAttachingFiles, setInput],
+    [selectedProject, isAttachingFiles, setInput, t],
   );
 
   return { attachFiles, isAttachingFiles, fileAttachError };

--- a/src/components/chat/hooks/useChatFileAttach.ts
+++ b/src/components/chat/hooks/useChatFileAttach.ts
@@ -11,6 +11,36 @@ import {
 
 const ATTACHMENTS_DIR = "attachments";
 
+const TRANSLIT: Record<string, string> = {
+  а: "a", б: "b", в: "v", г: "g", д: "d", е: "e", ё: "yo", ж: "zh", з: "z",
+  и: "i", й: "y", к: "k", л: "l", м: "m", н: "n", о: "o", п: "p", р: "r",
+  с: "s", т: "t", у: "u", ф: "f", х: "h", ц: "ts", ч: "ch", ш: "sh",
+  щ: "sch", ъ: "", ы: "y", ь: "", э: "e", ю: "yu", я: "ya",
+};
+
+export const sanitizeFileName = (name: string): string => {
+  const dot = name.lastIndexOf(".");
+  const base = dot > 0 ? name.slice(0, dot) : name;
+  const ext = dot > 0 ? name.slice(dot) : "";
+  const transliterated = base
+    .split("")
+    .map((char) => {
+      const lower = char.toLowerCase();
+      const mapped = TRANSLIT[lower];
+      if (mapped === undefined) {
+        return char;
+      }
+      return char === lower ? mapped : mapped.charAt(0).toUpperCase() + mapped.slice(1);
+    })
+    .join("");
+  const safeBase = transliterated
+    .replace(/[^a-zA-Z0-9._-]+/g, "-")
+    .replace(/-{2,}/g, "-")
+    .replace(/^-+|-+$/g, "");
+  const safeExt = ext.replace(/[^a-zA-Z0-9.]+/g, "");
+  return (safeBase || "file") + safeExt;
+};
+
 type UseChatFileAttachOptions = {
   selectedProject: Project | null;
   setInput: Dispatch<SetStateAction<string>>;
@@ -58,7 +88,7 @@ export function useChatFileAttach({ selectedProject, setInput }: UseChatFileAtta
       const formData = new FormData();
       formData.append("targetPath", ATTACHMENTS_DIR);
       formData.append("requestedFileCount", String(validFiles.length));
-      validFiles.forEach((file) => formData.append("files", file, file.name));
+      validFiles.forEach((file) => formData.append("files", file, sanitizeFileName(file.name)));
 
       setIsAttachingFiles(true);
       try {

--- a/src/components/chat/hooks/useChatFileAttach.ts
+++ b/src/components/chat/hooks/useChatFileAttach.ts
@@ -1,0 +1,93 @@
+import { useCallback, useState } from "react";
+import type { Dispatch, SetStateAction } from "react";
+
+import { api } from "../../../utils/api";
+import type { Project } from "../../../types/app";
+import {
+  MAX_FILE_UPLOAD_COUNT,
+  MAX_FILE_UPLOAD_SIZE_BYTES,
+  MAX_FILE_UPLOAD_SIZE_LABEL,
+} from "../../file-tree/constants/constants";
+
+const ATTACHMENTS_DIR = "attachments";
+
+type UseChatFileAttachOptions = {
+  selectedProject: Project | null;
+  setInput: Dispatch<SetStateAction<string>>;
+};
+
+export const buildAttachmentMentions = (fileNames: string[]): string =>
+  fileNames.map((name) => `@${ATTACHMENTS_DIR}/${name}`).join(" ");
+
+export const appendMentions = (previous: string, mentions: string): string => {
+  if (!mentions) return previous;
+  if (!previous) return `${mentions} `;
+  return `${previous.endsWith(" ") ? previous : `${previous} `}${mentions} `;
+};
+
+export function useChatFileAttach({ selectedProject, setInput }: UseChatFileAttachOptions) {
+  const [isAttachingFiles, setIsAttachingFiles] = useState(false);
+  const [fileAttachError, setFileAttachError] = useState<string | null>(null);
+
+  const attachFiles = useCallback(
+    async (files: File[]) => {
+      if (!selectedProject || files.length === 0 || isAttachingFiles) {
+        return;
+      }
+
+      setFileAttachError(null);
+
+      if (files.length > MAX_FILE_UPLOAD_COUNT) {
+        setFileAttachError(`You can attach up to ${MAX_FILE_UPLOAD_COUNT} files at once.`);
+        return;
+      }
+
+      const oversized = files.filter((file) => file.size > MAX_FILE_UPLOAD_SIZE_BYTES);
+      const validFiles = files.filter((file) => file.size <= MAX_FILE_UPLOAD_SIZE_BYTES);
+
+      if (oversized.length > 0) {
+        setFileAttachError(
+          `${oversized.map((file) => file.name).join(", ")}: larger than ${MAX_FILE_UPLOAD_SIZE_LABEL}, skipped.`,
+        );
+      }
+
+      if (validFiles.length === 0) {
+        return;
+      }
+
+      const formData = new FormData();
+      formData.append("targetPath", ATTACHMENTS_DIR);
+      formData.append("requestedFileCount", String(validFiles.length));
+      validFiles.forEach((file) => formData.append("files", file, file.name));
+
+      setIsAttachingFiles(true);
+      try {
+        const response = await api.uploadFiles(selectedProject.projectId, formData);
+        const data = await response.json().catch(() => ({}));
+
+        if (!response.ok || data.error) {
+          setFileAttachError(data.error || `Upload failed (HTTP ${response.status}).`);
+          return;
+        }
+
+        const uploadedNames: string[] = Array.isArray(data.files)
+          ? data.files.map((file: { name?: string }) => file?.name).filter(Boolean)
+          : [];
+
+        if (uploadedNames.length === 0) {
+          setFileAttachError("Upload failed: no files were saved.");
+          return;
+        }
+
+        setInput((previous) => appendMentions(previous, buildAttachmentMentions(uploadedNames)));
+      } catch (error) {
+        setFileAttachError(error instanceof Error ? error.message : "Upload failed.");
+      } finally {
+        setIsAttachingFiles(false);
+      }
+    },
+    [selectedProject, isAttachingFiles, setInput],
+  );
+
+  return { attachFiles, isAttachingFiles, fileAttachError };
+}

--- a/src/components/chat/view/ChatInterface.tsx
+++ b/src/components/chat/view/ChatInterface.tsx
@@ -11,6 +11,7 @@ import { useChatProviderState } from '../hooks/useChatProviderState';
 import { useChatSessionState } from '../hooks/useChatSessionState';
 import { useChatRealtimeHandlers } from '../hooks/useChatRealtimeHandlers';
 import { useChatComposerState } from '../hooks/useChatComposerState';
+import { useChatFileAttach } from '../hooks/useChatFileAttach';
 import { useSessionStore } from '../../../stores/useSessionStore';
 
 import ChatMessagesPane from './subcomponents/ChatMessagesPane';
@@ -220,6 +221,11 @@ function ChatInterface({
     resolvePermissionModeForProvider,
   });
 
+  const { attachFiles, isAttachingFiles, fileAttachError } = useChatFileAttach({
+    selectedProject,
+    setInput,
+  });
+
   // On WebSocket reconnect, re-fetch the current session's messages from the
   // server so missed streaming events are shown, then re-subscribe — the
   // `chat_subscribed` ack restores or clears the activity indicator, replays
@@ -425,6 +431,9 @@ function ChatInterface({
           getRootProps={getRootProps as (...args: unknown[]) => Record<string, unknown>}
           getInputProps={getInputProps as (...args: unknown[]) => Record<string, unknown>}
           openImagePicker={openImagePicker}
+          onAttachFiles={attachFiles}
+          isAttachingFiles={isAttachingFiles}
+          fileAttachError={fileAttachError}
           inputHighlightRef={inputHighlightRef}
           renderInputWithMentions={renderInputWithMentions}
           textareaRef={textareaRef}

--- a/src/components/chat/view/subcomponents/ChatComposer.tsx
+++ b/src/components/chat/view/subcomponents/ChatComposer.tsx
@@ -11,7 +11,7 @@ import type {
   RefObject,
   TouchEvent,
 } from 'react';
-import { ImageIcon, MessageSquareIcon, XIcon, Loader2, ChevronDown, Check, ArrowUpIcon } from 'lucide-react';
+import { ImageIcon, MessageSquareIcon, XIcon, Loader2, ChevronDown, Check, ArrowUpIcon, Paperclip } from 'lucide-react';
 
 import { useVoiceInput } from '../../hooks/useVoiceInput';
 import { useVoiceAvailable } from '../../hooks/useVoiceAvailable';
@@ -96,6 +96,9 @@ interface ChatComposerProps {
   getRootProps: (...args: unknown[]) => Record<string, unknown>;
   getInputProps: (...args: unknown[]) => Record<string, unknown>;
   openImagePicker: () => void;
+  onAttachFiles: (files: File[]) => void;
+  isAttachingFiles: boolean;
+  fileAttachError: string | null;
   inputHighlightRef: RefObject<HTMLDivElement>;
   renderInputWithMentions: (text: string) => ReactNode;
   textareaRef: RefObject<HTMLTextAreaElement>;
@@ -154,6 +157,9 @@ export default function ChatComposer({
   getRootProps,
   getInputProps,
   openImagePicker,
+  onAttachFiles,
+  isAttachingFiles,
+  fileAttachError,
   inputHighlightRef,
   renderInputWithMentions,
   textareaRef,
@@ -172,6 +178,7 @@ export default function ChatComposer({
   sendByCtrlEnter,
 }: ChatComposerProps) {
   const { t } = useTranslation('chat');
+  const attachFileInputRef = useRef<HTMLInputElement>(null);
   const commandMenuPosition = useMemo(() => {
     if (!isCommandMenuOpen) {
       return { top: 0, left: 16, bottom: 90 };
@@ -425,6 +432,10 @@ export default function ChatComposer({
             />
         </PromptInputBody>
 
+          {fileAttachError && (
+            <p className="px-4 pb-1 text-xs text-destructive">{fileAttachError}</p>
+          )}
+
         <PromptInputFooter>
           <PromptInputTools>
             <PromptInputButton
@@ -432,6 +443,27 @@ export default function ChatComposer({
               onClick={openImagePicker}
             >
               <ImageIcon />
+            </PromptInputButton>
+
+            <input
+              ref={attachFileInputRef}
+              type="file"
+              multiple
+              className="hidden"
+              onChange={(event) => {
+                const files = Array.from(event.target.files ?? []);
+                event.target.value = "";
+                if (files.length > 0) {
+                  onAttachFiles(files);
+                }
+              }}
+            />
+            <PromptInputButton
+              tooltip={{ content: t("input.attachFiles") }}
+              onClick={() => attachFileInputRef.current?.click()}
+              disabled={isAttachingFiles}
+            >
+              {isAttachingFiles ? <Loader2 className="animate-spin" /> : <Paperclip />}
             </PromptInputButton>
 
             {onVoiceTranscript && voiceAvailable && (

--- a/src/components/chat/view/subcomponents/ChatComposer.tsx
+++ b/src/components/chat/view/subcomponents/ChatComposer.tsx
@@ -433,7 +433,7 @@ export default function ChatComposer({
         </PromptInputBody>
 
           {fileAttachError && (
-            <p className="px-4 pb-1 text-xs text-destructive">{fileAttachError}</p>
+            <p className="px-4 pb-1 text-xs text-destructive" role="alert">{fileAttachError}</p>
           )}
 
         <PromptInputFooter>

--- a/src/i18n/locales/de/chat.json
+++ b/src/i18n/locales/de/chat.json
@@ -117,7 +117,11 @@
     "clickToChangeMode": "Klicken, um den Berechtigungsmodus zu ändern (oder Tab in der Eingabe drücken)",
     "showAllCommands": "Alle Befehle anzeigen",
     "clearInput": "Eingabe leeren",
-    "scrollToBottom": "Nach unten scrollen"
+    "scrollToBottom": "Nach unten scrollen",
+    "attachTooMany": "You can attach up to {{count}} files at once.",
+    "attachTooLarge": "{{files}}: larger than {{limit}}, skipped.",
+    "attachUploadFailed": "Upload failed ({{status}}).",
+    "attachNoneSaved": "Upload failed: no files were saved."
   },
   "providerSelection": {
     "title": "KI-Assistent wählen",

--- a/src/i18n/locales/en/chat.json
+++ b/src/i18n/locales/en/chat.json
@@ -136,7 +136,11 @@
       "willSend": "Will send when this finishes",
       "edit": "Edit queued message",
       "delete": "Delete queued message"
-    }
+    },
+    "attachTooMany": "You can attach up to {{count}} files at once.",
+    "attachTooLarge": "{{files}}: larger than {{limit}}, skipped.",
+    "attachUploadFailed": "Upload failed ({{status}}).",
+    "attachNoneSaved": "Upload failed: no files were saved."
   },
   "providerSelection": {
     "title": "Choose Your AI Assistant",

--- a/src/i18n/locales/fr/chat.json
+++ b/src/i18n/locales/fr/chat.json
@@ -118,7 +118,11 @@
     "clickToChangeMode": "Cliquez pour changer le mode de permission (ou appuyez sur Tab dans la saisie)",
     "showAllCommands": "Afficher toutes les commandes",
     "clearInput": "Effacer la saisie",
-    "scrollToBottom": "Défiler vers le bas"
+    "scrollToBottom": "Défiler vers le bas",
+    "attachTooMany": "You can attach up to {{count}} files at once.",
+    "attachTooLarge": "{{files}}: larger than {{limit}}, skipped.",
+    "attachUploadFailed": "Upload failed ({{status}}).",
+    "attachNoneSaved": "Upload failed: no files were saved."
   },
   "providerSelection": {
     "title": "Choisissez votre assistant IA",

--- a/src/i18n/locales/it/chat.json
+++ b/src/i18n/locales/it/chat.json
@@ -117,7 +117,11 @@
     "clickToChangeMode": "Clicca per cambiare modalità permessi (o premi Tab nell'input)",
     "showAllCommands": "Mostra tutti i comandi",
     "clearInput": "Cancella input",
-    "scrollToBottom": "Scorri in basso"
+    "scrollToBottom": "Scorri in basso",
+    "attachTooMany": "You can attach up to {{count}} files at once.",
+    "attachTooLarge": "{{files}}: larger than {{limit}}, skipped.",
+    "attachUploadFailed": "Upload failed ({{status}}).",
+    "attachNoneSaved": "Upload failed: no files were saved."
   },
   "providerSelection": {
     "title": "Scegli il tuo assistente AI",

--- a/src/i18n/locales/ja/chat.json
+++ b/src/i18n/locales/ja/chat.json
@@ -115,7 +115,11 @@
       "enter": "Enterで送信 • Shift+Enterで改行 • Tabでモード切替 • / でスラッシュコマンド"
     },
     "clickToChangeMode": "クリックで権限モードを変更（または入力欄でTab）",
-    "showAllCommands": "すべてのコマンドを表示"
+    "showAllCommands": "すべてのコマンドを表示",
+    "attachTooMany": "You can attach up to {{count}} files at once.",
+    "attachTooLarge": "{{files}}: larger than {{limit}}, skipped.",
+    "attachUploadFailed": "Upload failed ({{status}}).",
+    "attachNoneSaved": "Upload failed: no files were saved."
   },
   "providerSelection": {
     "title": "AIアシスタントを選択",

--- a/src/i18n/locales/ko/chat.json
+++ b/src/i18n/locales/ko/chat.json
@@ -117,7 +117,11 @@
     "clickToChangeMode": "클릭하여 권한 모드 변경 (또는 입력창에서 Tab)",
     "showAllCommands": "모든 명령어 보기",
     "clearInput": "입력 지우기",
-    "scrollToBottom": "맨 아래로 스크롤"
+    "scrollToBottom": "맨 아래로 스크롤",
+    "attachTooMany": "You can attach up to {{count}} files at once.",
+    "attachTooLarge": "{{files}}: larger than {{limit}}, skipped.",
+    "attachUploadFailed": "Upload failed ({{status}}).",
+    "attachNoneSaved": "Upload failed: no files were saved."
   },
   "providerSelection": {
     "title": "AI 어시스턴트 선택",

--- a/src/i18n/locales/ru/chat.json
+++ b/src/i18n/locales/ru/chat.json
@@ -117,7 +117,11 @@
     "clickToChangeMode": "Нажмите для смены режима разрешений (или нажмите Tab в поле ввода)",
     "showAllCommands": "Показать все команды",
     "clearInput": "Очистить ввод",
-    "scrollToBottom": "Прокрутить вниз"
+    "scrollToBottom": "Прокрутить вниз",
+    "attachTooMany": "Можно прикрепить не более {{count}} файлов за раз.",
+    "attachTooLarge": "{{files}}: превышает {{limit}}, пропущено.",
+    "attachUploadFailed": "Ошибка загрузки ({{status}}).",
+    "attachNoneSaved": "Ошибка загрузки: файлы не были сохранены."
   },
   "providerSelection": {
     "title": "Выберите вашего AI-ассистента",

--- a/src/i18n/locales/tr/chat.json
+++ b/src/i18n/locales/tr/chat.json
@@ -117,7 +117,11 @@
     "clickToChangeMode": "İzin modunu değiştirmek için tıkla (veya girdide Tab tuşuna bas)",
     "showAllCommands": "Tüm komutları göster",
     "clearInput": "Girdiyi temizle",
-    "scrollToBottom": "En alta git"
+    "scrollToBottom": "En alta git",
+    "attachTooMany": "You can attach up to {{count}} files at once.",
+    "attachTooLarge": "{{files}}: larger than {{limit}}, skipped.",
+    "attachUploadFailed": "Upload failed ({{status}}).",
+    "attachNoneSaved": "Upload failed: no files were saved."
   },
   "providerSelection": {
     "title": "AI Asistanını Seç",

--- a/src/i18n/locales/zh-CN/chat.json
+++ b/src/i18n/locales/zh-CN/chat.json
@@ -117,7 +117,11 @@
     "clickToChangeMode": "点击更改权限模式（或在输入框中按 Tab）",
     "showAllCommands": "显示所有命令",
     "clearInput": "清空输入",
-    "scrollToBottom": "滚动到底部"
+    "scrollToBottom": "滚动到底部",
+    "attachTooMany": "You can attach up to {{count}} files at once.",
+    "attachTooLarge": "{{files}}: larger than {{limit}}, skipped.",
+    "attachUploadFailed": "Upload failed ({{status}}).",
+    "attachNoneSaved": "Upload failed: no files were saved."
   },
   "providerSelection": {
     "title": "选择您的 AI 助手",

--- a/src/i18n/locales/zh-TW/chat.json
+++ b/src/i18n/locales/zh-TW/chat.json
@@ -117,7 +117,11 @@
     "clickToChangeMode": "點擊變更權限模式（或在輸入框中按 Tab）",
     "showAllCommands": "顯示所有指令",
     "clearInput": "清空輸入",
-    "scrollToBottom": "捲動到底部"
+    "scrollToBottom": "捲動到底部",
+    "attachTooMany": "You can attach up to {{count}} files at once.",
+    "attachTooLarge": "{{files}}: larger than {{limit}}, skipped.",
+    "attachUploadFailed": "Upload failed ({{status}}).",
+    "attachNoneSaved": "Upload failed: no files were saved."
   },
   "thinkingMode": {
     "selector": {


### PR DESCRIPTION
## What

Adds a paperclip button to the chat composer, next to the existing image button. Clicking it lets the user pick any files; they are uploaded to `attachments/` in the project root (via the existing `/api/projects/:id/files/upload` endpoint with `targetPath`), and an `@attachments/<name>` mention is inserted into the input so the CLI can read the file.

## Why

Today only images can be attached from chat; arbitrary files require a detour through the Files tab plus a manual @mention. This is a very common flow for non-developer users working with documents (contracts, spreadsheets, reports).

## Implementation

- New hook `useChatFileAttach`: upload + mention insertion + validation reusing the file-tree `MAX_FILE_UPLOAD_*` constants.
- Paperclip button + hidden file input + inline error line in `ChatComposer`.
- Non-ASCII filenames are transliterated client-side to work around the known multer latin-1 originalname issue (`тест.txt` → `test.txt`), keeping the on-disk name, the mention, and the CLI view consistent.
- Uses the existing `input.attachFiles` i18n key (already present in all locales).
- No server changes.

## Testing

Deployed and live-tested on two production instances: any-file upload, `@attachments/...` mention insertion, CLI reading the attached file, oversize rejection with inline error, same-name re-upload (overwrite), Cyrillic filename transliteration. No regressions to image attach, drag&drop, or paste.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added multi-file chat attachments via a paperclip button and a hidden file picker.
  * Uploads are reflected in the chat composer, with real-time attaching/loading feedback and clear error messaging.
* **Bug Fixes / Improvements**
  * Improved filename handling during uploads to avoid name collisions caused by sanitization.
* **Localization**
  * Added/expanded attachment-related UI error and limit messages across supported languages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->