### PR TITLE
feat: add Preview and Docker panels for remote dev access

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -59,6 +59,8 @@ import userRoutes from './routes/user.js';
 import pluginsRoutes from './routes/plugins.js';
 import providerRoutes from './modules/providers/provider.routes.js';
 import voiceRoutes from './voice-proxy.js';
+import previewRoutes from './routes/preview.js';
+import { previewProxyMiddleware, isPreviewAuthenticated } from './utils/preview-proxy.js';
 import browserUseRoutes from './modules/browser-use/browser-use.routes.js';
 import { assetsRoutes } from './modules/assets/index.js';
 import browserUseMcpRoutes from './modules/browser-use/browser-use-mcp.routes.js';
@@ -107,6 +109,7 @@ const wss = createWebSocketServer(server, {
     verifyClient: {
         isPlatform: IS_PLATFORM,
         authenticateWebSocket,
+        verifyPreviewCookie: isPreviewAuthenticated,
     },
     chat: {
         spawnFns: {
@@ -145,6 +148,12 @@ const wss = createWebSocketServer(server, {
 app.locals.wss = wss;
 
 app.use(cors({ exposedHeaders: ['X-Refreshed-Token'] }));
+
+// Preview proxy: serves /preview/<port>/ by streaming to a local dev server.
+// Mounted before the body parsers so request bodies pass through untouched, and
+// outside the JWT-protected /api mount because it self-authenticates via cookie.
+app.use(previewProxyMiddleware);
+
 app.use(express.json({
     limit: '50mb',
     type: (req) => {
@@ -219,6 +228,9 @@ app.use('/api/providers', authenticateToken, providerRoutes);
 app.use('/api/agent', agentRoutes);
 
 app.use('/api/voice', authenticateToken, voiceRoutes);
+
+// Preview API: mint the preview cookie, list ports, control docker (protected)
+app.use('/api/preview', authenticateToken, previewRoutes);
 
 // Serve public files (like api-docs.html)
 app.use(express.static(path.join(APP_ROOT, 'public')));

--- a/server/modules/websocket/services/preview-websocket-proxy.service.ts
+++ b/server/modules/websocket/services/preview-websocket-proxy.service.ts
@@ -1,0 +1,43 @@
+import { WebSocket } from 'ws';
+
+const PREVIEW_PREFIX_RE = /^\/preview\/(\d{1,5})(\/.*)?$/;
+
+/**
+ * Proxies a preview HMR / app websocket to the upstream dev server. The upgrade
+ * request is authenticated in verifyWebSocketClient (via the preview cookie);
+ * the target port is taken from the pathname.
+ */
+export function handlePreviewWsProxy(clientWs: WebSocket, pathname: string, search: string): void {
+  const match = pathname.match(PREVIEW_PREFIX_RE);
+  if (!match) {
+    clientWs.close(4400, 'Invalid preview path');
+    return;
+  }
+  const port = Number(match[1]);
+  if (!Number.isInteger(port) || port < 1 || port > 65535) {
+    clientWs.close(4400, 'Invalid preview port');
+    return;
+  }
+
+  const upstreamPath = `${match[2] || '/'}${search || ''}`;
+  const upstream = new WebSocket(`ws://127.0.0.1:${port}${upstreamPath}`);
+
+  upstream.on('message', (data, isBinary) => {
+    if (clientWs.readyState === WebSocket.OPEN) clientWs.send(data, { binary: isBinary });
+  });
+  clientWs.on('message', (data, isBinary) => {
+    if (upstream.readyState === WebSocket.OPEN) upstream.send(data, { binary: isBinary });
+  });
+  upstream.on('close', () => {
+    if (clientWs.readyState === WebSocket.OPEN) clientWs.close();
+  });
+  clientWs.on('close', () => {
+    if (upstream.readyState === WebSocket.OPEN) upstream.close();
+  });
+  upstream.on('error', () => {
+    if (clientWs.readyState === WebSocket.OPEN) clientWs.close(4502, 'Upstream error');
+  });
+  clientWs.on('error', () => {
+    if (upstream.readyState === WebSocket.OPEN) upstream.close();
+  });
+}

--- a/server/modules/websocket/services/websocket-auth.service.ts
+++ b/server/modules/websocket/services/websocket-auth.service.ts
@@ -10,6 +10,10 @@ type WebSocketAuthDependencies = {
     username?: string;
     [key: string]: unknown;
   } | null;
+  // Injected from the composition root so the websocket module stays free of
+  // direct util imports; returns true when the request carries a valid preview
+  // cookie (used to authorize /preview/* HMR sockets an iframe can't token).
+  verifyPreviewCookie: (req: AuthenticatedWebSocketRequest) => boolean;
 };
 
 /**
@@ -27,6 +31,16 @@ export function verifyWebSocketClient(
   }
 
   console.log('WebSocket connection attempt to:', `${loggedUrl.pathname}${loggedUrl.search}`);
+
+  // Preview HMR/app websockets authenticate with the preview cookie, since an
+  // iframe cannot attach a JWT to the sockets its app opens.
+  if (upgradeUrl.pathname.startsWith('/preview/')) {
+    if (dependencies.verifyPreviewCookie(request)) {
+      return true;
+    }
+    console.log('[WARN] Preview WebSocket rejected: missing/invalid preview cookie');
+    return false;
+  }
 
   // Platform mode: use the first DB user and skip token checks.
   if (dependencies.isPlatform) {

--- a/server/modules/websocket/services/websocket-server.service.ts
+++ b/server/modules/websocket/services/websocket-server.service.ts
@@ -5,6 +5,7 @@ import { WebSocketServer, type VerifyClientCallbackSync } from 'ws';
 import { handleChatConnection } from '@/modules/websocket/services/chat-websocket.service.js';
 import { verifyWebSocketClient } from '@/modules/websocket/services/websocket-auth.service.js';
 import { handlePluginWsProxy } from '@/modules/websocket/services/plugin-websocket-proxy.service.js';
+import { handlePreviewWsProxy } from '@/modules/websocket/services/preview-websocket-proxy.service.js';
 import { handleShellConnection } from '@/modules/websocket/services/shell-websocket.service.js';
 import { handleDesktopNotificationsConnection } from '@/modules/notifications/index.js';
 import type { AuthenticatedWebSocketRequest } from '@/shared/types.js';
@@ -71,6 +72,12 @@ export function createWebSocketServer(
 
     if (pathname.startsWith('/plugin-ws/')) {
       handlePluginWsProxy(ws, pathname, dependencies.getPluginPort);
+      return;
+    }
+
+    if (pathname.startsWith('/preview/')) {
+      const search = new URL(url, 'http://localhost').search;
+      handlePreviewWsProxy(ws, pathname, search);
       return;
     }
 

--- a/server/routes/preview.js
+++ b/server/routes/preview.js
@@ -1,0 +1,229 @@
+import { execFile } from 'node:child_process';
+import fs from 'node:fs';
+
+import express from 'express';
+
+import { PREVIEW_COOKIE, issuePreviewToken } from '../utils/preview-proxy.js';
+
+const router = express.Router();
+
+const EXEC_TIMEOUT_MS = 20_000;
+const DOCKER_ACTIONS = new Set(['ps', 'up', 'down', 'stop', 'restart', 'logs']);
+
+function run(cmd, args, options = {}) {
+  return new Promise((resolve) => {
+    execFile(
+      cmd,
+      args,
+      { timeout: EXEC_TIMEOUT_MS, maxBuffer: 10 * 1024 * 1024, ...options },
+      (err, stdout, stderr) => {
+        resolve({
+          ok: !err,
+          code: err?.code ?? 0,
+          stdout: String(stdout || ''),
+          stderr: String(stderr || (err && !stderr ? err.message : '')),
+        });
+      },
+    );
+  });
+}
+
+// POST /api/preview/session — mint a preview cookie for the authenticated user.
+// The iframe carries this cookie on every request the /preview proxy serves.
+router.post('/session', (req, res) => {
+  const token = issuePreviewToken();
+  res.setHeader('Set-Cookie', `${PREVIEW_COOKIE}=${token}; Path=/preview; HttpOnly; SameSite=Lax`);
+  res.json({ ok: true });
+});
+
+// GET /api/preview/ports — listening TCP ports on this machine plus docker
+// containers that publish a host port, so the UI can offer them for preview.
+router.get('/ports', async (_req, res) => {
+  const ports = new Map(); // port -> { port, source, name }
+
+  // Listening sockets (macOS/Linux via lsof).
+  const lsof = await run('lsof', ['-nP', '-iTCP', '-sTCP:LISTEN', '-P']);
+  if (lsof.ok) {
+    for (const line of lsof.stdout.split('\n').slice(1)) {
+      const cols = line.split(/\s+/);
+      if (cols.length < 9) continue;
+      const command = cols[0];
+      const nameField = cols[8] || '';
+      const portMatch = nameField.match(/:(\d+)$/);
+      if (!portMatch) continue;
+      const port = Number(portMatch[1]);
+      if (!Number.isInteger(port)) continue;
+      if (!ports.has(port)) ports.set(port, { port, source: 'process', name: command });
+    }
+  }
+
+  // Docker published ports.
+  const docker = await run('docker', ['ps', '--format', '{{.Names}}\t{{.Ports}}']);
+  if (docker.ok) {
+    for (const line of docker.stdout.split('\n')) {
+      if (!line.trim()) continue;
+      const [name, portsField = ''] = line.split('\t');
+      for (const m of portsField.matchAll(/(?:0\.0\.0\.0|127\.0\.0\.1|\[::\]):(\d+)->/g)) {
+        const port = Number(m[1]);
+        if (!Number.isInteger(port)) continue;
+        ports.set(port, { port, source: 'docker', name });
+      }
+    }
+  }
+
+  res.json({
+    ports: [...ports.values()].sort((a, b) => a.port - b.port),
+    dockerAvailable: docker.ok,
+  });
+});
+
+function normalizePort(entry) {
+  // `docker compose config --format json` may give a string ("3000:3000",
+  // "127.0.0.1:8080:80", "5432") or an object { published, target }.
+  if (entry && typeof entry === 'object') {
+    const published = entry.published != null ? Number(entry.published) : null;
+    const target = entry.target != null ? Number(entry.target) : null;
+    return { published: Number.isInteger(published) ? published : null, target };
+  }
+  if (typeof entry === 'string') {
+    const parts = entry.split(':');
+    if (parts.length === 1) return { published: null, target: Number(parts[0]) || null };
+    const published = Number(parts[parts.length - 2]);
+    const target = Number(parts[parts.length - 1]);
+    return {
+      published: Number.isInteger(published) ? published : null,
+      target: Number.isInteger(target) ? target : null,
+    };
+  }
+  return { published: null, target: null };
+}
+
+function parseComposePs(stdout) {
+  const byService = {};
+  const text = stdout.trim();
+  if (!text) return byService;
+  let rows = [];
+  try {
+    const parsed = JSON.parse(text);
+    rows = Array.isArray(parsed) ? parsed : [parsed];
+  } catch {
+    // Newline-delimited JSON objects (docker compose v2 default).
+    for (const line of text.split('\n')) {
+      if (!line.trim()) continue;
+      try {
+        rows.push(JSON.parse(line));
+      } catch {
+        /* skip */
+      }
+    }
+  }
+  for (const row of rows) {
+    const service = row.Service || row.service;
+    if (!service) continue;
+    byService[service] = {
+      state: row.State || row.state || 'unknown',
+      publishers: Array.isArray(row.Publishers) ? row.Publishers : [],
+    };
+  }
+  return byService;
+}
+
+// GET /api/preview/docker/services — resolve the project's compose file and
+// return its services with declared ports and current running state, so the UI
+// can show real services instead of asking the user to type names.
+router.get('/docker/services', async (req, res) => {
+  const projectPath = req.query.projectPath;
+  if (!projectPath || typeof projectPath !== 'string') {
+    return res.status(400).json({ error: 'projectPath is required' });
+  }
+  try {
+    if (!fs.statSync(projectPath).isDirectory()) {
+      return res.status(400).json({ error: 'projectPath is not a directory' });
+    }
+  } catch {
+    return res.status(400).json({ error: 'projectPath does not exist' });
+  }
+
+  const config = await run('docker', ['compose', 'config', '--format', 'json'], { cwd: projectPath });
+  if (!config.ok) {
+    // No compose file, or docker missing — tell the UI which.
+    const hasCompose = ['docker-compose.yml', 'docker-compose.yaml', 'compose.yml', 'compose.yaml'].some(
+      (f) => fs.existsSync(`${projectPath}/${f}`),
+    );
+    return res.json({
+      hasCompose,
+      dockerAvailable: !/not found|command not found|not recognized/i.test(config.stderr),
+      services: [],
+      error: config.stderr.trim() || null,
+    });
+  }
+
+  let parsed = {};
+  try {
+    parsed = JSON.parse(config.stdout);
+  } catch {
+    return res.json({ hasCompose: true, dockerAvailable: true, services: [], error: 'Failed to parse compose config' });
+  }
+
+  const ps = await run('docker', ['compose', 'ps', '--format', 'json', '--all'], { cwd: projectPath });
+  const running = ps.ok ? parseComposePs(ps.stdout) : {};
+
+  const services = Object.entries(parsed.services || {}).map(([name, def]) => {
+    const declaredPorts = (def.ports || []).map(normalizePort);
+    const live = running[name];
+    // Prefer actually-published ports from `ps` when the service is up.
+    const livePorts = live
+      ? (live.publishers || [])
+          .filter((p) => p.PublishedPort)
+          .map((p) => ({ published: Number(p.PublishedPort), target: Number(p.TargetPort) }))
+      : [];
+    const ports = livePorts.length ? livePorts : declaredPorts;
+    return {
+      name,
+      image: def.image || null,
+      state: live ? live.state : 'not created',
+      ports: ports.filter((p) => p.published != null),
+    };
+  });
+
+  res.json({ hasCompose: true, dockerAvailable: true, services });
+});
+
+// POST /api/preview/docker — run a whitelisted docker compose action in the
+// currently selected project's directory.
+router.post('/docker', async (req, res) => {
+  const { action, projectPath, service } = req.body || {};
+
+  if (!DOCKER_ACTIONS.has(action)) {
+    return res.status(400).json({ error: `Unsupported action: ${action}` });
+  }
+  if (!projectPath || typeof projectPath !== 'string') {
+    return res.status(400).json({ error: 'projectPath is required' });
+  }
+  let stat;
+  try {
+    stat = fs.statSync(projectPath);
+  } catch {
+    return res.status(400).json({ error: 'projectPath does not exist' });
+  }
+  if (!stat.isDirectory()) {
+    return res.status(400).json({ error: 'projectPath is not a directory' });
+  }
+  if (service && !/^[a-zA-Z0-9_.-]+$/.test(service)) {
+    return res.status(400).json({ error: 'Invalid service name' });
+  }
+
+  const argsByAction = {
+    ps: ['compose', 'ps'],
+    up: ['compose', 'up', '-d', ...(service ? [service] : [])],
+    down: ['compose', 'down'],
+    stop: ['compose', 'stop', ...(service ? [service] : [])],
+    restart: ['compose', 'restart', ...(service ? [service] : [])],
+    logs: ['compose', 'logs', '--tail', '200', '--no-color', ...(service ? [service] : [])],
+  };
+
+  const result = await run('docker', argsByAction[action], { cwd: projectPath });
+  res.json(result);
+});
+
+export default router;

--- a/server/utils/preview-proxy.js
+++ b/server/utils/preview-proxy.js
@@ -1,0 +1,199 @@
+import http from 'node:http';
+
+import jwt from 'jsonwebtoken';
+
+import { JWT_SECRET } from '../middleware/auth.js';
+
+// Name of the httpOnly cookie carrying the short-lived preview token. An iframe
+// cannot attach an Authorization header to its sub-resource requests, so the
+// preview surface authenticates itself with this cookie instead of a Bearer.
+export const PREVIEW_COOKIE = 'cloudcli_preview';
+const PREVIEW_TOKEN_TTL = '12h';
+
+// Query param used to bootstrap the cookie when the iframe is loaded from a
+// different origin than the one that set the cookie (dev mode). The middleware
+// exchanges it for the cookie and immediately redirects it out of the URL so
+// the proxied app never sees the token.
+const BOOTSTRAP_PARAM = '__cctoken';
+
+const PREVIEW_PREFIX_RE = /^\/preview\/(\d{1,5})(\/.*)?$/;
+const REFERER_PREFIX_RE = /\/preview\/(\d{1,5})(?:\/|$)/;
+
+export function issuePreviewToken() {
+  return jwt.sign({ preview: true }, JWT_SECRET, { expiresIn: PREVIEW_TOKEN_TTL });
+}
+
+export function verifyPreviewToken(token) {
+  if (!token) return false;
+  try {
+    const decoded = jwt.verify(token, JWT_SECRET);
+    return Boolean(decoded && decoded.preview === true);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * @param {string | undefined} header
+ * @returns {Record<string, string>}
+ */
+export function parseCookies(header) {
+  /** @type {Record<string, string>} */
+  const out = {};
+  if (!header) return out;
+  for (const part of header.split(';')) {
+    const idx = part.indexOf('=');
+    if (idx === -1) continue;
+    const key = part.slice(0, idx).trim();
+    if (!key) continue;
+    out[key] = decodeURIComponent(part.slice(idx + 1).trim());
+  }
+  return out;
+}
+
+export function isPreviewAuthenticated(req) {
+  const cookies = parseCookies(req.headers.cookie);
+  return verifyPreviewToken(cookies[PREVIEW_COOKIE]);
+}
+
+function isValidPort(port) {
+  return Number.isInteger(port) && port >= 1 && port <= 65535;
+}
+
+// Rewrite a redirect Location so the browser stays inside the /preview/<port>/
+// namespace instead of escaping to the app's own origin root.
+function rewriteLocation(location, port) {
+  if (!location) return location;
+  // Absolute URL pointing back at the upstream loopback host.
+  const loopbackMatch = location.match(/^https?:\/\/(?:127\.0\.0\.1|localhost)(?::\d+)?(\/.*)?$/i);
+  if (loopbackMatch) {
+    return `/preview/${port}${loopbackMatch[1] || '/'}`;
+  }
+  // Root-relative redirect from the app (e.g. "/login").
+  if (location.startsWith('/') && !location.startsWith('/preview/')) {
+    return `/preview/${port}${location}`;
+  }
+  return location;
+}
+
+function proxyHttp(req, res, port, upstreamPath) {
+  if (!isValidPort(port)) {
+    res.statusCode = 400;
+    res.end('Invalid preview port');
+    return;
+  }
+
+  const headers = { ...req.headers };
+  headers.host = `127.0.0.1:${port}`;
+  // Strip our own preview cookie so the proxied app never receives it.
+  if (headers.cookie) {
+    const kept = headers.cookie
+      .split(';')
+      .filter((c) => c.trim().split('=')[0].trim() !== PREVIEW_COOKIE)
+      .join('; ');
+    if (kept) headers.cookie = kept;
+    else delete headers.cookie;
+  }
+  // Ask upstream for uncompressed bytes so we can inject <base> into HTML.
+  delete headers['accept-encoding'];
+
+  const upstream = http.request(
+    { hostname: '127.0.0.1', port, path: upstreamPath, method: req.method, headers },
+    (proxyRes) => {
+      const resHeaders = { ...proxyRes.headers };
+      if (resHeaders.location) {
+        resHeaders.location = rewriteLocation(resHeaders.location, port);
+      }
+
+      const contentType = String(proxyRes.headers['content-type'] || '');
+      const isHtml = contentType.includes('text/html');
+
+      if (!isHtml) {
+        res.writeHead(proxyRes.statusCode || 502, resHeaders);
+        proxyRes.pipe(res);
+        return;
+      }
+
+      // Buffer HTML to inject a <base> tag; this makes the app's relative URLs
+      // resolve under /preview/<port>/. Absolute-path assets are handled
+      // separately by the Referer fallback in previewProxyMiddleware.
+      const chunks = [];
+      proxyRes.on('data', (c) => chunks.push(c));
+      proxyRes.on('end', () => {
+        let body = Buffer.concat(chunks).toString('utf8');
+        const baseTag = `<base href="/preview/${port}/">`;
+        if (/<head[^>]*>/i.test(body)) {
+          body = body.replace(/<head[^>]*>/i, (m) => `${m}${baseTag}`);
+        } else {
+          body = `${baseTag}${body}`;
+        }
+        delete resHeaders['content-length'];
+        delete resHeaders['content-encoding'];
+        res.writeHead(proxyRes.statusCode || 502, resHeaders);
+        res.end(body);
+      });
+    },
+  );
+
+  upstream.on('error', (err) => {
+    if (!res.headersSent) {
+      res.statusCode = 502;
+      res.end(`Preview upstream error on port ${port}: ${err.message}`);
+    } else {
+      res.end();
+    }
+  });
+
+  req.pipe(upstream);
+}
+
+/**
+ * Express middleware that serves the /preview/<port>/ proxy. Mount it BEFORE the
+ * body parsers so request bodies stream through untouched. It self-authenticates
+ * with the preview cookie, so it must stay outside the JWT-protected /api mount.
+ */
+export function previewProxyMiddleware(req, res, next) {
+  const url = new URL(req.url, 'http://localhost');
+  const pathname = url.pathname;
+
+  // Bootstrap: exchange a one-shot token in the query string for the cookie.
+  const bootstrapToken = url.searchParams.get(BOOTSTRAP_PARAM);
+  if (bootstrapToken && verifyPreviewToken(bootstrapToken)) {
+    url.searchParams.delete(BOOTSTRAP_PARAM);
+    res.setHeader(
+      'Set-Cookie',
+      `${PREVIEW_COOKIE}=${bootstrapToken}; Path=/preview; HttpOnly; SameSite=Lax`,
+    );
+    res.statusCode = 302;
+    res.setHeader('Location', `${pathname}${url.search}`);
+    res.end();
+    return;
+  }
+
+  const prefixMatch = pathname.match(PREVIEW_PREFIX_RE);
+  if (prefixMatch) {
+    if (!isPreviewAuthenticated(req)) {
+      res.statusCode = 401;
+      res.end('Preview session required');
+      return;
+    }
+    const port = Number(prefixMatch[1]);
+    const rest = prefixMatch[2] || '/';
+    proxyHttp(req, res, port, `${rest}${url.search}`);
+    return;
+  }
+
+  // Fallback for absolute-path assets (e.g. "/assets/app.js") requested by an
+  // app loaded under /preview/<port>/: recover the target port from the Referer.
+  const referer = req.headers.referer || req.headers.referrer;
+  if (referer && !pathname.startsWith('/api/')) {
+    const refMatch = String(referer).match(REFERER_PREFIX_RE);
+    if (refMatch && isPreviewAuthenticated(req)) {
+      const port = Number(refMatch[1]);
+      proxyHttp(req, res, port, req.url);
+      return;
+    }
+  }
+
+  next();
+}

--- a/src/components/docker/view/DockerPanel.tsx
+++ b/src/components/docker/view/DockerPanel.tsx
@@ -1,0 +1,230 @@
+import { useCallback, useEffect, useState, type ReactNode } from 'react';
+import { Play, Square, RotateCw, ScrollText, X, Container, RefreshCw, ExternalLink } from 'lucide-react';
+
+import { authenticatedFetch } from '../../../utils/api';
+import { Button } from '../../../shared/view/ui/Button';
+import type { Project } from '../../../types/app';
+
+type DockerPanelProps = {
+  selectedProject: Project | null;
+  isVisible: boolean;
+  onOpenPreview?: (port: number) => void;
+};
+
+type DockerAction = 'up' | 'down' | 'stop' | 'restart' | 'logs';
+
+type ServicePort = { published: number; target: number };
+type DockerService = {
+  name: string;
+  image: string | null;
+  state: string;
+  ports: ServicePort[];
+};
+
+function isRunning(state: string) {
+  return /run|up|healthy/i.test(state);
+}
+
+export default function DockerPanel({ selectedProject, isVisible, onOpenPreview }: DockerPanelProps) {
+  const [services, setServices] = useState<DockerService[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [hasCompose, setHasCompose] = useState(true);
+  const [dockerAvailable, setDockerAvailable] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState<string | null>(null); // `${action}:${service||'*'}`
+  const [logs, setLogs] = useState<{ title: string; body: string } | null>(null);
+
+  const projectPath = selectedProject?.fullPath || selectedProject?.path || '';
+
+  const loadServices = useCallback(async () => {
+    if (!projectPath) {
+      setServices([]);
+      return;
+    }
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await authenticatedFetch(
+        `/api/preview/docker/services?projectPath=${encodeURIComponent(projectPath)}`,
+      );
+      const data = await res.json();
+      setServices(Array.isArray(data.services) ? data.services : []);
+      setHasCompose(data.hasCompose !== false);
+      setDockerAvailable(data.dockerAvailable !== false);
+      setError(data.error || null);
+    } catch (err) {
+      setError((err as Error).message);
+    } finally {
+      setLoading(false);
+    }
+  }, [projectPath]);
+
+  useEffect(() => {
+    if (isVisible) void loadServices();
+  }, [isVisible, loadServices]);
+
+  const run = useCallback(
+    async (action: DockerAction, service?: string) => {
+      if (!projectPath) return;
+      const key = `${action}:${service || '*'}`;
+      setBusy(key);
+      try {
+        const res = await authenticatedFetch('/api/preview/docker', {
+          method: 'POST',
+          body: JSON.stringify({ action, projectPath, service }),
+        });
+        const data = await res.json();
+        if (action === 'logs') {
+          const body = [data.stdout, data.stderr].filter(Boolean).join('\n').trim();
+          setLogs({ title: service ? `logs · ${service}` : 'logs', body: body || '(no output)' });
+        } else if (data.error) {
+          setError(data.error);
+        }
+      } catch (err) {
+        setError((err as Error).message);
+      } finally {
+        setBusy(null);
+        if (action !== 'logs') void loadServices();
+      }
+    },
+    [projectPath, loadServices],
+  );
+
+  const anyRunning = services.some((s) => isRunning(s.state));
+
+  return (
+    <div className="flex h-full flex-col bg-background">
+      {/* Header / global actions */}
+      <div className="flex flex-wrap items-center gap-1.5 border-b border-border px-3 py-2">
+        <Container className="mr-1 h-4 w-4 text-muted-foreground" />
+        <span className="mr-auto text-sm font-medium">Docker Compose</span>
+        <Button size="sm" variant="ghost" onClick={loadServices} disabled={loading} className="h-8 w-8 p-0" title="Refresh">
+          <RefreshCw className={loading ? 'animate-spin' : ''} />
+        </Button>
+        <Button size="sm" variant="secondary" onClick={() => run('up')} disabled={!!busy || !hasCompose} className="h-8">
+          <Play /> up -d
+        </Button>
+        <Button
+          size="sm"
+          variant="secondary"
+          onClick={() => run('down')}
+          disabled={!!busy || !anyRunning}
+          className="h-8"
+        >
+          <Square /> down
+        </Button>
+      </div>
+
+      {/* Body */}
+      <div className="min-h-0 flex-1 overflow-auto">
+        {!projectPath ? (
+          <EmptyState text="Select a project to see its docker services." />
+        ) : !dockerAvailable ? (
+          <EmptyState text="Docker CLI not detected on this machine." tone="warn" />
+        ) : !hasCompose ? (
+          <EmptyState text="No docker-compose file found in this project." />
+        ) : services.length === 0 ? (
+          <EmptyState text={loading ? 'Loading services…' : error || 'No services defined.'} tone={error ? 'warn' : undefined} />
+        ) : (
+          <ul className="divide-y divide-border">
+            {services.map((svc) => {
+              const running = isRunning(svc.state);
+              return (
+                <li key={svc.name} className="flex flex-wrap items-center gap-2 px-3 py-2.5">
+                  <span
+                    className={`h-2 w-2 shrink-0 rounded-full ${running ? 'bg-green-500' : 'bg-muted-foreground/40'}`}
+                    title={svc.state}
+                  />
+                  <div className="min-w-0 flex-1">
+                    <div className="flex items-center gap-2">
+                      <span className="truncate text-sm font-medium">{svc.name}</span>
+                      <span className="shrink-0 text-xs text-muted-foreground">{svc.state}</span>
+                    </div>
+                    <div className="flex flex-wrap items-center gap-1.5 pt-0.5">
+                      {svc.image && (
+                        <span className="truncate font-mono text-[11px] text-muted-foreground">{svc.image}</span>
+                      )}
+                      {svc.ports.map((p) => (
+                        <button
+                          key={p.published}
+                          onClick={() => onOpenPreview?.(p.published)}
+                          disabled={!running}
+                          className="inline-flex items-center gap-1 rounded border border-border px-1.5 py-0.5 font-mono text-[11px] transition-colors hover:border-primary hover:text-primary disabled:opacity-40 disabled:hover:border-border disabled:hover:text-inherit"
+                          title={running ? `Preview localhost:${p.published}` : 'Service is not running'}
+                        >
+                          {p.published}
+                          {running && <ExternalLink className="h-3 w-3" />}
+                        </button>
+                      ))}
+                    </div>
+                  </div>
+                  <div className="flex shrink-0 items-center gap-1">
+                    <IconBtn title="restart" busy={busy === `restart:${svc.name}`} onClick={() => run('restart', svc.name)}>
+                      <RotateCw />
+                    </IconBtn>
+                    <IconBtn title="logs" busy={busy === `logs:${svc.name}`} onClick={() => run('logs', svc.name)}>
+                      <ScrollText />
+                    </IconBtn>
+                    {running ? (
+                      <IconBtn title="stop" busy={busy === `stop:${svc.name}`} onClick={() => run('stop', svc.name)}>
+                        <Square />
+                      </IconBtn>
+                    ) : (
+                      <IconBtn title="start" busy={busy === `up:${svc.name}`} onClick={() => run('up', svc.name)}>
+                        <Play />
+                      </IconBtn>
+                    )}
+                  </div>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </div>
+
+      {/* Logs drawer */}
+      {logs && (
+        <div className="flex max-h-[45%] flex-col border-t border-border bg-muted/30">
+          <div className="flex items-center gap-2 border-b border-border px-3 py-1.5">
+            <span className="text-xs font-medium">{logs.title}</span>
+            <Button size="sm" variant="ghost" onClick={() => setLogs(null)} className="ml-auto h-6 w-6 p-0" title="Close">
+              <X />
+            </Button>
+          </div>
+          <pre className="min-h-0 flex-1 overflow-auto whitespace-pre-wrap p-3 font-mono text-xs leading-relaxed text-foreground">
+            {logs.body}
+          </pre>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function EmptyState({ text, tone }: { text: string; tone?: 'warn' }) {
+  return (
+    <div className="flex h-full flex-col items-center justify-center gap-2 p-6 text-center">
+      <Container className="h-10 w-10 opacity-30" />
+      <p className={`text-sm ${tone === 'warn' ? 'text-amber-600 dark:text-amber-400' : 'text-muted-foreground'}`}>
+        {text}
+      </p>
+    </div>
+  );
+}
+
+function IconBtn({
+  children,
+  title,
+  busy,
+  onClick,
+}: {
+  children: ReactNode;
+  title: string;
+  busy: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <Button size="sm" variant="ghost" onClick={onClick} disabled={busy} className="h-8 w-8 p-0" title={title}>
+      {children}
+    </Button>
+  );
+}

--- a/src/components/main-content/view/MainContent.tsx
+++ b/src/components/main-content/view/MainContent.tsx
@@ -6,6 +6,8 @@ import StandaloneShell from '../../standalone-shell/view/StandaloneShell';
 import GitPanel from '../../git-panel/view/GitPanel';
 import PluginTabContent from '../../plugins/view/PluginTabContent';
 import { BrowserUsePanel } from '../../browser-use';
+import PreviewPanel from '../../preview/view/PreviewPanel';
+import DockerPanel from '../../docker/view/DockerPanel';
 import type { MainContentProps } from '../types/types';
 import { useTaskMaster } from '../../../contexts/TaskMasterContext';
 import { usePaletteOpsRegister } from '../../../contexts/PaletteOpsContext';
@@ -59,6 +61,16 @@ function MainContent({
   const { currentProject, setCurrentProject } = useTaskMaster() as TaskMasterContextValue;
   const { tasksEnabled, isTaskMasterInstalled } = useTasksSettings() as TasksSettingsContextValue;
   const [browserUseEnabled, setBrowserUseEnabled] = useState(false);
+  // Port requested from the Docker tab; opening it switches to the Preview tab.
+  const [previewPort, setPreviewPort] = useState<number | null>(null);
+
+  const openPreview = useCallback(
+    (port: number) => {
+      setPreviewPort(port);
+      setActiveTab('preview');
+    },
+    [setActiveTab],
+  );
 
   const shouldShowTasksTab = Boolean(tasksEnabled && isTaskMasterInstalled);
   const shouldShowBrowserTab = browserUseEnabled;
@@ -208,6 +220,27 @@ function MainContent({
           {shouldShowBrowserTab && activeTab === 'browser' && (
             <div className="h-full overflow-hidden">
               <BrowserUsePanel isVisible={activeTab === 'browser'} onShowSettings={onShowSettings} />
+            </div>
+          )}
+
+          {activeTab === 'preview' && (
+            <div className="h-full overflow-hidden">
+              <PreviewPanel
+                selectedProject={selectedProject}
+                isVisible={activeTab === 'preview'}
+                requestedPort={previewPort}
+                onPortConsumed={() => setPreviewPort(null)}
+              />
+            </div>
+          )}
+
+          {activeTab === 'docker' && (
+            <div className="h-full overflow-hidden">
+              <DockerPanel
+                selectedProject={selectedProject}
+                isVisible={activeTab === 'docker'}
+                onOpenPreview={openPreview}
+              />
             </div>
           )}
 

--- a/src/components/main-content/view/subcomponents/MainContentTabSwitcher.tsx
+++ b/src/components/main-content/view/subcomponents/MainContentTabSwitcher.tsx
@@ -1,4 +1,4 @@
-import { MessageSquare, Terminal, Folder, GitBranch, ClipboardCheck, MonitorPlay, type LucideIcon } from 'lucide-react';
+import { MessageSquare, Terminal, Folder, GitBranch, ClipboardCheck, MonitorPlay, Globe, Container, type LucideIcon } from 'lucide-react';
 import type { Dispatch, SetStateAction } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -32,10 +32,12 @@ type PluginTab = {
 type TabDefinition = BuiltInTab | PluginTab;
 
 const BASE_TABS: BuiltInTab[] = [
-  { kind: 'builtin', id: 'chat',  labelKey: 'tabs.chat',  icon: MessageSquare },
-  { kind: 'builtin', id: 'shell', labelKey: 'tabs.shell', icon: Terminal },
-  { kind: 'builtin', id: 'files', labelKey: 'tabs.files', icon: Folder },
-  { kind: 'builtin', id: 'git',   labelKey: 'tabs.git',   icon: GitBranch },
+  { kind: 'builtin', id: 'chat',    labelKey: 'tabs.chat',    icon: MessageSquare },
+  { kind: 'builtin', id: 'shell',   labelKey: 'tabs.shell',   icon: Terminal },
+  { kind: 'builtin', id: 'files',   labelKey: 'tabs.files',   icon: Folder },
+  { kind: 'builtin', id: 'git',     labelKey: 'tabs.git',     icon: GitBranch },
+  { kind: 'builtin', id: 'preview', labelKey: 'tabs.preview', icon: Globe },
+  { kind: 'builtin', id: 'docker',  labelKey: 'tabs.docker',  icon: Container },
 ];
 
 const BROWSER_TAB: BuiltInTab = {

--- a/src/components/preview/view/PreviewPanel.tsx
+++ b/src/components/preview/view/PreviewPanel.tsx
@@ -1,0 +1,197 @@
+import { useCallback, useEffect, useState } from 'react';
+import { RefreshCw, ExternalLink, Radar, Container, Globe } from 'lucide-react';
+
+import { authenticatedFetch } from '../../../utils/api';
+import { Button } from '../../../shared/view/ui/Button';
+import { Input } from '../../../shared/view/ui/Input';
+import type { Project } from '../../../types/app';
+
+type PreviewPanelProps = {
+  selectedProject: Project | null;
+  isVisible: boolean;
+  requestedPort?: number | null;
+  onPortConsumed?: () => void;
+};
+
+type DetectedPort = {
+  port: number;
+  source: 'process' | 'docker';
+  name: string;
+};
+
+export default function PreviewPanel({ isVisible, requestedPort, onPortConsumed }: PreviewPanelProps) {
+  const [portInput, setPortInput] = useState('');
+  const [activePort, setActivePort] = useState<number | null>(null);
+  const [ports, setPorts] = useState<DetectedPort[]>([]);
+  const [scanning, setScanning] = useState(false);
+  const [sessionReady, setSessionReady] = useState(false);
+  const [iframeKey, setIframeKey] = useState(0);
+
+  // Mint the preview cookie once; the proxied iframe authenticates with it.
+  useEffect(() => {
+    let cancelled = false;
+    authenticatedFetch('/api/preview/session', { method: 'POST' })
+      .then((r) => r.json())
+      .then(() => {
+        if (!cancelled) setSessionReady(true);
+      })
+      .catch(() => {
+        if (!cancelled) setSessionReady(true);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const scanPorts = useCallback(async () => {
+    setScanning(true);
+    try {
+      const res = await authenticatedFetch('/api/preview/ports');
+      const data = await res.json();
+      setPorts(Array.isArray(data.ports) ? data.ports : []);
+    } catch {
+      setPorts([]);
+    } finally {
+      setScanning(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (isVisible && ports.length === 0) {
+      void scanPorts();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isVisible]);
+
+  const openPort = useCallback((port: number) => {
+    setActivePort(port);
+    setPortInput(String(port));
+    setIframeKey((k) => k + 1);
+  }, []);
+
+  const submitPort = useCallback(() => {
+    const p = Number(portInput.trim());
+    if (Number.isInteger(p) && p >= 1 && p <= 65535) openPort(p);
+  }, [portInput, openPort]);
+
+  // A port picked from the Docker tab opens here.
+  useEffect(() => {
+    if (requestedPort && requestedPort !== activePort) {
+      openPort(requestedPort);
+      onPortConsumed?.();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [requestedPort]);
+
+  const previewUrl = activePort ? `/preview/${activePort}/` : '';
+
+  return (
+    <div className="flex h-full flex-col bg-background">
+      {/* Toolbar */}
+      <div className="flex flex-wrap items-center gap-2 border-b border-border px-3 py-2">
+        <div className="flex items-center gap-1.5">
+          <Input
+            type="number"
+            inputMode="numeric"
+            placeholder="Port (e.g. 3000)"
+            value={portInput}
+            onChange={(e) => setPortInput(e.target.value)}
+            onKeyDown={(e) => e.key === 'Enter' && submitPort()}
+            className="h-8 w-32"
+          />
+          <Button size="sm" variant="secondary" onClick={submitPort} className="h-8">
+            Open
+          </Button>
+        </div>
+
+        <Button
+          size="sm"
+          variant="ghost"
+          onClick={scanPorts}
+          disabled={scanning}
+          className="h-8"
+          title="Scan for listening ports"
+        >
+          <Radar className={scanning ? 'animate-spin' : ''} />
+          <span className="hidden sm:inline">Scan</span>
+        </Button>
+
+        <div className="ml-auto flex items-center gap-1">
+          <Button
+            size="sm"
+            variant="ghost"
+            onClick={() => setIframeKey((k) => k + 1)}
+            disabled={!activePort}
+            className="h-8 w-8 p-0"
+            title="Reload"
+          >
+            <RefreshCw />
+          </Button>
+          <Button
+            size="sm"
+            variant="ghost"
+            onClick={() => activePort && window.open(previewUrl, '_blank')}
+            disabled={!activePort}
+            className="h-8 w-8 p-0"
+            title="Open in new tab"
+          >
+            <ExternalLink />
+          </Button>
+        </div>
+      </div>
+
+      {/* Detected ports */}
+      {ports.length > 0 && (
+        <div className="flex flex-wrap gap-1.5 border-b border-border px-3 py-2">
+          {ports.map((p) => (
+            <button
+              key={`${p.source}-${p.port}`}
+              onClick={() => openPort(p.port)}
+              className={`inline-flex items-center gap-1.5 rounded-md border px-2 py-1 text-xs transition-colors ${
+                activePort === p.port
+                  ? 'border-primary bg-primary/10 text-primary'
+                  : 'border-border hover:bg-muted'
+              }`}
+              title={`${p.name} (${p.source})`}
+            >
+              {p.source === 'docker' ? (
+                <Container className="h-3 w-3" />
+              ) : (
+                <span className="h-1.5 w-1.5 rounded-full bg-green-500" />
+              )}
+              <span className="font-mono font-medium">{p.port}</span>
+              <span className="max-w-24 truncate text-muted-foreground">{p.name}</span>
+            </button>
+          ))}
+        </div>
+      )}
+
+      {/* Preview surface */}
+      <div className="relative min-h-0 flex-1 bg-white dark:bg-neutral-900">
+        {!activePort ? (
+          <div className="flex h-full flex-col items-center justify-center gap-2 p-6 text-center text-muted-foreground">
+            <Globe className="h-10 w-10 opacity-40" />
+            <p className="text-sm">
+              Enter a port or pick a detected one to preview a local server here.
+            </p>
+            <p className="max-w-sm text-xs opacity-70">
+              Your project&apos;s dev server (e.g. <span className="font-mono">localhost:3000</span>) is
+              proxied through CloudCLI, so it&apos;s reachable from your phone too.
+            </p>
+          </div>
+        ) : !sessionReady ? (
+          <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
+            Preparing preview…
+          </div>
+        ) : (
+          <iframe
+            key={iframeKey}
+            src={previewUrl}
+            title={`Preview localhost:${activePort}`}
+            className="h-full w-full border-0"
+          />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -23,6 +23,8 @@
     "files": "Files",
     "git": "Source Control",
     "tasks": "Tasks",
+    "preview": "Preview",
+    "docker": "Docker",
     "browser": "Browser",
     "computer": "Computer"
   },

--- a/src/types/app.ts
+++ b/src/types/app.ts
@@ -24,7 +24,7 @@ export type ProviderModelsCacheInfo = {
   source: 'memory' | 'disk' | 'fresh';
 };
 
-export type AppTab = 'chat' | 'files' | 'shell' | 'git' | 'tasks' | 'browser' | `plugin:${string}`;
+export type AppTab = 'chat' | 'files' | 'shell' | 'git' | 'tasks' | 'browser' | 'preview' | 'docker' | `plugin:${string}`;
 
 export interface ProjectSession {
   id: string;

--- a/vite.config.js
+++ b/vite.config.js
@@ -30,6 +30,13 @@ export default defineConfig(({ mode }) => {
       port: parseInt(env.VITE_PORT) || 5173,
       proxy: {
         '/api': `http://${proxyHost}:${serverPort}`,
+        '/preview': {
+          target: `http://${proxyHost}:${serverPort}`,
+          ws: true,
+          // The dev server (e.g. another Vite) sends redirects and HMR sockets;
+          // don't let this proxy rewrite them.
+          autoRewrite: false,
+        },
         '/ws': {
           target: `ws://${proxyHost}:${serverPort}`,
           ws: true


### PR DESCRIPTION
Preview tab: proxy a project's local dev server (localhost:<port>) through CloudCLI so it's reachable from mobile/remote. Raw pass-through proxy at /preview/<port>/ preserves headers, streams bodies, injects <base>, rewrites redirects, and falls back to the Referer for absolute-path assets. Authenticated via a dedicated httpOnly preview cookie since an iframe can't send a Bearer. HMR/app websockets are proxied through the websocket module; the cookie verifier is injected from the composition root to keep module boundaries clean.

Docker tab: reads the selected project's compose file via `docker compose config` + `ps`, listing services with live state, images, and published ports. Ports are clickable to open in the Preview tab. Per-service start/stop/restart/logs plus global up/down, all whitelisted server-side.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Preview and Docker tabs for accessing local application previews.
  * Preview supports port scanning, direct port entry, iframe viewing, reload, and opening in a new tab.
  * Added Docker Compose controls for starting, stopping, restarting services, viewing logs, and opening running service previews.
  * Added authenticated HTTP and WebSocket preview access with support for local assets and redirects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->