### PR TITLE
fix: discover plugin skills from config and symlinks

### DIFF
--- a/server/modules/providers/list/claude/claude-skills.provider.ts
+++ b/server/modules/providers/list/claude/claude-skills.provider.ts
@@ -15,6 +15,7 @@ import {
   readObjectRecord,
   readOptionalString,
   readProviderSkillMarkdownDefinition,
+  readStringArray,
 } from '@/shared/utils.js';
 
 const getClaudeHomePath = (): string => path.join(os.homedir(), '.claude');
@@ -166,6 +167,14 @@ export class ClaudeSkillsProvider extends SkillsProvider {
             continue;
           }
 
+          // Check plugin.json skills field first (supports paths like "./" or "./skills/foo")
+          const configSkills = await this.listPluginSkillsFromConfig(pluginFolder, pluginId, pluginName);
+          if (configSkills.length > 0) {
+            skills.push(...configSkills);
+            continue;
+          }
+
+          // Fallback: scan skills/ subdirectory
           const skillsPath = path.join(pluginFolder, 'skills');
           if (!(await pathExistsAsDirectory(skillsPath))) {
             continue;
@@ -179,6 +188,76 @@ export class ClaudeSkillsProvider extends SkillsProvider {
     }
 
     return skills;
+  }
+
+  /**
+   * Reads the `skills` field from plugin.json and resolves each entry to a
+   * SKILL.md file. Supports directory paths (scanned for SKILL.md) and direct
+   * .md file paths.
+   */
+  private async listPluginSkillsFromConfig(
+    pluginFolder: string,
+    pluginId: string,
+    pluginName: string,
+  ): Promise<ProviderSkill[]> {
+    try {
+      const pluginConfig = await readJsonConfig(
+        path.join(pluginFolder, '.claude-plugin', 'plugin.json'),
+      );
+      const skillPaths = readStringArray(pluginConfig.skills);
+      if (!skillPaths || skillPaths.length === 0) {
+        return [];
+      }
+
+      const skills: ProviderSkill[] = [];
+      for (const skillPath of skillPaths) {
+        const resolvedPath = path.resolve(pluginFolder, skillPath);
+
+        if (await pathExistsAsDirectory(resolvedPath)) {
+          // Directory: scan for SKILL.md files inside
+          const skillFiles = await findProviderSkillMarkdownFiles(resolvedPath, { recursive: true });
+          for (const skillFile of skillFiles) {
+            try {
+              const definition = await readProviderSkillMarkdownDefinition(skillFile);
+              skills.push({
+                provider: this.provider,
+                name: definition.name,
+                description: definition.description,
+                command: `/${pluginName}:${definition.name}`,
+                scope: 'plugin',
+                sourcePath: skillFile,
+                pluginName,
+                pluginId,
+              });
+            } catch {
+              // Bad skill file should not block siblings.
+            }
+          }
+        } else if (resolvedPath.toLowerCase().endsWith('.md')) {
+          // Direct .md file path
+          try {
+            const definition = await readProviderSkillMarkdownDefinition(resolvedPath);
+            skills.push({
+              provider: this.provider,
+              name: definition.name,
+              description: definition.description,
+              command: `/${pluginName}:${definition.name}`,
+              scope: 'plugin',
+              sourcePath: resolvedPath,
+              pluginName,
+              pluginId,
+            });
+          } catch {
+            // Bad skill file should not block siblings.
+          }
+        }
+      }
+
+      return skills;
+    } catch {
+      // Missing or malformed plugin.json is not an error.
+      return [];
+    }
   }
 
   private async listPluginCommandSkills(

--- a/server/modules/providers/list/claude/claude-skills.provider.ts
+++ b/server/modules/providers/list/claude/claude-skills.provider.ts
@@ -46,7 +46,7 @@ const listChildDirectories = async (directoryPath: string): Promise<string[]> =>
   try {
     const entries = await readdir(directoryPath, { withFileTypes: true });
     return entries
-      .filter((entry) => entry.isDirectory())
+      .filter((entry) => entry.isDirectory() || entry.isSymbolicLink())
       .map((entry) => path.join(directoryPath, entry.name))
       .sort((left, right) => left.localeCompare(right));
   } catch {

--- a/server/modules/providers/tests/skills.test.ts
+++ b/server/modules/providers/tests/skills.test.ts
@@ -839,3 +839,41 @@ test('providerSkillsService rejects managed skill creation for opencode', { conc
     /does not support managed global skills/i,
   );
 });
+
+/**
+ * This test verifies that skills installed as symlinks (e.g., via
+ * `ln -s`) are discovered correctly. This covers the common pattern
+ * of symlinking external skill repositories into ~/.claude/skills/.
+ */
+test('providerSkillsService discovers skills from symlinks', { concurrency: false }, async () => {
+  const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'llm-skills-symlink-'));
+
+  // External skill directory (simulates a git-cloned skill repo)
+  const externalSkillDir = path.join(tempRoot, 'external-skills', 'my-external-skill');
+  await fs.mkdir(externalSkillDir, { recursive: true });
+  await fs.writeFile(
+    path.join(externalSkillDir, 'SKILL.md'),
+    '---\nname: external-symlink-skill\ndescription: A skill installed via symlink\n---\n\nBody.\n',
+    'utf8',
+  );
+
+  // Symlink in ~/.claude/skills/ pointing to external directory
+  const skillsDir = path.join(tempRoot, '.claude', 'skills');
+  await fs.mkdir(skillsDir, { recursive: true });
+  await fs.symlink(externalSkillDir, path.join(skillsDir, 'my-external-skill'));
+
+  const restoreHomeDir = patchHomeDir(tempRoot);
+  try {
+    const skills = await providerSkillsService.listProviderSkills('claude');
+    const byName = new Map(skills.map((skill) => [skill.name, skill]));
+
+    const symlinkSkill = byName.get('external-symlink-skill');
+    assert.ok(symlinkSkill, 'symlinked skill should be discovered');
+    assert.equal(symlinkSkill?.scope, 'user');
+    assert.equal(symlinkSkill?.command, '/external-symlink-skill');
+    assert.match(symlinkSkill?.sourcePath ?? '', /SKILL\.md$/);
+  } finally {
+    restoreHomeDir();
+    await fs.rm(tempRoot, { recursive: true, force: true });
+  }
+});

