### PR TITLE
feat(shell): honor Claude skip-permissions setting in the web shell (RFC)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,6 +28,14 @@ HOST=0.0.0.0
 # Uncomment the following line if you have a custom claude cli path other than the default "claude"
 # CLAUDE_CLI_PATH=claude
 
+# Web shell: skip Claude Code permission prompts (SECURITY DOWNGRADE, default off)
+# When enabled, the web shell launches `claude` with --dangerously-skip-permissions,
+# so Claude Code runs tools without asking for approval. Leave this off unless you
+# fully trust the projects served by this instance. Can also be toggled from the UI
+# via Settings > Agents > Permissions > Claude > Skip Permissions (which overrides
+# this default). Accepted truthy values: 1, true, yes, on
+# SHELL_DANGEROUSLY_SKIP_PERMISSIONS=false
+
 # =============================================================================
 # DATABASE CONFIGURATION
 # =============================================================================

--- a/README.md
+++ b/README.md
@@ -163,6 +163,28 @@ To use Claude Code's full functionality, you'll need to manually enable tools:
 
 **Recommended approach**: Start with basic tools enabled and add more as needed. You can always adjust these settings later.
 
+### Web shell: skipping Claude Code permission prompts (opt-in)
+
+By default the web shell launches `claude` normally, so Claude Code still asks
+for approval before running tools. If you fully trust a project and want the web
+shell to skip those prompts, you can opt into launching Claude Code with
+`--dangerously-skip-permissions`. **This is a deliberate security downgrade and is
+off by default** — enable it only for projects you fully control.
+
+There are two ways to turn it on:
+
+- **From the UI** — enable **Skip Permissions** under **Settings → Agents →
+  Permissions → Claude**. This is the same toggle that controls permission
+  bypass in chat, and it now also applies to the web shell. Off by default.
+- **Server-wide (env)** — set `SHELL_DANGEROUSLY_SKIP_PERMISSIONS=true` for the
+  server. This is useful for headless / no-UI deployments. Accepted truthy
+  values: `1`, `true`, `yes`, `on`.
+
+Precedence: an explicit per-session choice from the UI overrides the server
+default. When neither is set, permission prompts stay on. The flag only applies
+to the `claude` provider; other providers (Codex, Cursor, opencode, plain shell)
+are never affected.
+
 ---
 
 ## Plugins

