### PR TITLE
fix: chat WebSocket reconnect reuses a stale token after refresh

### DIFF
--- a/src/contexts/WebSocketContext.tsx
+++ b/src/contexts/WebSocketContext.tsx
@@ -1,5 +1,6 @@
 import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
 import { useAuth } from '../components/auth/context/AuthContext';
+import { AUTH_TOKEN_STORAGE_KEY } from '../components/auth/constants';
 import { IS_PLATFORM } from '../constants/config';
 
 /**
@@ -109,7 +110,7 @@ const useWebSocketProviderState = (): WebSocketContextType => {
       // on an X-Refreshed-Token) so a reconnect uses the refreshed token rather
       // than a stale in-memory one. Mirrors the shell-WS / file-upload paths.
       const freshToken =
-        (typeof localStorage !== 'undefined' && localStorage.getItem('auth-token')) || token;
+        (typeof localStorage !== 'undefined' && localStorage.getItem(AUTH_TOKEN_STORAGE_KEY)) || token;
       const wsUrl = buildWebSocketUrl(freshToken);
 
       if (!wsUrl) return console.warn('No authentication token found for WebSocket connection');

--- a/src/contexts/WebSocketContext.tsx
+++ b/src/contexts/WebSocketContext.tsx
@@ -105,8 +105,12 @@ const useWebSocketProviderState = (): WebSocketContextType => {
   const connect = useCallback(() => {
     if (unmountedRef.current) return; // Prevent connection if unmounted
     try {
-      // Construct WebSocket URL
-      const wsUrl = buildWebSocketUrl(token);
+      // Read the freshest token from localStorage (authenticatedFetch updates it
+      // on an X-Refreshed-Token) so a reconnect uses the refreshed token rather
+      // than a stale in-memory one. Mirrors the shell-WS / file-upload paths.
+      const freshToken =
+        (typeof localStorage !== 'undefined' && localStorage.getItem('auth-token')) || token;
+      const wsUrl = buildWebSocketUrl(freshToken);
 
       if (!wsUrl) return console.warn('No authentication token found for WebSocket connection');
 


### PR DESCRIPTION
`authenticatedFetch` (`src/utils/api.js`) persists a refreshed JWT to `localStorage['auth-token']` when the server returns `X-Refreshed-Token`. But `WebSocketContext` builds the chat WS URL from AuthContext's in-memory `token`, which is seeded once at mount and only updated by login/logout, never re-synced from `localStorage`.

As a result, on a long-lived tab the chat WS auto-reconnect keeps reusing the original in-memory token and eventually fails at that token's true expiry, even though REST calls keep silently refreshing. The shell WS (`src/components/shell/utils/socket.ts`) and file upload already read `localStorage` fresh and are unaffected.

This reads the freshest `auth-token` from `localStorage` at (re)connect (falling back to the in-memory token), matching the shell-WS and file-upload paths.

One-line frontend change, no new dependencies. I didn't add a test since the repo has no frontend test harness, but I have a regression test for this from a downstream fork and am happy to contribute it if you add one.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved WebSocket connection reliability by using the most up-to-date authentication token available in the browser when establishing a connection.
  * Preserved existing WebSocket connection, messaging, and error-handling behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->