--- a/server/modules/providers/tests/skills.test.ts
+++ b/server/modules/providers/tests/skills.test.ts
@@ -319,6 +319,162 @@ test('providerSkillsService lists claude user, project, and enabled plugin skill
 });
 
 /**
+ * This test verifies that plugin skills defined via plugin.json's `skills`
+ * field are discovered correctly. This covers plugins that place SKILL.md at
+ * the root level (skills: ["./"]) or in custom subdirectories.
+ */
+test('providerSkillsService discovers plugin skills from plugin.json skills field', { concurrency: false }, async () => {
+  const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'llm-skills-plugin-config-'));
+
+  // Plugin with skills: ["./"] — SKILL.md at root level (e.g., web-access)
+  const rootSkillPluginPath = path.join(
+    tempRoot,
+    '.claude',
+    'plugins',
+    'cache',
+    'web-access',
+    'web-access',
+    'v1',
+  );
+
+  // Plugin with skills: ["./skills/custom"] — custom subdirectory
+  const customSubdirPluginPath = path.join(
+    tempRoot,
+    '.claude',
+    'plugins',
+    'cache',
+    'my-plugin',
+    'my-plugin',
+    'v1',
+  );
+
+  // Plugin with skills pointing to a direct .md file
+  const directFilePluginPath = path.join(
+    tempRoot,
+    '.claude',
+    'plugins',
+    'cache',
+    'file-plugin',
+    'file-plugin',
+    'v1',
+  );
+
+  const restoreHomeDir = patchHomeDir(tempRoot);
+  try {
+    // Setup: root-level skill plugin (skills: ["./"])
+    await writeClaudePluginManifest(rootSkillPluginPath, 'web-access');
+    // Write plugin.json with skills field
+    await fs.writeFile(
+      path.join(rootSkillPluginPath, '.claude-plugin', 'plugin.json'),
+      JSON.stringify({
+        name: 'web-access',
+        version: '1.0.0',
+        skills: ['./'],
+      }, null, 2),
+      'utf8',
+    );
+    // SKILL.md at root level
+    await fs.writeFile(
+      path.join(rootSkillPluginPath, 'SKILL.md'),
+      '---\nname: web-access\ndescription: Web browsing skill\n---\n\nBody.\n',
+      'utf8',
+    );
+
+    // Setup: custom subdirectory plugin (skills: ["./skills/custom"])
+    await writeClaudePluginManifest(customSubdirPluginPath, 'MyPlugin');
+    await fs.writeFile(
+      path.join(customSubdirPluginPath, '.claude-plugin', 'plugin.json'),
+      JSON.stringify({
+        name: 'MyPlugin',
+        version: '1.0.0',
+        skills: ['./skills/custom'],
+      }, null, 2),
+      'utf8',
+    );
+    await fs.mkdir(path.join(customSubdirPluginPath, 'skills', 'custom'), { recursive: true });
+    await fs.writeFile(
+      path.join(customSubdirPluginPath, 'skills', 'custom', 'SKILL.md'),
+      '---\nname: custom-skill\ndescription: Custom directory skill\n---\n\nBody.\n',
+      'utf8',
+    );
+
+    // Setup: direct .md file plugin (skills: ["./my-skill.md"])
+    await writeClaudePluginManifest(directFilePluginPath, 'FilePlugin');
+    await fs.writeFile(
+      path.join(directFilePluginPath, '.claude-plugin', 'plugin.json'),
+      JSON.stringify({
+        name: 'FilePlugin',
+        version: '1.0.0',
+        skills: ['./my-skill.md'],
+      }, null, 2),
+      'utf8',
+    );
+    await fs.writeFile(
+      path.join(directFilePluginPath, 'my-skill.md'),
+      '---\nname: file-skill\ndescription: Direct file skill\n---\n\nBody.\n',
+      'utf8',
+    );
+
+    // Write settings and installed_plugins
+    await fs.writeFile(
+      path.join(tempRoot, '.claude', 'settings.json'),
+      JSON.stringify({
+        enabledPlugins: {
+          'web-access@web-access': true,
+          'my-plugin@my-marketplace': true,
+          'file-plugin@file-marketplace': true,
+        },
+      }, null, 2),
+      'utf8',
+    );
+    await fs.writeFile(
+      path.join(tempRoot, '.claude', 'plugins', 'installed_plugins.json'),
+      JSON.stringify({
+        version: 2,
+        plugins: {
+          'web-access@web-access': [
+            { scope: 'user', installPath: rootSkillPluginPath, version: 'v1' },
+          ],
+          'my-plugin@my-marketplace': [
+            { scope: 'user', installPath: customSubdirPluginPath, version: 'v1' },
+          ],
+          'file-plugin@file-marketplace': [
+            { scope: 'user', installPath: directFilePluginPath, version: 'v1' },
+          ],
+        },
+      }, null, 2),
+      'utf8',
+    );
+
+    const skills = await providerSkillsService.listProviderSkills('claude');
+    const byName = new Map(skills.map((skill) => [skill.name, skill]));
+
+    // Root-level skill discovered via plugin.json skills: ["./"]
+    const rootSkill = byName.get('web-access');
+    assert.ok(rootSkill, 'web-access skill should be discovered from plugin.json skills field');
+    assert.equal(rootSkill?.scope, 'plugin');
+    assert.equal(rootSkill?.command, '/web-access:web-access');
+    assert.equal(rootSkill?.pluginName, 'web-access');
+    assert.match(rootSkill?.sourcePath ?? '', /SKILL\.md$/);
+
+    // Custom subdirectory skill
+    const customSkill = byName.get('custom-skill');
+    assert.ok(customSkill, 'custom-skill should be discovered from custom subdir');
+    assert.equal(customSkill?.scope, 'plugin');
+    assert.equal(customSkill?.command, '/MyPlugin:custom-skill');
+
+    // Direct .md file skill
+    const fileSkill = byName.get('file-skill');
+    assert.ok(fileSkill, 'file-skill should be discovered from direct .md path');
+    assert.equal(fileSkill?.scope, 'plugin');
+    assert.equal(fileSkill?.command, '/FilePlugin:file-skill');
+  } finally {
+    restoreHomeDir();
+    await fs.rm(tempRoot, { recursive: true, force: true });
+  }
+});
+
+/**
  * This test covers Codex repository/user/system skill folders and verifies that
  * repository lookup includes cwd, parent, and git root skill locations.
  */