--- a/server/modules/websocket/services/shell-websocket.service.ts
+++ b/server/modules/websocket/services/shell-websocket.service.ts
@@ -19,6 +19,7 @@ type ShellIncomingMessage = {
   initialCommand?: string;
   isPlainShell?: boolean;
   forceRestart?: boolean;
+  dangerouslySkipPermissions?: boolean;
 };
 
 type PtySessionEntry = {
@@ -109,13 +110,58 @@ function resolveResumeSessionId(
   return resolvedSessionId;
 }
 
+const SKIP_PERMISSIONS_ENV_KEY = 'SHELL_DANGEROUSLY_SKIP_PERMISSIONS';
+const SKIP_PERMISSIONS_FLAG = '--dangerously-skip-permissions';
+
+/**
+ * Interprets an environment string as a boolean opt-in. Only the common truthy
+ * spellings enable the flag; anything else (including unset) stays off.
+ */
+function parseBooleanEnv(value: string | undefined): boolean {
+  if (typeof value !== 'string') {
+    return false;
+  }
+
+  const normalized = value.trim().toLowerCase();
+  return normalized === '1' || normalized === 'true' || normalized === 'yes' || normalized === 'on';
+}
+
+/**
+ * Whether the web shell should launch Claude Code with
+ * `--dangerously-skip-permissions`, which bypasses its permission prompts.
+ *
+ * This is a deliberate security downgrade, so it is DEFAULT OFF and must be
+ * opted into explicitly. Precedence: an explicit per-session request from the
+ * client (the settings toggle) wins; otherwise the server-wide
+ * `SHELL_DANGEROUSLY_SKIP_PERMISSIONS` environment default applies. Both default
+ * to off, so the shell behaves exactly as before unless an operator opts in.
+ */
+export function shouldSkipClaudePermissions(
+  message: Pick<ShellIncomingMessage, 'dangerouslySkipPermissions'>,
+  env: NodeJS.ProcessEnv = process.env
+): boolean {
+  if (typeof message.dangerouslySkipPermissions === 'boolean') {
+    return message.dangerouslySkipPermissions;
+  }
+
+  return parseBooleanEnv(readEnvValue(env, SKIP_PERMISSIONS_ENV_KEY));
+}
+
+export type BuildShellCommandOptions = {
+  env?: NodeJS.ProcessEnv;
+  platform?: NodeJS.Platform;
+};
+
 /**
  * Resolves provider command line for plain shell and agent-backed shell modes.
  */
-function buildShellCommand(
+export function buildShellCommand(
   message: ShellIncomingMessage,
-  dependencies: ShellWebSocketDependencies
+  dependencies: ShellWebSocketDependencies,
+  options: BuildShellCommandOptions = {}
 ): string {
+  const env = options.env ?? process.env;
+  const platform = options.platform ?? os.platform();
   const hasSession = readBoolean(message.hasSession);
   const initialCommand = readString(message.initialCommand);
   const provider = readString(message.provider, 'claude');
@@ -138,7 +184,7 @@ function buildShellCommand(
 
   if (provider === 'codex') {
     if (resumeSessionId) {
-      if (os.platform() === 'win32') {
+      if (platform === 'win32') {
         return `codex resume "${resumeSessionId}"; if ($LASTEXITCODE -ne 0) { codex }`;
       }
       return `codex resume "${resumeSessionId}" || codex`;
@@ -153,14 +199,19 @@ function buildShellCommand(
     return initialCommand || 'opencode';
   }
 
-  const command = initialCommand || 'claude';
+  // The claude launcher is the only provider that supports (and defaults off on)
+  // permission-prompt bypass. `claudeBase` is reused across the resume fallback
+  // so both the primary and fallback invocation carry the same flags.
+  const claudeBase = shouldSkipClaudePermissions(message, env)
+    ? `claude ${SKIP_PERMISSIONS_FLAG}`
+    : 'claude';
   if (resumeSessionId) {
-    if (os.platform() === 'win32') {
-      return `claude --resume "${resumeSessionId}"; if ($LASTEXITCODE -ne 0) { claude }`;
+    if (platform === 'win32') {
+      return `${claudeBase} --resume "${resumeSessionId}"; if ($LASTEXITCODE -ne 0) { ${claudeBase} }`;
     }
-    return `claude --resume "${resumeSessionId}" || claude`;
+    return `${claudeBase} --resume "${resumeSessionId}" || ${claudeBase}`;
   }
-  return command;
+  return initialCommand || claudeBase;
 }
 
 function readEnvValue(env: NodeJS.ProcessEnv, key: string): string | undefined {

--- a/server/modules/websocket/tests/shell-websocket-command.test.ts
+++ b/server/modules/websocket/tests/shell-websocket-command.test.ts
@@ -1,0 +1,149 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  buildShellCommand,
+  shouldSkipClaudePermissions,
+} from '@/modules/websocket/services/shell-websocket.service.js';
+
+type Deps = Parameters<typeof buildShellCommand>[1];
+
+// Only resolveProviderSessionId is exercised by buildShellCommand; the rest are
+// output-scanning helpers that this path never calls.
+const deps: Deps = {
+  resolveProviderSessionId: (sessionId: string) => sessionId,
+  stripAnsiSequences: (content: string) => content,
+  normalizeDetectedUrl: () => null,
+  extractUrlsFromText: () => [],
+  shouldAutoOpenUrlFromOutput: () => false,
+};
+
+const SKIP = '--dangerously-skip-permissions';
+
+test('claude launches WITHOUT skip-permissions by default (no env, no flag)', () => {
+  const command = buildShellCommand({ provider: 'claude' }, deps, { env: {}, platform: 'linux' });
+  assert.equal(command, 'claude');
+  assert.ok(!command.includes(SKIP));
+});
+
+test('claude resume launches without skip-permissions by default (posix)', () => {
+  const command = buildShellCommand(
+    { provider: 'claude', hasSession: true, sessionId: 'sess-1' },
+    deps,
+    { env: {}, platform: 'linux' },
+  );
+  assert.equal(command, 'claude --resume "sess-1" || claude');
+  assert.ok(!command.includes(SKIP));
+});
+
+test('claude resume launches without skip-permissions by default (win32)', () => {
+  const command = buildShellCommand(
+    { provider: 'claude', hasSession: true, sessionId: 'sess-1' },
+    deps,
+    { env: {}, platform: 'win32' },
+  );
+  assert.equal(
+    command,
+    'claude --resume "sess-1"; if ($LASTEXITCODE -ne 0) { claude }',
+  );
+  assert.ok(!command.includes(SKIP));
+});
+
+test('SHELL_DANGEROUSLY_SKIP_PERMISSIONS=true enables the flag on the base command', () => {
+  const command = buildShellCommand({ provider: 'claude' }, deps, {
+    env: { SHELL_DANGEROUSLY_SKIP_PERMISSIONS: 'true' },
+    platform: 'linux',
+  });
+  assert.equal(command, `claude ${SKIP}`);
+});
+
+test('env opt-in applies the flag to both sides of the posix resume fallback', () => {
+  const command = buildShellCommand(
+    { provider: 'claude', hasSession: true, sessionId: 'sess-1' },
+    deps,
+    { env: { SHELL_DANGEROUSLY_SKIP_PERMISSIONS: '1' }, platform: 'linux' },
+  );
+  assert.equal(command, `claude ${SKIP} --resume "sess-1" || claude ${SKIP}`);
+});
+
+test('env opt-in applies the flag to both sides of the win32 resume fallback', () => {
+  const command = buildShellCommand(
+    { provider: 'claude', hasSession: true, sessionId: 'sess-1' },
+    deps,
+    { env: { SHELL_DANGEROUSLY_SKIP_PERMISSIONS: 'on' }, platform: 'win32' },
+  );
+  assert.equal(
+    command,
+    `claude ${SKIP} --resume "sess-1"; if ($LASTEXITCODE -ne 0) { claude ${SKIP} }`,
+  );
+});
+
+test('an explicit per-session request enables the flag even when env is unset', () => {
+  const command = buildShellCommand(
+    { provider: 'claude', dangerouslySkipPermissions: true },
+    deps,
+    { env: {}, platform: 'linux' },
+  );
+  assert.equal(command, `claude ${SKIP}`);
+});
+
+test('an explicit per-session opt-out overrides an enabled env default', () => {
+  const command = buildShellCommand(
+    { provider: 'claude', dangerouslySkipPermissions: false },
+    deps,
+    { env: { SHELL_DANGEROUSLY_SKIP_PERMISSIONS: 'true' }, platform: 'linux' },
+  );
+  assert.equal(command, 'claude');
+});
+
+test('the flag never leaks into other providers', () => {
+  const env = { SHELL_DANGEROUSLY_SKIP_PERMISSIONS: 'true' };
+  for (const provider of ['codex', 'cursor', 'opencode']) {
+    const command = buildShellCommand({ provider }, deps, { env, platform: 'linux' });
+    assert.ok(!command.includes(SKIP), `${provider} should never receive ${SKIP}`);
+  }
+});
+
+test('plain shell mode is unaffected by the opt-in', () => {
+  const command = buildShellCommand(
+    { isPlainShell: true, initialCommand: 'ls -la' },
+    deps,
+    { env: { SHELL_DANGEROUSLY_SKIP_PERMISSIONS: 'true' }, platform: 'linux' },
+  );
+  assert.equal(command, 'ls -la');
+});
+
+test('shouldSkipClaudePermissions treats only truthy env spellings as on', () => {
+  for (const value of ['1', 'true', 'TRUE', 'yes', 'on', ' true ']) {
+    assert.equal(
+      shouldSkipClaudePermissions({}, { SHELL_DANGEROUSLY_SKIP_PERMISSIONS: value }),
+      true,
+      `"${value}" should enable`,
+    );
+  }
+  for (const value of ['0', 'false', 'off', 'no', '', 'enabled', 'maybe']) {
+    assert.equal(
+      shouldSkipClaudePermissions({}, { SHELL_DANGEROUSLY_SKIP_PERMISSIONS: value }),
+      false,
+      `"${value}" should not enable`,
+    );
+  }
+});
+
+test('shouldSkipClaudePermissions defaults to off when nothing is set', () => {
+  assert.equal(shouldSkipClaudePermissions({}, {}), false);
+});
+
+test('shouldSkipClaudePermissions honours an explicit request over env', () => {
+  assert.equal(
+    shouldSkipClaudePermissions({ dangerouslySkipPermissions: true }, {}),
+    true,
+  );
+  assert.equal(
+    shouldSkipClaudePermissions(
+      { dangerouslySkipPermissions: false },
+      { SHELL_DANGEROUSLY_SKIP_PERMISSIONS: 'true' },
+    ),
+    false,
+  );
+});

--- a/src/components/shell/hooks/useShellConnection.ts
+++ b/src/components/shell/hooks/useShellConnection.ts
@@ -7,6 +7,26 @@ import type { Project, ProjectSession } from '../../../types/app';
 import { TERMINAL_INIT_DELAY_MS } from '../constants/constants';
 import { getShellWebSocketUrl, parseShellMessage, sendSocketMessage } from '../utils/socket';
 
+/**
+ * The web shell honors the same Claude "Skip Permissions" setting as the
+ * chat/SDK path (Settings → Agents → Permissions → Claude), persisted under
+ * `claude-settings`. When enabled, the server launches Claude Code with
+ * --dangerously-skip-permissions. Defaults to false / off.
+ */
+function readClaudeSkipPermissions(): boolean {
+  try {
+    const raw = localStorage.getItem('claude-settings');
+    if (!raw) {
+      return false;
+    }
+
+    const parsed = JSON.parse(raw) as { skipPermissions?: unknown };
+    return parsed?.skipPermissions === true;
+  } catch {
+    return false;
+  }
+}
+
 const ANSI_ESCAPE_REGEX =
   /(?:\u001B\[[0-?]*[ -/]*[@-~]|\u009B[0-?]*[ -/]*[@-~]|\u001B\][^\u0007\u001B]*(?:\u0007|\u001B\\)|\u009D[^\u0007\u009C]*(?:\u0007|\u009C)|\u001B[PX^_][^\u001B]*\u001B\\|[\u0090\u0098\u009E\u009F][^\u009C]*\u009C|\u001B[@-Z\\-_])/g;
 const PROCESS_EXIT_REGEX = /Process exited with code (\d+)/;
@@ -149,6 +169,10 @@ export function useShellConnection({
               initialCommand: initialCommandRef.current,
               isPlainShell: isPlainShellRef.current,
               forceRestart,
+              // Mirrors the Claude "Skip Permissions" setting; the server also
+              // honors a SHELL_DANGEROUSLY_SKIP_PERMISSIONS env default. Both are
+              // off by default. See shell-websocket.service.ts.
+              dangerouslySkipPermissions: readClaudeSkipPermissions(),
             });
           }, TERMINAL_INIT_DELAY_MS);
         };

--- a/src/components/shell/types/types.ts
+++ b/src/components/shell/types/types.ts
@@ -15,6 +15,7 @@ export type ShellInitMessage = {
   initialCommand: string | null | undefined;
   isPlainShell: boolean;
   forceRestart?: boolean;
+  dangerouslySkipPermissions?: boolean;
 };
 
 export type ShellResizeMessage = {


### PR DESCRIPTION
> **Draft / RFC.** This is a security-sensitive change and, per CONTRIBUTING
> ("Discuss first for new features"), I'm opening it as a draft to get direction
> before polishing. Happy to adjust or drop it if it's not something you want
> upstream.

## Motivation

The app already has a Claude **Skip Permissions** setting (Settings → Agents →
Permissions → Claude) that bypasses Claude Code's approval prompts in chat via
the SDK's `bypassPermissions` mode. The **web shell ignores it** — it always
launches `claude` normally — so the same project can auto-approve in chat but
still prompt in the shell, and the only way to change that today is a local patch
that hardcodes `--dangerously-skip-permissions`.

This makes the web shell **honor the existing Claude Skip Permissions setting**,
so one toggle governs both chat and shell, and adds a server-wide env default for
headless deployments. Prior art for permission-related config: #802 (Codex
permission env fallback).

## Design

Default is unchanged: with nothing enabled, the shell launches `claude` exactly
as before and prompts stay on.

- **UI (reuses the existing setting):** the shell sends the persisted
  `claude-settings.skipPermissions` value on its `init` message. Enabling
  **Settings → Agents → Permissions → Claude → Skip Permissions** now also makes
  the web shell launch `claude --dangerously-skip-permissions`. No new toggle.
- **Server-wide (env):** `SHELL_DANGEROUSLY_SKIP_PERMISSIONS` (default off;
  accepts `1`/`true`/`yes`/`on`), for headless / no-UI deployments.

**Precedence:** an explicit per-session value overrides the server default; when
neither is set, prompts stay on. The flag is scoped to the `claude` provider and
applied to both the primary invocation and the resume-fallback, on posix and
Windows. Codex / Cursor / opencode / plain shell are never affected (each already
has its own permission mechanism).

## Security notes

- Default off — no behavior change unless explicitly enabled.
- Non-boolean / garbage values fall back to "off".
- Reuses the setting that already carries an orange "dangerous" warning in the
  UI, rather than introducing a second, easier-to-miss control.
- Open question for maintainers: is folding the shell into the existing Claude
  Skip Permissions toggle the behavior you want, or should the shell bypass be
  independently controllable? Should the env var *gate* whether the UI setting
  applies to the shell at all? Guidance welcome.

## Changes

- Server: `shouldSkipClaudePermissions()` + `SHELL_DANGEROUSLY_SKIP_PERMISSIONS`
  wired into `buildShellCommand` (`shell-websocket.service.ts`), refactored to
  take injectable `env`/`platform` for testability.
- Client: the shell reads `claude-settings.skipPermissions` and sends it on the
  shell `init` message.
- Docs: README "Security & Tools Configuration" section and `.env.example`.

## Tests / verification

- New unit tests (`server/modules/websocket/tests/shell-websocket-command.test.ts`)
  asserting the **default-off** guarantee, env/per-session precedence, and
  behavior across posix/win32 and all providers.
- `npm run typecheck`, `npm run lint` (0 errors), full `node:test` suite, and
  `npm run build` — all pass. Server boots and the default path spawns plain
  `claude`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an opt-in “Skip Permissions” setting for Claude sessions.
  * Added support for configuring the setting server-wide through an environment variable.
  * Per-session settings override the server default, while other providers remain unaffected.

* **Documentation**
  * Documented configuration, security considerations, accepted values, defaults, and UI controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->