### PR TITLE
feat(i18n): add regional Spanish locales

### DIFF
--- a/src/i18n/config.js
+++ b/src/i18n/config.js
@@ -11,7 +11,6 @@
 
 import i18n from 'i18next';
 import { initReactI18next } from 'react-i18next';
-// eslint-disable-next-line import-x/order
 import LanguageDetector from 'i18next-browser-languagedetector';
 
 // Import translation resources
@@ -24,6 +23,20 @@ import enCodeEditor from './locales/en/codeEditor.json';
 // eslint-disable-next-line import-x/order
 import enTasks from './locales/en/tasks.json';
 
+import esESCommon from './locales/es-ES/common.json';
+import esESSettings from './locales/es-ES/settings.json';
+import esESAuth from './locales/es-ES/auth.json';
+import esESSidebar from './locales/es-ES/sidebar.json';
+import esESChat from './locales/es-ES/chat.json';
+import esESCodeEditor from './locales/es-ES/codeEditor.json';
+import esESTasks from './locales/es-ES/tasks.json';
+import es419Common from './locales/es-419/common.json';
+import es419Settings from './locales/es-419/settings.json';
+import es419Auth from './locales/es-419/auth.json';
+import es419Sidebar from './locales/es-419/sidebar.json';
+import es419Chat from './locales/es-419/chat.json';
+import es419CodeEditor from './locales/es-419/codeEditor.json';
+import es419Tasks from './locales/es-419/tasks.json';
 import koCommon from './locales/ko/common.json';
 import koSettings from './locales/ko/settings.json';
 import koAuth from './locales/ko/auth.json';
@@ -73,7 +86,6 @@ import trAuth from './locales/tr/auth.json';
 import trSidebar from './locales/tr/sidebar.json';
 import trChat from './locales/tr/chat.json';
 import trCodeEditor from './locales/tr/codeEditor.json';
-// eslint-disable-next-line import-x/order
 import trTasks from './locales/tr/tasks.json';
 import itCommon from './locales/it/common.json';
 import itSettings from './locales/it/settings.json';
@@ -125,6 +137,24 @@ i18n
         chat: enChat,
         codeEditor: enCodeEditor,
         tasks: enTasks,
