### PR TITLE
feat(i18n): add missing zh-CN translations for all namespaces

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -140,6 +140,7 @@ tasks/
 !src/i18n/locales/de/tasks.json
 !src/i18n/locales/tr/tasks.json
 !src/i18n/locales/it/tasks.json
+!src/i18n/locales/zh-CN/tasks.json
 
 # Git worktrees
 .worktrees/

--- a/src/i18n/config.js
+++ b/src/i18n/config.js
@@ -39,6 +39,7 @@ import zhSidebar from './locales/zh-CN/sidebar.json';
 import zhChat from './locales/zh-CN/chat.json';
 // eslint-disable-next-line import-x/order
 import zhCodeEditor from './locales/zh-CN/codeEditor.json';
+import zhTasks from './locales/zh-CN/tasks.json';
 
 import jaCommon from './locales/ja/common.json';
 import jaSettings from './locales/ja/settings.json';
@@ -141,6 +142,7 @@ i18n
         sidebar: zhSidebar,
         chat: zhChat,
         codeEditor: zhCodeEditor,
+        tasks: zhTasks,
       },
       ja: {
         common: jaCommon,

--- a/src/i18n/locales/zh-CN/chat.json
+++ b/src/i18n/locales/zh-CN/chat.json
@@ -17,7 +17,8 @@
     "tool": "工具",
     "claude": "Claude",
     "cursor": "Cursor",
-    "codex": "Codex"
+    "codex": "Codex",
+    "opencode": "OpenCode"
   },
   "tools": {
     "settings": "工具设置",
@@ -102,6 +103,14 @@
     },
     "technicalDetails": "技术细节"
   },
+  "voice": {
+    "input": "语音输入",
+    "stopRecording": "停止录音",
+    "transcribing": "转写中…",
+    "speak": "朗读",
+    "stopSpeaking": "停止",
+    "loading": "加载中…"
+  },
   "input": {
     "placeholder": "输入 / 调用命令，@ 选择文件，或向 {{provider}} 提问...",
     "placeholderDefault": "输入您的消息...",
@@ -112,12 +121,22 @@
     "stop": "停止",
     "hintText": {
       "ctrlEnter": "Ctrl+Enter 发送 • Shift+Enter 换行 • Tab 切换模式 • / 斜杠命令",
-      "enter": "Enter 发送 • Shift+Enter 换行 • Tab 切换模式 • / 斜杠命令"
+      "enter": "Enter 发送 • Shift+Enter 换行 • Tab 切换模式 • / 斜杠命令",
+      "queue": "Enter 排队发送下一条消息",
+      "updateQueued": "Enter 更新排队消息"
     },
     "clickToChangeMode": "点击更改权限模式（或在输入框中按 Tab）",
     "showAllCommands": "显示所有命令",
     "clearInput": "清空输入",
-    "scrollToBottom": "滚动到底部"
+    "scrollToBottom": "滚动到底部",
+    "queue": {
+      "sendNext": "排队发送下一条消息",
+      "update": "更新排队消息",
+      "label": "已排队",
+      "willSend": "将在当前完成后发送",
+      "edit": "编辑排队消息",
+      "delete": "删除排队消息"
+    }
   },
   "providerSelection": {
     "title": "选择您的 AI 助手",
@@ -133,6 +152,7 @@
       "claude": "准备好使用带有 {{model}} 的 Claude。请在下方开始输入您的消息。",
       "cursor": "准备好使用带有 {{model}} 的 Cursor。请在下方开始输入您的消息。",
       "codex": "准备好使用带有 {{model}} 的 Codex。请在下方开始输入您的消息。",
+      "opencode": "准备好使用带有 {{model}} 的 OpenCode。请在下方开始输入您的消息。",
       "default": "请在上方选择一个提供者以开始"
     },
     "pressToSearch": "按 <kbd>{{shortcut}}</kbd> 搜索会话、文件和提交"
@@ -202,6 +222,7 @@
       "label": "{{time}} elapsed",
       "startingNow": "Starting now"
     },
