### PR TITLE
fix model select and display issue

### DIFF
--- a/server/claude-sdk.js
+++ b/server/claude-sdk.js
@@ -174,6 +174,7 @@ function mapCliOptionsToSDK(options = {}) {
   delete sdkEnv.ANTHROPIC_DEFAULT_OPUS_MODEL;
   delete sdkEnv.ANTHROPIC_DEFAULT_SONNET_MODEL;
   delete sdkEnv.ANTHROPIC_DEFAULT_HAIKU_MODEL;
+  delete sdkEnv.CLAUDE_CODE_SUBAGENT_MODEL;
   sdkOptions.env = sdkEnv;
 
   // Resolve the executable eagerly on Windows because the SDK uses raw child_process.spawn,
@@ -483,7 +484,7 @@ async function queryClaudeSDK(command, options = {}, ws) {
   try {
     const resolvedModel = await providerModelsService.resolveResumeModel(
       'claude',
-      appSessionId ?? sessionId,
+      appSessionId?.trim() || sessionId,
       options.model,
     );
     let effortModels = CLAUDE_FALLBACK_MODELS;

--- a/server/claude-sdk.js
+++ b/server/claude-sdk.js
@@ -164,7 +164,17 @@ function mapCliOptionsToSDK(options = {}) {
 
   // Forward all host env vars (e.g. ANTHROPIC_BASE_URL) to the subprocess.
   // Since SDK 0.2.113, options.env replaces process.env instead of overlaying it.
-  sdkOptions.env = { ...process.env };
+  //
+  // Strip the model-selecting env vars first: the app owns model selection and
+  // passes it explicitly via `sdkOptions.model`. If the host has `ANTHROPIC_MODEL`
+  // (or the per-tier defaults) set, the subprocess would otherwise honor them —
+  // most visibly when the user picks `default`, silently overriding the choice.
+  const sdkEnv = { ...process.env };
+  delete sdkEnv.ANTHROPIC_MODEL;
+  delete sdkEnv.ANTHROPIC_DEFAULT_OPUS_MODEL;
+  delete sdkEnv.ANTHROPIC_DEFAULT_SONNET_MODEL;
+  delete sdkEnv.ANTHROPIC_DEFAULT_HAIKU_MODEL;
+  sdkOptions.env = sdkEnv;
 
   // Resolve the executable eagerly on Windows because the SDK uses raw child_process.spawn,
   // which does not reliably follow npm's shell wrappers like cross-spawn does.
@@ -458,7 +468,7 @@ async function loadMcpConfig(cwd) {
  * @returns {Promise<void>}
  */
 async function queryClaudeSDK(command, options = {}, ws) {
-  const { sessionId, sessionSummary } = options;
+  const { sessionId, appSessionId, sessionSummary } = options;
   let capturedSessionId = sessionId;
   let sessionCreatedSent = false;
 
@@ -473,7 +483,7 @@ async function queryClaudeSDK(command, options = {}, ws) {
   try {
     const resolvedModel = await providerModelsService.resolveResumeModel(
       'claude',
-      sessionId,
+      appSessionId ?? sessionId,
       options.model,
     );
     let effortModels = CLAUDE_FALLBACK_MODELS;

--- a/server/cursor-cli.js
+++ b/server/cursor-cli.js
@@ -30,8 +30,10 @@ function isWorkspaceTrustPrompt(text = '') {
 
 async function spawnCursor(command, options = {}, ws) {
   return new Promise(async (resolve, reject) => {
-    const { sessionId, projectPath, cwd, toolsSettings, skipPermissions, model, sessionSummary, images } = options;
-    const resolvedModel = await providerModelsService.resolveResumeModel('cursor', sessionId, model);
+    const { sessionId, appSessionId, projectPath, cwd, toolsSettings, skipPermissions, model, sessionSummary, images } = options;
+    // The session model override is stored under the app-facing session id, so
+    // resolve it with that id (falling back to the provider id when absent).
+    const resolvedModel = await providerModelsService.resolveResumeModel('cursor', appSessionId ?? sessionId, model);
     let capturedSessionId = sessionId; // Track session ID throughout the process
     let sessionCreatedSent = false; // Track if we've already sent session-created event
     let hasRetriedWithTrust = false;

--- a/server/cursor-cli.js
+++ b/server/cursor-cli.js
@@ -33,7 +33,7 @@ async function spawnCursor(command, options = {}, ws) {
     const { sessionId, appSessionId, projectPath, cwd, toolsSettings, skipPermissions, model, sessionSummary, images } = options;
     // The session model override is stored under the app-facing session id, so
     // resolve it with that id (falling back to the provider id when absent).
-    const resolvedModel = await providerModelsService.resolveResumeModel('cursor', appSessionId ?? sessionId, model);
+    const resolvedModel = await providerModelsService.resolveResumeModel('cursor', appSessionId?.trim() || sessionId, model);
     let capturedSessionId = sessionId; // Track session ID throughout the process
     let sessionCreatedSent = false; // Track if we've already sent session-created event
     let hasRetriedWithTrust = false;

--- a/server/modules/projects/services/project-delete.service.ts
+++ b/server/modules/projects/services/project-delete.service.ts
@@ -77,7 +77,11 @@ export async function deleteOrArchiveProject(projectId: string, force: boolean):
 
   await deleteSessionJsonlFilesForProjectPath(row.project_path);
   sessionsDb.deleteSessionsByProjectPath(row.project_path);
-  await deleteProviderSessionActiveModelChanges(sessionIds);
+  try {
+    await deleteProviderSessionActiveModelChanges(sessionIds);
+  } catch (error) {
+    console.warn('Failed to clean up session model overrides:', error);
+  }
   projectsDb.deleteProjectById(projectId);
 }
 

--- a/server/modules/projects/services/project-delete.service.ts
+++ b/server/modules/projects/services/project-delete.service.ts
@@ -2,7 +2,7 @@ import { promises as fs } from 'node:fs';
 import path from 'node:path';
 
 import { projectsDb, sessionsDb } from '@/modules/database/index.js';
-import { AppError } from '@/shared/utils.js';
+import { AppError, deleteProviderSessionActiveModelChanges } from '@/shared/utils.js';
 
 function uniqueJsonlPathsFromSessions(
   sessions: Array<{ jsonl_path: string | null }>,
@@ -69,8 +69,15 @@ export async function deleteOrArchiveProject(projectId: string, force: boolean):
     return;
   }
 
+  // Capture the session ids before the rows are removed so their per-session
+  // model overrides can be cleared alongside the permanent delete.
+  const sessionIds = sessionsDb
+    .getSessionsByProjectPathIncludingArchived(row.project_path)
+    .map((session) => session.session_id);
+
   await deleteSessionJsonlFilesForProjectPath(row.project_path);
   sessionsDb.deleteSessionsByProjectPath(row.project_path);
+  await deleteProviderSessionActiveModelChanges(sessionIds);
   projectsDb.deleteProjectById(projectId);
 }
 

--- a/server/modules/providers/list/claude/claude-models.provider.ts
+++ b/server/modules/providers/list/claude/claude-models.provider.ts
@@ -139,6 +139,12 @@ const ANSI_PATTERN = new RegExp(
   'g',
 );
 
+// Claude tags system-generated placeholder turns (e.g. an interrupted or
+// errored response) with sentinel model values like `<synthetic>`. These are
+// never a real model selection, so they must not mask the actual active model
+// recorded earlier in the transcript.
+const isPlaceholderClaudeModel = (model: string): boolean => model.startsWith('<');
+
 const extractClaudeEventModel = (event: ClaudeInitEvent, sessionId: string): string | null => {
   const eventSessionId = event.sessionId ?? event.session_id;
   if (eventSessionId && eventSessionId !== sessionId) {
@@ -151,12 +157,12 @@ const extractClaudeEventModel = (event: ClaudeInitEvent, sessionId: string): str
   }
 
   const directModel = event.model?.trim();
-  if (directModel) {
+  if (directModel && !isPlaceholderClaudeModel(directModel)) {
     return directModel;
   }
 
   const messageModel = event.message?.model?.trim();
-  return messageModel || null;
+  return messageModel && !isPlaceholderClaudeModel(messageModel) ? messageModel : null;
 };
 
 const stripAnsi = (value: string): string => value.replace(ANSI_PATTERN, '');
@@ -229,6 +235,40 @@ const readClaudeSessionModelFromJsonl = async (
   return null;
 };
 
+// Resolves the model recorded for a session to a catalog option value the model
+// picker can highlight. Explicit selections (picker override, `/model` command)
+// are already option values and pass through unchanged. A normal turn only
+// records the raw provider-native id (e.g. `claude-opus-4-8`), so it is mapped
+// back to the catalog option whose value names the model family.
+//
+// Families are derived from the catalog itself rather than hard-coded, so a
+// newly released model (e.g. a future `claude-<family>-*`) is matched as soon as
+// it has a catalog entry — no change is needed here. Unknown values are returned
+// as-is so callers can decide how to fall back.
+const resolveClaudeActiveOptionValue = (
+  model: string,
+  models: ProviderModelsDefinition,
+): string => {
+  const normalized = model.trim();
+  if (models.OPTIONS.some((option) => option.value === normalized)) {
+    return normalized;
+  }
+
+  const lowered = normalized.toLowerCase();
+  const familyMatch = models.OPTIONS
+    .filter((option) => {
+      const value = option.value.toLowerCase();
+      // Only simple family aliases (e.g. `opus`) can name a raw model id; skip
+      // decorated values like `opus[1m]` and non-model aliases like `default`.
+      return /^[a-z][a-z0-9.]*$/.test(value)
+        && (lowered === `claude-${value}` || lowered.startsWith(`claude-${value}-`));
+    })
+    // Prefer the most specific family when several share a prefix.
+    .sort((first, second) => second.value.length - first.value.length)[0];
+
+  return familyMatch?.value ?? normalized;
+};
+
 export class ClaudeProviderModels implements IProviderModels {
   async getSupportedModels(): Promise<ProviderModelsDefinition> {
     // claude creates a new jsonl file as a separate session for this request.
@@ -246,23 +286,30 @@ export class ClaudeProviderModels implements IProviderModels {
   }
 
   async getCurrentActiveModel(sessionId?: string): Promise<ProviderCurrentActiveModel> {
+    const models = await this.getSupportedModels();
     if (!sessionId?.trim()) {
-      return buildDefaultProviderCurrentActiveModel(await this.getSupportedModels());
+      return buildDefaultProviderCurrentActiveModel(models);
     }
 
     try {
-      const jsonlPath = sessionsDb.getSessionById(sessionId)?.jsonl_path;
+      const session = sessionsDb.getSessionById(sessionId);
+      const jsonlPath = session?.jsonl_path;
+      // The transcript records events under the provider-native session id, which
+      // differs from the app-facing session id the frontend passes here. Match on
+      // the provider id so the lookup is not filtered out; fall back to the given
+      // id for rows created before that mapping was stored.
+      const transcriptSessionId = session?.provider_session_id ?? sessionId;
       const activeModel = jsonlPath
-        ? await readClaudeSessionModelFromJsonl(sessionId, jsonlPath)
+        ? await readClaudeSessionModelFromJsonl(transcriptSessionId, jsonlPath)
         : null;
       if (activeModel?.model) {
-        return activeModel;
+        return { model: resolveClaudeActiveOptionValue(activeModel.model, models) };
       }
     } catch {
       // Fall through to the provider default when the session-backed lookup fails.
     }
 
-    return buildDefaultProviderCurrentActiveModel(await this.getSupportedModels());
+    return buildDefaultProviderCurrentActiveModel(models);
   }
 
   async changeActiveModel(

--- a/server/modules/providers/services/provider-models.service.ts
+++ b/server/modules/providers/services/provider-models.service.ts
@@ -306,7 +306,18 @@ export const createProviderModelsService = (dependencies: ProviderModelsServiceD
   const getCurrentActiveModel = async (
     provider: LLMProvider,
     sessionId?: string,
-  ): Promise<ProviderCurrentActiveModel> => resolveProvider(provider).models.getCurrentActiveModel(sessionId);
+  ): Promise<ProviderCurrentActiveModel> => {
+    // A model the user just picked in the UI is persisted as a session override
+    // that only lands in the provider's own transcript/config on the next resumed
+    // turn. Surface it here so reopening the model picker reflects the pending
+    // choice instead of the stale model still recorded in the provider source.
+    const changedModel = await getChangedActiveModel(provider, sessionId?.trim() ?? '');
+    if (changedModel.supported && changedModel.changed && changedModel.model?.trim()) {
+      return { model: changedModel.model.trim() };
+    }
+
+    return resolveProvider(provider).models.getCurrentActiveModel(sessionId);
+  };
 
   const changeActiveModel = async (
     provider: LLMProvider,

--- a/server/modules/providers/services/sessions.service.ts
+++ b/server/modules/providers/services/sessions.service.ts
@@ -269,7 +269,11 @@ export const sessionsService = {
 
     // Drop the per-session model override (keyed by the app session id) so the
     // override cache does not keep an orphaned entry after a permanent delete.
-    await deleteProviderSessionActiveModelChanges([sessionId]);
+    try {
+      await deleteProviderSessionActiveModelChanges([sessionId]);
+    } catch (error) {
+      console.warn('Failed to clean up session model override:', error);
+    }
 
     return {
       sessionId,

--- a/server/modules/providers/services/sessions.service.ts
+++ b/server/modules/providers/services/sessions.service.ts
@@ -11,7 +11,7 @@ import type {
   LLMProvider,
   NormalizedMessage,
 } from '@/shared/types.js';
-import { AppError } from '@/shared/utils.js';
+import { AppError, deleteProviderSessionActiveModelChanges } from '@/shared/utils.js';
 
 type CreateAppSessionResult = {
   sessionId: string;
@@ -266,6 +266,10 @@ export const sessionsService = {
         statusCode: 404,
       });
     }
+
+    // Drop the per-session model override (keyed by the app session id) so the
+    // override cache does not keep an orphaned entry after a permanent delete.
+    await deleteProviderSessionActiveModelChanges([sessionId]);
 
     return {
       sessionId,

--- a/server/modules/providers/tests/provider-models.service.test.ts
+++ b/server/modules/providers/tests/provider-models.service.test.ts
@@ -15,7 +15,11 @@ import type {
   ProviderModelsDefinition,
   ProviderSessionActiveModelChange,
 } from '@/shared/types.js';
-import { writeProviderSessionActiveModelChange } from '@/shared/utils.js';
+import {
+  deleteProviderSessionActiveModelChanges,
+  readProviderSessionActiveModelChange,
+  writeProviderSessionActiveModelChange,
+} from '@/shared/utils.js';
 
 const createModels = (value: string): ProviderModelsDefinition => ({
   OPTIONS: [{ value, label: value }],
@@ -287,6 +291,48 @@ test('provider models service delegates current active model lookups to the prov
   assert.equal(activeModel.model, 'opencode-session-123');
 });
 
+test('getCurrentActiveModel surfaces a pending session model override before the adapter', async () => {
+  const tempRoot = await mkdtemp(path.join(os.tmpdir(), 'provider-active-model-'));
+  const activeModelChangesPath = path.join(tempRoot, 'session-model-changes.json');
+
+  try {
+    let adapterCalls = 0;
+    const service = createProviderModelsService({
+      activeModelChangesPath,
+      resolveProvider: (provider) => ({
+        models: {
+          getSupportedModels: async () => createModels(`${provider}-models`),
+          getCurrentActiveModel: async () => {
+            adapterCalls += 1;
+            return createCurrentActiveModel(`${provider}-active`);
+          },
+          changeActiveModel: async (input) => createSessionActiveModelChange(provider, input),
+        },
+      }),
+    });
+
+    await writeProviderSessionActiveModelChange('claude', {
+      sessionId: 'session-789',
+      model: 'opus',
+    }, {
+      filePath: activeModelChangesPath,
+    });
+
+    // A pending override the user just picked wins over the provider's own
+    // (still-stale) transcript until the next resumed turn consumes it.
+    const overridden = await service.getCurrentActiveModel('claude', 'session-789');
+    assert.equal(overridden.model, 'opus');
+    assert.equal(adapterCalls, 0);
+
+    // Sessions without a pending override fall back to the provider adapter.
+    const fallback = await service.getCurrentActiveModel('claude', 'session-other');
+    assert.equal(fallback.model, 'claude-active');
+    assert.equal(adapterCalls, 1);
+  } finally {
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});
+
 test('provider models service delegates active model change requests to the provider adapter', async () => {
   const calls: Array<{ provider: LLMProvider; input: ProviderChangeActiveModelInput }> = [];
   const service = createProviderModelsService({
@@ -343,6 +389,35 @@ test('resolveResumeModel prefers a stored changed model over the requested one',
 
     const model = await service.resolveResumeModel('cursor', 'session-456', 'composer-2-fast');
     assert.equal(model, 'composer-2');
+  } finally {
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test('deleteProviderSessionActiveModelChanges removes only the targeted sessions', async () => {
+  const tempRoot = await mkdtemp(path.join(os.tmpdir(), 'provider-model-cleanup-'));
+  const activeModelChangesPath = path.join(tempRoot, 'session-model-changes.json');
+
+  try {
+    const write = (provider: LLMProvider, sessionId: string, model: string) =>
+      writeProviderSessionActiveModelChange(provider, { sessionId, model }, { filePath: activeModelChangesPath });
+    const read = (provider: LLMProvider, sessionId: string) =>
+      readProviderSessionActiveModelChange(provider, sessionId, { filePath: activeModelChangesPath });
+
+    await write('claude', 'session-keep', 'opus');
+    await write('claude', 'session-drop', 'sonnet');
+    await write('cursor', 'session-drop', 'composer-2'); // same id, different provider
+
+    await deleteProviderSessionActiveModelChanges(['session-drop'], { filePath: activeModelChangesPath });
+
+    // Untouched session survives.
+    const kept = await read('claude', 'session-keep');
+    assert.equal(kept.changed, true);
+    assert.equal(kept.model, 'opus');
+
+    // The deleted session id is removed for every provider.
+    assert.equal((await read('claude', 'session-drop')).changed, false);
+    assert.equal((await read('cursor', 'session-drop')).changed, false);
   } finally {
     await rm(tempRoot, { recursive: true, force: true });
   }

--- a/server/modules/websocket/services/chat-websocket.service.ts
+++ b/server/modules/websocket/services/chat-websocket.service.ts
@@ -199,6 +199,7 @@ async function handleChatSend(
     // global upload store may reach the provider runtimes' file reads.
     images: filterImagesToUploadStore(clientOptions.images),
     sessionId: session.provider_session_id ?? undefined,
+    appSessionId: session.session_id ?? undefined,
     resume: Boolean(session.provider_session_id),
     cwd: clientOptions.cwd ?? session.project_path ?? undefined,
     projectPath: session.project_path ?? clientOptions.projectPath,

--- a/server/openai-codex.js
+++ b/server/openai-codex.js
@@ -225,6 +225,7 @@ function mapPermissionModeToCodexOptions(permissionMode) {
 export async function queryCodex(command, options = {}, ws) {
   const {
     sessionId,
+    appSessionId,
     sessionSummary,
     cwd,
     projectPath,
@@ -236,7 +237,7 @@ export async function queryCodex(command, options = {}, ws) {
 
   const resolvedModel = await providerModelsService.resolveResumeModel(
     'codex',
-    sessionId,
+    appSessionId ?? sessionId,
     model,
   );
 

--- a/server/openai-codex.js
+++ b/server/openai-codex.js
@@ -237,7 +237,7 @@ export async function queryCodex(command, options = {}, ws) {
 
   const resolvedModel = await providerModelsService.resolveResumeModel(
     'codex',
-    appSessionId ?? sessionId,
+    appSessionId?.trim() || sessionId,
     model,
   );
 

--- a/server/opencode-cli.js
+++ b/server/opencode-cli.js
@@ -232,7 +232,7 @@ async function spawnOpenCode(command, options = {}, ws) {
       }
     };
 
-    void providerModelsService.resolveResumeModel('opencode', appSessionId ?? sessionId, model).then(async (resolvedModel) => {
+    void providerModelsService.resolveResumeModel('opencode', appSessionId?.trim() || sessionId, model).then(async (resolvedModel) => {
       let effortModels = null;
       try {
         effortModels = (await providerModelsService.getProviderModels('opencode')).models;

--- a/server/opencode-cli.js
+++ b/server/opencode-cli.js
@@ -124,7 +124,7 @@ function readOpenCodeTokenUsage(sessionId) {
 
 async function spawnOpenCode(command, options = {}, ws) {
   return new Promise((resolve, reject) => {
-    const { sessionId, projectPath, cwd, model, effort, sessionSummary, images, permissionMode } = options;
+    const { sessionId, appSessionId, projectPath, cwd, model, effort, sessionSummary, images, permissionMode } = options;
     const workingDir = cwd || projectPath || process.cwd();
     const processKey = sessionId || Date.now().toString();
     let capturedSessionId = sessionId || null;
@@ -232,7 +232,7 @@ async function spawnOpenCode(command, options = {}, ws) {
       }
     };
 
-    void providerModelsService.resolveResumeModel('opencode', sessionId, model).then(async (resolvedModel) => {
+    void providerModelsService.resolveResumeModel('opencode', appSessionId ?? sessionId, model).then(async (resolvedModel) => {
       let effortModels = null;
       try {
         effortModels = (await providerModelsService.getProviderModels('opencode')).models;

--- a/server/routes/commands.js
+++ b/server/routes/commands.js
@@ -36,16 +36,33 @@ const readModelProvider = (value) => {
 const hasConcreteSessionId = (value) =>
   typeof value === "string" && value.trim().length > 0;
 
-const resolveCommandModel = async (provider, catalog, sessionId) => {
-  if (!hasConcreteSessionId(sessionId)) {
-    return catalog.DEFAULT;
+const isCatalogModel = (catalog, model) =>
+  typeof model === "string" && catalog.OPTIONS.some((option) => option.value === model);
+
+const resolveCommandModel = async (provider, catalog, sessionId, requestedModel) => {
+  // A model pinned to this session (via the picker override) or set explicitly
+  // in the transcript resolves to a catalog option value. A normal turn only
+  // records the raw provider-native model id (e.g. "claude-opus-4-8"), which is
+  // not a catalog value and cannot be highlighted, so it is skipped here in
+  // favor of the composer's current selection below.
+  if (hasConcreteSessionId(sessionId)) {
+    const currentActiveModel = await providerModelsService.getCurrentActiveModel(
+      provider,
+      sessionId,
+    );
+    if (isCatalogModel(catalog, currentActiveModel?.model)) {
+      return currentActiveModel.model;
+    }
   }
 
-  const currentActiveModel = await providerModelsService.getCurrentActiveModel(
-    provider,
-    sessionId,
-  );
-  return currentActiveModel?.model || catalog.DEFAULT;
+  // The composer already reconciled its selection to a catalog option value and
+  // sends it as the requested model; it is what the next turn will actually use
+  // when no session override is pinned.
+  if (isCatalogModel(catalog, requestedModel)) {
+    return requestedModel;
+  }
+
+  return catalog.DEFAULT;
 };
 
 export const executeModelsCommand = async (args, context) => {
@@ -56,6 +73,7 @@ export const executeModelsCommand = async (args, context) => {
     currentProvider,
     catalog,
     context?.sessionId,
+    context?.model,
   );
   const availableModels = catalog.OPTIONS.map((option) => option.value);
   const availableOptions = catalog.OPTIONS.map((option) => ({
@@ -255,7 +273,7 @@ Custom commands can be created in:
     const tokenUsage = context?.tokenUsage || {};
     const provider = readModelProvider(context?.provider);
     const catalog = (await providerModelsService.getProviderModels(provider)).models;
-    const model = await resolveCommandModel(provider, catalog, context?.sessionId);
+    const model = await resolveCommandModel(provider, catalog, context?.sessionId, context?.model);
 
     const reportedUsed =
       Number(
@@ -358,7 +376,7 @@ Custom commands can be created in:
 
     const statusProvider = readModelProvider(context?.provider);
     const statusCatalog = (await providerModelsService.getProviderModels(statusProvider)).models;
-    const model = await resolveCommandModel(statusProvider, statusCatalog, context?.sessionId);
+    const model = await resolveCommandModel(statusProvider, statusCatalog, context?.sessionId, context?.model);
     const memoryUsage = process.memoryUsage();
 
     return {

--- a/server/routes/tests/commands.test.js
+++ b/server/routes/tests/commands.test.js
@@ -80,3 +80,80 @@ test('models command falls back to claude for unsupported providers', async () =
     providerModelsService.getCurrentActiveModel = originalGetCurrentActiveModel;
   }
 });
+
+test('models command prefers the requested catalog model over a raw session model id', async () => {
+  const originalGetProviderModels = providerModelsService.getProviderModels;
+  const originalGetCurrentActiveModel = providerModelsService.getCurrentActiveModel;
+
+  providerModelsService.getProviderModels = async () => ({
+    models: {
+      OPTIONS: [
+        { value: 'default', label: 'Default (recommended)' },
+        { value: 'opus', label: 'Opus' },
+      ],
+      DEFAULT: 'default',
+    },
+    cache: {
+      updatedAt: '2026-01-01T00:00:00.000Z',
+      expiresAt: '2026-01-04T00:00:00.000Z',
+      source: 'fresh',
+    },
+  });
+  // A normal turn only records the raw provider-native model id, which is not a
+  // catalog option value the picker can highlight.
+  providerModelsService.getCurrentActiveModel = async () => ({
+    model: 'claude-opus-4-8',
+  });
+
+  try {
+    const result = await executeModelsCommand([], {
+      provider: 'claude',
+      sessionId: 'session-abc',
+      model: 'opus',
+    });
+
+    assert.equal(result.data.current.model, 'opus');
+  } finally {
+    providerModelsService.getProviderModels = originalGetProviderModels;
+    providerModelsService.getCurrentActiveModel = originalGetCurrentActiveModel;
+  }
+});
+
+test('models command keeps a catalog session model (picker override) over the requested model', async () => {
+  const originalGetProviderModels = providerModelsService.getProviderModels;
+  const originalGetCurrentActiveModel = providerModelsService.getCurrentActiveModel;
+
+  providerModelsService.getProviderModels = async () => ({
+    models: {
+      OPTIONS: [
+        { value: 'default', label: 'Default (recommended)' },
+        { value: 'opus', label: 'Opus' },
+        { value: 'haiku', label: 'Haiku' },
+      ],
+      DEFAULT: 'default',
+    },
+    cache: {
+      updatedAt: '2026-01-01T00:00:00.000Z',
+      expiresAt: '2026-01-04T00:00:00.000Z',
+      source: 'fresh',
+    },
+  });
+  // A picker override / explicit "set model" line resolves to a catalog value
+  // and must win over the composer's (possibly stale) requested model.
+  providerModelsService.getCurrentActiveModel = async () => ({
+    model: 'haiku',
+  });
+
+  try {
+    const result = await executeModelsCommand([], {
+      provider: 'claude',
+      sessionId: 'session-abc',
+      model: 'opus',
+    });
+
+    assert.equal(result.data.current.model, 'haiku');
+  } finally {
+    providerModelsService.getProviderModels = originalGetProviderModels;
+    providerModelsService.getCurrentActiveModel = originalGetCurrentActiveModel;
+  }
+});

--- a/server/shared/utils.ts
+++ b/server/shared/utils.ts
@@ -722,6 +722,49 @@ export async function writeProviderSessionActiveModelChange(
   };
 }
 
+/**
+ * Removes persisted session model-change entries for the given app session ids
+ * (across all providers).
+ *
+ * Called when sessions are permanently deleted so the override cache does not
+ * accumulate orphaned entries. Archived (soft-deleted) sessions are intentionally
+ * left untouched so their pinned model survives an un-archive. A missing file or
+ * no matching entries is a no-op.
+ */
+export async function deleteProviderSessionActiveModelChanges(
+  sessionIds: readonly string[],
+  options: {
+    filePath?: string;
+  } = {},
+): Promise<void> {
+  const targetSessionIds = new Set(
+    sessionIds.map((sessionId) => sessionId.trim()).filter(Boolean),
+  );
+  if (targetSessionIds.size === 0) {
+    return;
+  }
+
+  const filePath = options.filePath ?? getProviderSessionActiveModelChangesPath();
+  const cacheFile = await readProviderSessionActiveModelChangeCacheFile(filePath);
+  const entries = Object.entries(cacheFile.entries);
+
+  // Keys are `${provider}:${sessionId}`; neither provider names nor the app
+  // session ids contain a colon, so the segment after the first one is the id.
+  const remainingEntries = entries.filter(([key]) => {
+    const sessionId = key.slice(key.indexOf(':') + 1);
+    return !targetSessionIds.has(sessionId);
+  });
+
+  if (remainingEntries.length === entries.length) {
+    return; // nothing matched — avoid rewriting (or creating) the file
+  }
+
+  await writeProviderSessionActiveModelChangeCacheFile(filePath, {
+    version: cacheFile.version,
+    entries: Object.fromEntries(remainingEntries),
+  });
+}
+
 // ---------------------------
 //----------------- WEBSOCKET PAYLOAD PARSING UTILITIES ------------
 /**

--- a/src/components/chat/hooks/useChatProviderState.ts
+++ b/src/components/chat/hooks/useChatProviderState.ts
@@ -540,6 +540,9 @@ export function useChatProviderState({ selectedSession, selectedProject: _select
       throw new Error('Unable to change the active model for this session.');
     }
 
+    // new session will use the latest model
+    setStoredProviderModel(targetProvider, model);
+
     return {
       scope: 'session' as const,
       changed: body.data.changed === true,


### PR DESCRIPTION
## Problem
Picking a Claude model from the chat `/models` picker had two independent bugs:
1. **Display** — the picker showed the wrong active model (e.g. `default`/`sonnet`
   while the session was actually running `opus`) and never reflected a just-made pick.
2. **Runtime** — the per-session override (stored by `/active-model`, keyed by the
   *app* session id) was never applied on resume, because runtimes looked it up with
   the *provider-native* session id.
Plus: a host `ANTHROPIC_MODEL` env var could silently override the explicit choice,
and the override cache accumulated orphaned entries.

## Root causes & fixes
Fixes https://github.com/siteboon/claudecodeui/issues/981

### Display — the picker reflects the real model
- `getCurrentActiveModel` now matches transcript events by `provider_session_id`
  (jsonl records the provider id, the frontend passes the app id → every event was
  rejected → fell back to `default`). `claude-models.provider.ts`
- Transcripts record the raw model id (`claude-opus-4-8`); `resolveClaudeActiveOptionValue`
  maps it back to the catalog alias (`opus`) for highlighting. Families are derived
  from the catalog, so a newly released model needs no code change here. `claude-models.provider.ts`
- System-placeholder turns (`"model":"<synthetic>"`) no longer mask the real model. `claude-models.provider.ts`
- A pending override is surfaced first, so reopening the picker shows the choice. `provider-models.service.ts`
- `resolveCommandModel` validates the value against the catalog and falls back to the
  composer's requested model; wired into `/models`, `/cost`, `/status`. `commands.js`

### Runtime — the model change takes effect
- Pass the app session id to the provider runtimes and resolve the override with it.
  `chat-websocket.service.ts`, `claude-sdk.js`, `cursor-cli.js`, `opencode-cli.js`, `openai-codex.js`

### Env precedence
- Strip `ANTHROPIC_MODEL` / `ANTHROPIC_DEFAULT_{OPUS,SONNET,HAIKU}_MODEL` from the SDK
  subprocess env so the explicit selection wins (notably for `default`). `claude-sdk.js`

### Override-cache hygiene
- New `deleteProviderSessionActiveModelChanges(sessionIds)`, called on permanent
  session delete and permanent project delete (archive is reversible → left untouched).
  `utils.ts`, `sessions.service.ts`, `project-delete.service.ts`

### Frontend
- After picking a model for a session, sync the composer model so new sessions inherit
  the latest choice. `useChatProviderState.ts`

## Tests
- Override surfaced before the adapter; raw-id → catalog fallback in the model command;
  override cleanup removes only the targeted sessions across providers.
- Green: server `tsc`, 16 provider-model + command tests, eslint.

## Known limitations (display-only, by design)
- `default` and `sonnet` share the same underlying model, so without an override a
  default session shows `sonnet` in the picker — self-corrects once the user picks. 
- Overrides are intentionally persistent (`changed:true`) — that's the per-session
  model memory; they are cleared only when the session/project is permanently deleted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Session-specific model selections now persist and take priority when resuming conversations.
  * Model selections made in the composer are applied consistently to model, cost, and status commands.
  * Provider-native model identifiers are translated into recognizable model-picker options.

* **Bug Fixes**
  * Prevented environment settings from unexpectedly overriding the selected model.
  * Improved model detection when resuming sessions.
  * Removed saved model overrides when sessions or projects are permanently deleted.

Another PR: https://github.com/siteboon/claudecodeui/pull/996 is for same purpose.
⚠️⚠️ This PR includes all the changes from PR #996, along with some additional fixes. Please review and merge only one of the two PRs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved model selection consistency across chat sessions, resumed conversations, and built-in commands.
  * The Models, Cost, and Status commands now reflect the selected session or composer model when applicable.
  * Selected provider models are saved for future use.

* **Bug Fixes**
  * Prevented placeholder or internal model values from replacing the active model.
  * Improved recognition of provider model names in the model picker.
  * Cleared session-specific model overrides when sessions or projects are permanently deleted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->