### PR TITLE
fix(claude): detect macOS Keychain authentication

### DIFF
--- a/server/modules/providers/list/claude/claude-auth.provider.ts
+++ b/server/modules/providers/list/claude/claude-auth.provider.ts
@@ -29,8 +29,8 @@ export class ClaudeProviderAuth implements IProviderAuth {
   private checkInstalled(): boolean {
     const cliPath = resolveClaudeCodeExecutablePath(process.env.CLAUDE_CLI_PATH);
     try {
-      this.spawnSync(cliPath, ['--version'], { stdio: 'ignore', timeout: 5000 });
-      return true;
+      const result = this.spawnSync(cliPath, ['--version'], { stdio: 'ignore', timeout: 5000 });
+      return !result.error && result.status === 0;
     } catch {
       return false;
     }

--- a/server/modules/providers/list/claude/claude-auth.provider.ts
+++ b/server/modules/providers/list/claude/claude-auth.provider.ts
@@ -21,13 +21,15 @@ const hasErrorCode = (error: unknown, code: string): boolean => (
 );
 
 export class ClaudeProviderAuth implements IProviderAuth {
+  constructor(private readonly spawnSync: typeof spawn.sync = spawn.sync) {}
+
   /**
    * Checks whether the Claude Code CLI is available on this host.
    */
   private checkInstalled(): boolean {
     const cliPath = resolveClaudeCodeExecutablePath(process.env.CLAUDE_CLI_PATH);
     try {
-      spawn.sync(cliPath, ['--version'], { stdio: 'ignore', timeout: 5000 });
+      this.spawnSync(cliPath, ['--version'], { stdio: 'ignore', timeout: 5000 });
       return true;
     } catch {
       return false;
@@ -61,6 +63,62 @@ export class ClaudeProviderAuth implements IProviderAuth {
       method: credentials.method,
       error: credentials.authenticated ? undefined : credentials.error || 'Not authenticated',
     };
+  }
+
+  /**
+   * Asks Claude Code to resolve its own authentication state, including credentials
+   * stored in the macOS Keychain. Older CLI versions fall back to the existing checks.
+   */
+  private checkCliAuthStatus(): ClaudeCredentialsStatus | null {
+    const cliPath = resolveClaudeCodeExecutablePath(process.env.CLAUDE_CLI_PATH);
+
+    let result: ReturnType<typeof spawn.sync>;
+    try {
+      result = this.spawnSync(cliPath, ['auth', 'status', '--json'], {
+        encoding: 'utf8',
+        timeout: 10000,
+      });
+    } catch {
+      return null;
+    }
+
+    if (result.error) {
+      return {
+        authenticated: false,
+        email: null,
+        method: null,
+        error: 'Unable to check Claude CLI authentication status. Try running claude auth status --json in a terminal.',
+      };
+    }
+
+    if (typeof result.stdout === 'string' && result.stdout.trim()) {
+      try {
+        const parsed = readObjectRecord(JSON.parse(result.stdout));
+
+        if (typeof parsed?.loggedIn === 'boolean') {
+          if (!parsed.loggedIn) {
+            return {
+              authenticated: false,
+              email: null,
+              method: null,
+              error: 'Claude CLI is not authenticated. Run claude /login or configure ANTHROPIC_API_KEY.',
+            };
+          }
+
+          const authMethod = readOptionalString(parsed.authMethod);
+          return {
+            authenticated: true,
+            email: readOptionalString(parsed.email) ?? null,
+            method: authMethod ? `cli:${authMethod}` : 'cli',
+          };
+        }
+      } catch {
+        // Fall back to the legacy credential checks when the command is unavailable
+        // or an older Claude version returns an unexpected response.
+      }
+    }
+
+    return null;
   }
 
   /**
@@ -98,6 +156,11 @@ export class ClaudeProviderAuth implements IProviderAuth {
 
     if (readOptionalString(settingsEnv.ANTHROPIC_AUTH_TOKEN)) {
       return { authenticated: true, email: 'Configured via settings.json', method: 'api_key' };
+    }
+
+    const cliStatus = this.checkCliAuthStatus();
+    if (cliStatus) {
+      return cliStatus;
     }
 
     try {

--- a/server/modules/providers/tests/claude-auth.test.ts
+++ b/server/modules/providers/tests/claude-auth.test.ts
@@ -7,13 +7,35 @@ import { ClaudeProviderAuth } from '@/modules/providers/list/claude/claude-auth.
 
 const createSpawnSync = (
   authResult: Record<string, unknown>,
+  versionResult: Record<string, unknown> = { status: 0 },
 ): typeof spawn.sync => ((_: string, args: readonly string[]) => {
   if (args[0] === '--version') {
-    return { status: 0 };
+    return versionResult;
   }
 
   return authResult;
 }) as unknown as typeof spawn.sync;
+
+test('Claude installation check rejects a missing executable', async () => {
+  const auth = new ClaudeProviderAuth(createSpawnSync({}, {
+    status: null,
+    error: Object.assign(new Error('not found'), { code: 'ENOENT' }),
+  }));
+
+  const status = await auth.getStatus();
+
+  assert.equal(status.installed, false);
+  assert.match(status.error ?? '', /not installed/i);
+});
+
+test('Claude installation check rejects a nonzero version exit', async () => {
+  const auth = new ClaudeProviderAuth(createSpawnSync({}, { status: 1 }));
+
+  const status = await auth.getStatus();
+
+  assert.equal(status.installed, false);
+  assert.match(status.error ?? '', /not installed/i);
+});
 
 test('Claude auth status recognizes a macOS Keychain-backed login', async () => {
   const auth = new ClaudeProviderAuth(createSpawnSync({

--- a/server/modules/providers/tests/claude-auth.test.ts
+++ b/server/modules/providers/tests/claude-auth.test.ts
@@ -1,0 +1,61 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import spawn from 'cross-spawn';
+
+import { ClaudeProviderAuth } from '@/modules/providers/list/claude/claude-auth.provider.js';
+
+const createSpawnSync = (
+  authResult: Record<string, unknown>,
+): typeof spawn.sync => ((_: string, args: readonly string[]) => {
+  if (args[0] === '--version') {
+    return { status: 0 };
+  }
+
+  return authResult;
+}) as unknown as typeof spawn.sync;
+
+test('Claude auth status recognizes a macOS Keychain-backed login', async () => {
+  const auth = new ClaudeProviderAuth(createSpawnSync({
+    status: 0,
+    stdout: JSON.stringify({
+      loggedIn: true,
+      authMethod: 'claude.ai',
+      email: 'person@example.com',
+    }),
+  }));
+
+  assert.deepEqual(await auth.getStatus(), {
+    installed: true,
+    provider: 'claude',
+    authenticated: true,
+    email: 'person@example.com',
+    method: 'cli:claude.ai',
+    error: undefined,
+  });
+});
+
+test('Claude auth status honors logged-out JSON even when the CLI exits with status 1', async () => {
+  const auth = new ClaudeProviderAuth(createSpawnSync({
+    status: 1,
+    stdout: JSON.stringify({ loggedIn: false }),
+  }));
+
+  const status = await auth.getStatus();
+
+  assert.equal(status.authenticated, false);
+  assert.equal(status.email, null);
+  assert.match(status.error ?? '', /not authenticated/i);
+});
+
+test('Claude auth status surfaces a CLI timeout instead of reporting Keychain users as logged out', async () => {
+  const auth = new ClaudeProviderAuth(createSpawnSync({
+    status: null,
+    error: Object.assign(new Error('timed out'), { code: 'ETIMEDOUT' }),
+  }));
+
+  const status = await auth.getStatus();
+
+  assert.equal(status.authenticated, false);
+  assert.match(status.error ?? '', /Unable to check Claude CLI authentication status/);
+});


### PR DESCRIPTION
Closes #556

## What changed

On macOS, CloudCLI can report Claude as disconnected even while conversations work because Claude Code stores OAuth credentials in Keychain rather than `~/.claude/.credentials.json`. Authentication status now comes from `claude auth status --json`, with the existing environment, settings, and legacy credential-file paths retained for compatibility.

## Why

Claude Code itself is the reliable authority for whether its credentials are usable. Asking the CLI avoids duplicating platform-specific credential-storage logic or attempting to read Keychain directly, and keeps CloudCLI aligned with the authentication source Claude actually uses at runtime.

The status response is parsed even when Claude exits with status 1, because that is its documented logged-out result rather than an unsupported-command failure. Timeouts remain distinguishable from a genuine logged-out response so Keychain-only users are not silently misreported.

This is a deliberately narrow follow-up to #881. That PR also changed the login command and refresh behavior; maintainers requested separate changes and noted that the existing `/login` flow exposes additional authentication choices. Those behaviors remain untouched here.

## Out of scope

The login command, available login methods, and modal refresh behavior are unchanged.

## Before and after

### Before

<!-- Add the screenshot showing Claude incorrectly reported as Disconnected here. -->

<img width="1316" height="856" alt="CleanShot 2026-07-18 at 11 43 02@2x" src="https://github.com/user-attachments/assets/6a36d0a2-c10d-489b-89eb-57d5ec238ae3" />


### After

<!-- Add the screenshot showing Claude correctly reported as Connected here. -->

<img width="1322" height="762" alt="CleanShot 2026-07-18 at 11 42 43@2x" src="https://github.com/user-attachments/assets/c40df8c2-514f-4d73-a75a-dfb73a7772ed" />


---

## Test plan

- [x] `npx tsx --tsconfig=server/tsconfig.json --test server/modules/providers/tests/claude-auth.test.ts`
- [x] `npm run typecheck`
- [x] `npm run lint` (passes with the repository's existing warnings)
- [x] `npm run build` (passes with the repository's existing CSS and bundle-size warnings)
- [x] Verified the development API reports `authenticated: true` with method `cli:claude.ai` for a macOS Keychain-backed login
- [x] Verified the Agents account card shows **Connected** in the development UI


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added CLI-based authentication status detection for Claude (including login state, method, and email when available).
  * CLI results now take precedence, while existing environment and credential-file checks remain in place.
* **Bug Fixes**
  * Improved handling of CLI errors, missing binaries, and non-standard outputs.
  * Correctly differentiates CLI timeouts from logged-out states to avoid incorrect authentication reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->