### PR TITLE
fix: bump @openai/codex-sdk to ^0.144.0 to support newer Codex models

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "@codemirror/theme-one-dark": "^6.1.2",
         "@iarna/toml": "^2.2.5",
         "@octokit/rest": "^22.0.0",
-        "@openai/codex-sdk": "^0.141.0",
+        "@openai/codex-sdk": "^0.144.0",
         "@replit/codemirror-minimap": "^0.5.2",
         "@tailwindcss/typography": "^0.5.16",
         "@uiw/react-codemirror": "^4.23.13",
@@ -4682,9 +4682,9 @@
       }
     },
     "node_modules/@openai/codex": {
-      "version": "0.141.0",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.141.0.tgz",
-      "integrity": "sha512-ACpAn/Z7JwBg431040zKOLpBtNdP024ixqwC/R2YM5tPrLG0wfSmrd/AVHPUExt6hOO6fEHwxM/ixAyzFleQXw==",
+      "version": "0.144.1",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.1.tgz",
+      "integrity": "sha512-Xir1zqPfpenhdoAoshN53uonzbBXj18COyzRkFlVZpSNyEl5XtkuYu9oddELePFN7K/0sXUcSO34Ad5IeCXPbw==",
       "license": "Apache-2.0",
       "bin": {
         "codex": "bin/codex.js"
@@ -4693,19 +4693,19 @@
         "node": ">=16"
       },
       "optionalDependencies": {
-        "@openai/codex-darwin-arm64": "npm:@openai/codex@0.141.0-darwin-arm64",
-        "@openai/codex-darwin-x64": "npm:@openai/codex@0.141.0-darwin-x64",
-        "@openai/codex-linux-arm64": "npm:@openai/codex@0.141.0-linux-arm64",
-        "@openai/codex-linux-x64": "npm:@openai/codex@0.141.0-linux-x64",
-        "@openai/codex-win32-arm64": "npm:@openai/codex@0.141.0-win32-arm64",
-        "@openai/codex-win32-x64": "npm:@openai/codex@0.141.0-win32-x64"
+        "@openai/codex-darwin-arm64": "npm:@openai/codex@0.144.1-darwin-arm64",
+        "@openai/codex-darwin-x64": "npm:@openai/codex@0.144.1-darwin-x64",
+        "@openai/codex-linux-arm64": "npm:@openai/codex@0.144.1-linux-arm64",
+        "@openai/codex-linux-x64": "npm:@openai/codex@0.144.1-linux-x64",
+        "@openai/codex-win32-arm64": "npm:@openai/codex@0.144.1-win32-arm64",
+        "@openai/codex-win32-x64": "npm:@openai/codex@0.144.1-win32-x64"
       }
     },
     "node_modules/@openai/codex-darwin-arm64": {
       "name": "@openai/codex",
-      "version": "0.141.0-darwin-arm64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.141.0-darwin-arm64.tgz",
-      "integrity": "sha512-BuroZvQQLJYLfQEG7MKMdxHtggDDlxeJCTot//MwEnbW8ga7P319EPos/FyOK9r/gh+E/KGxk+YAzEoHZPRGEg==",
+      "version": "0.144.1-darwin-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.1-darwin-arm64.tgz",
+      "integrity": "sha512-dABeDK+ATqMG54MGBd3VjpKfh5EOoqx9PKVQB2QYDaEXx3F6CdUCXue5QIMfr4OxziUj8pUcLAQyd+KFqiTUFw==",
       "cpu": [
         "arm64"
       ],
@@ -4720,9 +4720,9 @@
     },
     "node_modules/@openai/codex-darwin-x64": {
       "name": "@openai/codex",
-      "version": "0.141.0-darwin-x64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.141.0-darwin-x64.tgz",
-      "integrity": "sha512-kDP+egfjp3cuao1r9AdD8/skBxM7saT007VE82DB9mRUcqgKaxYHoPaHmKhlYOlFwPam0zsD6ORT6GJJhvGAKg==",
+      "version": "0.144.1-darwin-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.1-darwin-x64.tgz",
+      "integrity": "sha512-K2g3Q3tNxzFhV0SuzO6HcsYK7EQrp/o4HyeReyhkwVrwwUPoYwyIbB0IRjHIiDzRhbKriDccid2iyF5aPqdTcg==",
       "cpu": [
         "x64"
       ],
@@ -4737,9 +4737,9 @@
     },
     "node_modules/@openai/codex-linux-arm64": {
       "name": "@openai/codex",
-      "version": "0.141.0-linux-arm64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.141.0-linux-arm64.tgz",
-      "integrity": "sha512-jXAOSjMqAUUgfMo9ciAkioJKKAYDwOE40bLx4/2jR7Tfu4u9409X5fQlLuNLMgnlfuzUEk/UiibQE62a70bQaw==",
+      "version": "0.144.1-linux-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.1-linux-arm64.tgz",
+      "integrity": "sha512-451o15+XtaXCCb35t/KCyyPqXHnTPxPxtdqEYOnE3e4sH5AfnI/uVJwfdjOksMG6vRLy6R+fLvSDOMguRFLmQw==",
       "cpu": [
         "arm64"
       ],
@@ -4754,9 +4754,9 @@
     },
     "node_modules/@openai/codex-linux-x64": {
       "name": "@openai/codex",
-      "version": "0.141.0-linux-x64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.141.0-linux-x64.tgz",
-      "integrity": "sha512-q3xv538DT/Sb8rRq8apdKgrgA/isqs1fDfE5JhRDMmojYFA3zwDldlmdWWGdS3APtjf5UrDsqljSE9JHxnlWNA==",
+      "version": "0.144.1-linux-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.1-linux-x64.tgz",
+      "integrity": "sha512-HNGVI+BulrOaC/0IzBvd6EL62j7LrlbFKibrhw6hZjjCjAeUYzRB2jB4qDzXN1NfqDi6Xrvniof3kwbwab24lg==",
       "cpu": [
         "x64"
       ],
@@ -4770,12 +4770,12 @@
       }
     },
     "node_modules/@openai/codex-sdk": {
-      "version": "0.141.0",
-      "resolved": "https://registry.npmjs.org/@openai/codex-sdk/-/codex-sdk-0.141.0.tgz",
-      "integrity": "sha512-VCLsSJGSoOHcVAC/2+NrhtiBiCP/XF8YmCzzGocm8qNkAPN3a/+CcrvwUmvNSH53dU3TVi5Hp5zddov16BXLHw==",
+      "version": "0.144.1",
+      "resolved": "https://registry.npmjs.org/@openai/codex-sdk/-/codex-sdk-0.144.1.tgz",
+      "integrity": "sha512-NVb1R5+QJBecLrLrtljHkS7djXu/fGWVaA0FUhop6KgPTdeDzvgMo9uhgAuLi+4mwgf29IhMyNGU/kHG3aV4NA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@openai/codex": "0.141.0"
+        "@openai/codex": "0.144.1"
       },
       "engines": {
         "node": ">=18"
@@ -4783,9 +4783,9 @@
     },
     "node_modules/@openai/codex-win32-arm64": {
       "name": "@openai/codex",
-      "version": "0.141.0-win32-arm64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.141.0-win32-arm64.tgz",
-      "integrity": "sha512-87X5tvH1RmKQOHbgO5Cv+S0aXJ+saHTSSHEasJjbB1FtUoLbao29NTnkpkB2dAV3xtUJ/dmE8NgvbFEeWuMqUQ==",
+      "version": "0.144.1-win32-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.1-win32-arm64.tgz",
+      "integrity": "sha512-L4aDVEh9o1u7WYoxpSyv3un9Bz26YZYocOFqE2oHdEQDL2s6/LdtutLQc3oUZruLlEbkNsjSU0HI1OKsP0+Ctg==",
       "cpu": [
         "arm64"
       ],
@@ -4800,9 +4800,9 @@
     },
     "node_modules/@openai/codex-win32-x64": {
       "name": "@openai/codex",
-      "version": "0.141.0-win32-x64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.141.0-win32-x64.tgz",
-      "integrity": "sha512-4gur4DgFQIOc+DopNOI90IpNA66qBIyc5Lb5QYy66OOCXOvXpbOCpScuEFmT1xpaTzNUYhlRGA2NFWqSHQrKUQ==",
+      "version": "0.144.1-win32-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.1-win32-x64.tgz",
+      "integrity": "sha512-qv2HOp6v/nVP31p5I5GxYyL0wa79PMzim1+W9CKSV0UldjFV9AMbualA8PeXcYhbvvh9Y1UASXxwjuQdlyfAvw==",
       "cpu": [
         "x64"
       ],

--- a/package.json
+++ b/package.json
@@ -145,7 +145,7 @@
     "@codemirror/theme-one-dark": "^6.1.2",
     "@iarna/toml": "^2.2.5",
     "@octokit/rest": "^22.0.0",
-    "@openai/codex-sdk": "^0.141.0",
+    "@openai/codex-sdk": "^0.144.0",
     "@replit/codemirror-minimap": "^0.5.2",
     "@tailwindcss/typography": "^0.5.16",
     "@uiw/react-codemirror": "^4.23.13",


### PR DESCRIPTION
## Problem

Starting a Codex session with a newly released model (e.g. `gpt-5.6-sol`) fails with:

```json
{
  "type": "error",
  "status": 400,
  "error": {
    "type": "invalid_request_error",
    "message": "The 'gpt-5.6-sol' model requires a newer version of Codex. Please upgrade to the latest app or CLI and try again."
  }
}
```

The model appears in the model picker (the account genuinely has access to it), but execution is rejected by the OpenAI API because the bundled Codex engine is too old.

## Root cause

`package.json` pins `"@openai/codex-sdk": "^0.141.0"`. For `0.x` versions, the caret locks the minor version (`>=0.141.0 <0.142.0`), so installs can never resolve to `0.144.x` — the SDK (and its vendored `codex` binary) stays at `0.141.0`, which the API rejects for newer models.

## Fix

Bump the dependency to `^0.144.0`. The lockfile diff only touches `@openai/codex` / `@openai/codex-sdk` and their platform-specific binary packages.

## Verification

Tested on a Windows deployment of the published `1.36.1` package by upgrading the installed SDK in place to `0.144.1`:

- `gpt-5.6-sol` session now works end-to-end (real streamed reply)
- Regression: `gpt-5.5` sessions continue to work, no API breakage observed
- No crashes or behavioral changes in the Codex provider path

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Codex SDK dependency to a newer version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->