### PR TITLE
chore: refresh better-sqlite3 lock

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7970,9 +7970,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/better-sqlite3": {
-      "version": "12.6.2",
-      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.6.2.tgz",
-      "integrity": "sha512-8VYKM3MjCa9WcaSAI3hzwhmyHVlH8tiGFwf0RlTsZPWJ1I5MkzjiudCo4KC4DxOaL/53A5B1sI/IbldNFDbsKA==",
+      "version": "12.11.1",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.11.1.tgz",
+      "integrity": "sha512-dq9AtApgg5PGFtBzPFSBl3HZQjHok5gaQCM6zh2Yk0aSmDCs1CbnVI8/HgASQkNKsWFpseIO9beg5xxpYhbIfA==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
## Summary

- Refreshes the `package-lock.json` resolution for `better-sqlite3` from 12.6.2 to 12.11.1.
- Keeps the existing `^12.6.2` range in `package.json`.
- Changes no source code or runtime API.

## Why

The declared dependency range already allows 12.11.1, but the lock still resolved 12.6.2. While packaging CloudCLI 1.36.2 for CoderLuii/HolyClaude#67, two clean installations using this resolution produced the same production dependency tree. Upstreaming the three-line lock correction means downstream builds do not need to carry it separately.

One important limit: `better-sqlite3` 12.11.1 currently lists Node versions through 25 in its engine metadata. This PR does not claim official Node 26 support. npm reports that engine warning under Node 26.5.0, although the native module compiles and passes a direct database smoke there.

## Verification

- `npm ci` with Node 26.5.0 and npm 11.17.0: passed with the documented engine warning
- Native in-memory `better-sqlite3` create, insert, and query smoke: passed
- `npm run typecheck`: passed
- `npm run build`: passed
- `npm run lint`: passed with 0 errors and 250 existing warnings
- `git diff --check`: passed