+      },
+      'es-ES': {
+        common: esESCommon,
+        settings: esESSettings,
+        auth: esESAuth,
+        sidebar: esESSidebar,
+        chat: esESChat,
+        codeEditor: esESCodeEditor,
+        tasks: esESTasks,
+      },
+      'es-419': {
+        common: es419Common,
+        settings: es419Settings,
+        auth: es419Auth,
+        sidebar: es419Sidebar,
+        chat: es419Chat,
+        codeEditor: es419CodeEditor,
+        tasks: es419Tasks,
       },
       ko: {
         common: koCommon,

--- a/src/i18n/languages.js
+++ b/src/i18n/languages.js
@@ -20,6 +20,16 @@ export const languages = [
     nativeName: 'Français',
   },
   {
+    value: 'es-ES',
+    label: 'Spanish (Spain)',
+    nativeName: 'Español (España)',
+  },
+  {
+    value: 'es-419',
+    label: 'Spanish (Latin America)',
+    nativeName: 'Español (Latinoamérica)',
+  },
+  {
     value: 'ko',
     label: 'Korean',
     nativeName: '한국어',

--- a/src/i18n/languages.test.js
+++ b/src/i18n/languages.test.js
@@ -1,0 +1,40 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  getLanguage,
+  getLanguageValues,
+  isLanguageSupported,
+  languages,
+} from './languages.js';
+
+test('lists Spain and Latin American Spanish as adjacent, distinct options', () => {
+  const spanishFromSpain = {
+    value: 'es-ES',
+    label: 'Spanish (Spain)',
+    nativeName: 'Español (España)',
+  };
+  const latinAmericanSpanish = {
+    value: 'es-419',
+    label: 'Spanish (Latin America)',
+    nativeName: 'Español (Latinoamérica)',
+  };
+
+  const spainIndex = languages.findIndex(({ value }) => value === spanishFromSpain.value);
+  const latinAmericaIndex = languages.findIndex(({ value }) => value === latinAmericanSpanish.value);
+
+  assert.notEqual(spainIndex, -1);
+  assert.equal(latinAmericaIndex, spainIndex + 1);
+  assert.deepEqual(languages[spainIndex], spanishFromSpain);
+  assert.deepEqual(languages[latinAmericaIndex], latinAmericanSpanish);
+});
+
+test('language helpers preserve the two regional Spanish codes', () => {
+  assert.equal(getLanguage('es-ES')?.nativeName, 'Español (España)');
+  assert.equal(getLanguage('es-419')?.nativeName, 'Español (Latinoamérica)');
+  assert.equal(isLanguageSupported('es-ES'), true);
+  assert.equal(isLanguageSupported('es-419'), true);
+  assert.equal(isLanguageSupported('es'), false);
+  assert.ok(getLanguageValues().includes('es-ES'));
+  assert.ok(getLanguageValues().includes('es-419'));
+});

--- a/src/i18n/locales/es-419/auth.json
+++ b/src/i18n/locales/es-419/auth.json
@@ -1,0 +1,37 @@
+{
+  "login": {
+    "title": "Te damos la bienvenida de nuevo",
+    "description": "Inicia sesión en tu cuenta autoalojada de CloudCLI",
+    "username": "Nombre de usuario",
+    "password": "Contraseña",
+    "submit": "Iniciar sesión",
+    "loading": "Iniciando sesión...",
+    "errors": {
+      "invalidCredentials": "El nombre de usuario o la contraseña no son válidos",
+      "requiredFields": "Completa todos los campos",
+      "networkError": "Error de red. Intenta nuevamente."
+    },
+    "placeholders": {
+      "username": "Ingresa tu nombre de usuario",
+      "password": "Ingresa tu contraseña"
+    }
+  },
+  "register": {
+    "title": "Crear una cuenta",
+    "username": "Nombre de usuario",
+    "password": "Contraseña",
+    "confirmPassword": "Confirmar contraseña",
+    "submit": "Crear cuenta",
+    "loading": "Creando la cuenta...",
+    "errors": {
+      "passwordMismatch": "Las contraseñas no coinciden",
+      "usernameTaken": "Ese nombre de usuario ya está en uso",
+      "weakPassword": "La contraseña es demasiado débil"
+    }
+  },
+  "logout": {
+    "title": "Cerrar sesión",
+    "confirm": "¿Seguro que quieres cerrar sesión?",
+    "button": "Cerrar sesión"
+  }
+}

--- a/src/i18n/locales/es-419/chat.json
+++ b/src/i18n/locales/es-419/chat.json
@@ -1,0 +1,240 @@
+{
+  "codeBlock": {
+    "copy": "Copiar",
+    "copied": "Copiado",
+    "copyCode": "Copiar código"
+  },
+  "copyMessage": {
+    "copy": "Copiar mensaje",
+    "copied": "Mensaje copiado",
+    "selectFormat": "Seleccionar formato de copia",
+    "copyAsMarkdown": "Copiar como Markdown",
+    "copyAsText": "Copiar como texto"
+  },
+  "messageTypes": {
+    "user": "T",
+    "error": "Error",
+    "tool": "Herramienta",
+    "claude": "Claude",
+    "cursor": "Cursor",
+    "codex": "Codex",
+    "opencode": "OpenCode"
+  },
+  "tools": {
+    "settings": "Configuración de herramientas",
+    "error": "Error de herramienta",
+    "result": "Resultado de la herramienta",
+    "viewParams": "Ver parámetros de entrada",
+    "viewRawParams": "Ver parámetros sin procesar",
+    "viewDiff": "Ver diferencias de edición de",
+    "creatingFile": "Creando un archivo:",
+    "updatingTodo": "Actualizando la lista de tareas",
+    "read": "Leer",
+    "readFile": "Leer archivo",
+    "updateTodo": "Actualizar lista de tareas",
+    "readTodo": "Leer lista de tareas",
+    "searchResults": "resultados"
+  },
+  "search": {
+    "found": "Se encontraron {{count}} {{type}}",
+    "file": "archivo",
+    "files": "archivos",
+    "pattern": "patrón:",
+    "in": "en:"
+  },
+  "fileOperations": {
+    "updated": "Archivo actualizado correctamente",
+    "created": "Archivo creado correctamente",
+    "written": "Archivo escrito correctamente",
+    "diff": "Diferencias",
+    "newFile": "Nuevo archivo",
+    "viewContent": "Ver contenido del archivo",
+    "viewFullOutput": "Ver salida completa ({{count}} caracteres)",
+    "contentDisplayed": "El contenido del archivo se muestra en la vista de diferencias de arriba"
+  },
+  "interactive": {
+    "title": "Solicitud interactiva",
+    "waiting": "Esperando tu respuesta en la CLI",
+    "instruction": "Selecciona una opción en la terminal donde se ejecuta Claude.",
+    "selectedOption": "✓ Claude seleccionó la opción {{number}}",
+    "instructionDetail": "En la CLI, seleccionarías esta opción de forma interactiva con las teclas de dirección o escribiendo el número."
+  },
+  "thinking": {
+    "title": "Pensando...",
+    "emoji": "💭 Pensando..."
+  },
+  "json": {
+    "response": "Respuesta JSON"
+  },
+  "permissions": {
+    "grant": "Conceder permiso para {{tool}}",
+    "added": "Permiso agregado",
+    "addTo": "Agrega {{entry}} a Herramientas permitidas.",
+    "retry": "Permiso guardado. Reintenta la solicitud para usar la herramienta.",
+    "error": "No se pudieron actualizar los permisos. Intenta nuevamente.",
+    "openSettings": "Abrir configuración"
+  },
+  "todo": {
+    "updated": "La lista de tareas se actualizó correctamente",
+    "current": "Lista de tareas actual"
+  },
+  "plan": {
+    "viewPlan": "📋 Ver plan de implementación",
+    "title": "Plan de implementación"
+  },
+  "usageLimit": {
+    "resetAt": "Alcanzaste el límite de uso de Claude. Se restablecerá a las **{{time}} {{timezone}}** del {{date}}"
+  },
+  "codex": {
+    "permissionMode": "Modo de permisos",
+    "modes": {
+      "default": "Modo predeterminado",
+      "auto": "Modo automático",
+      "acceptEdits": "Aceptar ediciones",
+      "bypassPermissions": "Omitir permisos",
+      "plan": "Modo de planificación"
+    },
+    "descriptions": {
+      "default": "Solo los comandos de confianza (ls, cat, grep, git status, etc.) se ejecutan automáticamente. Los demás se omiten. Puede escribir en el espacio de trabajo.",
+      "auto": "Un clasificador de modelos decide en cada llamada de herramienta si la aprueba o la rechaza. Es autónomo, pero más seguro que Omitir permisos: aún puede haber rechazos.",
+      "acceptEdits": "Todos los comandos se ejecutan automáticamente dentro del espacio de trabajo. Modo completamente automático con ejecución aislada.",
+      "bypassPermissions": "Acceso completo al sistema sin restricciones. Todos los comandos se ejecutan automáticamente con acceso total al disco y a la red. Úsalo con precaución.",
+      "plan": "Modo de planificación: no se ejecuta ningún comando"
+    },
+    "technicalDetails": "Detalles técnicos"
+  },
+  "voice": {
+    "input": "Entrada de voz",
+    "stopRecording": "Detener grabación",
+    "transcribing": "Transcribiendo…",
+    "speak": "Leer en voz alta",
+    "stopSpeaking": "Detener",
+    "loading": "Cargando…"
+  },
+  "input": {
+    "placeholder": "Escribe / para comandos, @ para archivos o pregunta cualquier cosa a {{provider}}...",
+    "placeholderDefault": "Escribe tu mensaje...",
+    "disabled": "Entrada desactivada",
+    "attachFiles": "Adjuntar archivos",
+    "attachImages": "Adjuntar imágenes",
+    "send": "Enviar",
+    "stop": "Detener",
+    "hintText": {
+      "ctrlEnter": "Ctrl+Enter para enviar • Mayús+Enter para una línea nueva • Tab para cambiar de modo • / para comandos con barra",
+      "enter": "Enter para enviar • Mayús+Enter para una línea nueva • Tab para cambiar de modo • / para comandos con barra",
+      "queue": "Presiona Enter para poner en cola tu siguiente mensaje",
+      "updateQueued": "Presiona Enter para actualizar el mensaje en cola"
+    },
+    "clickToChangeMode": "Haz clic para cambiar el modo de permisos (o presiona Tab en la entrada)",
+    "showAllCommands": "Mostrar todos los comandos",
+    "clearInput": "Borrar entrada",
+    "scrollToBottom": "Ir al final",
+    "queue": {
+      "sendNext": "Poner en cola el siguiente mensaje",
+      "update": "Actualizar mensaje en cola",
+      "label": "En cola",
+      "willSend": "Se enviará cuando esto termine",
+      "edit": "Editar mensaje en cola",
+      "delete": "Eliminar mensaje en cola"
+    }
+  },
+  "providerSelection": {
+    "title": "Elige tu asistente de IA",
+    "description": "Selecciona un proveedor para iniciar una conversación",
+    "selectModel": "Seleccionar modelo",
+    "providerInfo": {
+      "anthropic": "de Anthropic",
+      "openai": "de OpenAI",
+      "cursorEditor": "Editor de código con IA",
+      "google": "de Google"
+    },
+    "readyPrompt": {
+      "claude": "Claude está listo con {{model}}. Comienza a escribir tu mensaje abajo.",
+      "cursor": "Cursor está listo con {{model}}. Comienza a escribir tu mensaje abajo.",
+      "codex": "Codex está listo con {{model}}. Comienza a escribir tu mensaje abajo.",
+      "opencode": "OpenCode está listo con {{model}}. Comienza a escribir tu mensaje abajo.",
+      "default": "Selecciona un proveedor arriba para comenzar"
+    },
+    "pressToSearch": "Presiona <kbd>{{shortcut}}</kbd> para buscar sesiones, archivos y commits"
+  },
+  "session": {
+    "continue": {
+      "title": "Continúa tu conversación",
+      "description": "Haz preguntas sobre tu código, solicita cambios o pide ayuda con tareas de desarrollo"
+    },
+    "loading": {
+      "olderMessages": "Cargando mensajes anteriores...",
+      "sessionMessages": "Cargando mensajes de la sesión..."
+    },
+    "messages": {
+      "showingOf": "Mostrando {{shown}} de {{total}} mensajes",
+      "scrollToLoad": "Desplázate hacia arriba para cargar más",
+      "showingLast": "Mostrando los últimos {{count}} mensajes ({{total}} en total)",
+      "loadEarlier": "Cargar mensajes anteriores",
+      "loadAll": "Cargar todos los mensajes",
+      "loadingAll": "Cargando todos los mensajes...",
+      "allLoaded": "Se cargaron todos los mensajes",
+      "perfWarning": "Se cargaron todos los mensajes; el desplazamiento puede ser más lento. Haz clic en \"Ir al final\" para recuperar el rendimiento."
+    }
+  },
+  "shell": {
+    "selectProject": {
+      "title": "Selecciona un proyecto",
+      "description": "Elige un proyecto para abrir una terminal interactiva en ese directorio"
+    },
+    "status": {
+      "newSession": "Nueva sesión",
+      "initializing": "Inicializando...",
+      "restarting": "Reiniciando..."
+    },
+    "actions": {
+      "disconnect": "Desconectar",
+      "disconnectTitle": "Desconectar de la terminal",
+      "restart": "Reiniciar",
+      "restartTitle": "Reiniciar terminal",
+      "connect": "Continuar en la terminal",
+      "connectTitle": "Conectar a la terminal"
+    },
+    "loading": "Cargando terminal...",
+    "connecting": "Conectando a la terminal...",
+    "startSession": "Iniciar una sesión de Claude",
+    "resumeSession": "Reanudar sesión: {{displayName}}...",
+    "runCommand": "Ejecutar {{command}} en {{projectName}}",
+    "startCli": "Iniciando Claude CLI en {{projectName}}",
+    "defaultCommand": "comando"
+  },
+  "claudeStatus": {
+    "actions": {
+      "thinking": "Pensando",
+      "processing": "Procesando",
+      "analyzing": "Analizando",
+      "working": "Trabajando",
+      "computing": "Calculando",
+      "reasoning": "Razonando"
+    },
+    "state": {
+      "live": "En vivo",
+      "paused": "En pausa"
+    },
+    "elapsed": {
+      "seconds": "{{count}} s",
+      "minutesSeconds": "{{minutes}} min {{seconds}} s",
+      "label": "{{time}} transcurrido",
+      "startingNow": "Comenzando ahora"
+    },
+    "stop": "Detener",
+    "controls": {
+      "stopGeneration": "Detener generación",
+      "pressEscToStop": "Presiona Esc en cualquier momento para detener"
+    },
+    "providers": {
+      "assistant": "Asistente"
+    }
+  },
+  "projectSelection": {
+    "startChatWithProvider": "Selecciona un proyecto para comenzar a chatear con {{provider}}"
+  },
+  "tasks": {
+    "nextTaskPrompt": "Inicia la siguiente tarea"
+  }
+}

--- a/src/i18n/locales/es-419/codeEditor.json
+++ b/src/i18n/locales/es-419/codeEditor.json
@@ -1,0 +1,41 @@
+{
+  "toolbar": {
+    "changes": "cambios",
+    "previousChange": "Cambio anterior",
+    "nextChange": "Cambio siguiente",
+    "hideDiff": "Ocultar el resaltado de diferencias",
+    "showDiff": "Mostrar el resaltado de diferencias",
+    "settings": "Configuración del editor",
+    "collapse": "Contraer el editor",
+    "expand": "Ampliar el editor a todo el ancho"
+  },
+  "loading": "Cargando {{fileName}}...",
+  "header": {
+    "showingChanges": "Mostrando cambios"
+  },
+  "actions": {
+    "download": "Descargar archivo",
+    "save": "Guardar",
+    "saving": "Guardando...",
+    "saved": "Guardado",
+    "exitFullscreen": "Salir de pantalla completa",
+    "fullscreen": "Pantalla completa",
+    "close": "Cerrar",
+    "previewMarkdown": "Vista previa de Markdown",
+    "editMarkdown": "Editar Markdown"
+  },
+  "footer": {
+    "lines": "Líneas:",
+    "characters": "Caracteres:",
+    "shortcuts": "Presiona Ctrl+S para guardar • Esc para cerrar"
+  },
+  "binaryFile": {
+    "title": "Archivo binario",
+    "message": "El archivo \"{{fileName}}\" no se puede mostrar en el editor de texto porque es un archivo binario."
+  },
+  "filePreview": {
+    "loading": "Cargando la vista previa...",
+    "error": "No se puede mostrar este archivo.",
+    "openInNewTab": "Abrir en una pestaña nueva"
+  }
+}

--- a/src/i18n/locales/es-419/common.json
+++ b/src/i18n/locales/es-419/common.json
@@ -1,0 +1,269 @@
+{
+  "buttons": {
+    "save": "Guardar",
+    "cancel": "Cancelar",
+    "delete": "Eliminar",
+    "create": "Crear",
+    "edit": "Editar",
+    "close": "Cerrar",
+    "confirm": "Confirmar",
+    "submit": "Enviar",
+    "retry": "Reintentar",
+    "refresh": "Actualizar",
+    "search": "Buscar",
+    "clear": "Borrar",
+    "copy": "Copiar",
+    "download": "Descargar",
+    "upload": "Cargar",
+    "browse": "Explorar"
+  },
+  "tabs": {
+    "chat": "Chat",
+    "shell": "Terminal",
+    "files": "Archivos",
+    "git": "Control de versiones",
+    "tasks": "Tareas",
+    "browser": "Navegador",
+    "computer": "Computadora"
+  },
+  "status": {
+    "loading": "Cargando...",
+    "success": "Correcto",
+    "error": "Error",
+    "failed": "Fallido",
+    "pending": "Pendiente",
+    "completed": "Completado",
+    "inProgress": "En curso"
+  },
+  "messages": {
+    "savedSuccessfully": "Guardado correctamente",
+    "deletedSuccessfully": "Eliminado correctamente",
+    "updatedSuccessfully": "Actualizado correctamente",
+    "operationFailed": "La operación falló",
+    "networkError": "Error de red. Revisa tu conexión.",
+    "unauthorized": "No tienes autorización. Inicia sesión.",
+    "notFound": "No encontrado",
+    "invalidInput": "Entrada no válida",
+    "requiredField": "Este campo es obligatorio",
+    "unknownError": "Ocurrió un error desconocido"
+  },
+  "navigation": {
+    "settings": "Configuración",
+    "home": "Inicio",
+    "back": "Atrás",
+    "next": "Siguiente",
+    "previous": "Anterior",
+    "logout": "Cerrar sesión"
+  },
+  "common": {
+    "language": "Idioma",
+    "theme": "Tema",
+    "darkMode": "Modo oscuro",
+    "lightMode": "Modo claro",
+    "name": "Nombre",
+    "description": "Descripción",
+    "enabled": "Activado",
+    "disabled": "Desactivado",
+    "optional": "Opcional",
+    "version": "Versión",
+    "select": "Seleccionar",
+    "selectAll": "Seleccionar todo",
+    "deselectAll": "Deseleccionar todo"
+  },
+  "time": {
+    "justNow": "Ahora mismo",
+    "minutesAgo": "Hace {{count}} min",
+    "hoursAgo": "Hace {{count}} h",
+    "daysAgo": "Hace {{count}} días",
+    "yesterday": "Ayer"
+  },
+  "fileOperations": {
+    "newFile": "Nuevo archivo",
+    "newFolder": "Nueva carpeta",
+    "rename": "Cambiar nombre",
+    "move": "Mover",
+    "copyPath": "Copiar ruta",
+    "openInEditor": "Abrir en el editor"
+  },
+  "mainContent": {
+    "loading": "Cargando CloudCLI",
+    "settingUpWorkspace": "Preparando tu espacio de trabajo...",
+    "chooseProject": "Elige tu proyecto",
+    "selectProjectDescription": "Selecciona un proyecto en la barra lateral para comenzar a programar con Claude. Cada proyecto contiene tus sesiones de chat y el historial de archivos.",
+    "tip": "Consejo",
+    "createProjectMobile": "Toca el botón de menú de arriba para acceder a los proyectos",
+    "createProjectDesktop": "Crea un proyecto haciendo clic en el ícono de carpeta de la barra lateral",
+    "newSession": "Nueva sesión",
+    "untitledSession": "Sesión sin título",
+    "projectFiles": "Archivos del proyecto"
+  },
+  "fileTree": {
+    "loading": "Cargando archivos...",
+    "files": "Archivos",
+    "simpleView": "Vista simple",
+    "compactView": "Vista compacta",
+    "detailedView": "Vista detallada",
+    "searchPlaceholder": "Buscar archivos y carpetas...",
+    "clearSearch": "Borrar búsqueda",
+    "name": "Nombre",
+    "size": "Tamaño",
+    "modified": "Modificado",
+    "permissions": "Permisos",
+    "noFilesFound": "No se encontraron archivos",
+    "checkProjectPath": "Revisa si se puede acceder a la ruta del proyecto",
+    "noMatchesFound": "No se encontraron coincidencias",
+    "tryDifferentSearch": "Prueba otro término o borra la búsqueda",
+    "justNow": "ahora mismo",
+    "minAgo": "hace {{count}} min",
+    "hoursAgo": "hace {{count}} h",
+    "daysAgo": "hace {{count}} días",
+    "newFile": "Nuevo archivo (Cmd+N)",
+    "newFolder": "Nueva carpeta (Cmd+Mayús+N)",
+    "refresh": "Actualizar",
+    "collapseAll": "Contraer todo",
+    "context": {
+      "rename": "Cambiar nombre",
+      "delete": "Eliminar",
+      "copyPath": "Copiar ruta",
+      "download": "Descargar",
+      "newFile": "Nuevo archivo",
+      "newFolder": "Nueva carpeta",
+      "refresh": "Actualizar",
+      "menuLabel": "Menú contextual del archivo",
+      "loading": "Cargando..."
+    }
+  },
+  "projectWizard": {
+    "title": "Crear un proyecto",
+    "steps": {
+      "type": "Tipo",
+      "configure": "Configurar",
+      "confirm": "Confirmar"
+    },
+    "step1": {
+      "question": "¿Ya tienes un espacio de trabajo o quieres crear uno nuevo?",
+      "existing": {
+        "title": "Espacio de trabajo existente",
+        "description": "Ya tengo un espacio de trabajo en mi servidor y solo necesito agregarlo a la lista de proyectos"
+      },
+      "new": {
+        "title": "Nuevo espacio de trabajo",
+        "description": "Crea un espacio de trabajo y, si quieres, clona un repositorio de GitHub"
+      }
+    },
+    "step2": {
+      "existingPath": "Ruta del espacio de trabajo",
+      "newPath": "Ruta del espacio de trabajo",
+      "existingPlaceholder": "/ruta/al/espacio/de/trabajo/existente",
+      "newPlaceholder": "/ruta/al/nuevo/espacio/de/trabajo",
+      "existingHelp": "Ruta completa al directorio del espacio de trabajo existente",
+      "newHelp": "Ruta completa al directorio del espacio de trabajo",
+      "githubUrl": "URL de GitHub (opcional)",
+      "githubPlaceholder": "https://github.com/usuario/repositorio",
+      "githubHelp": "Opcional: indica una URL de GitHub para clonar un repositorio",
+      "githubAuth": "Autenticación de GitHub (opcional)",
+      "githubAuthHelp": "Solo se necesita para repositorios privados. Los repositorios públicos se pueden clonar sin autenticación.",
+      "loadingTokens": "Cargando tokens guardados...",
+      "storedToken": "Token guardado",
+      "newToken": "Nuevo token",
+      "nonePublic": "Ninguno (público)",
+      "selectToken": "Seleccionar token",
+      "selectTokenPlaceholder": "-- Selecciona un token --",
+      "tokenPlaceholder": "ghp_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+      "tokenHelp": "Este token se usará solo para esta operación",
+      "publicRepoInfo": "Los repositorios públicos no requieren autenticación. Si vas a clonar uno, puedes omitir el token.",
+      "noTokensHelp": "No hay tokens guardados. Puedes agregarlos en Configuración → Claves de API para reutilizarlos fácilmente.",
+      "optionalTokenPublic": "Token de GitHub (opcional para repositorios públicos)",
+      "tokenPublicPlaceholder": "ghp_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx (déjalo vacío para repositorios públicos)"
+    },
+    "step3": {
+      "reviewConfig": "Revisa la configuración",
+      "existingWorkspace": "Espacio de trabajo existente",
+      "newWorkspace": "Nuevo espacio de trabajo",
+      "path": "Ruta:",
+      "cloneFrom": "Clonar desde:",
+      "authentication": "Autenticación:",
+      "usingStoredToken": "Token guardado utilizado:",
+      "usingProvidedToken": "Se usará el token proporcionado",
+      "noAuthentication": "Sin autenticación",
+      "sshKey": "Clave SSH",
+      "existingInfo": "El espacio de trabajo se agregará a tu lista de proyectos y estará disponible para las sesiones de Claude/Cursor.",
+      "newWithClone": "El repositorio se clonará desde esta carpeta.",
+      "newEmpty": "El espacio de trabajo se agregará a tu lista de proyectos y estará disponible para las sesiones de Claude/Cursor.",
+      "cloningRepository": "Clonando el repositorio..."
+    },
+    "buttons": {
+      "cancel": "Cancelar",
+      "back": "Atrás",
+      "next": "Siguiente",
+      "createProject": "Crear proyecto",
+      "creating": "Creando...",
+      "cloning": "Clonando..."
+    },
+    "errors": {
+      "selectType": "Indica si tienes un espacio de trabajo o quieres crear uno nuevo",
+      "providePath": "Indica una ruta para el espacio de trabajo",
+      "failedToCreate": "No se pudo crear el espacio de trabajo",
+      "failedToCreateFolder": "No se pudo crear la carpeta"
+    }
+  },
+  "notifications": {
+    "genericTool": "una herramienta",
+    "codes": {
+      "generic": {
+        "info": {
+          "title": "Notificación"
+        }
+      },
+      "permission": {
+        "required": {
+          "title": "Acción necesaria",
+          "body": "{{toolName}} espera tu decisión."
+        }
+      },
+      "run": {
+        "stopped": {
+          "title": "Ejecución detenida",
+          "body": "Motivo: {{reason}}"
+        },
+        "failed": {
+          "title": "La ejecución falló"
+        }
+      },
+      "agent": {
+        "notification": {
+          "title": "Notificación del agente"
+        }
+      }
+    }
+  },
+  "versionUpdate": {
+    "title": "Actualización disponible",
+    "newVersionReady": "Hay una nueva versión disponible",
+    "currentVersion": "Versión actual",
+    "latestVersion": "Última versión",
+    "whatsNew": "Novedades:",
+    "viewFullRelease": "Ver la versión completa",
+    "updateProgress": "Progreso de la actualización:",
+    "manualUpgrade": "Actualización manual:",
+    "npmUpgradeCommand": "npm install -g @cloudcli-ai/cloudcli@latest",
+    "manualUpgradeHint": "También puedes hacer clic en \"Actualizar ahora\" para ejecutar la actualización automáticamente.",
+    "updateCompleted": "La actualización terminó correctamente.",
+    "restartServer": "Reinicia el servidor para aplicar los cambios.",
+    "updateFailed": "La actualización falló",
+    "buttons": {
+      "close": "Cerrar",
+      "later": "Más tarde",
+      "copyCommand": "Copiar comando",
+      "updateNow": "Actualizar ahora",
+      "updating": "Actualizando..."
+    },
+    "ariaLabels": {
+      "closeModal": "Cerrar el cuadro de actualización de versión",
+      "showSidebar": "Mostrar la barra lateral",
+      "settings": "Configuración",
+      "updateAvailable": "Actualización disponible",
+      "closeSidebar": "Cerrar la barra lateral"
+    }
+  }
+}

--- a/src/i18n/locales/es-419/settings.json
+++ b/src/i18n/locales/es-419/settings.json
@@ -1,0 +1,572 @@
+{
+  "title": "Configuración",
+  "tabs": {
+    "account": "Cuenta",
+    "permissions": "Permisos",
+    "mcpServers": "Servidores MCP",
+    "skills": "Habilidades",
+    "appearance": "Apariencia"
+  },
+  "account": {
+    "title": "Cuenta",
+    "language": "Idioma",
+    "languageLabel": "Idioma de la interfaz",
+    "languageDescription": "Elige tu idioma preferido para la interfaz",
+    "username": "Nombre de usuario",
+    "email": "Correo electrónico",
+    "profile": "Perfil",
+    "changePassword": "Cambiar contraseña"
+  },
+  "mcp": {
+    "title": "Servidores MCP",
+    "addServer": "Agregar servidor",
+    "editServer": "Editar servidor",
+    "deleteServer": "Eliminar servidor",
+    "serverName": "Nombre del servidor",
+    "serverType": "Tipo de servidor",
+    "config": "Configuración",
+    "testConnection": "Probar conexión",
+    "status": "Estado",
+    "connected": "Conectado",
+    "disconnected": "Desconectado",
+    "scope": {
+      "label": "Ámbito",
+      "user": "Usuario",
+      "project": "Proyecto"
+    }
+  },
+  "appearance": {
+    "title": "Apariencia",
+    "theme": "Tema",
+    "codeEditor": "Editor de código",
+    "editorTheme": "Tema del editor",
+    "wordWrap": "Ajuste de línea",
+    "showMinimap": "Mostrar minimapa",
+    "lineNumbers": "Números de línea",
+    "fontSize": "Tamaño de fuente"
+  },
+  "actions": {
+    "saveChanges": "Guardar cambios",
+    "resetToDefaults": "Restablecer valores predeterminados",
+    "cancelChanges": "Cancelar cambios"
+  },
+  "voiceSettings": {
+    "title": "Voz",
+    "description": "Entrada de voz a texto y lectura en voz alta mediante un backend de audio compatible con OpenAI.",
+    "enable": "Activar voz",
+    "enableDescription": "Muestra el botón del micrófono y el botón de lectura en voz alta en los mensajes.",
+    "backendTitle": "Backend",
+    "backendDescription": "Conecta con OpenAI, Groq o un servidor local (LocalAI, Speaches, Kokoro-FastAPI). Déjalo vacío para usar el valor predeterminado del servidor.",
+    "baseUrl": "URL base",
+    "apiKey": "Clave de API",
+    "sttModel": "Modelo de voz a texto",
+    "ttsModel": "Modelo de texto a voz",
+    "voice": "Voz",
+    "format": "Formato de audio",
+    "note": "El navegador llama directamente a una URL base personalizada, que debe admitir solicitudes CORS del navegador. Déjala vacía para usar el backend configurado en el servidor."
+  },
+  "quickSettings": {
+    "title": "Configuración rápida",
+    "sections": {
+      "appearance": "Apariencia",
+      "toolDisplay": "Visualización de herramientas",
+      "inputSettings": "Configuración de entrada"
+    },
+    "darkMode": "Modo oscuro",
+    "showRawParameters": "Mostrar parámetros sin procesar",
+    "showThinking": "Mostrar razonamiento",
+    "sendByCtrlEnter": "Enviar con Ctrl+Intro",
+    "voiceEnabled": "Voz (micrófono y lectura en voz alta)",
+    "sendByCtrlEnterDescription": "Cuando está activado, Ctrl+Intro envía el mensaje en lugar de Intro. Es útil para usuarios de IME y evita envíos accidentales.",
+    "dragHandle": {
+      "dragging": "Arrastrando el control",
+      "closePanel": "Cerrar panel de configuración",
+      "openPanel": "Abrir panel de configuración",
+      "draggingStatus": "Arrastrando...",
+      "toggleAndMove": "Haz clic para alternar o arrastra para mover"
+    }
+  },
+  "terminalShortcuts": {
+    "title": "Atajos del terminal",
+    "sectionKeys": "Teclas",
+    "sectionNavigation": "Navegación",
+    "escape": "Escape",
+    "tab": "Tab",
+    "shiftTab": "Mayús+Tab",
+    "arrowUp": "Flecha arriba",
+    "arrowDown": "Flecha abajo",
+    "scrollDown": "Desplazar hacia abajo",
+    "handle": {
+      "closePanel": "Cerrar panel de atajos",
+      "openPanel": "Abrir panel de atajos"
+    }
+  },
+  "mainTabs": {
+    "label": "Configuración",
+    "agents": "Agentes",
+    "appearance": "Apariencia",
+    "git": "Git",
+    "apiTokens": "API y tokens",
+    "voice": "Voz",
+    "tasks": "Tareas",
+    "browser": "Navegador",
+    "notifications": "Notificaciones",
+    "plugins": "Complementos",
+    "about": "Acerca de"
+  },
+  "notifications": {
+    "title": "Notificaciones",
+    "description": "Controla qué eventos de notificación recibes.",
+    "webPush": {
+      "title": "Notificar en este navegador",
+      "enable": "Activar notificaciones",
+      "disable": "Desactivar notificaciones",
+      "enabled": "Las notificaciones están activadas en este navegador",
+      "loading": "Actualizando...",
+      "unsupported": "Este navegador no admite notificaciones push.",
+      "denied": "Las notificaciones push están bloqueadas. Permítelas en la configuración del navegador."
+    },
+    "desktop": {
+      "title": "Notificar en esta aplicación de escritorio",
+      "enable": "Activar notificaciones",
+      "disable": "Desactivar notificaciones",
+      "enabled": "Las notificaciones están activadas en esta aplicación de escritorio",
+      "unsupported": "Este sistema no admite notificaciones de escritorio."
+    },
+    "sound": {
+      "title": "Sonido",
+      "description": "Reproduce un tono breve cuando termina una ejecución del chat o necesita aprobación para una herramienta.",
+      "enabled": "Activado",
+      "test": "Probar sonido"
+    },
+    "events": {
+      "title": "Tipos de evento",
+      "actionRequired": "Acción necesaria",
+      "stop": "Ejecución detenida",
+      "error": "La ejecución ha fallado"
+    }
+  },
+  "appearanceSettings": {
+    "darkMode": {
+      "label": "Modo oscuro",
+      "description": "Alterna entre los temas claro y oscuro"
+    },
+    "projectSorting": {
+      "label": "Orden de proyectos",
+      "description": "Cómo se ordenan los proyectos en la barra lateral",
+      "alphabetical": "Alfabético",
+      "recentActivity": "Actividad reciente"
+    },
+    "codeEditor": {
+      "title": "Editor de código",
+      "theme": {
+        "label": "Tema del editor",
+        "description": "Tema predeterminado del editor de código"
+      },
+      "wordWrap": {
+        "label": "Ajuste de línea",
+        "description": "Activa de forma predeterminada el ajuste de línea en el editor"
+      },
+      "showMinimap": {
+        "label": "Mostrar minimapa",
+        "description": "Muestra un minimapa para facilitar la navegación por la vista de diferencias"
+      },
+      "lineNumbers": {
+        "label": "Mostrar números de línea",
+        "description": "Muestra los números de línea en el editor"
+      },
+      "fontSize": {
+        "label": "Tamaño de fuente",
+        "description": "Tamaño de la fuente del editor en píxeles"
+      }
+    }
+  },
+  "mcpForm": {
+    "title": {
+      "add": "Agregar servidor MCP",
+      "edit": "Editar servidor MCP"
+    },
+    "importMode": {
+      "form": "Entrada de formulario",
+      "json": "Importar JSON"
+    },
+    "scope": {
+      "label": "Ámbito",
+      "userGlobal": "Usuario (global)",
+      "projectLocal": "Proyecto (local)",
+      "userDescription": "Ámbito de usuario: disponible en todos los proyectos de tu computadora",
+      "projectDescription": "Ámbito local: disponible solo en el proyecto seleccionado",
+      "cannotChange": "El ámbito no puede cambiarse al editar un servidor existente"
+    },
+    "fields": {
+      "serverName": "Nombre del servidor",
+      "transportType": "Tipo de transporte",
+      "command": "Comando",
+      "arguments": "Argumentos (uno por línea)",
+      "jsonConfig": "Configuración JSON",
+      "url": "URL",
+      "envVars": "Variables de entorno (CLAVE=valor, una por línea)",
+      "headers": "Encabezados (CLAVE=valor, uno por línea)",
+      "selectProject": "Selecciona un proyecto..."
+    },
+    "placeholders": {
+      "serverName": "mi-servidor"
+    },
+    "validation": {
+      "missingType": "Falta un campo obligatorio: type",
+      "stdioRequiresCommand": "El tipo stdio requiere el campo command",
+      "httpRequiresUrl": "El tipo {{type}} requiere el campo url",
+      "invalidJson": "El formato JSON no es válido",
+      "jsonHelp": "Pega la configuración de tu servidor MCP en formato JSON. Formatos de ejemplo:",
+      "jsonExampleStdio": "• stdio: {\"type\":\"stdio\",\"command\":\"npx\",\"args\":[\"@upstash/context7-mcp\"]}",
+      "jsonExampleHttp": "• http/sse: {\"type\":\"http\",\"url\":\"https://api.example.com/mcp\"}"
+    },
+    "configDetails": "Detalles de configuración (de {{configFile}})",
+    "projectPath": "Ruta: {{path}}",
+    "actions": {
+      "cancel": "Cancelar",
+      "saving": "Guardando...",
+      "addServer": "Agregar servidor",
+      "updateServer": "Actualizar servidor"
+    }
+  },
+  "saveStatus": {
+    "success": "La configuración se guardó correctamente.",
+    "error": "No se pudo guardar la configuración",
+    "saving": "Guardando..."
+  },
+  "footerActions": {
+    "save": "Guardar configuración",
+    "cancel": "Cancelar"
+  },
+  "git": {
+    "title": "Configuración de Git",
+    "description": "Configura tu identidad de Git para los commits. Esta configuración se aplicará globalmente mediante git config --global",
+    "name": {
+      "label": "Nombre de Git",
+      "help": "Tu nombre para los commits de Git"
+    },
+    "email": {
+      "label": "Correo de Git",
+      "help": "Tu correo electrónico para los commits de Git"
+    },
+    "actions": {
+      "save": "Guardar configuración",
+      "saving": "Guardando..."
+    },
+    "status": {
+      "success": "Guardado correctamente"
+    }
+  },
+  "apiKeys": {
+    "title": "Claves de API",
+    "description": "Genera claves de API para acceder a la API externa desde otras aplicaciones.",
+    "newKey": {
+      "alertTitle": "⚠️ Guarda tu clave de API",
+      "alertMessage": "Esta es la única vez que verás la clave. Guárdala en un lugar seguro.",
+      "iveSavedIt": "Ya la guardé"
+    },
+    "form": {
+      "placeholder": "Nombre de la clave de API (p. ej., Servidor de producción)",
+      "createButton": "Crear",
+      "cancelButton": "Cancelar"
+    },
+    "newButton": "Nueva clave de API",
+    "empty": "Aún no se ha creado ninguna clave de API.",
+    "list": {
+      "created": "Creada:",
+      "lastUsed": "Último uso:"
+    },
+    "confirmDelete": "¿Seguro que quieres eliminar esta clave de API?",
+    "status": {
+      "active": "Activa",
+      "inactive": "Inactiva"
+    },
+    "github": {
+      "title": "Tokens de GitHub",
+      "description": "Añade tokens de acceso personal de GitHub para clonar repositorios privados mediante la API externa.",
+      "descriptionAlt": "Añade tokens de acceso personal de GitHub para clonar repositorios privados. También puedes enviar tokens directamente en las solicitudes de API sin guardarlos.",
+      "addButton": "Agregar token",
+      "form": {
+        "namePlaceholder": "Nombre del token (p. ej., Repositorios personales)",
+        "tokenPlaceholder": "Token de acceso personal de GitHub (ghp_...)",
+        "descriptionPlaceholder": "Descripción (opcional)",
+        "addButton": "Agregar token",
+        "cancelButton": "Cancelar",
+        "howToCreate": "Cómo crear un token de acceso personal de GitHub →"
+      },
+      "empty": "Aún no se agregó ningún token de GitHub.",
+      "added": "Agregado:",
+      "confirmDelete": "¿Seguro que quieres eliminar este token de GitHub?"
+    },
+    "apiDocsLink": "Documentación de la API",
+    "documentation": {
+      "title": "Documentación de la API externa",
+      "description": "Aprende a usar la API externa para iniciar sesiones de Claude/Cursor desde tus aplicaciones.",
+      "viewLink": "Ver documentación de la API →"
+    },
+    "loading": "Cargando...",
+    "version": {
+      "updateAvailable": "Actualización disponible: v{{version}}"
+    }
+  },
+  "tasks": {
+    "checking": "Comprobando la instalación de TaskMaster...",
+    "notInstalled": {
+      "title": "La CLI de TaskMaster AI no está instalada",
+      "description": "La CLI de TaskMaster es necesaria para usar las funciones de gestión de tareas. Instálala para empezar:",
+      "installCommand": "npm install -g task-master-ai",
+      "viewOnGitHub": "Ver en GitHub",
+      "afterInstallation": "Después de instalarla:",
+      "steps": {
+        "restart": "Reinicia esta aplicación",
+        "autoAvailable": "Las funciones de TaskMaster estarán disponibles automáticamente",
+        "initCommand": "Usa task-master init en el directorio de tu proyecto"
+      }
+    },
+    "settings": {
+      "enableLabel": "Activar la integración con TaskMaster",
+      "enableDescription": "Muestra las tareas, los avisos y los indicadores de la barra lateral de TaskMaster en toda la interfaz"
+    }
+  },
+  "agents": {
+    "authStatus": {
+      "checking": "Comprobando...",
+      "connected": "Conectado",
+      "notConnected": "Sin conexión",
+      "disconnected": "Desconectado",
+      "checkingAuth": "Comprobando el estado de autenticación...",
+      "loggedInAs": "Sesión iniciada como {{email}}",
+      "authenticatedUser": "usuario autenticado"
+    },
+    "account": {
+      "claude": {
+        "description": "Asistente de IA Anthropic Claude"
+      },
+      "cursor": {
+        "description": "Editor de código con IA Cursor"
+      },
+      "codex": {
+        "description": "Asistente de IA OpenAI Codex"
+      },
+      "opencode": {
+        "description": "Asistente CLI OpenCode"
+      }
+    },
+    "connectionStatus": "Estado de conexión",
+    "login": {
+      "title": "Inicio de sesión",
+      "reAuthenticate": "Volver a autenticarse",
+      "description": "Inicia sesión en tu cuenta de {{agent}} para activar las funciones de IA",
+      "reAuthDescription": "Inicia sesión con otra cuenta o actualiza las credenciales",
+      "button": "Iniciar sesión",
+      "reLoginButton": "Volver a iniciar sesión"
+    },
+    "error": "Error: {{error}}"
+  },
+  "permissions": {
+    "title": "Configuración de permisos",
+    "skipPermissions": {
+      "label": "Omitir solicitudes de permisos (usar con precaución)",
+      "claudeDescription": "Equivale a la opción --dangerously-skip-permissions",
+      "cursorDescription": "Equivale a la opción -f de Cursor CLI"
+    },
+    "allowedTools": {
+      "title": "Herramientas permitidas",
+      "description": "Herramientas permitidas automáticamente sin solicitar permiso",
+      "placeholder": "p. ej., \"Bash(git log:*)\" o \"Write\"",
+      "quickAdd": "Agregar herramientas comunes rápidamente:",
+      "empty": "No hay herramientas permitidas configuradas"
+    },
+    "blockedTools": {
+      "title": "Herramientas bloqueadas",
+      "description": "Herramientas bloqueadas automáticamente sin solicitar permiso",
+      "placeholder": "p. ej., \"Bash(rm:*)\"",
+      "empty": "No hay herramientas bloqueadas configuradas"
+    },
+    "allowedCommands": {
+      "title": "Comandos de terminal permitidos",
+      "description": "Comandos de terminal permitidos automáticamente sin solicitar permiso",
+      "placeholder": "p. ej., \"Shell(ls)\" o \"Shell(git status)\"",
+      "quickAdd": "Agregar comandos comunes rápidamente:",
+      "empty": "No hay comandos permitidos configurados"
+    },
+    "blockedCommands": {
+      "title": "Comandos de terminal bloqueados",
+      "description": "Comandos de terminal bloqueados automáticamente",
+      "placeholder": "p. ej., \"Shell(rm -rf)\" o \"Shell(sudo)\"",
+      "empty": "No hay comandos bloqueados configurados"
+    },
+    "toolExamples": {
+      "title": "Ejemplos de patrones de herramientas:",
+      "bashGitLog": "- Permitir todos los comandos git log",
+      "bashGitDiff": "- Permitir todos los comandos git diff",
+      "write": "- Permitir todos los usos de la herramienta Write",
+      "bashRm": "- Bloquear todos los comandos rm (peligroso)"
+    },
+    "shellExamples": {
+      "title": "Ejemplos de comandos de terminal:",
+      "ls": "- Permitir el comando ls",
+      "gitStatus": "- Permitir git status",
+      "npmInstall": "- Permitir npm install",
+      "rmRf": "- Bloquear la eliminación recursiva"
+    },
+    "codex": {
+      "permissionMode": "Modo de permisos",
+      "description": "Controla cómo gestiona Codex las modificaciones de archivos y la ejecución de comandos",
+      "modes": {
+        "default": {
+          "title": "Predeterminado",
+          "description": "Solo los comandos de confianza (ls, cat, grep, git status, etc.) se ejecutan automáticamente. Los demás se omiten. Puede escribir en el espacio de trabajo."
+        },
+        "acceptEdits": {
+          "title": "Aceptar ediciones",
+          "description": "Todos los comandos se ejecutan automáticamente dentro del espacio de trabajo. Modo completamente automático con ejecución aislada."
+        },
+        "bypassPermissions": {
+          "title": "Omitir permisos",
+          "description": "Acceso completo al sistema sin restricciones. Todos los comandos se ejecutan automáticamente con acceso total al disco y a la red. Úsalo con precaución."
+        }
+      },
+      "technicalDetails": "Detalles técnicos",
+      "technicalInfo": {
+        "default": "sandboxMode=workspace-write, approvalPolicy=untrusted. Comandos de confianza: cat, cd, grep, head, ls, pwd, tail, git status/log/diff/show, find (sin -exec), etc.",
+        "acceptEdits": "sandboxMode=workspace-write, approvalPolicy=never. Todos los comandos se ejecutan automáticamente en el directorio del proyecto.",
+        "bypassPermissions": "sandboxMode=danger-full-access, approvalPolicy=never. Acceso completo al sistema; úsalo solo en entornos de confianza.",
+        "overrideNote": "Puedes sustituir este valor en cada sesión con el botón de modo de la interfaz del chat."
+      }
+    },
+    "actions": {
+      "add": "Agregar"
+    }
+  },
+  "mcpServers": {
+    "title": "Servidores MCP",
+    "description": {
+      "claude": "Los servidores Model Context Protocol proporcionan herramientas y fuentes de datos adicionales a Claude",
+      "cursor": "Los servidores Model Context Protocol proporcionan herramientas y fuentes de datos adicionales a Cursor",
+      "codex": "Los servidores Model Context Protocol proporcionan herramientas y fuentes de datos adicionales a Codex",
+      "opencode": "Los servidores Model Context Protocol proporcionan herramientas y fuentes de datos adicionales a OpenCode"
+    },
+    "addButton": "Agregar servidor MCP",
+    "empty": "No hay servidores MCP configurados",
+    "serverType": "Tipo",
+    "scope": {
+      "local": "local",
+      "user": "usuario"
+    },
+    "config": {
+      "command": "Comando",
+      "url": "URL",
+      "args": "Argumentos",
+      "environment": "Entorno"
+    },
+    "tools": {
+      "title": "Herramientas",
+      "count": "({{count}}):",
+      "more": "+{{count}} más"
+    },
+    "actions": {
+      "edit": "Editar servidor",
+      "delete": "Eliminar servidor"
+    },
+    "managed": {
+      "badge": "Gestionado",
+      "hint": "Gestionado por CloudCLI."
+    },
+    "help": {
+      "title": "Acerca de MCP para Codex",
+      "description": "Codex admite servidores MCP basados en stdio. Puedes agregar servidores que amplíen las capacidades de Codex con herramientas y recursos adicionales."
+    }
+  },
+  "pluginSettings": {
+    "title": "Complementos",
+    "description": "Amplía la interfaz con complementos personalizados. Instálalos desde Git o coloca una carpeta en ~/.claude-code-ui/plugins/",
+    "installPlaceholder": "https://github.com/usuario/mi-complemento",
+    "installButton": "Instalar",
+    "installing": "Instalando…",
+    "securityWarning": "Instala solo complementos cuyo código fuente hayas revisado o de autores en los que confíes.",
+    "scanningPlugins": "Buscando complementos…",
+    "noPluginsInstalled": "No hay complementos instalados",
+    "pullLatest": "Obtener lo último de Git",
+    "noGitRemote": "No hay remoto de Git; la actualización no está disponible",
+    "uninstallPlugin": "Desinstalar complemento",
+    "confirmUninstall": "Haz clic de nuevo para confirmar",
+    "confirmUninstallMessage": "¿Quieres quitar {{name}}? Esta acción no se puede deshacer.",
+    "cancel": "Cancelar",
+    "remove": "Quitar",
+    "updateFailed": "La actualización ha fallado",
+    "installFailed": "La instalación ha fallado",
+    "uninstallFailed": "La desinstalación ha fallado",
+    "toggleFailed": "No se ha podido alternar",
+    "starterPluginLabel": "Complemento inicial",
+    "starter": "Inicial",
+    "docs": "Documentación",
+    "sections": {
+      "officialTitle": "Complementos oficiales",
+      "officialDescription": "Mantenidos por el equipo de CloudCLI y listos para instalar directamente.",
+      "unofficialTitle": "Otros complementos",
+      "unofficialDescription": "Complementos e integraciones no oficiales de otros usuarios. Revisa el código fuente antes de instalarlos."
+    },
+    "starterPlugin": {
+      "name": "Estadísticas del proyecto",
+      "badge": "inicial",
+      "description": "Número de archivos, líneas de código, desglose por tipo de archivo y actividad reciente del proyecto.",
+      "install": "Instalar"
+    },
+    "terminalPlugin": {
+      "name": "Terminal",
+      "badge": "oficial",
+      "description": "Terminal integrado con acceso completo al shell directamente desde la interfaz.",
+      "install": "Instalar"
+    },
+    "scheduledPromptPlugin": {
+      "name": "Solicitudes programadas",
+      "badge": "no oficial",
+      "description": "Programa solicitudes del espacio de trabajo, revisa el historial de ejecuciones y gestiona tareas locales recurrentes.",
+      "install": "Instalar"
+    },
+    "claudeWatchPlugin": {
+      "name": "Claude Watch",
+      "badge": "no oficial",
+      "description": "Supervisa sesiones largas de Claude Code para detectar bloqueos y muestra controles del proceso.",
+      "install": "Instalar"
+    },
+    "prismCloudCLI": {
+      "name": "PRISM CloudCLI",
+      "badge": "no oficial",
+      "description": "Inteligencia de sesiones para Claude Code dentro de CloudCLI. Descubre por qué tus sesiones consumen tokens sin salir del navegador.",
+      "install": "Instalar"
+    },
+    "sessionManagerPlugin": {
+      "name": "Sesiones",
+      "badge": "no oficial",
+      "description": "Consulta, gestiona y termina sesiones activas de Claude Code.",
+      "install": "Instalar"
+    },
+    "tokenCostCalculatorPlugin": {
+      "name": "Calculadora de costes de tokens",
+      "badge": "no oficial",
+      "description": "Calcula los costos de API a partir de los precios de los modelos y el uso de tokens, con precios predefinidos para distintos modelos.",
+      "install": "Instalar"
+    },
+    "taskQueuePlugin": {
+      "name": "Cola de tareas",
+      "badge": "no oficial",
+      "description": "Panel de la cola de tareas para consultar, filtrar e iniciar tareas de agentes.",
+      "install": "Instalar"
+    },
+    "githubIssuesBoardPlugin": {
+      "name": "Panel de incidencias de GitHub",
+      "badge": "no oficial",
+      "description": "Panel Kanban de incidencias de GitHub con sincronización bidireccional de TaskMaster e instalación automática de la habilidad /github-task de la CLI",
+      "install": "Instalar"
+    },
+    "morePlugins": "Más",
+    "enable": "Activar",
+    "disable": "Desactivar",
+    "installAriaLabel": "URL del repositorio Git del complemento",
+    "tab": "pestaña",
+    "runningStatus": "en ejecución"
+  }
+}

--- a/src/i18n/locales/es-419/sidebar.json
+++ b/src/i18n/locales/es-419/sidebar.json
@@ -1,0 +1,145 @@
+{
+  "projects": {
+    "title": "Proyectos",
+    "newProject": "Nuevo proyecto",
+    "deleteProject": "Quitar proyecto",
+    "renameProject": "Cambiar nombre del proyecto",
+    "noProjects": "No se encontraron proyectos",
+    "loadingProjects": "Cargando proyectos...",
+    "searchPlaceholder": "Buscar proyectos...",
+    "projectNamePlaceholder": "Nombre del proyecto",
+    "starred": "Destacados",
+    "all": "Todos",
+    "untitledSession": "Sesión sin título",
+    "newSession": "Nueva sesión",
+    "codexSession": "Sesión de Codex",
+    "fetchingProjects": "Obteniendo tus proyectos y sesiones de Claude",
+    "projects": "proyectos",
+    "noMatchingProjects": "No hay proyectos coincidentes",
+    "tryDifferentSearch": "Intenta cambiar el término de búsqueda",
+    "runClaudeCli": "Ejecuta Claude CLI en el directorio de un proyecto para comenzar"
+  },
+  "app": {
+    "title": "CloudCLI",
+    "subtitle": "Interfaz del asistente de programación con IA"
+  },
+  "sessions": {
+    "title": "Sesiones",
+    "newSession": "Nueva sesión",
+    "deleteSession": "Eliminar sesión",
+    "renameSession": "Cambiar nombre de la sesión",
+    "noSessions": "Aún no hay sesiones",
+    "loadingSessions": "Cargando sesiones...",
+    "unnamed": "Sin nombre",
+    "loading": "Cargando...",
+    "showMore": "Mostrar más sesiones"
+  },
+  "tooltips": {
+    "viewEnvironments": "Ver entornos",
+    "hideSidebar": "Ocultar la barra lateral",
+    "createProject": "Crear un proyecto",
+    "refresh": "Actualizar proyectos y sesiones (Ctrl+R)",
+    "renameProject": "Cambiar nombre del proyecto (F2)",
+    "deleteProject": "Quitar proyecto de la barra lateral (Supr)",
+    "addToFavorites": "Agregar a favoritos",
+    "removeFromFavorites": "Quitar de favoritos",
+    "editSessionName": "Editar manualmente el nombre de la sesión",
+    "deleteSession": "Eliminar esta sesión de forma permanente",
+    "activeSessionIndicator": "Sesión activa recientemente (últimos 10 minutos)",
+    "save": "Guardar",
+    "cancel": "Cancelar",
+    "clearSearch": "Borrar búsqueda",
+    "openCommandPalette": "Abrir la paleta de comandos",
+    "attentionRequiredIndicator": "La sesión requiere atención"
+  },
+  "navigation": {
+    "chat": "Chat",
+    "files": "Archivos",
+    "git": "Git",
+    "terminal": "Terminal",
+    "tasks": "Tareas"
+  },
+  "actions": {
+    "refresh": "Actualizar",
+    "settings": "Configuración",
+    "collapseAll": "Contraer todo",
+    "expandAll": "Expandir todo",
+    "cancel": "Cancelar",
+    "save": "Guardar",
+    "delete": "Eliminar",
+    "rename": "Cambiar nombre",
+    "joinCommunity": "Unirse a la comunidad",
+    "reportIssue": "Reportar un problema",
+    "starOnGithub": "Destacar en GitHub"
+  },
+  "branding": {
+    "openSource": "Código abierto"
+  },
+  "status": {
+    "active": "Activa",
+    "inactive": "Inactiva",
+    "thinking": "Pensando...",
+    "error": "Error",
+    "aborted": "Cancelada",
+    "unknown": "Desconocida"
+  },
+  "time": {
+    "justNow": "Ahora mismo",
+    "oneMinuteAgo": "Hace 1 min",
+    "minutesAgo": "Hace {{count}} min",
+    "oneHourAgo": "Hace 1 hora",
+    "hoursAgo": "Hace {{count}} horas",
+    "oneDayAgo": "Hace 1 día",
+    "daysAgo": "Hace {{count}} días"
+  },
+  "messages": {
+    "deleteConfirm": "¿Seguro que quieres eliminarlo?",
+    "renameSuccess": "Se cambió el nombre correctamente",
+    "deleteSuccess": "Se eliminó correctamente",
+    "errorOccurred": "Ocurrió un error",
+    "deleteSessionConfirm": "¿Seguro que quieres eliminar esta sesión? Esta acción no se puede deshacer.",
+    "deleteProjectConfirm": "¿Quieres quitar este proyecto de la barra lateral? Los archivos, las memorias y los datos de sesión no se eliminarán.",
+    "enterProjectPath": "Ingresa una ruta de proyecto",
+    "deleteSessionFailed": "No se pudo eliminar la sesión. Intenta nuevamente.",
+    "deleteSessionError": "Error al eliminar la sesión. Intenta nuevamente.",
+    "renameSessionFailed": "No se pudo cambiar el nombre de la sesión. Intenta nuevamente.",
+    "renameSessionError": "Error al cambiar el nombre de la sesión. Intenta nuevamente.",
+    "deleteProjectFailed": "No se pudo quitar el proyecto. Intenta nuevamente.",
+    "deleteProjectError": "Error al quitar el proyecto. Intenta nuevamente.",
+    "createProjectFailed": "No se pudo crear el proyecto. Intenta nuevamente.",
+    "createProjectError": "Error al crear el proyecto. Intenta nuevamente.",
+    "updateProjectError": "Error al actualizar el proyecto. Intenta nuevamente.",
+    "refreshError": "No se pudo actualizar. Intenta nuevamente.",
+    "restoreProjectFailed": "No se pudo restaurar el proyecto. Intenta nuevamente.",
+    "restoreProjectError": "Error al restaurar el proyecto. Intenta nuevamente.",
+    "restoreSessionFailed": "No se pudo restaurar la sesión. Intenta nuevamente.",
+    "restoreSessionError": "Error al restaurar la sesión. Intenta nuevamente."
+  },
+  "version": {
+    "updateAvailable": "Actualización disponible",
+    "restartRequired": "Actualización instalada; reinicia el servidor para aplicarla"
+  },
+  "search": {
+    "modeProjects": "Proyectos",
+    "modeConversations": "Conversaciones",
+    "conversationsPlaceholder": "Buscar en las conversaciones...",
+    "searching": "Buscando...",
+    "noResults": "No se encontraron resultados",
+    "tryDifferentQuery": "Intenta otra búsqueda",
+    "matches_one": "{{count}} coincidencia",
+    "matches_other": "{{count}} coincidencias",
+    "projectsScanned_one": "{{count}} proyecto analizado",
+    "projectsScanned_other": "{{count}} proyectos analizados"
+  },
+  "deleteConfirmation": {
+    "deleteProject": "Quitar proyecto",
+    "deleteSession": "Eliminar sesión",
+    "confirmDelete": "¿Qué quieres hacer con",
+    "sessionCount_one": "Este proyecto contiene {{count}} conversación.",
+    "sessionCount_other": "Este proyecto contiene {{count}} conversaciones.",
+    "removeFromSidebar": "Quitar solo de la barra lateral",
+    "deleteAllData": "Eliminar todos los datos de forma permanente",
+    "allConversationsDeleted": "El proyecto se quitará de la barra lateral. Se conservarán tus archivos, memorias y datos de sesión.",
+    "cannotUndo": "Puedes volver a agregar el proyecto más adelante."
+  }
+}

--- a/src/i18n/locales/es-419/tasks.json
+++ b/src/i18n/locales/es-419/tasks.json
@@ -1,0 +1,142 @@
+{
+  "notConfigured": {
+    "title": "TaskMaster AI no está configurado",
+    "description": "TaskMaster ayuda a dividir proyectos complejos en tareas manejables con asistencia basada en IA",
+    "whatIsTitle": "🎯 ¿Qué es TaskMaster?",
+    "features": {
+      "aiPowered": "Gestión de tareas con IA: divide proyectos complejos en subtareas manejables",
+      "prdTemplates": "Plantillas de PRD: genera tareas a partir de documentos de requisitos del producto",
+      "dependencyTracking": "Seguimiento de dependencias: comprende las relaciones entre tareas y el orden de ejecución",
+      "progressVisualization": "Visualización del progreso: tableros Kanban y análisis detallados de tareas",
+      "cliIntegration": "Integración con CLI: usa comandos de TaskMaster para flujos de trabajo avanzados"
+    },
+    "initializeButton": "Inicializar TaskMaster AI"
+  },
+  "gettingStarted": {
+    "title": "Primeros pasos con TaskMaster",
+    "subtitle": "TaskMaster se inicializó. Esto es lo que debes hacer ahora:",
+    "steps": {
+      "createPRD": {
+        "title": "Crear un documento de requisitos del producto (PRD)",
+        "description": "Explica la idea de tu proyecto y crea un PRD que describa lo que quieres desarrollar.",
+        "addButton": "Agregar PRD",
+        "existingPRDs": "PRD existentes:"
+      },
+      "generateTasks": {
+        "title": "Generar tareas desde el PRD",
+        "description": "Cuando tengas un PRD, pide a tu asistente de IA que lo analice y TaskMaster lo dividirá automáticamente en tareas manejables con detalles de implementación."
+      },
+      "analyzeTasks": {
+        "title": "Analizar y ampliar tareas",
+        "description": "Pide a tu asistente de IA que analice la complejidad de las tareas y las divida en subtareas detalladas para facilitar su implementación."
+      },
+      "startBuilding": {
+        "title": "Comenzar a desarrollar",
+        "description": "Pide a tu asistente de IA que comience a trabajar en las tareas, actualice su estado y agregue otras nuevas a medida que evolucione el proyecto."
+      }
+    },
+    "tip": "💡 Consejo: comienza con un PRD para aprovechar al máximo la generación de tareas con IA de TaskMaster"
+  },
+  "setupModal": {
+    "title": "Configuración de TaskMaster",
+    "subtitle": "CLI interactiva para {{projectName}}",
+    "willStart": "La inicialización de TaskMaster comenzará automáticamente",
+    "completed": "La configuración de TaskMaster terminó. Ya puedes cerrar esta ventana.",
+    "closeButton": "Cerrar",
+    "closeContinueButton": "Cerrar y continuar"
+  },
+  "helpGuide": {
+    "title": "Primeros pasos con TaskMaster",
+    "subtitle": "Tu guía para gestionar tareas de forma productiva",
+    "examples": {
+      "parsePRD": "💬 Ejemplo:\n\"Acabo de inicializar un proyecto nuevo con Claude Task Master. Tengo un PRD en .taskmaster/docs/prd.txt. ¿Puedes ayudarme a analizarlo y configurar las tareas iniciales?\"",
+      "expandTask": "💬 Ejemplo:\n\"La tarea 5 parece compleja. ¿Puedes dividirla en subtareas?\"",
+      "addTask": "💬 Ejemplo:\n\"Agrega una tarea nueva para implementar la carga de imágenes de perfil de usuario mediante Cloudinary e investiga el mejor enfoque.\""
+    },
+    "moreExamples": "Ver más ejemplos y patrones de uso →",
+    "proTips": {
+      "title": "💡 Consejos",
+      "search": "Usa la barra de búsqueda para encontrar tareas específicas rápidamente",
+      "views": "Alterna entre las vistas Kanban, Lista y Cuadrícula con los controles de vista",
+      "filters": "Usa filtros para enfocarte en estados o prioridades de tarea específicos",
+      "details": "Haz clic en cualquier tarea para consultar la información detallada y gestionar las subtareas"
+    },
+    "learnMore": {
+      "title": "📚 Más información",
+      "description": "TaskMaster AI es un sistema avanzado de gestión de tareas creado para desarrolladores. Consulta la documentación y los ejemplos, o contribuye al proyecto.",
+      "githubButton": "Ver en GitHub"
+    }
+  },
+  "search": {
+    "placeholder": "Buscar tareas..."
+  },
+  "filters": {
+    "button": "Filtros",
+    "status": "Estado",
+    "priority": "Prioridad",
+    "sortBy": "Ordenar por",
+    "allStatuses": "Todos los estados",
+    "allPriorities": "Todas las prioridades",
+    "showing": "Mostrando {{filtered}} de {{total}} tareas",
+    "clearFilters": "Borrar filtros"
+  },
+  "sort": {
+    "id": "ID",
+    "status": "Estado",
+    "priority": "Prioridad",
+    "idAsc": "ID (ascendente)",
+    "idDesc": "ID (descendente)",
+    "titleAsc": "Título (A-Z)",
+    "titleDesc": "Título (Z-A)",
+    "statusAsc": "Estado (pendientes primero)",
+    "statusDesc": "Estado (terminadas primero)",
+    "priorityAsc": "Prioridad (alta primero)",
+    "priorityDesc": "Prioridad (baja primero)"
+  },
+  "views": {
+    "kanban": "Vista Kanban",
+    "list": "Vista de lista",
+    "grid": "Vista de cuadrícula"
+  },
+  "kanban": {
+    "pending": "📋 Por hacer",
+    "inProgress": "🚀 En curso",
+    "done": "✅ Terminadas",
+    "blocked": "🚫 Bloqueadas",
+    "deferred": "⏳ Pospuestas",
+    "cancelled": "❌ Canceladas",
+    "noTasksYet": "Aún no hay tareas",
+    "tasksWillAppear": "Las tareas aparecerán aquí",
+    "moveTasksHere": "Mueve aquí las tareas cuando comiencen",
+    "completedTasksHere": "Las tareas terminadas aparecen aquí",
+    "statusTasksHere": "Las tareas con este estado aparecerán aquí"
+  },
+  "buttons": {
+    "help": "Guía de primeros pasos de TaskMaster",
+    "prds": "PRD",
+    "addPRD": "Agregar PRD",
+    "addTask": "Agregar tarea",
+    "createNewPRD": "Crear PRD",
+    "prdsAvailable": "{{count}} PRD disponibles"
+  },
+  "prd": {
+    "modified": "Modificado: {{date}}"
+  },
+  "statuses": {
+    "pending": "Pendiente",
+    "in-progress": "En curso",
+    "done": "Terminada",
+    "blocked": "Bloqueada",
+    "deferred": "Pospuesta",
+    "cancelled": "Cancelada"
+  },
+  "priorities": {
+    "high": "Alta",
+    "medium": "Media",
+    "low": "Baja"
+  },
+  "noMatchingTasks": {
+    "title": "Ninguna tarea coincide con los filtros",
+    "description": "Intenta ajustar la búsqueda o los criterios de filtrado."
+  }
+}

--- a/src/i18n/locales/es-ES/auth.json
+++ b/src/i18n/locales/es-ES/auth.json
@@ -1,0 +1,37 @@
+{
+  "login": {
+    "title": "Te damos la bienvenida de nuevo",
+    "description": "Inicia sesión en tu cuenta autohospedada de CloudCLI",
+    "username": "Nombre de usuario",
+    "password": "Contraseña",
+    "submit": "Iniciar sesión",
+    "loading": "Iniciando sesión...",
+    "errors": {
+      "invalidCredentials": "El nombre de usuario o la contraseña no son válidos",
+      "requiredFields": "Completa todos los campos",
+      "networkError": "Error de red. Inténtalo de nuevo."
+    },
+    "placeholders": {
+      "username": "Introduce tu nombre de usuario",
+      "password": "Introduce tu contraseña"
+    }
+  },
+  "register": {
+    "title": "Crear una cuenta",
+    "username": "Nombre de usuario",
+    "password": "Contraseña",
+    "confirmPassword": "Confirmar contraseña",
+    "submit": "Crear cuenta",
+    "loading": "Creando la cuenta...",
+    "errors": {
+      "passwordMismatch": "Las contraseñas no coinciden",
+      "usernameTaken": "Ese nombre de usuario ya está en uso",
+      "weakPassword": "La contraseña es demasiado débil"
+    }
+  },
+  "logout": {
+    "title": "Cerrar sesión",
+    "confirm": "¿Seguro que quieres cerrar sesión?",
+    "button": "Cerrar sesión"
+  }
+}

--- a/src/i18n/locales/es-ES/chat.json
+++ b/src/i18n/locales/es-ES/chat.json
@@ -1,0 +1,240 @@
+{
+  "codeBlock": {
+    "copy": "Copiar",
+    "copied": "Copiado",
+    "copyCode": "Copiar código"
+  },
+  "copyMessage": {
+    "copy": "Copiar mensaje",
+    "copied": "Mensaje copiado",
+    "selectFormat": "Seleccionar formato de copia",
+    "copyAsMarkdown": "Copiar como Markdown",
+    "copyAsText": "Copiar como texto"
+  },
+  "messageTypes": {
+    "user": "T",
+    "error": "Error",
+    "tool": "Herramienta",
+    "claude": "Claude",
+    "cursor": "Cursor",
+    "codex": "Codex",
+    "opencode": "OpenCode"
+  },
+  "tools": {
+    "settings": "Ajustes de herramientas",
+    "error": "Error de herramienta",
+    "result": "Resultado de la herramienta",
+    "viewParams": "Ver parámetros de entrada",
+    "viewRawParams": "Ver parámetros sin procesar",
+    "viewDiff": "Ver diferencias de edición de",
+    "creatingFile": "Creando un fichero:",
+    "updatingTodo": "Actualizando la lista de tareas",
+    "read": "Leer",
+    "readFile": "Leer fichero",
+    "updateTodo": "Actualizar lista de tareas",
+    "readTodo": "Leer lista de tareas",
+    "searchResults": "resultados"
+  },
+  "search": {
+    "found": "Se han encontrado {{count}} {{type}}",
+    "file": "fichero",
+    "files": "ficheros",
+    "pattern": "patrón:",
+    "in": "en:"
+  },
+  "fileOperations": {
+    "updated": "Fichero actualizado correctamente",
+    "created": "Fichero creado correctamente",
+    "written": "Fichero escrito correctamente",
+    "diff": "Diferencias",
+    "newFile": "Nuevo fichero",
+    "viewContent": "Ver contenido del fichero",
+    "viewFullOutput": "Ver salida completa ({{count}} caracteres)",
+    "contentDisplayed": "El contenido del fichero se muestra en la vista de diferencias de arriba"
+  },
+  "interactive": {
+    "title": "Solicitud interactiva",
+    "waiting": "Esperando tu respuesta en la CLI",
+    "instruction": "Selecciona una opción en el terminal donde se ejecuta Claude.",
+    "selectedOption": "✓ Claude ha seleccionado la opción {{number}}",
+    "instructionDetail": "En la CLI, seleccionarías esta opción de forma interactiva con las teclas de dirección o escribiendo el número."
+  },
+  "thinking": {
+    "title": "Pensando...",
+    "emoji": "💭 Pensando..."
+  },
+  "json": {
+    "response": "Respuesta JSON"
+  },
+  "permissions": {
+    "grant": "Conceder permiso para {{tool}}",
+    "added": "Permiso añadido",
+    "addTo": "Añade {{entry}} a Herramientas permitidas.",
+    "retry": "Permiso guardado. Reintenta la solicitud para usar la herramienta.",
+    "error": "No se han podido actualizar los permisos. Inténtalo de nuevo.",
+    "openSettings": "Abrir ajustes"
+  },
+  "todo": {
+    "updated": "La lista de tareas se ha actualizado correctamente",
+    "current": "Lista de tareas actual"
+  },
+  "plan": {
+    "viewPlan": "📋 Ver plan de implementación",
+    "title": "Plan de implementación"
+  },
+  "usageLimit": {
+    "resetAt": "Has alcanzado el límite de uso de Claude. Se restablecerá a las **{{time}} {{timezone}}** del {{date}}"
+  },
+  "codex": {
+    "permissionMode": "Modo de permisos",
+    "modes": {
+      "default": "Modo predeterminado",
+      "auto": "Modo automático",
+      "acceptEdits": "Aceptar ediciones",
+      "bypassPermissions": "Omitir permisos",
+      "plan": "Modo de planificación"
+    },
+    "descriptions": {
+      "default": "Solo los comandos de confianza (ls, cat, grep, git status, etc.) se ejecutan automáticamente. Los demás se omiten. Puede escribir en el espacio de trabajo.",
+      "auto": "Un clasificador de modelos decide en cada llamada de herramienta si la aprueba o la rechaza. Es autónomo, pero más seguro que Omitir permisos: aún puede haber rechazos.",
+      "acceptEdits": "Todos los comandos se ejecutan automáticamente dentro del espacio de trabajo. Modo completamente automático con ejecución aislada.",
+      "bypassPermissions": "Acceso completo al sistema sin restricciones. Todos los comandos se ejecutan automáticamente con acceso total al disco y a la red. Úsalo con precaución.",
+      "plan": "Modo de planificación: no se ejecuta ningún comando"
+    },
+    "technicalDetails": "Detalles técnicos"
+  },
+  "voice": {
+    "input": "Entrada de voz",
+    "stopRecording": "Detener grabación",
+    "transcribing": "Transcribiendo…",
+    "speak": "Leer en voz alta",
+    "stopSpeaking": "Detener",
+    "loading": "Cargando…"
+  },
+  "input": {
+    "placeholder": "Escribe / para comandos, @ para ficheros o pregunta cualquier cosa a {{provider}}...",
+    "placeholderDefault": "Escribe tu mensaje...",
+    "disabled": "Entrada desactivada",
+    "attachFiles": "Adjuntar ficheros",
+    "attachImages": "Adjuntar imágenes",
+    "send": "Enviar",
+    "stop": "Detener",
+    "hintText": {
+      "ctrlEnter": "Ctrl+Intro para enviar • Mayús+Intro para una línea nueva • Tab para cambiar de modo • / para comandos con barra",
+      "enter": "Intro para enviar • Mayús+Intro para una línea nueva • Tab para cambiar de modo • / para comandos con barra",
+      "queue": "Pulsa Intro para poner en cola tu siguiente mensaje",
+      "updateQueued": "Pulsa Intro para actualizar el mensaje en cola"
+    },
+    "clickToChangeMode": "Haz clic para cambiar el modo de permisos (o pulsa Tab en la entrada)",
+    "showAllCommands": "Mostrar todos los comandos",
+    "clearInput": "Borrar entrada",
+    "scrollToBottom": "Ir al final",
+    "queue": {
+      "sendNext": "Poner en cola el siguiente mensaje",
+      "update": "Actualizar mensaje en cola",
+      "label": "En cola",
+      "willSend": "Se enviará cuando esto termine",
+      "edit": "Editar mensaje en cola",
+      "delete": "Eliminar mensaje en cola"
+    }
+  },
+  "providerSelection": {
+    "title": "Elige tu asistente de IA",
+    "description": "Selecciona un proveedor para iniciar una conversación",
+    "selectModel": "Seleccionar modelo",
+    "providerInfo": {
+      "anthropic": "de Anthropic",
+      "openai": "de OpenAI",
+      "cursorEditor": "Editor de código con IA",
+      "google": "de Google"
+    },
+    "readyPrompt": {
+      "claude": "Claude está listo con {{model}}. Empieza a escribir tu mensaje abajo.",
+      "cursor": "Cursor está listo con {{model}}. Empieza a escribir tu mensaje abajo.",
+      "codex": "Codex está listo con {{model}}. Empieza a escribir tu mensaje abajo.",
+      "opencode": "OpenCode está listo con {{model}}. Empieza a escribir tu mensaje abajo.",
+      "default": "Selecciona un proveedor arriba para empezar"
+    },
+    "pressToSearch": "Pulsa <kbd>{{shortcut}}</kbd> para buscar sesiones, ficheros y commits"
+  },
+  "session": {
+    "continue": {
+      "title": "Continúa tu conversación",
+      "description": "Haz preguntas sobre tu código, solicita cambios o pide ayuda con tareas de desarrollo"
+    },
+    "loading": {
+      "olderMessages": "Cargando mensajes anteriores...",
+      "sessionMessages": "Cargando mensajes de la sesión..."
+    },
+    "messages": {
+      "showingOf": "Mostrando {{shown}} de {{total}} mensajes",
+      "scrollToLoad": "Desplázate hacia arriba para cargar más",
+      "showingLast": "Mostrando los últimos {{count}} mensajes ({{total}} en total)",
+      "loadEarlier": "Cargar mensajes anteriores",
+      "loadAll": "Cargar todos los mensajes",
+      "loadingAll": "Cargando todos los mensajes...",
+      "allLoaded": "Se han cargado todos los mensajes",
+      "perfWarning": "Se han cargado todos los mensajes; el desplazamiento puede ser más lento. Haz clic en «Ir al final» para recuperar el rendimiento."
+    }
+  },
+  "shell": {
+    "selectProject": {
+      "title": "Selecciona un proyecto",
+      "description": "Elige un proyecto para abrir un terminal interactivo en ese directorio"
+    },
+    "status": {
+      "newSession": "Nueva sesión",
+      "initializing": "Inicializando...",
+      "restarting": "Reiniciando..."
+    },
+    "actions": {
+      "disconnect": "Desconectar",
+      "disconnectTitle": "Desconectar del terminal",
+      "restart": "Reiniciar",
+      "restartTitle": "Reiniciar terminal",
+      "connect": "Continuar en el terminal",
+      "connectTitle": "Conectar al terminal"
+    },
+    "loading": "Cargando terminal...",
+    "connecting": "Conectando al terminal...",
+    "startSession": "Iniciar una sesión de Claude",
+    "resumeSession": "Reanudar sesión: {{displayName}}...",
+    "runCommand": "Ejecutar {{command}} en {{projectName}}",
+    "startCli": "Iniciando Claude CLI en {{projectName}}",
+    "defaultCommand": "comando"
+  },
+  "claudeStatus": {
+    "actions": {
+      "thinking": "Pensando",
+      "processing": "Procesando",
+      "analyzing": "Analizando",
+      "working": "Trabajando",
+      "computing": "Calculando",
+      "reasoning": "Razonando"
+    },
+    "state": {
+      "live": "En directo",
+      "paused": "En pausa"
+    },
+    "elapsed": {
+      "seconds": "{{count}} s",
+      "minutesSeconds": "{{minutes}} min {{seconds}} s",
+      "label": "{{time}} transcurrido",
+      "startingNow": "Empezando ahora"
+    },
+    "stop": "Detener",
+    "controls": {
+      "stopGeneration": "Detener generación",
+      "pressEscToStop": "Pulsa Esc en cualquier momento para detener"
+    },
+    "providers": {
+      "assistant": "Asistente"
+    }
+  },
+  "projectSelection": {
+    "startChatWithProvider": "Selecciona un proyecto para empezar a chatear con {{provider}}"
+  },
+  "tasks": {
+    "nextTaskPrompt": "Inicia la siguiente tarea"
+  }
+}

--- a/src/i18n/locales/es-ES/codeEditor.json
+++ b/src/i18n/locales/es-ES/codeEditor.json
@@ -1,0 +1,41 @@
+{
+  "toolbar": {
+    "changes": "cambios",
+    "previousChange": "Cambio anterior",
+    "nextChange": "Cambio siguiente",
+    "hideDiff": "Ocultar el resaltado de diferencias",
+    "showDiff": "Mostrar el resaltado de diferencias",
+    "settings": "Ajustes del editor",
+    "collapse": "Contraer el editor",
+    "expand": "Ampliar el editor a todo el ancho"
+  },
+  "loading": "Cargando {{fileName}}...",
+  "header": {
+    "showingChanges": "Mostrando cambios"
+  },
+  "actions": {
+    "download": "Descargar fichero",
+    "save": "Guardar",
+    "saving": "Guardando...",
+    "saved": "Guardado",
+    "exitFullscreen": "Salir de pantalla completa",
+    "fullscreen": "Pantalla completa",
+    "close": "Cerrar",
+    "previewMarkdown": "Previsualizar Markdown",
+    "editMarkdown": "Editar Markdown"
+  },
+  "footer": {
+    "lines": "Líneas:",
+    "characters": "Caracteres:",
+    "shortcuts": "Pulsa Ctrl+S para guardar • Esc para cerrar"
+  },
+  "binaryFile": {
+    "title": "Fichero binario",
+    "message": "El fichero «{{fileName}}» no puede mostrarse en el editor de texto porque es un fichero binario."
+  },
+  "filePreview": {
+    "loading": "Cargando la vista previa...",
+    "error": "No se puede mostrar este fichero.",
+    "openInNewTab": "Abrir en una pestaña nueva"
+  }
+}

--- a/src/i18n/locales/es-ES/common.json
+++ b/src/i18n/locales/es-ES/common.json
@@ -1,0 +1,269 @@
+{
+  "buttons": {
+    "save": "Guardar",
+    "cancel": "Cancelar",
+    "delete": "Eliminar",
+    "create": "Crear",
+    "edit": "Editar",
+    "close": "Cerrar",
+    "confirm": "Confirmar",
+    "submit": "Enviar",
+    "retry": "Reintentar",
+    "refresh": "Actualizar",
+    "search": "Buscar",
+    "clear": "Borrar",
+    "copy": "Copiar",
+    "download": "Descargar",
+    "upload": "Subir",
+    "browse": "Explorar"
+  },
+  "tabs": {
+    "chat": "Chat",
+    "shell": "Terminal",
+    "files": "Ficheros",
+    "git": "Control de versiones",
+    "tasks": "Tareas",
+    "browser": "Navegador",
+    "computer": "Ordenador"
+  },
+  "status": {
+    "loading": "Cargando...",
+    "success": "Correcto",
+    "error": "Error",
+    "failed": "Fallido",
+    "pending": "Pendiente",
+    "completed": "Completado",
+    "inProgress": "En curso"
+  },
+  "messages": {
+    "savedSuccessfully": "Guardado correctamente",
+    "deletedSuccessfully": "Eliminado correctamente",
+    "updatedSuccessfully": "Actualizado correctamente",
+    "operationFailed": "La operación ha fallado",
+    "networkError": "Error de red. Comprueba tu conexión.",
+    "unauthorized": "No tienes autorización. Inicia sesión.",
+    "notFound": "No encontrado",
+    "invalidInput": "Entrada no válida",
+    "requiredField": "Este campo es obligatorio",
+    "unknownError": "Se ha producido un error desconocido"
+  },
+  "navigation": {
+    "settings": "Ajustes",
+    "home": "Inicio",
+    "back": "Atrás",
+    "next": "Siguiente",
+    "previous": "Anterior",
+    "logout": "Cerrar sesión"
+  },
+  "common": {
+    "language": "Idioma",
+    "theme": "Tema",
+    "darkMode": "Modo oscuro",
+    "lightMode": "Modo claro",
+    "name": "Nombre",
+    "description": "Descripción",
+    "enabled": "Activado",
+    "disabled": "Desactivado",
+    "optional": "Opcional",
+    "version": "Versión",
+    "select": "Seleccionar",
+    "selectAll": "Seleccionar todo",
+    "deselectAll": "Deseleccionar todo"
+  },
+  "time": {
+    "justNow": "Ahora mismo",
+    "minutesAgo": "Hace {{count}} min",
+    "hoursAgo": "Hace {{count}} h",
+    "daysAgo": "Hace {{count}} días",
+    "yesterday": "Ayer"
+  },
+  "fileOperations": {
+    "newFile": "Nuevo fichero",
+    "newFolder": "Nueva carpeta",
+    "rename": "Cambiar nombre",
+    "move": "Mover",
+    "copyPath": "Copiar ruta",
+    "openInEditor": "Abrir en el editor"
+  },
+  "mainContent": {
+    "loading": "Cargando CloudCLI",
+    "settingUpWorkspace": "Preparando tu espacio de trabajo...",
+    "chooseProject": "Elige tu proyecto",
+    "selectProjectDescription": "Selecciona un proyecto en la barra lateral para empezar a programar con Claude. Cada proyecto contiene tus sesiones de chat y el historial de ficheros.",
+    "tip": "Consejo",
+    "createProjectMobile": "Toca el botón de menú de arriba para acceder a los proyectos",
+    "createProjectDesktop": "Crea un proyecto haciendo clic en el icono de carpeta de la barra lateral",
+    "newSession": "Nueva sesión",
+    "untitledSession": "Sesión sin título",
+    "projectFiles": "Ficheros del proyecto"
+  },
+  "fileTree": {
+    "loading": "Cargando ficheros...",
+    "files": "Ficheros",
+    "simpleView": "Vista sencilla",
+    "compactView": "Vista compacta",
+    "detailedView": "Vista detallada",
+    "searchPlaceholder": "Buscar ficheros y carpetas...",
+    "clearSearch": "Borrar búsqueda",
+    "name": "Nombre",
+    "size": "Tamaño",
+    "modified": "Modificado",
+    "permissions": "Permisos",
+    "noFilesFound": "No se han encontrado ficheros",
+    "checkProjectPath": "Comprueba si se puede acceder a la ruta del proyecto",
+    "noMatchesFound": "No se han encontrado coincidencias",
+    "tryDifferentSearch": "Prueba otro término o borra la búsqueda",
+    "justNow": "ahora mismo",
+    "minAgo": "hace {{count}} min",
+    "hoursAgo": "hace {{count}} h",
+    "daysAgo": "hace {{count}} días",
+    "newFile": "Nuevo fichero (Cmd+N)",
+    "newFolder": "Nueva carpeta (Cmd+Mayús+N)",
+    "refresh": "Actualizar",
+    "collapseAll": "Contraer todo",
+    "context": {
+      "rename": "Cambiar nombre",
+      "delete": "Eliminar",
+      "copyPath": "Copiar ruta",
+      "download": "Descargar",
+      "newFile": "Nuevo fichero",
+      "newFolder": "Nueva carpeta",
+      "refresh": "Actualizar",
+      "menuLabel": "Menú contextual del fichero",
+      "loading": "Cargando..."
+    }
+  },
+  "projectWizard": {
+    "title": "Crear un proyecto",
+    "steps": {
+      "type": "Tipo",
+      "configure": "Configurar",
+      "confirm": "Confirmar"
+    },
+    "step1": {
+      "question": "¿Ya tienes un espacio de trabajo o quieres crear uno nuevo?",
+      "existing": {
+        "title": "Espacio de trabajo existente",
+        "description": "Ya tengo un espacio de trabajo en mi servidor y solo necesito añadirlo a la lista de proyectos"
+      },
+      "new": {
+        "title": "Nuevo espacio de trabajo",
+        "description": "Crea un espacio de trabajo y, si quieres, clona un repositorio de GitHub"
+      }
+    },
+    "step2": {
+      "existingPath": "Ruta del espacio de trabajo",
+      "newPath": "Ruta del espacio de trabajo",
+      "existingPlaceholder": "/ruta/al/espacio/de/trabajo/existente",
+      "newPlaceholder": "/ruta/al/nuevo/espacio/de/trabajo",
+      "existingHelp": "Ruta completa al directorio del espacio de trabajo existente",
+      "newHelp": "Ruta completa al directorio del espacio de trabajo",
+      "githubUrl": "URL de GitHub (opcional)",
+      "githubPlaceholder": "https://github.com/usuario/repositorio",
+      "githubHelp": "Opcional: indica una URL de GitHub para clonar un repositorio",
+      "githubAuth": "Autenticación de GitHub (opcional)",
+      "githubAuthHelp": "Solo es necesaria para repositorios privados. Los repositorios públicos se pueden clonar sin autenticación.",
+      "loadingTokens": "Cargando tokens guardados...",
+      "storedToken": "Token guardado",
+      "newToken": "Nuevo token",
+      "nonePublic": "Ninguno (público)",
+      "selectToken": "Seleccionar token",
+      "selectTokenPlaceholder": "-- Selecciona un token --",
+      "tokenPlaceholder": "ghp_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+      "tokenHelp": "Este token se usará solo para esta operación",
+      "publicRepoInfo": "Los repositorios públicos no requieren autenticación. Si vas a clonar uno, puedes omitir el token.",
+      "noTokensHelp": "No hay tokens guardados. Puedes añadirlos en Ajustes → Claves de API para reutilizarlos fácilmente.",
+      "optionalTokenPublic": "Token de GitHub (opcional para repositorios públicos)",
+      "tokenPublicPlaceholder": "ghp_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx (déjalo vacío para repositorios públicos)"
+    },
+    "step3": {
+      "reviewConfig": "Revisa la configuración",
+      "existingWorkspace": "Espacio de trabajo existente",
+      "newWorkspace": "Nuevo espacio de trabajo",
+      "path": "Ruta:",
+      "cloneFrom": "Clonar desde:",
+      "authentication": "Autenticación:",
+      "usingStoredToken": "Token guardado utilizado:",
+      "usingProvidedToken": "Se usará el token proporcionado",
+      "noAuthentication": "Sin autenticación",
+      "sshKey": "Clave SSH",
+      "existingInfo": "El espacio de trabajo se añadirá a tu lista de proyectos y estará disponible para las sesiones de Claude/Cursor.",
+      "newWithClone": "El repositorio se clonará desde esta carpeta.",
+      "newEmpty": "El espacio de trabajo se añadirá a tu lista de proyectos y estará disponible para las sesiones de Claude/Cursor.",
+      "cloningRepository": "Clonando el repositorio..."
+    },
+    "buttons": {
+      "cancel": "Cancelar",
+      "back": "Atrás",
+      "next": "Siguiente",
+      "createProject": "Crear proyecto",
+      "creating": "Creando...",
+      "cloning": "Clonando..."
+    },
+    "errors": {
+      "selectType": "Indica si tienes un espacio de trabajo o quieres crear uno nuevo",
+      "providePath": "Indica una ruta para el espacio de trabajo",
+      "failedToCreate": "No se ha podido crear el espacio de trabajo",
+      "failedToCreateFolder": "No se ha podido crear la carpeta"
+    }
+  },
+  "notifications": {
+    "genericTool": "una herramienta",
+    "codes": {
+      "generic": {
+        "info": {
+          "title": "Notificación"
+        }
+      },
+      "permission": {
+        "required": {
+          "title": "Acción necesaria",
+          "body": "{{toolName}} espera tu decisión."
+        }
+      },
+      "run": {
+        "stopped": {
+          "title": "Ejecución detenida",
+          "body": "Motivo: {{reason}}"
+        },
+        "failed": {
+          "title": "La ejecución ha fallado"
+        }
+      },
+      "agent": {
+        "notification": {
+          "title": "Notificación del agente"
+        }
+      }
+    }
+  },
+  "versionUpdate": {
+    "title": "Actualización disponible",
+    "newVersionReady": "Hay una nueva versión disponible",
+    "currentVersion": "Versión actual",
+    "latestVersion": "Última versión",
+    "whatsNew": "Novedades:",
+    "viewFullRelease": "Ver la versión completa",
+    "updateProgress": "Progreso de la actualización:",
+    "manualUpgrade": "Actualización manual:",
+    "npmUpgradeCommand": "npm install -g @cloudcli-ai/cloudcli@latest",
+    "manualUpgradeHint": "También puedes hacer clic en «Actualizar ahora» para ejecutar la actualización automáticamente.",
+    "updateCompleted": "La actualización ha terminado correctamente.",
+    "restartServer": "Reinicia el servidor para aplicar los cambios.",
+    "updateFailed": "La actualización ha fallado",
+    "buttons": {
+      "close": "Cerrar",
+      "later": "Más tarde",
+      "copyCommand": "Copiar comando",
+      "updateNow": "Actualizar ahora",
+      "updating": "Actualizando..."
+    },
+    "ariaLabels": {
+      "closeModal": "Cerrar el cuadro de actualización de versión",
+      "showSidebar": "Mostrar la barra lateral",
+      "settings": "Ajustes",
+      "updateAvailable": "Actualización disponible",
+      "closeSidebar": "Cerrar la barra lateral"
+    }
+  }
+}

--- a/src/i18n/locales/es-ES/settings.json
+++ b/src/i18n/locales/es-ES/settings.json
@@ -1,0 +1,572 @@
+{
+  "title": "Ajustes",
+  "tabs": {
+    "account": "Cuenta",
+    "permissions": "Permisos",
+    "mcpServers": "Servidores MCP",
+    "skills": "Habilidades",
+    "appearance": "Apariencia"
+  },
+  "account": {
+    "title": "Cuenta",
+    "language": "Idioma",
+    "languageLabel": "Idioma de la interfaz",
+    "languageDescription": "Elige el idioma que prefieres para la interfaz",
+    "username": "Nombre de usuario",
+    "email": "Correo electrónico",
+    "profile": "Perfil",
+    "changePassword": "Cambiar contraseña"
+  },
+  "mcp": {
+    "title": "Servidores MCP",
+    "addServer": "Añadir servidor",
+    "editServer": "Editar servidor",
+    "deleteServer": "Eliminar servidor",
+    "serverName": "Nombre del servidor",
+    "serverType": "Tipo de servidor",
+    "config": "Configuración",
+    "testConnection": "Probar conexión",
+    "status": "Estado",
+    "connected": "Conectado",
+    "disconnected": "Desconectado",
+    "scope": {
+      "label": "Ámbito",
+      "user": "Usuario",
+      "project": "Proyecto"
+    }
+  },
+  "appearance": {
+    "title": "Apariencia",
+    "theme": "Tema",
+    "codeEditor": "Editor de código",
+    "editorTheme": "Tema del editor",
+    "wordWrap": "Ajuste de línea",
+    "showMinimap": "Mostrar minimapa",
+    "lineNumbers": "Números de línea",
+    "fontSize": "Tamaño de fuente"
+  },
+  "actions": {
+    "saveChanges": "Guardar cambios",
+    "resetToDefaults": "Restablecer valores predeterminados",
+    "cancelChanges": "Cancelar cambios"
+  },
+  "voiceSettings": {
+    "title": "Voz",
+    "description": "Entrada de voz a texto y lectura en voz alta mediante un backend de audio compatible con OpenAI.",
+    "enable": "Activar voz",
+    "enableDescription": "Muestra el botón del micrófono y el botón de lectura en voz alta en los mensajes.",
+    "backendTitle": "Backend",
+    "backendDescription": "Conecta con OpenAI, Groq o un servidor local (LocalAI, Speaches, Kokoro-FastAPI). Déjalo vacío para usar el valor predeterminado del servidor.",
+    "baseUrl": "URL base",
+    "apiKey": "Clave de API",
+    "sttModel": "Modelo de voz a texto",
+    "ttsModel": "Modelo de texto a voz",
+    "voice": "Voz",
+    "format": "Formato de audio",
+    "note": "El navegador llama directamente a una URL base personalizada, que debe admitir solicitudes CORS del navegador. Déjala vacía para usar el backend configurado en el servidor."
+  },
+  "quickSettings": {
+    "title": "Ajustes rápidos",
+    "sections": {
+      "appearance": "Apariencia",
+      "toolDisplay": "Visualización de herramientas",
+      "inputSettings": "Ajustes de entrada"
+    },
+    "darkMode": "Modo oscuro",
+    "showRawParameters": "Mostrar parámetros sin procesar",
+    "showThinking": "Mostrar razonamiento",
+    "sendByCtrlEnter": "Enviar con Ctrl+Intro",
+    "voiceEnabled": "Voz (micrófono y lectura en voz alta)",
+    "sendByCtrlEnterDescription": "Cuando está activado, Ctrl+Intro envía el mensaje en lugar de Intro. Es útil para usuarios de IME y evita envíos accidentales.",
+    "dragHandle": {
+      "dragging": "Arrastrando el control",
+      "closePanel": "Cerrar panel de ajustes",
+      "openPanel": "Abrir panel de ajustes",
+      "draggingStatus": "Arrastrando...",
+      "toggleAndMove": "Haz clic para alternar o arrastra para mover"
+    }
+  },
+  "terminalShortcuts": {
+    "title": "Atajos del terminal",
+    "sectionKeys": "Teclas",
+    "sectionNavigation": "Navegación",
+    "escape": "Escape",
+    "tab": "Tab",
+    "shiftTab": "Mayús+Tab",
+    "arrowUp": "Flecha arriba",
+    "arrowDown": "Flecha abajo",
+    "scrollDown": "Desplazar hacia abajo",
+    "handle": {
+      "closePanel": "Cerrar panel de atajos",
+      "openPanel": "Abrir panel de atajos"
+    }
+  },
+  "mainTabs": {
+    "label": "Ajustes",
+    "agents": "Agentes",
+    "appearance": "Apariencia",
+    "git": "Git",
+    "apiTokens": "API y tokens",
+    "voice": "Voz",
+    "tasks": "Tareas",
+    "browser": "Navegador",
+    "notifications": "Notificaciones",
+    "plugins": "Complementos",
+    "about": "Acerca de"
+  },
+  "notifications": {
+    "title": "Notificaciones",
+    "description": "Controla qué eventos de notificación recibes.",
+    "webPush": {
+      "title": "Notificar en este navegador",
+      "enable": "Activar notificaciones",
+      "disable": "Desactivar notificaciones",
+      "enabled": "Las notificaciones están activadas en este navegador",
+      "loading": "Actualizando...",
+      "unsupported": "Este navegador no admite notificaciones push.",
+      "denied": "Las notificaciones push están bloqueadas. Permítelas en los ajustes del navegador."
+    },
+    "desktop": {
+      "title": "Notificar en esta aplicación de escritorio",
+      "enable": "Activar notificaciones",
+      "disable": "Desactivar notificaciones",
+      "enabled": "Las notificaciones están activadas en esta aplicación de escritorio",
+      "unsupported": "Este sistema no admite notificaciones de escritorio."
+    },
+    "sound": {
+      "title": "Sonido",
+      "description": "Reproduce un tono breve cuando termina una ejecución del chat o necesita aprobación para una herramienta.",
+      "enabled": "Activado",
+      "test": "Probar sonido"
+    },
+    "events": {
+      "title": "Tipos de evento",
+      "actionRequired": "Acción necesaria",
+      "stop": "Ejecución detenida",
+      "error": "La ejecución ha fallado"
+    }
+  },
+  "appearanceSettings": {
+    "darkMode": {
+      "label": "Modo oscuro",
+      "description": "Alterna entre los temas claro y oscuro"
+    },
+    "projectSorting": {
+      "label": "Orden de proyectos",
+      "description": "Cómo se ordenan los proyectos en la barra lateral",
+      "alphabetical": "Alfabético",
+      "recentActivity": "Actividad reciente"
+    },
+    "codeEditor": {
+      "title": "Editor de código",
+      "theme": {
+        "label": "Tema del editor",
+        "description": "Tema predeterminado del editor de código"
+      },
+      "wordWrap": {
+        "label": "Ajuste de línea",
+        "description": "Activa de forma predeterminada el ajuste de línea en el editor"
+      },
+      "showMinimap": {
+        "label": "Mostrar minimapa",
+        "description": "Muestra un minimapa para facilitar la navegación por la vista de diferencias"
+      },
+      "lineNumbers": {
+        "label": "Mostrar números de línea",
+        "description": "Muestra los números de línea en el editor"
+      },
+      "fontSize": {
+        "label": "Tamaño de fuente",
+        "description": "Tamaño de la fuente del editor en píxeles"
+      }
+    }
+  },
+  "mcpForm": {
+    "title": {
+      "add": "Añadir servidor MCP",
+      "edit": "Editar servidor MCP"
+    },
+    "importMode": {
+      "form": "Entrada de formulario",
+      "json": "Importar JSON"
+    },
+    "scope": {
+      "label": "Ámbito",
+      "userGlobal": "Usuario (global)",
+      "projectLocal": "Proyecto (local)",
+      "userDescription": "Ámbito de usuario: disponible en todos los proyectos del equipo",
+      "projectDescription": "Ámbito local: disponible solo en el proyecto seleccionado",
+      "cannotChange": "El ámbito no puede cambiarse al editar un servidor existente"
+    },
+    "fields": {
+      "serverName": "Nombre del servidor",
+      "transportType": "Tipo de transporte",
+      "command": "Comando",
+      "arguments": "Argumentos (uno por línea)",
+      "jsonConfig": "Configuración JSON",
+      "url": "URL",
+      "envVars": "Variables de entorno (CLAVE=valor, una por línea)",
+      "headers": "Cabeceras (CLAVE=valor, una por línea)",
+      "selectProject": "Selecciona un proyecto..."
+    },
+    "placeholders": {
+      "serverName": "mi-servidor"
+    },
+    "validation": {
+      "missingType": "Falta un campo obligatorio: type",
+      "stdioRequiresCommand": "El tipo stdio requiere el campo command",
+      "httpRequiresUrl": "El tipo {{type}} requiere el campo url",
+      "invalidJson": "El formato JSON no es válido",
+      "jsonHelp": "Pega la configuración de tu servidor MCP en formato JSON. Formatos de ejemplo:",
+      "jsonExampleStdio": "• stdio: {\"type\":\"stdio\",\"command\":\"npx\",\"args\":[\"@upstash/context7-mcp\"]}",
+      "jsonExampleHttp": "• http/sse: {\"type\":\"http\",\"url\":\"https://api.example.com/mcp\"}"
+    },
+    "configDetails": "Detalles de configuración (de {{configFile}})",
+    "projectPath": "Ruta: {{path}}",
+    "actions": {
+      "cancel": "Cancelar",
+      "saving": "Guardando...",
+      "addServer": "Añadir servidor",
+      "updateServer": "Actualizar servidor"
+    }
+  },
+  "saveStatus": {
+    "success": "Los ajustes se han guardado correctamente.",
+    "error": "No se han podido guardar los ajustes",
+    "saving": "Guardando..."
+  },
+  "footerActions": {
+    "save": "Guardar ajustes",
+    "cancel": "Cancelar"
+  },
+  "git": {
+    "title": "Configuración de Git",
+    "description": "Configura tu identidad de Git para los commits. Estos ajustes se aplicarán globalmente mediante git config --global",
+    "name": {
+      "label": "Nombre de Git",
+      "help": "Tu nombre para los commits de Git"
+    },
+    "email": {
+      "label": "Correo de Git",
+      "help": "Tu correo electrónico para los commits de Git"
+    },
+    "actions": {
+      "save": "Guardar configuración",
+      "saving": "Guardando..."
+    },
+    "status": {
+      "success": "Guardado correctamente"
+    }
+  },
+  "apiKeys": {
+    "title": "Claves de API",
+    "description": "Genera claves de API para acceder a la API externa desde otras aplicaciones.",
+    "newKey": {
+      "alertTitle": "⚠️ Guarda tu clave de API",
+      "alertMessage": "Esta es la única vez que verás la clave. Guárdala en un lugar seguro.",
+      "iveSavedIt": "Ya la he guardado"
+    },
+    "form": {
+      "placeholder": "Nombre de la clave de API (p. ej., Servidor de producción)",
+      "createButton": "Crear",
+      "cancelButton": "Cancelar"
+    },
+    "newButton": "Nueva clave de API",
+    "empty": "Aún no se ha creado ninguna clave de API.",
+    "list": {
+      "created": "Creada:",
+      "lastUsed": "Último uso:"
+    },
+    "confirmDelete": "¿Seguro que quieres eliminar esta clave de API?",
+    "status": {
+      "active": "Activa",
+      "inactive": "Inactiva"
+    },
+    "github": {
+      "title": "Tokens de GitHub",
+      "description": "Añade tokens de acceso personal de GitHub para clonar repositorios privados mediante la API externa.",
+      "descriptionAlt": "Añade tokens de acceso personal de GitHub para clonar repositorios privados. También puedes enviar tokens directamente en las solicitudes de API sin guardarlos.",
+      "addButton": "Añadir token",
+      "form": {
+        "namePlaceholder": "Nombre del token (p. ej., Repositorios personales)",
+        "tokenPlaceholder": "Token de acceso personal de GitHub (ghp_...)",
+        "descriptionPlaceholder": "Descripción (opcional)",
+        "addButton": "Añadir token",
+        "cancelButton": "Cancelar",
+        "howToCreate": "Cómo crear un token de acceso personal de GitHub →"
+      },
+      "empty": "Aún no se ha añadido ningún token de GitHub.",
+      "added": "Añadido:",
+      "confirmDelete": "¿Seguro que quieres eliminar este token de GitHub?"
+    },
+    "apiDocsLink": "Documentación de la API",
+    "documentation": {
+      "title": "Documentación de la API externa",
+      "description": "Aprende a usar la API externa para iniciar sesiones de Claude/Cursor desde tus aplicaciones.",
+      "viewLink": "Ver documentación de la API →"
+    },
+    "loading": "Cargando...",
+    "version": {
+      "updateAvailable": "Actualización disponible: v{{version}}"
+    }
+  },
+  "tasks": {
+    "checking": "Comprobando la instalación de TaskMaster...",
+    "notInstalled": {
+      "title": "La CLI de TaskMaster AI no está instalada",
+      "description": "La CLI de TaskMaster es necesaria para usar las funciones de gestión de tareas. Instálala para empezar:",
+      "installCommand": "npm install -g task-master-ai",
+      "viewOnGitHub": "Ver en GitHub",
+      "afterInstallation": "Después de instalarla:",
+      "steps": {
+        "restart": "Reinicia esta aplicación",
+        "autoAvailable": "Las funciones de TaskMaster estarán disponibles automáticamente",
+        "initCommand": "Usa task-master init en el directorio de tu proyecto"
+      }
+    },
+    "settings": {
+      "enableLabel": "Activar la integración con TaskMaster",
+      "enableDescription": "Muestra las tareas, los avisos y los indicadores de la barra lateral de TaskMaster en toda la interfaz"
+    }
+  },
+  "agents": {
+    "authStatus": {
+      "checking": "Comprobando...",
+      "connected": "Conectado",
+      "notConnected": "Sin conexión",
+      "disconnected": "Desconectado",
+      "checkingAuth": "Comprobando el estado de autenticación...",
+      "loggedInAs": "Sesión iniciada como {{email}}",
+      "authenticatedUser": "usuario autenticado"
+    },
+    "account": {
+      "claude": {
+        "description": "Asistente de IA Anthropic Claude"
+      },
+      "cursor": {
+        "description": "Editor de código con IA Cursor"
+      },
+      "codex": {
+        "description": "Asistente de IA OpenAI Codex"
+      },
+      "opencode": {
+        "description": "Asistente CLI OpenCode"
+      }
+    },
+    "connectionStatus": "Estado de conexión",
+    "login": {
+      "title": "Inicio de sesión",
+      "reAuthenticate": "Volver a autenticarse",
+      "description": "Inicia sesión en tu cuenta de {{agent}} para activar las funciones de IA",
+      "reAuthDescription": "Inicia sesión con otra cuenta o actualiza las credenciales",
+      "button": "Iniciar sesión",
+      "reLoginButton": "Volver a iniciar sesión"
+    },
+    "error": "Error: {{error}}"
+  },
+  "permissions": {
+    "title": "Ajustes de permisos",
+    "skipPermissions": {
+      "label": "Omitir solicitudes de permisos (usar con precaución)",
+      "claudeDescription": "Equivale a la opción --dangerously-skip-permissions",
+      "cursorDescription": "Equivale a la opción -f de Cursor CLI"
+    },
+    "allowedTools": {
+      "title": "Herramientas permitidas",
+      "description": "Herramientas permitidas automáticamente sin solicitar permiso",
+      "placeholder": "p. ej., \"Bash(git log:*)\" o \"Write\"",
+      "quickAdd": "Añadir herramientas habituales rápidamente:",
+      "empty": "No hay herramientas permitidas configuradas"
+    },
+    "blockedTools": {
+      "title": "Herramientas bloqueadas",
+      "description": "Herramientas bloqueadas automáticamente sin solicitar permiso",
+      "placeholder": "p. ej., \"Bash(rm:*)\"",
+      "empty": "No hay herramientas bloqueadas configuradas"
+    },
+    "allowedCommands": {
+      "title": "Comandos de terminal permitidos",
+      "description": "Comandos de terminal permitidos automáticamente sin solicitar permiso",
+      "placeholder": "p. ej., \"Shell(ls)\" o \"Shell(git status)\"",
+      "quickAdd": "Añadir comandos habituales rápidamente:",
+      "empty": "No hay comandos permitidos configurados"
+    },
+    "blockedCommands": {
+      "title": "Comandos de terminal bloqueados",
+      "description": "Comandos de terminal bloqueados automáticamente",
+      "placeholder": "p. ej., \"Shell(rm -rf)\" o \"Shell(sudo)\"",
+      "empty": "No hay comandos bloqueados configurados"
+    },
+    "toolExamples": {
+      "title": "Ejemplos de patrones de herramientas:",
+      "bashGitLog": "- Permitir todos los comandos git log",
+      "bashGitDiff": "- Permitir todos los comandos git diff",
+      "write": "- Permitir todos los usos de la herramienta Write",
+      "bashRm": "- Bloquear todos los comandos rm (peligroso)"
+    },
+    "shellExamples": {
+      "title": "Ejemplos de comandos de terminal:",
+      "ls": "- Permitir el comando ls",
+      "gitStatus": "- Permitir git status",
+      "npmInstall": "- Permitir npm install",
+      "rmRf": "- Bloquear la eliminación recursiva"
+    },
+    "codex": {
+      "permissionMode": "Modo de permisos",
+      "description": "Controla cómo gestiona Codex las modificaciones de ficheros y la ejecución de comandos",
+      "modes": {
+        "default": {
+          "title": "Predeterminado",
+          "description": "Solo los comandos de confianza (ls, cat, grep, git status, etc.) se ejecutan automáticamente. Los demás se omiten. Puede escribir en el espacio de trabajo."
+        },
+        "acceptEdits": {
+          "title": "Aceptar ediciones",
+          "description": "Todos los comandos se ejecutan automáticamente dentro del espacio de trabajo. Modo completamente automático con ejecución aislada."
+        },
+        "bypassPermissions": {
+          "title": "Omitir permisos",
+          "description": "Acceso completo al sistema sin restricciones. Todos los comandos se ejecutan automáticamente con acceso total al disco y a la red. Úsalo con precaución."
+        }
+      },
+      "technicalDetails": "Detalles técnicos",
+      "technicalInfo": {
+        "default": "sandboxMode=workspace-write, approvalPolicy=untrusted. Comandos de confianza: cat, cd, grep, head, ls, pwd, tail, git status/log/diff/show, find (sin -exec), etc.",
+        "acceptEdits": "sandboxMode=workspace-write, approvalPolicy=never. Todos los comandos se ejecutan automáticamente en el directorio del proyecto.",
+        "bypassPermissions": "sandboxMode=danger-full-access, approvalPolicy=never. Acceso completo al sistema; úsalo solo en entornos de confianza.",
+        "overrideNote": "Puedes sustituir este valor en cada sesión con el botón de modo de la interfaz del chat."
+      }
+    },
+    "actions": {
+      "add": "Añadir"
+    }
+  },
+  "mcpServers": {
+    "title": "Servidores MCP",
+    "description": {
+      "claude": "Los servidores Model Context Protocol proporcionan herramientas y fuentes de datos adicionales a Claude",
+      "cursor": "Los servidores Model Context Protocol proporcionan herramientas y fuentes de datos adicionales a Cursor",
+      "codex": "Los servidores Model Context Protocol proporcionan herramientas y fuentes de datos adicionales a Codex",
+      "opencode": "Los servidores Model Context Protocol proporcionan herramientas y fuentes de datos adicionales a OpenCode"
+    },
+    "addButton": "Añadir servidor MCP",
+    "empty": "No hay servidores MCP configurados",
+    "serverType": "Tipo",
+    "scope": {
+      "local": "local",
+      "user": "usuario"
+    },
+    "config": {
+      "command": "Comando",
+      "url": "URL",
+      "args": "Argumentos",
+      "environment": "Entorno"
+    },
+    "tools": {
+      "title": "Herramientas",
+      "count": "({{count}}):",
+      "more": "+{{count}} más"
+    },
+    "actions": {
+      "edit": "Editar servidor",
+      "delete": "Eliminar servidor"
+    },
+    "managed": {
+      "badge": "Gestionado",
+      "hint": "Gestionado por CloudCLI."
+    },
+    "help": {
+      "title": "Acerca de MCP para Codex",
+      "description": "Codex admite servidores MCP basados en stdio. Puedes añadir servidores que amplíen las capacidades de Codex con herramientas y recursos adicionales."
+    }
+  },
+  "pluginSettings": {
+    "title": "Complementos",
+    "description": "Amplía la interfaz con complementos personalizados. Instálalos desde Git o coloca una carpeta en ~/.claude-code-ui/plugins/",
+    "installPlaceholder": "https://github.com/usuario/mi-complemento",
+    "installButton": "Instalar",
+    "installing": "Instalando…",
+    "securityWarning": "Instala solo complementos cuyo código fuente hayas revisado o de autores en los que confíes.",
+    "scanningPlugins": "Buscando complementos…",
+    "noPluginsInstalled": "No hay complementos instalados",
+    "pullLatest": "Obtener lo último de Git",
+    "noGitRemote": "No hay remoto de Git; la actualización no está disponible",
+    "uninstallPlugin": "Desinstalar complemento",
+    "confirmUninstall": "Haz clic de nuevo para confirmar",
+    "confirmUninstallMessage": "¿Quieres quitar {{name}}? Esta acción no se puede deshacer.",
+    "cancel": "Cancelar",
+    "remove": "Quitar",
+    "updateFailed": "La actualización ha fallado",
+    "installFailed": "La instalación ha fallado",
+    "uninstallFailed": "La desinstalación ha fallado",
+    "toggleFailed": "No se ha podido alternar",
+    "starterPluginLabel": "Complemento inicial",
+    "starter": "Inicial",
+    "docs": "Documentación",
+    "sections": {
+      "officialTitle": "Complementos oficiales",
+      "officialDescription": "Mantenidos por el equipo de CloudCLI y listos para instalar directamente.",
+      "unofficialTitle": "Otros complementos",
+      "unofficialDescription": "Complementos e integraciones no oficiales de otros usuarios. Revisa el código fuente antes de instalarlos."
+    },
+    "starterPlugin": {
+      "name": "Estadísticas del proyecto",
+      "badge": "inicial",
+      "description": "Número de ficheros, líneas de código, desglose por tipo de fichero y actividad reciente del proyecto.",
+      "install": "Instalar"
+    },
+    "terminalPlugin": {
+      "name": "Terminal",
+      "badge": "oficial",
+      "description": "Terminal integrado con acceso completo al shell directamente desde la interfaz.",
+      "install": "Instalar"
+    },
+    "scheduledPromptPlugin": {
+      "name": "Solicitudes programadas",
+      "badge": "no oficial",
+      "description": "Programa solicitudes del espacio de trabajo, revisa el historial de ejecuciones y gestiona tareas locales recurrentes.",
+      "install": "Instalar"
+    },
+    "claudeWatchPlugin": {
+      "name": "Claude Watch",
+      "badge": "no oficial",
+      "description": "Supervisa sesiones largas de Claude Code para detectar bloqueos y muestra controles del proceso.",
+      "install": "Instalar"
+    },
+    "prismCloudCLI": {
+      "name": "PRISM CloudCLI",
+      "badge": "no oficial",
+      "description": "Inteligencia de sesiones para Claude Code dentro de CloudCLI. Descubre por qué tus sesiones consumen tokens sin salir del navegador.",
+      "install": "Instalar"
+    },
+    "sessionManagerPlugin": {
+      "name": "Sesiones",
+      "badge": "no oficial",
+      "description": "Consulta, gestiona y termina sesiones activas de Claude Code.",
+      "install": "Instalar"
+    },
+    "tokenCostCalculatorPlugin": {
+      "name": "Calculadora de costes de tokens",
+      "badge": "no oficial",
+      "description": "Calcula los costes de API a partir de los precios de los modelos y el uso de tokens, con precios predefinidos para distintos modelos.",
+      "install": "Instalar"
+    },
+    "taskQueuePlugin": {
+      "name": "Cola de tareas",
+      "badge": "no oficial",
+      "description": "Panel de la cola de tareas para consultar, filtrar e iniciar tareas de agentes.",
+      "install": "Instalar"
+    },
+    "githubIssuesBoardPlugin": {
+      "name": "Panel de incidencias de GitHub",
+      "badge": "no oficial",
+      "description": "Panel Kanban de incidencias de GitHub con sincronización bidireccional de TaskMaster e instalación automática de la habilidad /github-task de la CLI",
+      "install": "Instalar"
+    },
+    "morePlugins": "Más",
+    "enable": "Activar",
+    "disable": "Desactivar",
+    "installAriaLabel": "URL del repositorio Git del complemento",
+    "tab": "pestaña",
+    "runningStatus": "en ejecución"
+  }
+}

--- a/src/i18n/locales/es-ES/sidebar.json
+++ b/src/i18n/locales/es-ES/sidebar.json
@@ -1,0 +1,145 @@
+{
+  "projects": {
+    "title": "Proyectos",
+    "newProject": "Nuevo proyecto",
+    "deleteProject": "Quitar proyecto",
+    "renameProject": "Cambiar nombre del proyecto",
+    "noProjects": "No se han encontrado proyectos",
+    "loadingProjects": "Cargando proyectos...",
+    "searchPlaceholder": "Buscar proyectos...",
+    "projectNamePlaceholder": "Nombre del proyecto",
+    "starred": "Destacados",
+    "all": "Todos",
+    "untitledSession": "Sesión sin título",
+    "newSession": "Nueva sesión",
+    "codexSession": "Sesión de Codex",
+    "fetchingProjects": "Obteniendo tus proyectos y sesiones de Claude",
+    "projects": "proyectos",
+    "noMatchingProjects": "No hay proyectos coincidentes",
+    "tryDifferentSearch": "Prueba a cambiar el término de búsqueda",
+    "runClaudeCli": "Ejecuta Claude CLI en el directorio de un proyecto para empezar"
+  },
+  "app": {
+    "title": "CloudCLI",
+    "subtitle": "Interfaz del asistente de programación con IA"
+  },
+  "sessions": {
+    "title": "Sesiones",
+    "newSession": "Nueva sesión",
+    "deleteSession": "Eliminar sesión",
+    "renameSession": "Cambiar nombre de la sesión",
+    "noSessions": "Aún no hay sesiones",
+    "loadingSessions": "Cargando sesiones...",
+    "unnamed": "Sin nombre",
+    "loading": "Cargando...",
+    "showMore": "Mostrar más sesiones"
+  },
+  "tooltips": {
+    "viewEnvironments": "Ver entornos",
+    "hideSidebar": "Ocultar la barra lateral",
+    "createProject": "Crear un proyecto",
+    "refresh": "Actualizar proyectos y sesiones (Ctrl+R)",
+    "renameProject": "Cambiar nombre del proyecto (F2)",
+    "deleteProject": "Quitar proyecto de la barra lateral (Supr)",
+    "addToFavorites": "Añadir a favoritos",
+    "removeFromFavorites": "Quitar de favoritos",
+    "editSessionName": "Editar manualmente el nombre de la sesión",
+    "deleteSession": "Eliminar esta sesión de forma permanente",
+    "activeSessionIndicator": "Sesión activa recientemente (últimos 10 minutos)",
+    "save": "Guardar",
+    "cancel": "Cancelar",
+    "clearSearch": "Borrar búsqueda",
+    "openCommandPalette": "Abrir la paleta de comandos",
+    "attentionRequiredIndicator": "La sesión requiere atención"
+  },
+  "navigation": {
+    "chat": "Chat",
+    "files": "Ficheros",
+    "git": "Git",
+    "terminal": "Terminal",
+    "tasks": "Tareas"
+  },
+  "actions": {
+    "refresh": "Actualizar",
+    "settings": "Ajustes",
+    "collapseAll": "Contraer todo",
+    "expandAll": "Expandir todo",
+    "cancel": "Cancelar",
+    "save": "Guardar",
+    "delete": "Eliminar",
+    "rename": "Cambiar nombre",
+    "joinCommunity": "Unirse a la comunidad",
+    "reportIssue": "Informar de un problema",
+    "starOnGithub": "Destacar en GitHub"
+  },
+  "branding": {
+    "openSource": "Código abierto"
+  },
+  "status": {
+    "active": "Activa",
+    "inactive": "Inactiva",
+    "thinking": "Pensando...",
+    "error": "Error",
+    "aborted": "Cancelada",
+    "unknown": "Desconocida"
+  },
+  "time": {
+    "justNow": "Ahora mismo",
+    "oneMinuteAgo": "Hace 1 min",
+    "minutesAgo": "Hace {{count}} min",
+    "oneHourAgo": "Hace 1 hora",
+    "hoursAgo": "Hace {{count}} horas",
+    "oneDayAgo": "Hace 1 día",
+    "daysAgo": "Hace {{count}} días"
+  },
+  "messages": {
+    "deleteConfirm": "¿Seguro que quieres eliminarlo?",
+    "renameSuccess": "Se ha cambiado el nombre correctamente",
+    "deleteSuccess": "Se ha eliminado correctamente",
+    "errorOccurred": "Se ha producido un error",
+    "deleteSessionConfirm": "¿Seguro que quieres eliminar esta sesión? Esta acción no se puede deshacer.",
+    "deleteProjectConfirm": "¿Quieres quitar este proyecto de la barra lateral? Los ficheros, las memorias y los datos de sesión no se eliminarán.",
+    "enterProjectPath": "Introduce una ruta de proyecto",
+    "deleteSessionFailed": "No se ha podido eliminar la sesión. Inténtalo de nuevo.",
+    "deleteSessionError": "Error al eliminar la sesión. Inténtalo de nuevo.",
+    "renameSessionFailed": "No se ha podido cambiar el nombre de la sesión. Inténtalo de nuevo.",
+    "renameSessionError": "Error al cambiar el nombre de la sesión. Inténtalo de nuevo.",
+    "deleteProjectFailed": "No se ha podido quitar el proyecto. Inténtalo de nuevo.",
+    "deleteProjectError": "Error al quitar el proyecto. Inténtalo de nuevo.",
+    "createProjectFailed": "No se ha podido crear el proyecto. Inténtalo de nuevo.",
+    "createProjectError": "Error al crear el proyecto. Inténtalo de nuevo.",
+    "updateProjectError": "Error al actualizar el proyecto. Inténtalo de nuevo.",
+    "refreshError": "No se ha podido actualizar. Inténtalo de nuevo.",
+    "restoreProjectFailed": "No se ha podido restaurar el proyecto. Inténtalo de nuevo.",
+    "restoreProjectError": "Error al restaurar el proyecto. Inténtalo de nuevo.",
+    "restoreSessionFailed": "No se ha podido restaurar la sesión. Inténtalo de nuevo.",
+    "restoreSessionError": "Error al restaurar la sesión. Inténtalo de nuevo."
+  },
+  "version": {
+    "updateAvailable": "Actualización disponible",
+    "restartRequired": "Actualización instalada; reinicia el servidor para aplicarla"
+  },
+  "search": {
+    "modeProjects": "Proyectos",
+    "modeConversations": "Conversaciones",
+    "conversationsPlaceholder": "Buscar en las conversaciones...",
+    "searching": "Buscando...",
+    "noResults": "No se han encontrado resultados",
+    "tryDifferentQuery": "Prueba otra búsqueda",
+    "matches_one": "{{count}} coincidencia",
+    "matches_other": "{{count}} coincidencias",
+    "projectsScanned_one": "{{count}} proyecto analizado",
+    "projectsScanned_other": "{{count}} proyectos analizados"
+  },
+  "deleteConfirmation": {
+    "deleteProject": "Quitar proyecto",
+    "deleteSession": "Eliminar sesión",
+    "confirmDelete": "¿Qué quieres hacer con",
+    "sessionCount_one": "Este proyecto contiene {{count}} conversación.",
+    "sessionCount_other": "Este proyecto contiene {{count}} conversaciones.",
+    "removeFromSidebar": "Quitar solo de la barra lateral",
+    "deleteAllData": "Eliminar todos los datos de forma permanente",
+    "allConversationsDeleted": "El proyecto se quitará de la barra lateral. Se conservarán tus ficheros, memorias y datos de sesión.",
+    "cannotUndo": "Puedes volver a añadir el proyecto más adelante."
+  }
+}

--- a/src/i18n/locales/es-ES/tasks.json
+++ b/src/i18n/locales/es-ES/tasks.json
@@ -1,0 +1,142 @@
+{
+  "notConfigured": {
+    "title": "TaskMaster AI no está configurado",
+    "description": "TaskMaster ayuda a dividir proyectos complejos en tareas manejables con asistencia basada en IA",
+    "whatIsTitle": "🎯 ¿Qué es TaskMaster?",
+    "features": {
+      "aiPowered": "Gestión de tareas con IA: divide proyectos complejos en subtareas manejables",
+      "prdTemplates": "Plantillas de PRD: genera tareas a partir de documentos de requisitos del producto",
+      "dependencyTracking": "Seguimiento de dependencias: comprende las relaciones entre tareas y el orden de ejecución",
+      "progressVisualization": "Visualización del progreso: tableros Kanban y análisis detallados de tareas",
+      "cliIntegration": "Integración con CLI: usa comandos de TaskMaster para flujos de trabajo avanzados"
+    },
+    "initializeButton": "Inicializar TaskMaster AI"
+  },
+  "gettingStarted": {
+    "title": "Primeros pasos con TaskMaster",
+    "subtitle": "TaskMaster se ha inicializado. Esto es lo que debes hacer ahora:",
+    "steps": {
+      "createPRD": {
+        "title": "Crear un documento de requisitos del producto (PRD)",
+        "description": "Explica la idea de tu proyecto y crea un PRD que describa lo que quieres desarrollar.",
+        "addButton": "Añadir PRD",
+        "existingPRDs": "PRD existentes:"
+      },
+      "generateTasks": {
+        "title": "Generar tareas desde el PRD",
+        "description": "Cuando tengas un PRD, pide a tu asistente de IA que lo analice y TaskMaster lo dividirá automáticamente en tareas manejables con detalles de implementación."
+      },
+      "analyzeTasks": {
+        "title": "Analizar y ampliar tareas",
+        "description": "Pide a tu asistente de IA que analice la complejidad de las tareas y las divida en subtareas detalladas para facilitar su implementación."
+      },
+      "startBuilding": {
+        "title": "Empezar a desarrollar",
+        "description": "Pide a tu asistente de IA que empiece a trabajar en las tareas, actualice su estado y añada otras nuevas a medida que evolucione el proyecto."
+      }
+    },
+    "tip": "💡 Consejo: empieza con un PRD para aprovechar al máximo la generación de tareas con IA de TaskMaster"
+  },
+  "setupModal": {
+    "title": "Configuración de TaskMaster",
+    "subtitle": "CLI interactiva para {{projectName}}",
+    "willStart": "La inicialización de TaskMaster comenzará automáticamente",
+    "completed": "La configuración de TaskMaster ha terminado. Ya puedes cerrar esta ventana.",
+    "closeButton": "Cerrar",
+    "closeContinueButton": "Cerrar y continuar"
+  },
+  "helpGuide": {
+    "title": "Primeros pasos con TaskMaster",
+    "subtitle": "Tu guía para gestionar tareas de forma productiva",
+    "examples": {
+      "parsePRD": "💬 Ejemplo:\n\"Acabo de inicializar un proyecto nuevo con Claude Task Master. Tengo un PRD en .taskmaster/docs/prd.txt. ¿Puedes ayudarme a analizarlo y configurar las tareas iniciales?\"",
+      "expandTask": "💬 Ejemplo:\n\"La tarea 5 parece compleja. ¿Puedes dividirla en subtareas?\"",
+      "addTask": "💬 Ejemplo:\n\"Añade una tarea nueva para implementar la subida de imágenes de perfil de usuario mediante Cloudinary e investiga el mejor enfoque.\""
+    },
+    "moreExamples": "Ver más ejemplos y patrones de uso →",
+    "proTips": {
+      "title": "💡 Consejos",
+      "search": "Usa la barra de búsqueda para encontrar tareas concretas rápidamente",
+      "views": "Alterna entre las vistas Kanban, Lista y Cuadrícula con los controles de vista",
+      "filters": "Usa filtros para centrarte en estados o prioridades de tarea concretos",
+      "details": "Haz clic en cualquier tarea para consultar la información detallada y gestionar las subtareas"
+    },
+    "learnMore": {
+      "title": "📚 Más información",
+      "description": "TaskMaster AI es un sistema avanzado de gestión de tareas creado para desarrolladores. Consulta la documentación y los ejemplos, o contribuye al proyecto.",
+      "githubButton": "Ver en GitHub"
+    }
+  },
+  "search": {
+    "placeholder": "Buscar tareas..."
+  },
+  "filters": {
+    "button": "Filtros",
+    "status": "Estado",
+    "priority": "Prioridad",
+    "sortBy": "Ordenar por",
+    "allStatuses": "Todos los estados",
+    "allPriorities": "Todas las prioridades",
+    "showing": "Mostrando {{filtered}} de {{total}} tareas",
+    "clearFilters": "Borrar filtros"
+  },
+  "sort": {
+    "id": "ID",
+    "status": "Estado",
+    "priority": "Prioridad",
+    "idAsc": "ID (ascendente)",
+    "idDesc": "ID (descendente)",
+    "titleAsc": "Título (A-Z)",
+    "titleDesc": "Título (Z-A)",
+    "statusAsc": "Estado (pendientes primero)",
+    "statusDesc": "Estado (terminadas primero)",
+    "priorityAsc": "Prioridad (alta primero)",
+    "priorityDesc": "Prioridad (baja primero)"
+  },
+  "views": {
+    "kanban": "Vista Kanban",
+    "list": "Vista de lista",
+    "grid": "Vista de cuadrícula"
+  },
+  "kanban": {
+    "pending": "📋 Por hacer",
+    "inProgress": "🚀 En curso",
+    "done": "✅ Terminadas",
+    "blocked": "🚫 Bloqueadas",
+    "deferred": "⏳ Aplazadas",
+    "cancelled": "❌ Canceladas",
+    "noTasksYet": "Aún no hay tareas",
+    "tasksWillAppear": "Las tareas aparecerán aquí",
+    "moveTasksHere": "Mueve aquí las tareas cuando empiecen",
+    "completedTasksHere": "Las tareas terminadas aparecen aquí",
+    "statusTasksHere": "Las tareas con este estado aparecerán aquí"
+  },
+  "buttons": {
+    "help": "Guía de primeros pasos de TaskMaster",
+    "prds": "PRD",
+    "addPRD": "Añadir PRD",
+    "addTask": "Añadir tarea",
+    "createNewPRD": "Crear PRD",
+    "prdsAvailable": "{{count}} PRD disponibles"
+  },
+  "prd": {
+    "modified": "Modificado: {{date}}"
+  },
+  "statuses": {
+    "pending": "Pendiente",
+    "in-progress": "En curso",
+    "done": "Terminada",
+    "blocked": "Bloqueada",
+    "deferred": "Aplazada",
+    "cancelled": "Cancelada"
+  },
+  "priorities": {
+    "high": "Alta",
+    "medium": "Media",
+    "low": "Baja"
+  },
+  "noMatchingTasks": {
+    "title": "Ninguna tarea coincide con los filtros",
+    "description": "Prueba a ajustar la búsqueda o los criterios de filtrado."
+  }
+}

--- a/src/i18n/spanishLocales.test.js
+++ b/src/i18n/spanishLocales.test.js
@@ -1,0 +1,120 @@
+import assert from 'node:assert/strict';
+import { readFileSync, readdirSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const currentDirectory = dirname(fileURLToPath(import.meta.url));
+const localeDirectory = join(currentDirectory, 'locales');
+const englishDirectory = join(localeDirectory, 'en');
+const spanishLocaleCodes = ['es-ES', 'es-419'];
+const namespaceFiles = readdirSync(englishDirectory)
+  .filter((fileName) => fileName.endsWith('.json'))
+  .sort();
+
+const readJson = (path) => JSON.parse(readFileSync(path, 'utf8'));
+
+const flattenStrings = (value, path = [], entries = new Map()) => {
+  if (typeof value === 'string') {
+    entries.set(path.join('.'), value);
+    return entries;
+  }
+
+  if (Array.isArray(value)) {
+    value.forEach((item, index) => flattenStrings(item, [...path, String(index)], entries));
+    return entries;
+  }
+
+  if (value && typeof value === 'object') {
+    Object.entries(value).forEach(([key, item]) => {
+      flattenStrings(item, [...path, key], entries);
+    });
+  }
+
+  return entries;
+};
+
+const interpolationTokens = (value) => [
+  ...value.matchAll(/{{\s*([^},\s]+)/g),
+].map((match) => match[1]).sort();
+
+for (const localeCode of spanishLocaleCodes) {
+  test(`${localeCode} translates every namespace without losing keys or placeholders`, () => {
+    const localePath = join(localeDirectory, localeCode);
+    const localeFiles = readdirSync(localePath)
+      .filter((fileName) => fileName.endsWith('.json'))
+      .sort();
+
+    assert.deepEqual(localeFiles, namespaceFiles);
+
+    let translatedValues = 0;
+    let totalValues = 0;
+
+    for (const namespaceFile of namespaceFiles) {
+      const englishEntries = flattenStrings(readJson(join(englishDirectory, namespaceFile)));
+      const localizedEntries = flattenStrings(readJson(join(localePath, namespaceFile)));
+
+      assert.deepEqual(
+        [...localizedEntries.keys()].sort(),
+        [...englishEntries.keys()].sort(),
+        `${localeCode}/${namespaceFile} must preserve the English key set`,
+      );
+
+      for (const [key, englishValue] of englishEntries) {
+        const localizedValue = localizedEntries.get(key);
+        assert.deepEqual(
+          interpolationTokens(localizedValue),
+          interpolationTokens(englishValue),
+          `${localeCode}/${namespaceFile}:${key} must preserve interpolation tokens`,
+        );
+        totalValues += 1;
+        if (localizedValue !== englishValue) translatedValues += 1;
+      }
+    }
+
+    assert.ok(
+      translatedValues / totalValues > 0.75,
+      `${localeCode} must translate the UI instead of relying on English fallback`,
+    );
+  });
+}
+
+test('Spain and Latin American Spanish are independently localized artifacts', () => {
+  let differingValues = 0;
+
+  for (const namespaceFile of namespaceFiles) {
+    const spainEntries = flattenStrings(
+      readJson(join(localeDirectory, 'es-ES', namespaceFile)),
+    );
+    const latinAmericaEntries = flattenStrings(
+      readJson(join(localeDirectory, 'es-419', namespaceFile)),
+    );
+
+    for (const [key, spainValue] of spainEntries) {
+      if (spainValue !== latinAmericaEntries.get(key)) differingValues += 1;
+    }
+  }
+
+  assert.ok(
+    differingValues >= 20,
+    'regional Spanish bundles must contain deliberate vocabulary and grammar differences',
+  );
+});
+
+test('i18next switches between the two exact regional resources', async () => {
+  const storage = new Map();
+  globalThis.localStorage = {
+    getItem: (key) => storage.get(key) ?? null,
+    setItem: (key, value) => storage.set(key, value),
+  };
+
+  const { default: i18n } = await import('./config.js');
+
+  await i18n.changeLanguage('es-ES');
+  assert.equal(i18n.resolvedLanguage, 'es-ES');
+  assert.equal(i18n.t('tabs.computer', { ns: 'common' }), 'Ordenador');
+
+  await i18n.changeLanguage('es-419');
+  assert.equal(i18n.resolvedLanguage, 'es-419');
+  assert.equal(i18n.t('tabs.computer', { ns: 'common' }), 'Computadora');
+});

--- a/src/shared/view/ui/LanguageSelector.test.tsx
+++ b/src/shared/view/ui/LanguageSelector.test.tsx
@@ -1,0 +1,40 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { I18nextProvider } from 'react-i18next';
+
+const selectClassNames = (html: string) => {
+  const match = html.match(/<select[^>]*class="([^"]+)"/);
+  assert.ok(match, 'language selector should render a select element');
+  return new Set(match[1].split(/\s+/));
+};
+
+test('regional Spanish names have enough width to remain distinguishable', async () => {
+  const storedValues = new Map([['userLanguage', 'es-ES']]);
+  globalThis.localStorage = {
+    get length() {
+      return storedValues.size;
+    },
+    clear: () => storedValues.clear(),
+    getItem: (key) => storedValues.get(key) ?? null,
+    key: (index) => [...storedValues.keys()][index] ?? null,
+    removeItem: (key) => storedValues.delete(key),
+    setItem: (key, value) => storedValues.set(key, value),
+  };
+
+  const [{ default: i18n }, { default: LanguageSelector }] = await Promise.all([
+    import('../../../i18n/config.js'),
+    import('./LanguageSelector'),
+  ]);
+
+  const renderSelector = (compact: boolean) => renderToStaticMarkup(
+    <I18nextProvider i18n={i18n}>
+      <LanguageSelector compact={compact} />
+    </I18nextProvider>,
+  );
+
+  assert.ok(selectClassNames(renderSelector(false)).has('w-52'));
+  assert.ok(selectClassNames(renderSelector(true)).has('min-w-52'));
+});

--- a/src/shared/view/ui/LanguageSelector.tsx
+++ b/src/shared/view/ui/LanguageSelector.tsx
@@ -37,7 +37,7 @@ export default function LanguageSelector({ compact = false }: LanguageSelectorPr
         <select
           value={i18n.language}
           onChange={handleLanguageChange}
-          className="w-auto min-w-[120px] max-w-[160px] rounded-lg border border-input bg-card p-2 text-sm text-foreground focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary"
+          className="w-auto min-w-52 max-w-full rounded-lg border border-input bg-card p-2 text-sm text-foreground focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary"
         >
           {languages.map((lang) => (
             <option key={lang.value} value={lang.value}>
@@ -63,7 +63,7 @@ export default function LanguageSelector({ compact = false }: LanguageSelectorPr
       <select
         value={i18n.language}
         onChange={handleLanguageChange}
-        className="w-36 rounded-lg border border-input bg-card p-2 text-sm text-foreground focus:border-primary focus:ring-1 focus:ring-primary"
+        className="w-52 max-w-full rounded-lg border border-input bg-card p-2 text-sm text-foreground focus:border-primary focus:ring-1 focus:ring-primary"
       >
         {languages.map((lang) => (
           <option key={lang.value} value={lang.value}>


### PR DESCRIPTION
## Summary

- add adjacent Spain Spanish (es-ES) and Latin American Spanish (es-419) language options
- register independent translations for all seven UI namespaces and preserve every English key/interpolation token
- widen both language selectors so the regional names remain fully visible
- add regression coverage for locale completeness, runtime switching, persistence, and selector width

## Product context

Implements the regional Spanish behavior described in the Feishu PRD:
https://awaken-intelligence.feishu.cn/wiki/CSoawT8pliSFFuk7s8Tc5x2gnLe

## Verification

- 18/18 Node tests pass
- npm run typecheck
- npm run build
- npm run lint (0 errors; existing repository warnings only)
- Playwright browser check at 1440x900: both labels visible, es-419 persisted, no page errors


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Spanish (Spain) and Spanish (Latin America) as selectable languages.
  * Added comprehensive regional Spanish translations across authentication, chat, editor, settings, sidebar, and task-management interfaces.

* **UI Improvements**
  * Improved language selector sizing for compact and full settings layouts.

* **Tests**
  * Added coverage verifying translation completeness, regional differences, language switching, and selector styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->