### PR TITLE
fix: install browser runtime outside process cwd

### DIFF
--- a/server/modules/browser-use/browser-use.service.ts
+++ b/server/modules/browser-use/browser-use.service.ts
@@ -74,13 +74,20 @@ const sessions = new Map<string, BrowserUseSession>();
 const handles = new Map<string, RuntimeHandle>();
 let installPromise: Promise<{ success: boolean; message: string }> | null = null;
 let lastInstallMessage: string | null = null;
-let runtimeProbeCache: { value: RuntimeProbe; updatedAt: number } | null = null;
+let runtimeProbeCache: { value: RuntimeProbe; updatedAt: number; runtimeInstallDir: string } | null = null;
 
 const DEFAULT_SETTINGS: BrowserUseSettings = {
   enabled: false,
 };
 const AGENT_OWNER_ID = 'agent';
 const PROFILE_ROOT = path.join(os.homedir(), '.cloudcli', 'browser-use', 'profiles');
+const RUNTIME_ROOT = path.join(os.homedir(), '.cloudcli', 'browser-use', 'runtime');
+const PLAYWRIGHT_RUNTIME_VERSION = '1.61.1';
+const RUNTIME_PACKAGE_JSON = JSON.stringify({
+  private: true,
+  name: 'cloudcli-browser-use-runtime',
+  version: '0.0.0',
+}, null, 2);
 const MCP_SERVER_NAME = 'cloudcli-browser';
 const LEGACY_MCP_SERVER_NAMES = ['cloudcli-browser-use'];
 const RUNTIME_READINESS_CACHE_TTL_MS = 30_000;
@@ -141,11 +148,35 @@ function getSetupMessage(settings: BrowserUseSettings, readiness: RuntimeReadine
   return readiness.installMessage || 'Browser runtime is not ready.';
 }
 
+function getRuntimeInstallDir(): string {
+  return process.env.CLOUDCLI_BROWSER_USE_RUNTIME_DIR || RUNTIME_ROOT;
+}
+
+function getRuntimePackageJsonPath(): string {
+  return path.join(getRuntimeInstallDir(), 'package.json');
+}
+
+function ensureRuntimeInstallDir(): string {
+  const runtimeDir = getRuntimeInstallDir();
+  const packageJsonPath = path.join(runtimeDir, 'package.json');
+  fs.mkdirSync(runtimeDir, { recursive: true });
+
+  if (!fs.existsSync(packageJsonPath)) {
+    fs.writeFileSync(packageJsonPath, `${RUNTIME_PACKAGE_JSON}\n`, 'utf8');
+  }
+
+  return runtimeDir;
+}
+
 function getPlaywright(): any | null {
   try {
     return require('playwright');
   } catch {
-    return null;
+    try {
+      return createRequire(getRuntimePackageJsonPath())('playwright');
+    } catch {
+      return null;
+    }
   }
 }
 