+    "stop": "停止",
     "controls": {
       "stopGeneration": "Stop Generation",
       "pressEscToStop": "Press Esc anytime to stop"

--- a/src/i18n/locales/zh-CN/codeEditor.json
+++ b/src/i18n/locales/zh-CN/codeEditor.json
@@ -20,7 +20,9 @@
     "saved": "已保存！",
     "exitFullscreen": "退出全屏",
     "fullscreen": "全屏",
-    "close": "关闭"
+    "close": "关闭",
+    "previewMarkdown": "预览 Markdown",
+    "editMarkdown": "编辑 Markdown"
   },
   "footer": {
     "lines": "行数：",
@@ -30,5 +32,10 @@
   "binaryFile": {
     "title": "二进制文件",
     "message": "文件 \"{{fileName}}\" 无法在文本编辑器中显示，因为它是二进制文件。"
+  },
+  "filePreview": {
+    "loading": "正在加载预览...",
+    "error": "无法显示此文件。",
+    "openInNewTab": "在新标签页中打开"
   }
 }

--- a/src/i18n/locales/zh-CN/settings.json
+++ b/src/i18n/locales/zh-CN/settings.json
@@ -4,6 +4,7 @@
     "account": "账户",
     "permissions": "权限",
     "mcpServers": "MCP 服务器",
+    "skills": "技能",
     "appearance": "外观"
   },
   "account": {
@@ -49,6 +50,21 @@
     "resetToDefaults": "重置为默认值",
     "cancelChanges": "取消更改"
   },
