### PR TITLE
fix: prevent NODE_ENV leakage into spawned child processes

### DIFF
--- a/electron/localServer.js
+++ b/electron/localServer.js
@@ -6,6 +6,7 @@ import os from 'node:os';
 import path from 'node:path';
 
 import { ServerInstaller } from './serverInstaller.js';
+import { buildChildProcessEnv } from '../server/utils/childProcessEnv.js';
 
 const DEFAULT_PORT = 3001;
 const HOST = '127.0.0.1';
@@ -408,14 +409,13 @@ export class LocalServerController {
     this.ownedServerProcess = spawn(runtime.command, [serverEntry], {
       cwd: serverCwd,
       detached: true,
-      env: {
-        ...process.env,
+      env: buildChildProcessEnv({
         ...runtime.env,
         HOST: bindHost,
         SERVER_PORT: String(port),
         NODE_ENV: 'production',
         PATH: getDesktopPath(),
-      },
+      }),
       stdio: ['ignore', 'pipe', 'pipe'],
       windowsHide: true,
     });

--- a/electron/main.js
+++ b/electron/main.js
@@ -8,6 +8,7 @@ import { DesktopWindowManager } from './desktopWindow.js';
 import { DesktopNotificationsController } from './desktopNotifications.js';
 import { LocalServerController } from './localServer.js';
 import { TabsController } from './tabs.js';
+import { buildChildProcessEnv } from '../server/utils/childProcessEnv.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -487,6 +488,7 @@ async function openEnvironmentInSsh(environment) {
     spawn('osascript', ['-e', `tell application "Terminal" to do script "${escaped}"`], {
       detached: true,
       stdio: 'ignore',
+      env: buildChildProcessEnv(),
     }).unref();
   } else {
     clipboard.writeText(sshCommand);

--- a/electron/serverInstaller.js
+++ b/electron/serverInstaller.js
@@ -6,6 +6,8 @@ import https from 'node:https';
 import os from 'node:os';
 import path from 'node:path';
 
+import { buildChildProcessEnv } from '../server/utils/childProcessEnv.js';
+
 /**
  * Installs the versioned local server runtime used by CloudCLI Desktop.
  *
@@ -232,6 +234,7 @@ export class ServerInstaller {
       const child = spawn('tar', ['-xzf', archivePath, '-C', destDir], {
         stdio: ['ignore', 'ignore', 'pipe'],
         windowsHide: true,
+        env: buildChildProcessEnv(),
       });
       let stderr = '';
       child.stderr?.on('data', (c) => (stderr += c));
@@ -248,6 +251,7 @@ export class ServerInstaller {
       const child = spawn('tar', ['-tzf', archivePath], {
         stdio: ['ignore', 'pipe', 'pipe'],
         windowsHide: true,
+        env: buildChildProcessEnv(),
       });
       let stdout = '';
       let stderr = '';

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -162,6 +162,7 @@ export default tseslint.config(
             "server/shared/frontmatter.ts",
             "server/shared/claude-cli-path.ts",
             "server/shared/image-attachments.ts",
+            "server/utils/childProcessEnv.js",
           ], // classify shared utility files so modules can depend on them explicitly
           mode: "file",
         },

--- a/scripts/release/build-server-bundle.js
+++ b/scripts/release/build-server-bundle.js
@@ -5,6 +5,7 @@ import fs from 'node:fs/promises';
 import path from 'node:path';
 import { spawn } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
+import { buildChildProcessEnv } from '../../server/utils/childProcessEnv.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const rootDir = path.resolve(__dirname, '..', '..');
@@ -129,11 +130,10 @@ await writeServerPackageJson(stageDir);
 console.log('Installing production server dependencies into bundle stage...');
 await run('npm', ['ci', '--omit=dev'], {
   cwd: stageDir,
-  env: {
-    ...process.env,
+  env: buildChildProcessEnv({
     npm_config_audit: 'false',
     npm_config_fund: 'false',
-  },
+  }),
 });
 
 const electronVersion = getElectronVersion();
@@ -143,11 +143,10 @@ const electronRebuild = process.platform === 'win32'
 console.log(`Rebuilding native server dependencies for Electron ${electronVersion} (${arch})...`);
 await run(electronRebuild, ['--version', electronVersion, '--module-dir', stageDir, '--arch', arch, '--force'], {
   cwd: rootDir,
-  env: {
-    ...process.env,
+  env: buildChildProcessEnv({
     npm_config_audit: 'false',
     npm_config_fund: 'false',
-  },
+  }),
 });
 
 if (await pathExists(path.join(stageDir, 'scripts', 'fix-node-pty.js'))) {

--- a/server/claude-sdk.js
+++ b/server/claude-sdk.js
@@ -23,6 +23,7 @@ import { buildClaudeUserContent, normalizeImageDescriptors } from './shared/imag
 import { CLAUDE_FALLBACK_MODELS } from './modules/providers/list/claude/claude-models.provider.js';
 import { providerModelsService } from './modules/providers/services/provider-models.service.js';
 import { resolveClaudeCodeExecutablePath } from './shared/claude-cli-path.js';
+import { buildChildProcessEnv } from './utils/childProcessEnv.js';
 import {
   createNotificationEvent,
   notifyRunFailed,
@@ -162,9 +163,11 @@ function mapCliOptionsToSDK(options = {}) {
 
   const sdkOptions = {};
 
-  // Forward all host env vars (e.g. ANTHROPIC_BASE_URL) to the subprocess.
+  // Forward all host env vars (e.g. ANTHROPIC_BASE_URL) to the subprocess, except
+  // NODE_ENV — agent sessions run arbitrary project code/builds and should not
+  // silently run in production mode just because CloudCLI's server process does.
   // Since SDK 0.2.113, options.env replaces process.env instead of overlaying it.
-  sdkOptions.env = { ...process.env };
+  sdkOptions.env = buildChildProcessEnv();
 
   // Resolve the executable eagerly on Windows because the SDK uses raw child_process.spawn,
   // which does not reliably follow npm's shell wrappers like cross-spawn does.

--- a/server/cli.js
+++ b/server/cli.js
@@ -18,6 +18,7 @@ import fs from 'fs';
 import path from 'path';
 import os from 'os';
 import { findAppRoot, getModuleDir } from './utils/runtime-paths.js';
+import { buildChildProcessEnv } from './utils/childProcessEnv.js';
 
 const __dirname = getModuleDir(import.meta.url);
 // The CLI is compiled into dist-server/server, but it still needs to read the top-level
@@ -210,7 +211,7 @@ function isNewerVersion(v1, v2) {
 async function checkForUpdates(silent = false) {
     try {
         const { execSync } = await import('child_process');
-        const latestVersion = execSync('npm show @cloudcli-ai/cloudcli version', { encoding: 'utf8' }).trim();
+        const latestVersion = execSync('npm show @cloudcli-ai/cloudcli version', { encoding: 'utf8', env: buildChildProcessEnv() }).trim();
         const currentVersion = packageJson.version;
 
         if (isNewerVersion(latestVersion, currentVersion)) {
@@ -243,7 +244,7 @@ async function updatePackage() {
         }
 
         console.log(`${c.info('[INFO]')} Updating from ${currentVersion} to ${latestVersion}...`);
-        execSync('npm update -g @cloudcli-ai/cloudcli', { stdio: 'inherit' });
+        execSync('npm update -g @cloudcli-ai/cloudcli', { stdio: 'inherit', env: buildChildProcessEnv() });
         console.log(`${c.ok('[OK]')} Update complete! Restart cloudcli to use the new version.`);
     } catch (e) {
         console.error(`${c.error('[ERROR]')} Update failed: ${e.message}`);
@@ -377,6 +378,7 @@ async function sandboxCommand(args) {
         const result = execFileSync('sbx', subcmd, {
             encoding: 'utf8',
             stdio: opts.inherit ? 'inherit' : 'pipe',
+            env: buildChildProcessEnv(),
         });
         return result || '';
     };

--- a/server/cursor-cli.js
+++ b/server/cursor-cli.js
@@ -6,6 +6,7 @@ import { sessionsService } from './modules/providers/services/sessions.service.j
 import { providerAuthService } from './modules/providers/services/provider-auth.service.js';
 import { providerModelsService } from './modules/providers/services/provider-models.service.js';
 import { createCompleteMessage, createNormalizedMessage, flattenPromptForWindowsShell } from './shared/utils.js';
+import { buildChildProcessEnv } from './utils/childProcessEnv.js';
 
 // cross-spawn resolves .cmd shims/PATHEXT on Windows and delegates to
 // child_process.spawn everywhere else.
@@ -134,7 +135,7 @@ async function spawnCursor(command, options = {}, ws) {
       const cursorProcess = spawnFunction('cursor-agent', args, {
         cwd: workingDir,
         stdio: ['pipe', 'pipe', 'pipe'],
-        env: { ...process.env } // Inherit all environment variables
+        env: buildChildProcessEnv() // Inherit all environment variables except NODE_ENV
       });
 
       activeCursorProcesses.set(processKey, cursorProcess);

--- a/server/index.js
+++ b/server/index.js
@@ -69,6 +69,7 @@ import { configureWebPush } from './services/vapid-keys.js';
 import { validateApiKey, authenticateToken, authenticateWebSocket } from './middleware/auth.js';
 import { IS_PLATFORM } from './constants/config.js';
 import { c } from './utils/colors.js';
+import { buildChildProcessEnv } from './utils/childProcessEnv.js';
 
 const __dirname = getModuleDir(import.meta.url);
 // The server source runs from /server, while the compiled output runs from /dist-server/server.
@@ -265,7 +266,7 @@ app.post('/api/system/update', authenticateToken, async (req, res) => {
 
         const child = spawn('sh', ['-c', updateCommand], {
             cwd: updateCwd,
-            env: process.env
+            env: buildChildProcessEnv()
         });
 
         let output = '';

--- a/server/modules/browser-use/browser-use.service.ts
+++ b/server/modules/browser-use/browser-use.service.ts
@@ -10,6 +10,7 @@ import spawn from 'cross-spawn';
 import { appConfigDb } from '@/modules/database/index.js';
 import { providerMcpService } from '@/modules/providers/index.js';
 import { getModuleDir } from '@/utils/runtime-paths.js';
+import { buildChildProcessEnv } from '@/utils/childProcessEnv.js';
 
 const require = createRequire(import.meta.url);
 const __dirname = getModuleDir(import.meta.url);
@@ -249,7 +250,7 @@ function runCommand(command: string, args: string[]): Promise<void> {
   return new Promise((resolve, reject) => {
     const child = spawn(command, args, {
       cwd: process.cwd(),
-      env: process.env,
+      env: buildChildProcessEnv(),
       shell: false,
       stdio: ['ignore', 'pipe', 'pipe'],
     });

--- a/server/modules/projects/services/project-clone.service.ts
+++ b/server/modules/projects/services/project-clone.service.ts
@@ -4,6 +4,7 @@ import path from 'node:path';
 // cross-spawn: drop-in spawn with Windows .cmd/PATHEXT resolution.
 import spawn from 'cross-spawn';
 
+import { buildChildProcessEnv } from '@/utils/childProcessEnv.js';
 import { githubTokensDb } from '@/modules/database/index.js';
 import { createProject } from '@/modules/projects/services/project-management.service.js';
 import type { WorkspacePathValidationResult } from '@/shared/types.js';
@@ -129,10 +130,9 @@ const defaultDependencies: CloneProjectDependencies = {
   spawnGitClone: (cloneUrl: string, clonePath: string): GitCloneProcess =>
     spawn('git', ['clone', '--progress', '--', cloneUrl, clonePath], {
       stdio: ['ignore', 'pipe', 'pipe'],
-      env: {
-        ...process.env,
+      env: buildChildProcessEnv({
         GIT_TERMINAL_PROMPT: '0',
-      },
+      }),
     }) as unknown as GitCloneProcess,
   registerProject: async (
     projectPath: string,

--- a/server/modules/providers/list/claude/claude-auth.provider.ts
+++ b/server/modules/providers/list/claude/claude-auth.provider.ts
@@ -8,6 +8,7 @@ import { resolveClaudeCodeExecutablePath } from '@/shared/claude-cli-path.js';
 import type { IProviderAuth } from '@/shared/interfaces.js';
 import type { ProviderAuthStatus } from '@/shared/types.js';
 import { readObjectRecord, readOptionalString } from '@/shared/utils.js';
+import { buildChildProcessEnv } from '@/utils/childProcessEnv.js';
 
 type ClaudeCredentialsStatus = {
   authenticated: boolean;
@@ -27,7 +28,7 @@ export class ClaudeProviderAuth implements IProviderAuth {
   private checkInstalled(): boolean {
     const cliPath = resolveClaudeCodeExecutablePath(process.env.CLAUDE_CLI_PATH);
     try {
-      spawn.sync(cliPath, ['--version'], { stdio: 'ignore', timeout: 5000 });
+      spawn.sync(cliPath, ['--version'], { stdio: 'ignore', timeout: 5000, env: buildChildProcessEnv() });
       return true;
     } catch {
       return false;

--- a/server/modules/providers/list/codex/codex-auth.provider.ts
+++ b/server/modules/providers/list/codex/codex-auth.provider.ts
@@ -7,6 +7,7 @@ import spawn from 'cross-spawn';
 import type { IProviderAuth } from '@/shared/interfaces.js';
 import type { ProviderAuthStatus } from '@/shared/types.js';
 import { readObjectRecord, readOptionalString } from '@/shared/utils.js';
+import { buildChildProcessEnv } from '@/utils/childProcessEnv.js';
 
 type CodexCredentialsStatus = {
   authenticated: boolean;
@@ -21,7 +22,7 @@ export class CodexProviderAuth implements IProviderAuth {
    */
   private checkInstalled(): boolean {
     try {
-      spawn.sync('codex', ['--version'], { stdio: 'ignore', timeout: 5000 });
+      spawn.sync('codex', ['--version'], { stdio: 'ignore', timeout: 5000, env: buildChildProcessEnv() });
       return true;
     } catch {
       return false;

--- a/server/modules/providers/list/cursor/cursor-auth.provider.ts
+++ b/server/modules/providers/list/cursor/cursor-auth.provider.ts
@@ -1,5 +1,6 @@
 import spawn from 'cross-spawn';
 
+import { buildChildProcessEnv } from '@/utils/childProcessEnv.js';
 import type { IProviderAuth } from '@/shared/interfaces.js';
 import type { ProviderAuthStatus } from '@/shared/types.js';
 
@@ -16,7 +17,7 @@ export class CursorProviderAuth implements IProviderAuth {
    */
   private checkInstalled(): boolean {
     try {
-      spawn.sync('cursor-agent', ['--version'], { stdio: 'ignore', timeout: 5000 });
+      spawn.sync('cursor-agent', ['--version'], { stdio: 'ignore', timeout: 5000, env: buildChildProcessEnv() });
       return true;
     } catch {
       return false;
@@ -74,7 +75,7 @@ export class CursorProviderAuth implements IProviderAuth {
       }, 5000);
 
       try {
-        childProcess = spawn('cursor-agent', ['status']);
+        childProcess = spawn('cursor-agent', ['status'], { env: buildChildProcessEnv() });
       } catch {
         clearTimeout(timeout);
         processCompleted = true;

--- a/server/modules/providers/list/cursor/cursor-models.provider.ts
+++ b/server/modules/providers/list/cursor/cursor-models.provider.ts
@@ -4,6 +4,7 @@ import path from 'node:path';
 
 import crossSpawn from 'cross-spawn';
 
+import { buildChildProcessEnv } from '@/utils/childProcessEnv.js';
 import type { IProviderModels } from '@/shared/interfaces.js';
 import type {
   ProviderChangeActiveModelInput,
@@ -633,7 +634,7 @@ const parseModelsOutput = (text: string): CursorModelRow[] => {
 
 const runCursorListModels = (): Promise<string> => new Promise((resolve, reject) => {
   const cursorProcess = spawnFunction('cursor-agent', ['--list-models'], {
-    env: { ...process.env },
+    env: buildChildProcessEnv(),
   });
 
   let stdout = '';

--- a/server/modules/providers/list/opencode/opencode-auth.provider.ts
+++ b/server/modules/providers/list/opencode/opencode-auth.provider.ts
@@ -7,6 +7,7 @@ import spawn from 'cross-spawn';
 import type { IProviderAuth } from '@/shared/interfaces.js';
 import type { ProviderAuthStatus } from '@/shared/types.js';
 import { readObjectRecord, readOptionalString } from '@/shared/utils.js';
+import { buildChildProcessEnv } from '@/utils/childProcessEnv.js';
 
 type OpenCodeCredentialsStatus = {
   authenticated: boolean;
@@ -29,7 +30,7 @@ export class OpenCodeProviderAuth implements IProviderAuth {
    */
   private checkInstalled(): boolean {
     try {
-      const result = spawn.sync('opencode', ['--version'], { stdio: 'ignore', timeout: 5000 });
+      const result = spawn.sync('opencode', ['--version'], { stdio: 'ignore', timeout: 5000, env: buildChildProcessEnv() });
       return !result.error && result.status === 0;
     } catch {
       return false;

--- a/server/modules/providers/list/opencode/opencode-models.provider.ts
+++ b/server/modules/providers/list/opencode/opencode-models.provider.ts
@@ -1,6 +1,7 @@
 import Database from 'better-sqlite3';
 import crossSpawn from 'cross-spawn';
 
+import { buildChildProcessEnv } from '@/utils/childProcessEnv.js';
 import type { IProviderModels } from '@/shared/interfaces.js';
 import type {
   ProviderChangeActiveModelInput,
@@ -386,7 +387,7 @@ const parseOpenCodeSessionModelValue = (rawModel: unknown): string | null => {
 const runOpenCodeModelsCommand = (): Promise<string> => new Promise((resolve, reject) => {
   const openCodeProcess = spawnFunction('opencode', ['models', '--verbose'], {
     cwd: process.cwd(),
-    env: { ...process.env },
+    env: buildChildProcessEnv(),
   });
 
   let stdout = '';

--- a/server/modules/providers/services/session-conversations-search.service.ts
+++ b/server/modules/providers/services/session-conversations-search.service.ts
@@ -6,6 +6,7 @@ import { spawn } from 'cross-spawn';
 import { rgPath } from '@vscode/ripgrep';
 
 import { projectsDb, sessionsDb } from '@/modules/database/index.js';
+import { buildChildProcessEnv } from '@/utils/childProcessEnv.js';
 
 type AnyRecord = Record<string, any>;
 type SearchableProvider = 'claude' | 'codex';
@@ -586,6 +587,7 @@ async function runRipgrepFilesWithMatches(
     const rg = spawn(rgPath, args, {
       stdio: ['ignore', 'pipe', 'pipe'],
       windowsHide: true,
+      env: buildChildProcessEnv(),
     });
 
     const stdoutChunks: Buffer[] = [];

--- a/server/modules/websocket/services/shell-websocket.service.ts
+++ b/server/modules/websocket/services/shell-websocket.service.ts
@@ -6,6 +6,7 @@ import pty, { type IPty } from 'node-pty';
 import { WebSocket, type RawData } from 'ws';
 
 import { parseIncomingJsonObject } from '@/shared/utils.js';
+import { buildChildProcessEnv } from '@/utils/childProcessEnv.js';
 
 type ShellIncomingMessage = {
   type?: string;
@@ -339,13 +340,12 @@ export function handleShellConnection(
           cols: termCols,
           rows: termRows,
           cwd: resolvedProjectPath,
-          env: {
-            ...process.env,
+          env: buildChildProcessEnv({
             [prioritizedPath.key]: prioritizedPath.value,
             TERM: 'xterm-256color',
             COLORTERM: 'truecolor',
             FORCE_COLOR: '3',
-          },
+          }),
         });
 
         ptySessionsMap.set(ptySessionKey, {

--- a/server/opencode-cli.js
+++ b/server/opencode-cli.js
@@ -9,6 +9,7 @@ import { providerAuthService } from './modules/providers/services/provider-auth.
 import { providerModelsService } from './modules/providers/services/provider-models.service.js';
 import { notifyRunFailed, notifyRunStopped } from './services/notification-orchestrator.js';
 import { createCompleteMessage, createNormalizedMessage, flattenPromptForWindowsShell, getOpenCodeDatabasePath } from './shared/utils.js';
+import { buildChildProcessEnv } from './utils/childProcessEnv.js';
 
 // cross-spawn resolves .cmd shims/PATHEXT on Windows and delegates to
 // child_process.spawn everywhere else.
@@ -268,7 +269,7 @@ async function spawnOpenCode(command, options = {}, ws) {
       opencodeProcess = spawnFunction('opencode', args, {
         cwd: workingDir,
         stdio: ['pipe', 'pipe', 'pipe'],
-        env: { ...process.env, ...permissionOptions.env },
+        env: buildChildProcessEnv(permissionOptions.env),
       });
 
       activeOpenCodeProcesses.set(processKey, opencodeProcess);

--- a/server/routes/agent.js
+++ b/server/routes/agent.js
@@ -14,6 +14,7 @@ import { Octokit } from '@octokit/rest';
 import { providerModelsService } from '../modules/providers/services/provider-models.service.js';
 import { IS_PLATFORM } from '../constants/config.js';
 import { normalizeProjectPath } from '../shared/utils.js';
+import { buildChildProcessEnv } from '../utils/childProcessEnv.js';
 
 const router = express.Router();
 
@@ -71,7 +72,8 @@ async function getGitRemoteUrl(repoPath) {
   return new Promise((resolve, reject) => {
     const gitProcess = spawn('git', ['config', '--get', 'remote.origin.url'], {
       cwd: repoPath,
-      stdio: ['pipe', 'pipe', 'pipe']
+      stdio: ['pipe', 'pipe', 'pipe'],
+      env: buildChildProcessEnv()
     });
 
     let stdout = '';
@@ -229,7 +231,8 @@ async function getCommitMessages(projectPath, limit = 5) {
   return new Promise((resolve, reject) => {
     const gitProcess = spawn('git', ['log', `-${limit}`, '--pretty=format:%s'], {
       cwd: projectPath,
-      stdio: ['pipe', 'pipe', 'pipe']
+      stdio: ['pipe', 'pipe', 'pipe'],
+      env: buildChildProcessEnv()
     });
 
     let stdout = '';
@@ -380,7 +383,8 @@ async function cloneGitHubRepo(githubUrl, githubToken = null, projectPath) {
 
       // Execute git clone
       const gitProcess = spawn('git', ['clone', '--depth', '1', cloneUrl, cloneDir], {
-        stdio: ['pipe', 'pipe', 'pipe']
+        stdio: ['pipe', 'pipe', 'pipe'],
+        env: buildChildProcessEnv()
       });
 
       let stdout = '';
@@ -1055,7 +1059,8 @@ router.post('/', validateExternalApiKey, async (req, res) => {
           console.log('🔄 Creating local branch...');
           const checkoutProcess = spawn('git', ['checkout', '-b', finalBranchName], {
             cwd: finalProjectPath,
-            stdio: 'pipe'
+            stdio: 'pipe',
+            env: buildChildProcessEnv()
           });
 
           await new Promise((resolve, reject) => {
@@ -1071,7 +1076,8 @@ router.post('/', validateExternalApiKey, async (req, res) => {
                   console.log(`ℹ️ Branch '${finalBranchName}' already exists locally, checking out...`);
                   const checkoutExisting = spawn('git', ['checkout', finalBranchName], {
                     cwd: finalProjectPath,
-                    stdio: 'pipe'
+                    stdio: 'pipe',
+                    env: buildChildProcessEnv()
                   });
                   checkoutExisting.on('close', (checkoutCode) => {
                     if (checkoutCode === 0) {
@@ -1092,7 +1098,8 @@ router.post('/', validateExternalApiKey, async (req, res) => {
           console.log('🔄 Pushing branch to remote...');
           const pushProcess = spawn('git', ['push', '-u', 'origin', finalBranchName], {
             cwd: finalProjectPath,
-            stdio: 'pipe'
+            stdio: 'pipe',
+            env: buildChildProcessEnv()
           });
 
           await new Promise((resolve, reject) => {

--- a/server/routes/git.js
+++ b/server/routes/git.js
@@ -6,6 +6,7 @@ import { promises as fs } from 'fs';
 import { projectsDb } from '../modules/database/index.js';
 import { queryClaudeSDK } from '../claude-sdk.js';
 import { spawnCursor } from '../cursor-cli.js';
+import { buildChildProcessEnv } from '../utils/childProcessEnv.js';
 
 const router = express.Router();
 const COMMIT_DIFF_CHARACTER_LIMIT = 500_000;
@@ -14,6 +15,7 @@ function spawnAsync(command, args, options = {}) {
   return new Promise((resolve, reject) => {
     const child = spawn(command, args, {
       ...options,
+      env: buildChildProcessEnv(options.env),
       shell: false,
     });
 

--- a/server/routes/taskmaster.js
+++ b/server/routes/taskmaster.js
@@ -18,6 +18,7 @@ import spawn from 'cross-spawn';
 import { projectsDb } from '../modules/database/index.js';
 import { detectTaskMasterMCPServer } from '../utils/mcp-detector.js';
 import { broadcastTaskMasterProjectUpdate, broadcastTaskMasterTasksUpdate } from '../utils/taskmaster-websocket.js';
+import { buildChildProcessEnv } from '../utils/childProcessEnv.js';
 
 /**
  * Resolve the absolute project directory from a DB-assigned `projectId`.
@@ -514,6 +515,7 @@ router.post('/init/:projectId', async (req, res) => {
         // Run taskmaster init command
         const initProcess = spawn('npx', ['task-master', 'init'], {
             cwd: projectPath,
+            env: buildChildProcessEnv(),
             stdio: ['pipe', 'pipe', 'pipe']
         });
 
@@ -616,6 +618,7 @@ router.post('/add-task/:projectId', async (req, res) => {
         // Run task-master add-task command
         const addTaskProcess = spawn('npx', args, {
             cwd: projectPath,
+            env: buildChildProcessEnv(),
             stdio: ['pipe', 'pipe', 'pipe']
         });
 
@@ -694,6 +697,7 @@ router.put('/update-task/:projectId/:taskId', async (req, res) => {
         if (status && Object.keys(req.body).length === 1) {
             const setStatusProcess = spawn('npx', ['task-master-ai', 'set-status', `--id=${taskId}`, `--status=${status}`], {
                 cwd: projectPath,
+                env: buildChildProcessEnv(),
                 stdio: ['pipe', 'pipe', 'pipe']
             });
 
@@ -746,6 +750,7 @@ router.put('/update-task/:projectId/:taskId', async (req, res) => {
 
             const updateProcess = spawn('npx', ['task-master-ai', 'update-task', `--id=${taskId}`, `--prompt=${prompt}`], {
                 cwd: projectPath,
+                env: buildChildProcessEnv(),
                 stdio: ['pipe', 'pipe', 'pipe']
             });
 
@@ -842,6 +847,7 @@ router.post('/parse-prd/:projectId', async (req, res) => {
         // Run task-master parse-prd command
         const parsePRDProcess = spawn('npx', args, {
             cwd: projectPath,
+            env: buildChildProcessEnv(),
             stdio: ['pipe', 'pipe', 'pipe']
         });
 

--- a/server/routes/taskmaster.js
+++ b/server/routes/taskmaster.js
@@ -44,9 +44,10 @@ const router = express.Router();
 async function checkTaskMasterInstallation() {
     return new Promise((resolve) => {
         // Check if task-master command is available
-        const child = spawn('which', ['task-master'], { 
+        const child = spawn('which', ['task-master'], {
             stdio: ['ignore', 'pipe', 'pipe'],
-            shell: true 
+            shell: true,
+            env: buildChildProcessEnv()
         });
         
         let output = '';
@@ -63,9 +64,10 @@ async function checkTaskMasterInstallation() {
         child.on('close', (code) => {
             if (code === 0 && output.trim()) {
                 // TaskMaster is installed, get version
-                const versionChild = spawn('task-master', ['--version'], { 
+                const versionChild = spawn('task-master', ['--version'], {
                     stdio: ['ignore', 'pipe', 'pipe'],
-                    shell: true 
+                    shell: true,
+                    env: buildChildProcessEnv()
                 });
                 
                 let versionOutput = '';

--- a/server/routes/user.js
+++ b/server/routes/user.js
@@ -4,12 +4,13 @@ import spawn from 'cross-spawn';
 import { userDb } from '../modules/database/index.js';
 import { authenticateToken } from '../middleware/auth.js';
 import { getSystemGitConfig } from '../utils/gitConfig.js';
+import { buildChildProcessEnv } from '../utils/childProcessEnv.js';
 
 const router = express.Router();
 
 function spawnAsync(command, args, options = {}) {
   return new Promise((resolve, reject) => {
-    const child = spawn(command, args, { ...options, shell: false });
+    const child = spawn(command, args, { ...options, env: buildChildProcessEnv(options.env), shell: false });
     let stdout = '';
     let stderr = '';
     child.stdout.on('data', (data) => { stdout += data.toString(); });

--- a/server/shared/claude-cli-path.ts
+++ b/server/shared/claude-cli-path.ts
@@ -2,6 +2,8 @@ import { execFileSync } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
 
+import { buildChildProcessEnv } from '@/utils/childProcessEnv.js';
+
 const DEFAULT_CLAUDE_COMMAND = 'claude';
 const CLAUDE_SCRIPT_EXTENSIONS = new Set(['.cjs', '.js', '.jsx', '.mjs', '.ts', '.tsx']);
 const CLAUDE_WRAPPER_SEGMENTS = ['node_modules', '@anthropic-ai', 'claude-code', 'bin', 'claude.exe'] as const;
@@ -94,6 +96,7 @@ function resolveWindowsClaudeExecutablePath(
       encoding: 'utf8',
       stdio: ['ignore', 'pipe', 'ignore'],
       windowsHide: true,
+      env: buildChildProcessEnv(),
     });
     const candidates = stdout
       .split(/\r?\n/)

--- a/server/utils/README.md
+++ b/server/utils/README.md
@@ -35,11 +35,35 @@ env: buildChildProcessEnv({ TERM: 'xterm-256color' })
 | `server/cursor-cli.js` | Cursor agent sessions |
 | `server/opencode-cli.js` | OpenCode agent sessions |
 | `server/index.js` | Self-update (`npm install` / `git pull`) |
-| `server/routes/taskmaster.js` | `task-master` init and PRD-parsing subprocesses |
+| `server/routes/taskmaster.js` | `task-master` install check, version, and PRD-parsing subprocesses |
 | `server/utils/commandParser.js` | Allowlisted user-invoked commands |
-| `server/utils/plugin-loader.js` | Plugin `npm install` and `npm run build` |
+| `server/utils/plugin-loader.js` | Plugin `npm install`/`npm run build` and git clone/pull |
 | `server/modules/browser-use/browser-use.service.ts` | browser-use install/runtime commands |
 | `server/modules/websocket/services/shell-websocket.service.ts` | Interactive terminal (PTY) shell sessions |
+| `server/utils/gitConfig.js` | System git config reads |
+| `server/routes/git.js` | Git operations issued from the Git panel |
+| `server/routes/user.js` | Per-user git subprocess helper |
+| `server/routes/agent.js` | Git remote/log/clone/checkout/push for the external agent API |
+| `server/modules/projects/services/project-clone.service.ts` | `git clone` for new projects |
+| `server/shared/claude-cli-path.ts` | Windows Claude CLI path resolution |
+| `server/modules/providers/list/claude/claude-auth.provider.ts` | Claude CLI install check |
+| `server/modules/providers/list/codex/codex-auth.provider.ts` | Codex CLI install check |
+| `server/modules/providers/list/cursor/cursor-auth.provider.ts` | Cursor CLI install check and status |
+| `server/modules/providers/list/cursor/cursor-models.provider.ts` | Cursor model listing |
+| `server/modules/providers/list/opencode/opencode-auth.provider.ts` | OpenCode CLI install check |
+| `server/modules/providers/list/opencode/opencode-models.provider.ts` | OpenCode model listing |
+| `server/modules/providers/services/session-conversations-search.service.ts` | ripgrep session search |
+| `electron/localServer.js` | Owned local server process |
+| `electron/main.js` | SSH terminal launch (macOS) |
+| `electron/serverInstaller.js` | Server bundle extraction |
+| `scripts/release/build-server-bundle.js` | Release bundle dependency install/rebuild |
+
+**Total known sites: 48** (16 fixed prior to this audit + 32 found in a
+full audit of every `spawn`/`exec`/`execSync`/`execFile*` call in
+`server/`, `electron/`, and `scripts/`). That audit was more thorough
+than the first pass, but per-site verification status still varies —
+treat the PR description's table as the source of truth for individual
+site status, not this summary count.
 
 ## Note on plugin-process-manager.js
 

--- a/server/utils/README.md
+++ b/server/utils/README.md
@@ -1,0 +1,46 @@
+# server/utils/childProcessEnv.js
+
+## Overview
+
+This app's server process runs with `NODE_ENV=production` in production (correctly, set by its systemd unit). Any child process the server spawns inherits that value by default unless it's explicitly stripped. When `NODE_ENV=production` leaks into `npm`/`npx` invocations, those tools silently skip installing `devDependencies`, which breaks builds, lint, and typecheck in ways that are confusing to debug from the resulting error alone.
+
+## The problem
+
+Spawning child processes with an unfiltered `{ ...process.env }` spread — or passing `process.env` directly as `env` — carries `NODE_ENV` along with everything else. As of this writing, this same mistake had turned up at 10 spawn sites across the codebase. That count came from tracing the original bug reports, not from an exhaustive audit of every `spawn`/`exec` call in the repo — treat it as a snapshot, not a final tally.
+
+## Usage
+
+Whenever this codebase spawns a child process, build its `env` with `buildChildProcessEnv()` instead of spreading or referencing `process.env` directly:
+
+```js
+// Don't:
+spawn('npm', ['install'], { env: { ...process.env } });
+
+// Do:
+import { buildChildProcessEnv } from './childProcessEnv.js';
+spawn('npm', ['install'], { env: buildChildProcessEnv() });
+```
+
+It returns a copy of `process.env` with `NODE_ENV` removed. Pass an optional object to add or override specific keys on top of the cleaned environment:
+
+```js
+env: buildChildProcessEnv({ TERM: 'xterm-256color' })
+```
+
+## Current usage
+
+| File | What it spawns |
+|---|---|
+| `server/claude-sdk.js` | Claude Code agent sessions |
+| `server/cursor-cli.js` | Cursor agent sessions |
+| `server/opencode-cli.js` | OpenCode agent sessions |
+| `server/index.js` | Self-update (`npm install` / `git pull`) |
+| `server/routes/taskmaster.js` | `task-master` init and PRD-parsing subprocesses |
+| `server/utils/commandParser.js` | Allowlisted user-invoked commands |
+| `server/utils/plugin-loader.js` | Plugin `npm install` and `npm run build` |
+| `server/modules/browser-use/browser-use.service.ts` | browser-use install/runtime commands |
+| `server/modules/websocket/services/shell-websocket.service.ts` | Interactive terminal (PTY) shell sessions |
+
+## Note on plugin-process-manager.js
+
+`server/utils/plugin-process-manager.js`'s `buildPluginEnv()` had the same `NODE_ENV` leak and was fixed too, but it intentionally does not use `buildChildProcessEnv()`. It builds env from scratch as a curated allowlist (not a `process.env` spread), so it drops `NODE_ENV` inline instead — routing an allowlist through `buildChildProcessEnv()` would widen it into a full-env passthrough.

--- a/server/utils/README.md
+++ b/server/utils/README.md
@@ -62,7 +62,7 @@ env: buildChildProcessEnv({ TERM: 'xterm-256color' })
 | `electron/serverInstaller.js` | Server bundle extraction |
 | `scripts/release/build-server-bundle.js` | Release bundle dependency install/rebuild |
 
-**Total known sites: 48** (16 fixed prior to this audit + 32 found in a
+**Total known sites: 48** (16 fixed before this audit + 32 found in a
 full audit of every `spawn`/`exec`/`execSync`/`execFile*` call in
 `server/`, `electron/`, and `scripts/`). That audit was more thorough
 than the first pass, but per-site verification status still varies —

--- a/server/utils/README.md
+++ b/server/utils/README.md
@@ -2,24 +2,28 @@
 
 ## Overview
 
-This app's server process runs with `NODE_ENV=production` in production (correctly, set by its systemd unit). Any child process the server spawns inherits that value by default unless it's explicitly stripped. When `NODE_ENV=production` leaks into `npm`/`npx` invocations, those tools silently skip installing `devDependencies`, which breaks builds, lint, and typecheck in ways that are confusing to debug from the resulting error alone.
+`NODE_ENV=production` commonly ends up in a Node server's own environment — Heroku's Node.js buildpack sets it automatically by default, and it's standard boilerplate in hand-rolled systemd units and Dockerfiles. This app's own code never reads `NODE_ENV` at runtime, but any child process the server spawns inherits whatever's in its environment by default unless explicitly stripped. When `NODE_ENV=production` leaks into `npm`/`npx` invocations specifically, those tools silently skip installing `devDependencies`, breaking builds, lint, and typecheck in ways that are confusing to debug from the resulting error alone. Deployments that never set `NODE_ENV` (e.g. this project's documented bare `pm2 start` production instructions) aren't affected by the underlying issue, and applying this fix is a no-op for them.
 
 ## The problem
 
-Spawning child processes with an unfiltered `{ ...process.env }` spread — or passing `process.env` directly as `env` — carries `NODE_ENV` along with everything else. As of this writing, this same mistake had turned up at 10 spawn sites across the codebase. That count came from tracing the original bug reports, not from an exhaustive audit of every `spawn`/`exec` call in the repo — treat it as a snapshot, not a final tally.
+Spawning child processes with an unfiltered `{ ...process.env }` spread — or passing `process.env` directly as `env` — carries `NODE_ENV` along with everything else. This mistake was found at multiple spawn sites across the codebase, first via a small pass tracing specific bug reports, then via a full audit of every `spawn`/`exec` call in the repo. See "Current usage" below for the current site count and coverage caveats.
 
 ## Usage
 
-Whenever this codebase spawns a child process, build its `env` with `buildChildProcessEnv()` instead of spreading or referencing `process.env` directly:
+Whenever this codebase spawns a child process — via `spawn`, `exec`, `execFile`, `execSync`, `execFileSync`, or any wrapper around them — build its `env` with `buildChildProcessEnv()` instead of spreading or referencing `process.env` directly. This applies regardless of which of Node's child_process functions you're using; the leak isn't specific to `spawn()`.
 
 ```js
-// Don't:
+// Don't, in any of these forms:
 spawn('npm', ['install'], { env: { ...process.env } });
+execSync('git clone ...', { env: process.env });
+execFile('rg', args, { env: { ...process.env, EXTRA: 'value' } });
 
 // Do:
-import { buildChildProcessEnv } from './childProcessEnv.js';
+import { buildChildProcessEnv } from '../utils/childProcessEnv.js'; // adjust to your file's actual relative path
 spawn('npm', ['install'], { env: buildChildProcessEnv() });
 ```
+
+The import path above is only `./childProcessEnv.js` for files already inside `server/utils/` — everywhere else, adjust it to the correct relative path to `server/utils/childProcessEnv.js`.
 
 It returns a copy of `process.env` with `NODE_ENV` removed. Pass an optional object to add or override specific keys on top of the cleaned environment:
 

--- a/server/utils/childProcessEnv.js
+++ b/server/utils/childProcessEnv.js
@@ -1,0 +1,7 @@
+// NODE_ENV=production leaks into child processes when process.env is spread or
+// referenced directly, causing npm/npx tooling to silently skip devDependencies.
+// Always build subprocess env through this helper instead of spreading process.env.
+export function buildChildProcessEnv(extra = {}) {
+  const { NODE_ENV, ...rest } = process.env;
+  return { ...rest, ...extra };
+}

--- a/server/utils/commandParser.js
+++ b/server/utils/commandParser.js
@@ -6,6 +6,7 @@ import { promisify } from 'util';
 import { parse as parseShellCommand } from 'shell-quote';
 
 import { parseFrontMatter } from '../shared/frontmatter.js';
+import { buildChildProcessEnv } from './childProcessEnv.js';
 
 const execFileAsync = promisify(execFile);
 
@@ -285,7 +286,7 @@ export async function processBashCommands(content, options = {}) {
           timeout,
           maxBuffer: 1024 * 1024, // 1MB max output
           shell: false, // IMPORTANT: No shell interpretation
-          env: { ...process.env, PATH: process.env.PATH } // Inherit PATH for finding commands
+          env: buildChildProcessEnv() // Inherit host env (minus NODE_ENV) for finding commands
         }
       );
 

--- a/server/utils/gitConfig.js
+++ b/server/utils/gitConfig.js
@@ -1,9 +1,11 @@
 // cross-spawn: drop-in spawn with Windows .cmd/PATHEXT resolution.
 import spawn from 'cross-spawn';
 
+import { buildChildProcessEnv } from './childProcessEnv.js';
+
 function spawnAsync(command, args) {
   return new Promise((resolve, reject) => {
-    const child = spawn(command, args, { shell: false });
+    const child = spawn(command, args, { shell: false, env: buildChildProcessEnv() });
     let stdout = '';
     child.stdout.on('data', (data) => { stdout += data.toString(); });
     child.on('error', (error) => { reject(error); });

--- a/server/utils/plugin-loader.js
+++ b/server/utils/plugin-loader.js
@@ -4,6 +4,8 @@ import os from 'os';
 
 import { spawn } from 'cross-spawn';
 
+import { buildChildProcessEnv } from './childProcessEnv.js';
+
 const PLUGINS_DIR = path.join(os.homedir(), '.claude-code-ui', 'plugins');
 const PLUGINS_CONFIG_PATH = path.join(os.homedir(), '.claude-code-ui', 'plugins.json');
 
@@ -110,6 +112,7 @@ function runBuildIfNeeded(dir, packageJsonPath, onSuccess, onError) {
   const buildProcess = spawn('npm', ['run', 'build'], {
     cwd: dir,
     stdio: ['ignore', 'pipe', 'pipe'],
+    env: buildChildProcessEnv(),
   });
 
   let stderr = '';
@@ -342,6 +345,7 @@ export function installPluginFromGit(url) {
         const npmProcess = spawn('npm', ['install', '--ignore-scripts'], {
           cwd: tempDir,
           stdio: ['ignore', 'pipe', 'pipe'],
+          env: buildChildProcessEnv(),
         });
 
         npmProcess.on('close', (npmCode) => {
@@ -409,6 +413,7 @@ export function updatePluginFromGit(name) {
         const npmProcess = spawn('npm', ['install', '--ignore-scripts'], {
           cwd: pluginDir,
           stdio: ['ignore', 'pipe', 'pipe'],
+          env: buildChildProcessEnv(),
         });
         npmProcess.on('close', (npmCode) => {
           if (npmCode !== 0) {

--- a/server/utils/plugin-loader.js
+++ b/server/utils/plugin-loader.js
@@ -299,6 +299,7 @@ export function installPluginFromGit(url) {
 
     const gitProcess = spawn('git', ['clone', '--depth', '1', '--', url, tempDir], {
       stdio: ['ignore', 'pipe', 'pipe'],
+      env: buildChildProcessEnv(),
     });
 
     let stderr = '';
@@ -383,6 +384,7 @@ export function updatePluginFromGit(name) {
     const gitProcess = spawn('git', ['pull', '--ff-only', '--'], {
       cwd: pluginDir,
       stdio: ['ignore', 'pipe', 'pipe'],
+      env: buildChildProcessEnv(),
     });
 
     let stderr = '';

--- a/server/utils/plugin-process-manager.js
+++ b/server/utils/plugin-process-manager.js
@@ -2,6 +2,7 @@ import path from 'path';
 
 // cross-spawn: drop-in spawn with Windows .cmd/PATHEXT resolution.
 import spawn from 'cross-spawn';
+
 import { scanPlugins, getPluginsConfig, getPluginDir } from './plugin-loader.js';
 
 // Map<pluginName, { process, port }>
@@ -24,7 +25,6 @@ function buildPluginEnv(name) {
   const env = {
     PATH: process.env.PATH,
     HOME: process.env.HOME,
-    NODE_ENV: process.env.NODE_ENV || 'production',
     PLUGIN_NAME: name,
   };
 


### PR DESCRIPTION
### What

I hand roll my deployment using systemd and was plagued with these errors, so I set about to do something about it. This PR is the result. On the face of it, it does look massive, but for the most part it's just one line replacements ensuring something isn't there which ordinarily isn't there anyway in a standard deployment.

The root cause is that any deployment method setting `NODE_ENV=production` on the server's process causes this bug. This includes Heroku's Node.js buildpack, which does so **automatically by default**, with no user opt-in required. It's also common in hand-rolled systemd units and Docker configs, both of which routinely carry `Environment=NODE_ENV=production` / `ENV NODE_ENV=production` as standard boilerplate for Node production deployments generally, independent of this project specifically. The same applies to this project's own documented PM2 deployment path: PM2 does not set `NODE_ENV=production` by default, but it can be triggered the same way — via an `ecosystem.config.js` `env_production` block, or the `--env production` flag used directly in the reproduction below.

Child processes spawned by the server inherit that value by default unless it's explicitly stripped. When it reaches npm/npx invocations, they silently skip devDependencies, breaking build/lint/typecheck downstream—and because the failure surfaces as a confusing, unrelated-looking npm error, it's easy for the actual cause (inherited `NODE_ENV`) to go unnoticed.

The actual problem is broader than the npm/npx symptom: it's full, unfiltered env inheritance—`{ ...process.env }` spreads or a raw `process.env` reference passed as `env`—at any spawn site, not just npm/npx ones. That's why this PR also touches plain git/tar/rg spawns that don't look NODE_ENV-related at a glance: any of them passing unfiltered `process.env` carries `NODE_ENV` (and, on Electron, other host vars) along regardless of whether the visible symptom had shown up yet.

Notably, this app's own runtime code never reads `NODE_ENV` itself (verified: the only reference in `server/` is the one this PR already routes through the shared helper). The bug is entirely about the *server* leaking an ambient, extremely common env var into things it spawns—not about the app needing or depending on that value for its own behavior.

This class of bug is exactly the kind a lint rule could catch at write-time rather than relying on someone reading `server/utils/README.md` before adding a new spawn call. A `no-restricted-syntax` rule targeting a `process.env` spread or direct reference passed as `env` to `spawn`/`exec`/`execFile`/`execSync`/`execFileSync` would be cheap to add (no new dependency, runs in existing lint/build) and would have caught most of the 48 sites here automatically. It wouldn't catch misuse buried inside the three hand-rolled `spawnAsync` wrapper functions (`git.js`, `user.js`, `gitConfig.js`) since those build `env` internally before calling the real `child_process` API, but it'd cover every new direct call going forward, which is where most of these leaks originated. Happy to put this together as a follow-up PR if there's interest, rather than scope-creeping it into this one.

**Related prior PRs:**
- #851 added a Windows-only env allowlist to `plugin-process-manager.js`'s `buildPluginEnv()`, but didn't touch its `NODE_ENV` hardcoding—that's still handled there, intentionally, as an exception (see below).
- #964 was a large refactor touching several of the same files (`git.js`, `user.js`, `gitConfig.js`, `opencode-cli.js`)—it left the `spawn`/env logic untouched in the first three (only the `spawn` import changed, to `cross-spawn`), but it directly touched the leaking line in `opencode-cli.js`, adding a `permissionOptions.env` merge onto the same unfiltered `{ ...process.env }` spread. That PR built new functionality on top of the existing leak rather than missing it.


### Change

Adds `server/utils/childProcessEnv.js` exporting `buildChildProcessEnv()`, which returns `process.env` with `NODE_ENV` stripped (optionally merged with overrides). Routes all identified spawn/exec/execFile call sites through it. See `server/utils/README.md` for usage.

**Exception:** `plugin-process-manager.js`'s `buildPluginEnv()` builds its env from scratch as a curated allowlist, not a `process.env` spread. It drops `NODE_ENV` inline rather than routing through `buildChildProcessEnv()` — piping an allowlist through that helper would widen it into a full passthrough, defeating the point of the allowlist.

### How to Reproduce

1. Set `NODE_ENV=production` on the CloudCLI server process itself (e.g. via
   `pm2 start ... --env production`, a systemd unit's `Environment=`, or
   any deployment method that sets it at the process level).
2. Open a chat session with any agent (Claude, Cursor, OpenCode).
3. Ask the agent to run `echo $NODE_ENV`.

**Before this fix:** the agent's shell reports `production` — the server's
own `NODE_ENV` leaked into the spawned agent process via unfiltered
`process.env` inheritance.

**After this fix:** the agent's shell reports nothing — `NODE_ENV` is
absent, because `buildChildProcessEnv()` strips it before the child
process is spawned.

Tested directly against `server/claude-sdk.js` (the core agent session
spawn) with the server's `NODE_ENV` explicitly set to `production` and
otherwise-identical process environments on both branches.

*(My Claude insists you be informed this is only representative of this one call site... obviously.)*

### Scope: 48 known sites

Grouped by what's actually being spawned, since that's more useful for review than which pass of my investigation found each one. Verification status is per-site regardless of category.

**CLI agent sessions (3)** — the core Claude/Cursor/OpenCode process spawns:

| Site | Verification |
|---|---|
| `server/claude-sdk.js` | live-verified |
| `server/cursor-cli.js` | live-verified |
| `server/opencode-cli.js` | live-verified |

**Provider CLI auth & model checks (8):**

| Site | Verification |
|---|---|
| `cursor-auth.provider.ts:19,77` | live-verified |
| `claude-auth.provider.ts:30` | live-verified |
| `opencode-auth.provider.ts:32` | live-verified |
| `codex-auth.provider.ts:24` | code-reviewed only (codex binary not installed in sandbox) |
| `cursor-models.provider.ts:636` | live-verified, sandbox-direct |
| `opencode-models.provider.ts:389` | live-verified, sandbox-direct |
| `claude-cli-path.ts:93` (`where.exe`) | code-reviewed only (Windows-only path) |

**Git operations (12)** — includes the 3 hand-rolled wrapper definitions, each patched at source (see note below):

| Site | Verification |
|---|---|
| `agent.js:72` (remote), `:230` (log), `:382` (clone), `:1056,1072,1093` (checkout/push) — 6 sites | mix: live-verified where the git binary path was exercised directly, code-reviewed for the identical-pattern sites |
| `project-clone.service.ts:133` | live-verified, sandbox-direct |
| `plugin-loader.js:300` (clone) | live-verified |
| `plugin-loader.js:383` (pull) | code-reviewed only (needs existing checkout) |
| `routes/git.js` `spawnAsync()` wrapper (~45 callers) | live-verified — real caller triggered via running app's Source Control tab; 51 call sites grepped, none override `env` |
| `routes/user.js` `spawnAsync()` wrapper (2 callers) | live-verified — real caller triggered via profile settings save |
| `utils/gitConfig.js` `spawnAsync()` wrapper (2 callers) | live-verified — called real exported `getSystemGitConfig()` |

**Plugin system (4):**

| Site | Verification |
|---|---|
| `plugin-loader.js` npm install/build (3 sites) | live-verified |
| `plugin-process-manager.js` `buildPluginEnv()` — **allowlist exception**, not routed through `buildChildProcessEnv()` (see note below) | code-reviewed — confirmed no `...process.env` spread present |

**Release, installer & Electron tooling (6):**

| Site | Verification |
|---|---|
| `electron/localServer.js:412` | code-reviewed only (Electron desktop process required) |
| `electron/serverInstaller.js:232,248` (tar, 2 sites) | live-verified — real round trip |
| `electron/main.js:487` (osascript, macOS SSH terminal) — found during final sweep, not in original scope | code-reviewed only (macOS/Electron-only path) |
| `build-server-bundle.js:133` (npm ci) | live-verified — full run to completion in isolated scratch dir |
| `build-server-bundle.js:147` (electron-rebuild) | code-reviewed only (live run would leave native bindings ABI-incompatible for rest of session) |

**Misc server utilities (15):**

| Site | Verification |
|---|---|
| `index.js` self-update | live-verified |
| `utils/commandParser.js` | live-verified |
| `browser-use.service.ts` | live-verified |
| `shell-websocket.service.ts` | live-verified |
| `taskmaster.js:518,621,700,753,850` (5 sites) | live-verified |
| `taskmaster.js:47` (which) | live-verified |
| `taskmaster.js:66` (--version) | code-reviewed only (binary not installed) |
| `session-conversations-search.service.ts:586` (ripgrep) | code-reviewed only (`@vscode/ripgrep` binary missing) |
| `cli.js:213` (npm show) | live-verified |
| `cli.js:246` (npm update -g) | code-reviewed only (too disruptive to trigger live) |
| `cli.js:377` (sbx) | code-reviewed only (sbx not installed) |

**A note on "sandbox-direct":** 4 sites above are marked this way — live-verified using the real spawn call shape, but triggered from a standalone script rather than through the running app with process ancestry to `cloudcli.service`. One confidence tier below the app-triggered/wrapper verifications, but exercising the identical one-line fix already proven correct elsewhere.

### On coverage

This is a full audit of every `spawn`/`exec`/`execSync`/`execFile*` call in `server/`, `electron/`, and `scripts/` — not just the sites traced from the original bug reports. But per-site verification varies (live-tested vs. code-reviewed-only, as detailed above), and this isn't guaranteed to be the literal final word on every subprocess call in the repo. If you spot one I missed, happy to follow up.

### Note: not in scope

Three hand-rolled `spawnAsync` wrapper functions exist independently in `git.js`, `user.js`, and `gitConfig.js` — confirmed as organic drift via separate git histories, not copy-paste. Each was patched at its own definition. Consolidating them into one shared wrapper is a reasonable follow-up but out of scope here.

### Testing

- `npm run build` — exit 0 (`build:client` via vite, `build:server` via tsc + tsc-alias)
- `build.mjs` doesn't cover `electron/` or `scripts/`; those four touched files were additionally checked with `node --check` (syntax-valid) and their relative import of `server/utils/childProcessEnv.js` confirmed to resolve at runtime.
- Per-site live/code-review verification detail above.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented runtime mode (`NODE_ENV`) from leaking into launched tools and subprocesses.
  * Improved consistency by standardizing how environment variables are constructed for Git, shell, package/CLI, plugins, AI tools, and archive/build/verification steps.
  * Preserved required overrides (such as `PATH` and command-specific settings).
* **Documentation**
  * Added clear guidance on constructing child-process environments safely, with examples of updated spawn sites and known coverage limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->