### PR TITLE
fix: resolve per-session model overrides using app session ID

### DIFF
--- a/server/claude-sdk.js
+++ b/server/claude-sdk.js
@@ -475,6 +475,7 @@ async function queryClaudeSDK(command, options = {}, ws) {
       'claude',
       sessionId,
       options.model,
+      options.appSessionId,
     );
     let effortModels = CLAUDE_FALLBACK_MODELS;
     try {

--- a/server/modules/providers/services/provider-models.service.ts
+++ b/server/modules/providers/services/provider-models.service.ts
@@ -324,15 +324,21 @@ export const createProviderModelsService = (dependencies: ProviderModelsServiceD
     provider: LLMProvider,
     sessionId: string | undefined,
     requestedModel?: string | null,
+    appSessionId?: string | null,
   ): Promise<string | undefined> => {
     const normalizedRequestedModel = typeof requestedModel === 'string' ? requestedModel.trim() : '';
-    if (!sessionId?.trim()) {
+    if (!sessionId?.trim() && !appSessionId?.trim()) {
       return normalizedRequestedModel || undefined;
     }
 
-    const changedModel = await getChangedActiveModel(provider, sessionId);
-    if (changedModel.supported && changedModel.changed && changedModel.model?.trim()) {
-      return changedModel.model.trim();
+    // Prefer appSessionId for looking up per-session model overrides,
+    // since that's what the /active-model endpoint stores against.
+    const lookupId = appSessionId?.trim() || sessionId?.trim();
+    if (lookupId) {
+      const changedModel = await getChangedActiveModel(provider, lookupId);
+      if (changedModel.supported && changedModel.changed && changedModel.model?.trim()) {
+        return changedModel.model.trim();
+      }
     }
 
     return normalizedRequestedModel || undefined;

--- a/server/modules/providers/tests/provider-models.service.test.ts
+++ b/server/modules/providers/tests/provider-models.service.test.ts
@@ -347,3 +347,46 @@ test('resolveResumeModel prefers a stored changed model over the requested one',
     await rm(tempRoot, { recursive: true, force: true });
   }
 });
+
+/**
+ * This test verifies that resolveResumeModel uses the appSessionId parameter
+ * to look up per-session model overrides, since the /active-model endpoint
+ * stores changes against the app session ID, not the provider-native session ID.
+ */
+test('resolveResumeModel uses appSessionId for model override lookup', async () => {
+  const tempRoot = await mkdtemp(path.join(os.tmpdir(), 'provider-model-appsession-'));
+  const activeModelChangesPath = path.join(tempRoot, 'session-model-changes.json');
+
+  try {
+    const service = createProviderModelsService({
+      activeModelChangesPath,
+      resolveProvider: (provider) => ({
+        models: {
+          getSupportedModels: async () => createModels(`${provider}-models`),
+          getCurrentActiveModel: async () => createCurrentActiveModel(`${provider}-active`),
+          changeActiveModel: async (input) => createSessionActiveModelChange(provider, input),
+        },
+      }),
+    });
+
+    // Store model change using app session ID (what the /active-model endpoint does)
+    await writeProviderSessionActiveModelChange('claude', {
+      sessionId: 'app-session-abc',
+      model: 'claude-opus-4-6',
+    }, {
+      filePath: activeModelChangesPath,
+    });
+
+    // When provider-native session ID differs from app session ID,
+    // resolveResumeModel should use appSessionId to find the override
+    const model = await service.resolveResumeModel(
+      'claude',
+      'provider-native-session-xyz', // different from app session ID
+      'claude-sonnet-4-6',
+      'app-session-abc', // app session ID where the change was stored
+    );
+    assert.equal(model, 'claude-opus-4-6');
+  } finally {
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});

--- a/server/modules/websocket/services/chat-websocket.service.ts
+++ b/server/modules/websocket/services/chat-websocket.service.ts
@@ -202,6 +202,9 @@ async function handleChatSend(
     resume: Boolean(session.provider_session_id),
     cwd: clientOptions.cwd ?? session.project_path ?? undefined,
     projectPath: session.project_path ?? clientOptions.projectPath,
+    // Pass the app-level session id so provider runtimes can resolve
+    // per-session model overrides stored by the /active-model endpoint.
+    appSessionId: sessionId,
   };
 
   try {


### PR DESCRIPTION
## Problem

The `/active-model` endpoint stores model changes against the **app session ID**, but `resolveResumeModel` was looking them up using the **provider-native session ID**. These IDs differ, so the stored model override was never found.

This caused the model switching feature in the Chat UI to appear to work (showing "APPLIES NEXT RESPONSE") but the model never actually changed.

## Root Cause

1. Frontend calls `POST /api/providers/claude/sessions/{appSessionId}/active-model` to store the model change
2. Backend stores the change keyed by `claude:{appSessionId}`
3. When sending a message, `handleChatSend` passes `session.provider_session_id` to the runtime
4. `resolveResumeModel` looks up `claude:{provider_session_id}` — different key, no match found

## Solution

- Pass `appSessionId` from `handleChatSend` to provider runtimes
- Update `resolveResumeModel` to accept optional `appSessionId` parameter
- Use `appSessionId` (fallback to `sessionId`) for model override lookup

## Changes

- `server/modules/websocket/services/chat-websocket.service.ts` — Pass `appSessionId` in runtime options
- `server/modules/providers/services/provider-models.service.ts` — Update `resolveResumeModel` to use `appSessionId`
- `server/claude-sdk.js` — Pass `appSessionId` to `resolveResumeModel`
- `server/modules/providers/tests/provider-models.service.test.ts` — Add test for appSessionId-based resolution

## Test Results

All 11 provider-models tests pass (including new test):
- ✅ New: `resolveResumeModel uses appSessionId for model override lookup`
- ✅ 10 existing tests unchanged

All 8 skills tests also pass.

Fixes #981

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved model selection for resumed Claude conversations by correctly applying per-session model overrides.
  * Ensured model overrides remain available when provider and application session identifiers differ.

* **Tests**
  * Added coverage verifying that application-level session model overrides are resolved correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->