@@ -223,14 +254,16 @@ function probeRuntime(): RuntimeProbe {
 function getRuntimeReadiness(options: { force?: boolean } = {}): RuntimeReadiness {
   const now = Date.now();
   const cachedProbe = runtimeProbeCache;
+  const runtimeInstallDir = getRuntimeInstallDir();
   const canUseCache = !options.force
     && !installPromise
     && cachedProbe
+    && cachedProbe.runtimeInstallDir === runtimeInstallDir
     && now - cachedProbe.updatedAt < RUNTIME_READINESS_CACHE_TTL_MS;
   const probe = canUseCache ? cachedProbe.value : probeRuntime();
 
   if (!canUseCache && !installPromise) {
-    runtimeProbeCache = { value: probe, updatedAt: now };
+    runtimeProbeCache = { value: probe, updatedAt: now, runtimeInstallDir };
   }
 
   return {
@@ -245,12 +278,12 @@ const INSTALL_COMMAND_TIMEOUT_MS = Number.parseInt(
   10,
 );
 
-function runCommand(command: string, args: string[]): Promise<void> {
+function runCommand(command: string, args: string[], cwd: string): Promise<void> {
   return new Promise((resolve, reject) => {
     const child = spawn(command, args, {
-      cwd: process.cwd(),
+      cwd,
       env: process.env,
-      shell: false,
+      shell: process.platform === 'win32',
       stdio: ['ignore', 'pipe', 'pipe'],
     });
     const output: string[] = [];
@@ -302,19 +335,24 @@ async function installRuntime(): Promise<{ success: boolean; message: string }> 
   }
 
   const npmCommand = process.platform === 'win32' ? 'npm.cmd' : 'npm';
+  const runtimeDir = ensureRuntimeInstallDir();
   runtimeProbeCache = null;
   installPromise = (async () => {
     try {
       lastInstallMessage = 'Installing Playwright package...';
-      await runCommand(npmCommand, ['install', '--no-save', '--no-package-lock', 'playwright']);
+      await runCommand(
+        npmCommand,
+        ['install', '--no-save', '--no-package-lock', `playwright@${PLAYWRIGHT_RUNTIME_VERSION}`],
+        runtimeDir,
+      );
 
       if (process.platform === 'linux') {
         lastInstallMessage = 'Installing Chromium system dependencies...';
-        await runCommand(npmCommand, ['exec', '--', 'playwright', 'install-deps', 'chromium']);
+        await runCommand(npmCommand, ['exec', '--', 'playwright', 'install-deps', 'chromium'], runtimeDir);
       }
 
       lastInstallMessage = 'Installing Chromium runtime...';
-      await runCommand(npmCommand, ['exec', '--', 'playwright', 'install', 'chromium']);
+      await runCommand(npmCommand, ['exec', '--', 'playwright', 'install', 'chromium'], runtimeDir);
 
       lastInstallMessage = 'Browser runtime installed.';
       return { success: true, message: lastInstallMessage };

--- a/server/modules/browser-use/tests/browser-use.service.test.ts
+++ b/server/modules/browser-use/tests/browser-use.service.test.ts
@@ -1,10 +1,320 @@
 import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
+import http from 'node:http';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 import test from 'node:test';
 
-import { browserUseService } from '@/modules/browser-use/browser-use.service.js';
+process.env.DATABASE_PATH = path.join(fs.mkdtempSync(path.join(os.tmpdir(), 'cloudcli-browser-db-')), 'auth.db');
+
+const { browserUseService } = await import('@/modules/browser-use/browser-use.service.js');
+const { appConfigDb, closeConnection } = await import('@/modules/database/index.js');
+
+function writeFakePlaywright(runtimeDir: string) {
+  const moduleDir = path.join(runtimeDir, 'node_modules', 'playwright');
+  const chromiumDir = path.join(moduleDir, 'chromium');
+  fs.mkdirSync(chromiumDir, { recursive: true });
+  fs.writeFileSync(path.join(chromiumDir, process.platform === 'win32' ? 'chrome.exe' : 'chrome'), '', 'utf8');
+  fs.writeFileSync(path.join(moduleDir, 'package.json'), JSON.stringify({
+    name: 'playwright',
+    main: 'index.cjs',
+  }), 'utf8');
+  fs.writeFileSync(path.join(moduleDir, 'index.cjs'), `
+const fs = require('node:fs');
+const http = require('node:http');
+const path = require('node:path');
+
+const state = {
+  launches: 0,
+  contexts: 0,
+  pages: 0,
+  browserCloses: 0,
+  contextCloses: 0,
+  navigations: [],
+};
+
+const executablePath = path.join(__dirname, 'chromium', ${JSON.stringify(process.platform === 'win32' ? 'chrome.exe' : 'chrome')});
+
+function fetchText(url) {
+  return new Promise((resolve, reject) => {
+    http.get(url, (response) => {
+      let body = '';
+      response.setEncoding('utf8');
+      response.on('data', (chunk) => { body += chunk; });
+      response.on('end', () => resolve(body));
+    }).on('error', reject);
+  });
+}
+
+function titleFromHtml(html) {
+  const match = String(html).match(/<title>(.*?)<\\/title>/i);
+  return match ? match[1] : '';
+}
+
+function textFromHtml(html) {
+  return String(html).replace(/<[^>]+>/g, ' ').replace(/\\s+/g, ' ').trim();
+}
+
+function createPage() {
+  state.pages += 1;
+  let currentUrl = 'about:blank';
+  let html = '<html><title></title><body></body></html>';
+  return {
+    async screenshot() {
+      return Buffer.from('fake-screenshot');
+    },
+    async title() {
+      return titleFromHtml(html);
+    },
+    url() {
+      return currentUrl;
+    },
+    viewportSize() {
+      return { width: 1440, height: 900 };
+    },
+    async goto(url) {
+      currentUrl = url;
+      state.navigations.push(url);
+      html = await fetchText(url);
+    },
+    locator(selector) {
+      return {
+        first() {
+          return this;
+        },
+        async innerText() {
+          return selector === 'body' ? textFromHtml(html) : '';
+        },
+        async boundingBox() {
+          return { x: 0, y: 0, width: 10, height: 10 };
+        },
+        async click() {},
+        async fill() {},
+        async selectOption() {},
+        async waitFor() {},
+      };
+    },
+    getByText() {
+      return this.locator('body');
+    },
+    mouse: {
+      async click() {},
+    },
+    keyboard: {
+      async type() {},
+      async press() {},
+    },
+    async waitForURL() {},
+    async waitForTimeout() {},
+    async close() {},
+  };
+}
+
+function createContext() {
+  state.contexts += 1;
+  const pages = [];
+  return {
+    pages() {
+      return pages;
+    },
+    async newPage() {
+      const page = createPage();
+      pages.push(page);
+      return page;
+    },
+    async close() {
+      state.contextCloses += 1;
+    },
+  };
+}
+
+module.exports = {
+  __state: state,
+  __runtimeDir: path.resolve(__dirname, '..', '..'),
+  chromium: {
+    executablePath() {
+      return executablePath;
+    },
+    async launch() {
+      state.launches += 1;
+      return {
+        async newContext() {
+          return createContext();
+        },
+        async close() {
+          state.browserCloses += 1;
+        },
+      };
+    },
+    async launchPersistentContext() {
+      return createContext();
+    },
+  },
+};
+`, 'utf8');
+}
+
+function writeFakeNpm(rootDir: string): { binDir: string; logPath: string } {
+  const binDir = path.join(rootDir, 'bin');
+  const logPath = path.join(rootDir, 'npm-log.jsonl');
+  const scriptPath = path.join(rootDir, 'fake-npm.cjs');
+  fs.mkdirSync(binDir);
+  fs.writeFileSync(scriptPath, `
+const fs = require('node:fs');
+const path = require('node:path');
+
+const logPath = ${JSON.stringify(logPath)};
+fs.appendFileSync(logPath, JSON.stringify({ cwd: process.cwd(), args: process.argv.slice(2) }) + '\\n');
+
+if (process.argv[2] === 'install') {
+  const moduleDir = path.join(process.cwd(), 'node_modules', 'playwright');
+  const chromiumDir = path.join(moduleDir, 'chromium');
+  fs.mkdirSync(chromiumDir, { recursive: true });
+  fs.writeFileSync(path.join(chromiumDir, ${JSON.stringify(process.platform === 'win32' ? 'chrome.exe' : 'chrome')}), '');
+  fs.writeFileSync(path.join(moduleDir, 'package.json'), JSON.stringify({ name: 'playwright', main: 'index.cjs' }));
+  fs.writeFileSync(path.join(moduleDir, 'index.cjs'), [
+    "const path = require('node:path');",
+    ${JSON.stringify(`const executablePath = path.join(__dirname, 'chromium', ${JSON.stringify(process.platform === 'win32' ? 'chrome.exe' : 'chrome')});`)},
+    "module.exports = {",
+    "  __runtimeDir: path.resolve(__dirname, '..', '..'),",
+    "  chromium: {",
+    "    executablePath() { return executablePath; },",
+    "    async launch() { throw new Error('not used by install test'); },",
+    "  },",
+    "};",
+  ].join('\\n'));
+}
+`, 'utf8');
+
+  if (process.platform === 'win32') {
+    const command = path.join(binDir, 'npm.cmd');
+    fs.writeFileSync(command, `@echo off\r\n"${process.execPath}" "${scriptPath}" %*\r\n`, 'utf8');
+    return { binDir, logPath };
+  }
+
+  const command = path.join(binDir, 'npm');
+  fs.writeFileSync(command, `#!/bin/sh\nexec "${process.execPath}" "${scriptPath}" "$@"\n`, { mode: 0o755 });
+  return { binDir, logPath };
+}
+
+function readJsonLines(filePath: string): any[] {
+  return fs.readFileSync(filePath, 'utf8')
+    .trim()
+    .split('\n')
+    .filter(Boolean)
+    .map((line) => JSON.parse(line));
+}
+
+function setBrowserEnabled(enabled: boolean) {
+  appConfigDb.set('browser_use_settings', JSON.stringify({ enabled }));
+}
+
+test.after(async () => {
+  await browserUseService.stopAllSessions();
+  closeConnection();
+});
 
 test('browser monitor list starts empty without agent sessions', async () => {
   const sessions = await browserUseService.listSessions();
 
   assert.deepEqual(sessions, []);
+});
+
+test('installRuntime installs and resolves Playwright from the CloudCLI runtime directory', async () => {
+  const rootDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cloudcli-browser-install-'));
+  const runtimeDir = path.join(rootDir, 'runtime');
+  const cwd = path.join(rootDir, 'cwd');
+  fs.mkdirSync(cwd);
+  const fakeNpm = writeFakeNpm(rootDir);
+  const originalRuntimeDir = process.env.CLOUDCLI_BROWSER_USE_RUNTIME_DIR;
+  const originalPath = process.env.PATH;
+  const originalCwd = process.cwd();
+
+  process.env.CLOUDCLI_BROWSER_USE_RUNTIME_DIR = runtimeDir;
+  process.env.PATH = `${fakeNpm.binDir}${path.delimiter}${originalPath || ''}`;
+  process.chdir(cwd);
+
+  try {
+    const result = await browserUseService.installRuntime();
+    const commands = readJsonLines(fakeNpm.logPath);
+    const require = createRequire(path.join(runtimeDir, 'package.json'));
+    const playwright = require('playwright');
+
+    assert.equal(result.success, true);
+    assert.equal(result.status.playwrightInstalled, true);
+    assert.equal(result.status.chromiumInstalled, true);
+    assert.equal(playwright.__runtimeDir, path.resolve(runtimeDir));
+    assert.equal(fs.existsSync(path.join(runtimeDir, 'package.json')), true);
+    assert.equal(fs.existsSync(path.join(cwd, 'node_modules', 'playwright')), false);
+    assert.ok(commands.length >= 2);
+    assert.ok(commands.every((entry) => path.resolve(entry.cwd) === path.resolve(runtimeDir)));
+    assert.deepEqual(commands[0].args, ['install', '--no-save', '--no-package-lock', 'playwright@1.61.1']);
+    assert.ok(commands.some((entry) => entry.args.join(' ') === 'exec -- playwright install chromium'));
+  } finally {
+    process.chdir(originalCwd);
+    if (originalRuntimeDir === undefined) {
+      delete process.env.CLOUDCLI_BROWSER_USE_RUNTIME_DIR;
+    } else {
+      process.env.CLOUDCLI_BROWSER_USE_RUNTIME_DIR = originalRuntimeDir;
+    }
+    if (originalPath === undefined) {
+      delete process.env.PATH;
+    } else {
+      process.env.PATH = originalPath;
+    }
+  }
+});
+
+test('agent sessions launch, navigate to localhost, and clean up with runtime Playwright', async () => {
+  const rootDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cloudcli-browser-session-'));
+  const runtimeDir = path.join(rootDir, 'runtime');
+  const originalRuntimeDir = process.env.CLOUDCLI_BROWSER_USE_RUNTIME_DIR;
+  process.env.CLOUDCLI_BROWSER_USE_RUNTIME_DIR = runtimeDir;
+  writeFakePlaywright(runtimeDir);
+  setBrowserEnabled(true);
+  let sessionId: string | null = null;
+
+  const server = http.createServer((_request, response) => {
+    response.writeHead(200, { 'Content-Type': 'text/html' });
+    response.end('<!doctype html><title>Local Runtime Test</title><main>Hello localhost</main>');
+  });
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const address = server.address();
+  assert.ok(address && typeof address === 'object');
+  const url = `http://127.0.0.1:${address.port}/runtime`;
+
+  try {
+    const session = await browserUseService.createAgentSession();
+    sessionId = session.id;
+    const navigated = await browserUseService.agentNavigate(session.id, url);
+    const snapshot = await browserUseService.agentSnapshot(session.id);
+    const stopped = await browserUseService.stopSession(session.id);
+    const require = createRequire(path.join(runtimeDir, 'package.json'));
+    const playwright = require('playwright');
+
+    assert.equal(session.status, 'ready');
+    assert.equal(navigated.url, url);
+    assert.equal(navigated.title, 'Local Runtime Test');
+    assert.match(snapshot.text, /Hello localhost/);
+    assert.equal(stopped.stopped, true);
+    assert.equal(playwright.__state.launches, 1);
+    assert.deepEqual(playwright.__state.navigations, [url]);
+    assert.equal(playwright.__state.contextCloses, 1);
+    assert.equal(playwright.__state.browserCloses, 1);
+    await browserUseService.deleteSession(session.id);
+  } finally {
+    await new Promise<void>((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+    if (sessionId) {
+      await browserUseService.deleteSession(sessionId);
+    }
+    setBrowserEnabled(false);
+    if (originalRuntimeDir === undefined) {
+      delete process.env.CLOUDCLI_BROWSER_USE_RUNTIME_DIR;
+    } else {
+      process.env.CLOUDCLI_BROWSER_USE_RUNTIME_DIR = originalRuntimeDir;
+    }
+  }
 });


### PR DESCRIPTION
## Problem

A global CloudCLI 1.36.1 install can say the Browser Use runtime installed successfully, then still report Playwright and Chromium as unavailable.

The installer runs npm from `process.cwd()`, while CloudCLI resolves Playwright relative to the Browser Use service. When CloudCLI starts from another directory, npm installs the package in one place and CloudCLI looks for it somewhere else.

## What changed

- Install Playwright in `~/.cloudcli/browser-use/runtime` instead of the launch directory.
- Pin the Browser Use runtime to Playwright 1.61.1.
- Resolve the normal packaged dependency first, then check the Browser Use runtime directory.
- Run the package and browser installation commands from that same runtime directory.
- Keep the Windows `npm.cmd` handling needed on current Node releases.
- Return a setup error when the runtime directory cannot be created, and allow retry after the path is fixed.
- Add tests for installation, resolution, browser launch, localhost navigation, snapshots, and cleanup.

## Prior work

@benjaminberes-bp identified the isolated runtime directory and Windows `npm.cmd` fix in #917. That PR now conflicts with `main` and also includes separate Claude SDK and launcher changes. This PR brings only the Browser Use runtime fix onto current `main`, with focused tests and a live global-install check. The other Windows changes in #917 remain separate.

I hit this while testing CoderLuii/HolyClaude#66. That issue's arm64 Chromium crash was fixed in HolyClaude's image packaging and is separate from this CloudCLI installer problem.

## Checks

Updated against current `main` (CloudCLI 1.37.3).

- `npm ci`
- Browser Use tests: 3 passed, including directory setup failure and retry.
- `npm run typecheck`
- `npm run lint` (warnings remain; no errors)
- `npm run build`
- Windows 11 / Node 24: installed Playwright and Chromium from an unrelated working directory, then launched Chromium, opened a localhost page, captured a snapshot, and stopped and deleted the session. The launch directory stayed free of runtime dependencies.

The earlier Linux container check has not been rerun for this refresh.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Browser automation runtime installation now supports a configurable installation directory.
  * Playwright can be loaded from the configured runtime directory when unavailable from the default location.
  * Runtime setup installs a pinned Playwright version and Chromium in the selected directory.
  * Browser automation supports improved Windows command execution and working-directory handling.

* **Bug Fixes**
  * Runtime readiness checks now account for the installation directory, preventing stale results from being reused incorrectly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->