+  "voiceSettings": {
+    "title": "语音",
+    "description": "通过兼容 OpenAI 的音频后端实现语音转文字输入和朗读功能。",
+    "enable": "启用语音",
+    "enableDescription": "在消息上显示麦克风按钮和朗读按钮。",
+    "backendTitle": "后端",
+    "backendDescription": "指向 OpenAI、Groq 或本地服务器（LocalAI、Speaches、Kokoro-FastAPI）。留空以使用服务器默认值。",
+    "baseUrl": "基础 URL",
+    "apiKey": "API 密钥",
+    "sttModel": "语音转文字模型",
+    "ttsModel": "文字转语音模型",
+    "voice": "语音",
+    "format": "音频格式",
+    "note": "自定义基础 URL 由您的浏览器直接调用，必须允许浏览器 CORS 请求。留空以使用服务器配置的后端。"
+  },
   "quickSettings": {
     "title": "快速设置",
     "sections": {
@@ -60,6 +76,7 @@
     "showRawParameters": "显示原始参数",
     "showThinking": "显示思考过程",
     "sendByCtrlEnter": "使用 Ctrl+Enter 发送",
+    "voiceEnabled": "语音（麦克风 + 朗读）",
     "sendByCtrlEnterDescription": "启用后，按 Ctrl+Enter 发送消息，而不是仅按 Enter。这对于使用输入法的用户可以避免意外发送。",
     "dragHandle": {
       "dragging": "正在拖拽手柄",
@@ -90,8 +107,9 @@
     "appearance": "外观",
     "git": "Git",
     "apiTokens": "API 和令牌",
+    "voice": "语音",
     "tasks": "任务",
-    "computer": "计算机使用",
+    "browser": "浏览器",
     "notifications": "通知",
     "plugins": "插件",
     "about": "关于"
@@ -100,13 +118,20 @@
     "title": "通知",
     "description": "控制你希望接收的通知事件。",
     "webPush": {
-      "title": "Web 推送通知",
-      "enable": "启用推送通知",
-      "disable": "关闭推送通知",
-      "enabled": "推送通知已启用",
+      "title": "通知此浏览器",
+      "enable": "启用通知",
+      "disable": "关闭通知",
+      "enabled": "此浏览器已启用通知",
       "loading": "更新中...",
       "unsupported": "此浏览器不支持推送通知。",
       "denied": "推送通知已被阻止，请在浏览器设置中允许。"
+    },
+    "desktop": {
+      "title": "通知此桌面应用",
+      "enable": "启用通知",
+      "disable": "关闭通知",
+      "enabled": "此桌面应用已启用通知",
+      "unsupported": "此系统不支持桌面通知。"
     },
     "sound": {
       "title": "声音",
@@ -323,6 +348,9 @@
       },
       "codex": {
         "description": "OpenAI Codex AI 助手"
+      },
+      "opencode": {
+        "description": "OpenCode CLI 助手"
       }
     },
     "connectionStatus": "连接状态",
@@ -417,7 +445,8 @@
     "description": {
       "claude": "Model Context Protocol 服务器为 Claude 提供额外的工具和数据源",
       "cursor": "Model Context Protocol 服务器为 Cursor 提供额外的工具和数据源",
-      "codex": "Model Context Protocol 服务器为 Codex 提供额外的工具和数据源"
+      "codex": "Model Context Protocol 服务器为 Codex 提供额外的工具和数据源",
+      "opencode": "Model Context Protocol 服务器为 OpenCode 提供额外的工具和数据源"
     },
     "addButton": "添加 MCP 服务器",
     "empty": "未配置 MCP 服务器",
@@ -440,6 +469,10 @@
     "actions": {
       "edit": "编辑服务器",
       "delete": "删除服务器"
+    },
+    "managed": {
+      "badge": "已托管",
+      "hint": "由 CloudCLI 管理。"
     },
     "help": {
       "title": "关于 Codex MCP",
@@ -466,13 +499,67 @@
     "installFailed": "安装失败",
     "uninstallFailed": "卸载失败",
     "toggleFailed": "切换失败",
-    "buildYourOwn": "构建您自己的插件",
+    "starterPluginLabel": "入门插件",
     "starter": "入门模板",
     "docs": "文档",
+    "sections": {
+      "officialTitle": "官方插件",
+      "officialDescription": "由 CloudCLI 团队维护，可直接安装。",
+      "unofficialTitle": "其他插件",
+      "unofficialDescription": "来自其他用户的非官方插件和集成。安装前请审查源代码。"
+    },
     "starterPlugin": {
       "name": "项目统计",
       "badge": "入门",
       "description": "查看项目的文件数、代码行数、文件类型分布以及最近活动。",
+      "install": "安装"
+    },
+    "terminalPlugin": {
+      "name": "终端",
+      "badge": "官方",
+      "description": "集成终端，可直接在界面内获得完整 Shell 访问权限。",
+      "install": "安装"
+    },
+    "scheduledPromptPlugin": {
+      "name": "定时提示",
+      "badge": "非官方",
+      "description": "安排工作区提示、查看运行历史并管理定期本地任务。",
+      "install": "安装"
+    },
+    "claudeWatchPlugin": {
+      "name": "Claude Watch",
+      "badge": "非官方",
+      "description": "监控长时间运行的 Claude Code 会话，检测挂起并暴露进程控制。",
+      "install": "安装"
+    },
+    "prismCloudCLI": {
+      "name": "PRISM CloudCLI",
+      "badge": "非官方",
+      "description": "CloudCLI 内的 Claude Code 会话智能分析。无需离开浏览器即可了解会话为何消耗大量 Token。",
+      "install": "安装"
+    },
+    "sessionManagerPlugin": {
+      "name": "会话管理",
+      "badge": "非官方",
+      "description": "查看、管理和终止活跃的 Claude Code 会话。",
+      "install": "安装"
+    },
+    "tokenCostCalculatorPlugin": {
+      "name": "Token 费用计算器",
+      "badge": "非官方",
+      "description": "根据模型价格和 Token 使用量计算 API 费用，支持预设模型定价。",
+      "install": "安装"
+    },
+    "taskQueuePlugin": {
+      "name": "任务队列",
+      "badge": "非官方",
+      "description": "任务队列仪表板，用于查看、筛选和启动 Agent 任务。",
+      "install": "安装"
+    },
+    "githubIssuesBoardPlugin": {
+      "name": "GitHub Issues 看板",
+      "badge": "非官方",
+      "description": "GitHub Issues 看板，支持双向 TaskMaster 同步和 /github-task CLI 技能自动安装",
       "install": "安装"
     },
     "morePlugins": "更多",

--- a/src/i18n/locales/zh-CN/tasks.json
+++ b/src/i18n/locales/zh-CN/tasks.json
@@ -1,0 +1,142 @@
+{
+  "notConfigured": {
+    "title": "TaskMaster AI 尚未配置",
+    "description": "TaskMaster 帮助将复杂的项目分解为可管理的任务，配合 AI 驱动的辅助功能",
+    "whatIsTitle": "🎯 什么是 TaskMaster？",
+    "features": {
+      "aiPowered": "AI 驱动的任务管理：将复杂项目分解为可管理的子任务",
+      "prdTemplates": "PRD 模板：从产品需求文档生成任务",
+      "dependencyTracking": "依赖追踪：了解任务关系和执行顺序",
+      "progressVisualization": "进度可视化：看板和详细的任务分析",
+      "cliIntegration": "CLI 集成：使用 taskmaster 命令进行高级工作流"
+    },
+    "initializeButton": "初始化 TaskMaster AI"
+  },
+  "gettingStarted": {
+    "title": "开始使用 TaskMaster",
+    "subtitle": "TaskMaster 已初始化！以下是接下来要做的事：",
+    "steps": {
+      "createPRD": {
+        "title": "创建产品需求文档（PRD）",
+        "description": "讨论您的项目构想并创建描述您想构建什么的 PRD。",
+        "addButton": "添加 PRD",
+        "existingPRDs": "现有的 PRD："
+      },
+      "generateTasks": {
+        "title": "从 PRD 生成任务",
+        "description": "一旦您有了 PRD，请 AI 助手解析它，TaskMaster 将自动将其分解为可管理的任务，包含实现细节。"
+      },
+      "analyzeTasks": {
+        "title": "分析并展开任务",
+        "description": "请 AI 助手分析任务复杂度，并将其展开为详细的子任务以便于实现。"
+      },
+      "startBuilding": {
+        "title": "开始构建",
+        "description": "请 AI 助手开始处理任务、更新状态，并在项目演进时添加新任务。"
+      }
+    },
+    "tip": "💡 提示：从 PRD 开始可以充分利用 TaskMaster 的 AI 驱动任务生成功能"
+  },
+  "setupModal": {
+    "title": "TaskMaster 设置",
+    "subtitle": "{{projectName}} 的交互式 CLI",
+    "willStart": "TaskMaster 初始化将自动开始",
+    "completed": "TaskMaster 设置完成！您现在可以关闭此窗口。",
+    "closeButton": "关闭",
+    "closeContinueButton": "关闭并继续"
+  },
+  "helpGuide": {
+    "title": "开始使用 TaskMaster",
+    "subtitle": "您的高效任务管理指南",
+    "examples": {
+      "parsePRD": "💬 示例：\n「我刚用 Claude Task Master 初始化了一个新项目。我有一个 PRD 在 .taskmaster/docs/prd.txt。你能帮我解析它并设置初始任务吗？」",
+      "expandTask": "💬 示例：\n「任务 5 看起来很复杂。你能把它分解成子任务吗？」",
+      "addTask": "💬 示例：\n「请添加一个新任务来实现使用 Cloudinary 的用户个人头像上传功能，研究最佳方法。」"
+    },
+    "moreExamples": "查看更多示例和使用模式 →",
+    "proTips": {
+      "title": "💡 专业提示",
+      "search": "使用搜索栏快速找到特定任务",
+      "views": "使用视图切换在看板、列表和网格视图之间切换",
+      "filters": "使用筛选器聚焦特定任务状态或优先级",
+      "details": "点击任何任务以查看详细信息和管理子任务"
+    },
+    "learnMore": {
+      "title": "📚 了解更多",
+      "description": "TaskMaster AI 是为开发者打造的高级任务管理系统。获取文档、示例并为项目做出贡献。",
+      "githubButton": "在 GitHub 上查看"
+    }
+  },
+  "search": {
+    "placeholder": "搜索任务..."
+  },
+  "filters": {
+    "button": "筛选",
+    "status": "状态",
+    "priority": "优先级",
+    "sortBy": "排序方式",
+    "allStatuses": "所有状态",
+    "allPriorities": "所有优先级",
+    "showing": "显示 {{filtered}} / {{total}} 个任务",
+    "clearFilters": "清除筛选"
+  },
+  "sort": {
+    "id": "ID",
+    "status": "状态",
+    "priority": "优先级",
+    "idAsc": "ID（递增）",
+    "idDesc": "ID（递减）",
+    "titleAsc": "标题（A-Z）",
+    "titleDesc": "标题（Z-A）",
+    "statusAsc": "状态（待处理优先）",
+    "statusDesc": "状态（已完成优先）",
+    "priorityAsc": "优先级（高优先）",
+    "priorityDesc": "优先级（低优先）"
+  },
+  "views": {
+    "kanban": "看板视图",
+    "list": "列表视图",
+    "grid": "网格视图"
+  },
+  "kanban": {
+    "pending": "📋 待办",
+    "inProgress": "🚀 进行中",
+    "done": "✅ 已完成",
+    "blocked": "🚫 已阻止",
+    "deferred": "⏳ 已延后",
+    "cancelled": "❌ 已取消",
+    "noTasksYet": "暂无任务",
+    "tasksWillAppear": "任务将显示在这里",
+    "moveTasksHere": "开始后将任务移到这里",
+    "completedTasksHere": "已完成的任务显示在这里",
+    "statusTasksHere": "此状态的任务将显示在这里"
+  },
+  "buttons": {
+    "help": "TaskMaster 入门指南",
+    "prds": "PRD",
+    "addPRD": "添加 PRD",
+    "addTask": "添加任务",
+    "createNewPRD": "创建新 PRD",
+    "prdsAvailable": "{{count}} 个 PRD 可用"
+  },
+  "prd": {
+    "modified": "修改时间：{{date}}"
+  },
+  "statuses": {
+    "pending": "待处理",
+    "in-progress": "进行中",
+    "done": "已完成",
+    "blocked": "已阻止",
+    "deferred": "已延后",
+    "cancelled": "已取消"
+  },
+  "priorities": {
+    "high": "高",
+    "medium": "中",
+    "low": "低"
+  },
+  "noMatchingTasks": {
+    "title": "没有符合筛选条件的任务",
+    "description": "尝试调整您的搜索或筛选条件。"
+  }
+}


### PR DESCRIPTION
## Motivation

This PR completes the partially-translated Simplified Chinese (zh-CN) localization. The project already included Chinese support, but several files were missing keys, and `tasks.json` was never loaded due to a `.gitignore` configuration gap. This aims to help Chinese-speaking users use the open-source project more comfortably.

## Changes

- **New** `src/i18n/locales/zh-CN/tasks.json` — 94 keys matching `en/tasks.json` exactly
- **Completed missing keys** in `settings.json` (+101 lines: voice settings, plugin marketplace, desktop notifications, skills tab, OpenCode agent, etc.)
- **Completed missing keys** in `chat.json` (+27 lines: `voice.*`, `input.queue.*`, `messageTypes.opencode`, `providerSelection.readyPrompt.opencode`,  `claudeStatus.stop`)
- **Completed missing keys** in `codeEditor.json` (+9 lines: markdown preview/edit labels, `filePreview.*`)
- **Fixed** `.gitignore`: added `!src/i18n/locales/zh-CN/tasks.json` exception. The file previously glob-ignored `tasks.json` and re-allowed it per-language (en, fr, ja, ru, de, tr, it), but `zh-CN` was missing from the allowlist, making the file uncommittable even if created
- **Fixed** `src/i18n/config.js`: registered `zhTasks` import and added it to the `zh-CN` resource bundle, following the same pattern as `ja`, `ru`, `de`, `tr`, `it`, `zh-TW`. Previously `zh-CN/tasks.json` was never imported, so it would not have been loaded even with the `.gitignore` fix

## Verification

- All 7 zh-CN/*.json files (auth, chat, common, codeEditor, settings, sidebar, tasks) have identical key counts with their English counterparts — no missing or extra keys
- All JSON files parse without errors
- Live-tested on a running instance: login page, settings page, project view, and TaskMaster settings all display Chinese correctly
- Identified and confirmed 3 English fallback strings in the current version (Voice, Browser, Skills in the settings navigation) that this PR resolves

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Simplified Chinese translations for TaskMaster, including setup, task management, filtering, and view modes.
  * Expanded Chinese voice, message queue, browser notification, plugin, MCP, and OpenCode translations.
  * Added localized Markdown preview and file preview controls.
  * Added Chinese voice settings and expanded settings navigation.
* **Improvements**
  * Improved Chinese chat, editor, settings, and notification wording for newly available features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->