--- a/server/shared/utils.ts
+++ b/server/shared/utils.ts
@@ -910,7 +910,7 @@ export async function findProviderSkillMarkdownFiles(
     }
 
     for (const entry of entries) {
-      if (entry.isDirectory()) {
+      if (entry.isDirectory() || entry.isSymbolicLink()) {
         await collectRecursive(path.join(dirPath, entry.name));
       }
     }
@@ -925,7 +925,7 @@ export async function findProviderSkillMarkdownFiles(
     const entries = await readdir(rootDir, { withFileTypes: true });
 
     for (const entry of entries) {
-      if (!entry.isDirectory()) {
+      if (!entry.isDirectory() && !entry.isSymbolicLink()) {
         continue;
       }
 


### PR DESCRIPTION
## Problem

Two issues prevented plugin/user skills from being discovered by the Web UI:

1. **Plugin skills from `plugin.json`**: Plugins that define skills via `plugin.json`'s `skills` field (e.g., `skills: ["./"]`) were not discovered, even though the CLI discovers them correctly.

2. **Symlinked skills**: Skills installed as symlinks (e.g., `ln -s /external/repo ~/.claude/skills/my-skill`) were not discovered.

## Root Cause

1. The Web UI only scanned for `skills/` and `commands/` subdirectories, but didn't read `plugin.json`'s `skills` field.

2. `readdir` with `withFileTypes: true` returns `isSymbolicLink: true` for symlinks, but the code only checked `isDirectory()`.

## Solution

1. Added `listPluginSkillsFromConfig()` to read `plugin.json`'s `skills` field and resolve each entry to SKILL.md files.

2. Updated `findProviderSkillMarkdownFiles` and `listChildDirectories` to check for `entry.isSymbolicLink()` in addition to `entry.isDirectory()`.

## Changes

- `server/modules/providers/list/claude/claude-skills.provider.ts` — Added `listPluginSkillsFromConfig()`, updated `listChildDirectories`
- `server/shared/utils.ts` — Updated `findProviderSkillMarkdownFiles` to follow symlinks
- `server/modules/providers/tests/skills.test.ts` — Added tests for plugin.json skills field and symlink discovery

## Test Results

All 8 tests pass:
- ✅ New: `providerSkillsService discovers plugin skills from plugin.json skills field`
- ✅ New: `providerSkillsService discovers skills from symlinks`
- ✅ 6 existing tests unchanged

Fixes #990
Fixes #992

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Plugin-provided skills can now be discovered from the `skills` entries in each plugin’s `plugin.json`.
  * Skills can be defined via directories or direct Markdown file paths.
* **Bug Fixes**
  * Improved plugin skill discovery for custom skill locations, with directory scanning used as a fallback when needed.
  * Skill discovery now follows symbolic links to directories.
* **Tests**
  * Added coverage for config-based skill discovery and symlinked skills.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->