### PR TITLE
fix: resolve Claude auth status via `claude auth status` instead of a credentials file

### DIFF
--- a/server/modules/providers/list/claude/claude-auth.provider.ts
+++ b/server/modules/providers/list/claude/claude-auth.provider.ts
@@ -100,6 +100,29 @@ export class ClaudeProviderAuth implements IProviderAuth {
       return { authenticated: true, email: 'Configured via settings.json', method: 'api_key' };
     }
 
+    // Fall back to a plaintext credentials file if one exists (older Claude
+    // Code versions, or platforms where OAuth creds aren't OS-keychain backed).
+    const fileCredentials = await this.readCredentialsFile();
+    if (fileCredentials) {
+      return fileCredentials;
+    }
+
+    // Claude Code stores OAuth credentials in a macOS Keychain entry whose
+    // service name is derived from CLAUDE_CONFIG_DIR (a different, hashed
+    // service name per profile) rather than a file we can read directly.
+    // That derivation isn't a stable contract we should reimplement, so defer
+    // to the CLI's own `claude auth status`, which already resolves it
+    // correctly (file, keychain, or otherwise) for whichever CLAUDE_CONFIG_DIR
+    // is active in this process's environment.
+    return this.checkCliAuthStatus(missingCredentialsError);
+  }
+
+  /**
+   * Reads the plaintext OAuth credentials file, when Claude Code uses one.
+   * Returns null (rather than an "unauthenticated" result) when the file is
+   * simply absent, so the caller can fall back to `claude auth status`.
+   */
+  private async readCredentialsFile(): Promise<ClaudeCredentialsStatus | null> {
     try {
       const credPath = path.join(os.homedir(), '.claude', '.credentials.json');
       const content = await readFile(credPath, 'utf8');
@@ -107,46 +130,91 @@ export class ClaudeProviderAuth implements IProviderAuth {
       const oauth = readObjectRecord(creds.claudeAiOauth);
       const accessToken = readOptionalString(oauth?.accessToken);
 
-      if (accessToken) {
-        const expiresAt = typeof oauth?.expiresAt === 'number' ? oauth.expiresAt : undefined;
-        const email = readOptionalString(creds.email) ?? readOptionalString(creds.user) ?? null;
-        if (!expiresAt || Date.now() < expiresAt) {
-          return {
-            authenticated: true,
-            email,
-            method: 'credentials_file',
-          };
-        }
+      if (!accessToken) {
+        return null;
+      }
 
-        return {
-          authenticated: false,
-          email: null,
-          method: null,
-          error: 'Claude login has expired. Run claude /login again.',
-        };
+      const expiresAt = typeof oauth?.expiresAt === 'number' ? oauth.expiresAt : undefined;
+      const email = readOptionalString(creds.email) ?? readOptionalString(creds.user) ?? null;
+      if (!expiresAt || Date.now() < expiresAt) {
+        return { authenticated: true, email, method: 'credentials_file' };
       }
 
       return {
         authenticated: false,
         email: null,
         method: null,
-        error: missingCredentialsError,
+        error: 'Claude login has expired. Run claude /login again.',
       };
     } catch (error) {
-      let errorMessage = 'Unable to read Claude credentials. Run claude /login again.';
-
       if (hasErrorCode(error, 'ENOENT')) {
-        errorMessage = missingCredentialsError;
-      } else if (error instanceof SyntaxError) {
-        errorMessage = 'Claude credentials are unreadable. Run claude /login again.';
+        return null;
       }
 
       return {
         authenticated: false,
         email: null,
         method: null,
-        error: errorMessage,
+        error: error instanceof SyntaxError
+          ? 'Claude credentials are unreadable. Run claude /login again.'
+          : 'Unable to read Claude credentials. Run claude /login again.',
       };
     }
+  }
+
+  /**
+   * Resolves OAuth login state via `claude auth status --json`, inheriting
+   * this process's environment (including CLAUDE_CONFIG_DIR) so it reports
+   * the profile actually in use rather than always the default one.
+   */
+  private async checkCliAuthStatus(missingCredentialsError: string): Promise<ClaudeCredentialsStatus> {
+    const cliPath = resolveClaudeCodeExecutablePath(process.env.CLAUDE_CLI_PATH);
+
+    let result;
+    try {
+      result = spawn.sync(cliPath, ['auth', 'status', '--json'], {
+        timeout: 10000,
+        encoding: 'utf8',
+        env: process.env,
+      });
+    } catch {
+      return {
+        authenticated: false,
+        email: null,
+        method: null,
+        error: 'Unable to check Claude authentication status. Run claude /login again.',
+      };
+    }
+
+    const stdout = typeof result.stdout === 'string' ? result.stdout.trim() : '';
+    if (!stdout) {
+      return { authenticated: false, email: null, method: null, error: missingCredentialsError };
+    }
+
+    let parsed: Record<string, unknown>;
+    try {
+      parsed = readObjectRecord(JSON.parse(stdout)) ?? {};
+    } catch {
+      return {
+        authenticated: false,
+        email: null,
+        method: null,
+        error: 'Unable to parse Claude authentication status. Run claude /login again.',
+      };
+    }
+
+    if (parsed.loggedIn !== true) {
+      return { authenticated: false, email: null, method: null, error: missingCredentialsError };
+    }
+
+    const orgName = readOptionalString(parsed.orgName);
+    const email = readOptionalString(parsed.email) ?? (orgName ? `Authenticated (${orgName})` : null);
+    const authMethod = readOptionalString(parsed.authMethod);
+
+    return {
+      authenticated: true,
+      email,
+      method: authMethod === 'claude.ai' ? 'oauth' : (readOptionalString(parsed.apiProvider) ?? 'api_key'),
+    };
   }
 }


### PR DESCRIPTION
## Summary

The Settings → Agents → Claude → Account tab always reports "Disconnected" / "Claude CLI is not authenticated" for OAuth-based logins (`claude /login`), even when `claude` itself is genuinely logged in and working fine in a real shell.

## Root cause

`claude-auth.provider.ts`'s `checkCredentials()` only ever checks a plaintext `~/.claude/.credentials.json` file for OAuth login state. On macOS, Claude Code actually stores OAuth credentials in the system **Keychain**, under a service name that includes a hash derived from `CLAUDE_CONFIG_DIR` when it's set (verified: a distinct Keychain entry — `Claude Code-credentials` for the default profile, `Claude Code-credentials-<hash>` for a `CLAUDE_CONFIG_DIR`-scoped profile). So the file the provider checks for simply never exists for any OAuth login on this platform, and it always falls through to "not authenticated" — regardless of whether the CLI is actually logged in, and regardless of which `CLAUDE_CONFIG_DIR`/profile is active.

## Fix

Reimplementing that Keychain service-name hashing isn't a stable contract to build against (it's an internal detail of the CLI, not a documented interface). Instead, this shells out to `claude auth status --json`, inheriting the current process environment (so `CLAUDE_CONFIG_DIR`, if set, is naturally respected) and lets the CLI itself resolve however it actually stores credentials — file, Keychain, or anything else it might use in the future. The plaintext-file check is kept as a fast path first, for platforms/older versions that do use a file.

```
$ claude auth status
{
  "loggedIn": true,
  "authMethod": "claude.ai",
  "apiProvider": "firstParty",
  "email": "rj@example.com",
  "orgId": "...",
  "orgName": "...",
  "subscriptionType": "team"
}
```

## Testing

- `npm run typecheck` — clean
- `npm run lint` — no new errors
- `npm run build` — clean
- Invoked the compiled `ClaudeProviderAuth` directly (isolated from any other change, based straight off current `main`) for three cases:
  - default-profile OAuth login → correctly reports the account email, `authenticated: true`
  - `CLAUDE_CONFIG_DIR`-scoped OAuth login to a **different** account → correctly reports that different account's email
  - an unauthenticated `CLAUDE_CONFIG_DIR` → correctly reports `authenticated: false` with the expected error message

## Note

This is independent of #1034 (which fixes `CLAUDE_CONFIG_DIR` handling for projects/sessions/settings elsewhere in the app) — either can merge first, they don't depend on each other.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Claude authentication detection by checking local credentials first and falling back to the Claude Code CLI when needed.
  * Added clearer handling for expired, missing, unreadable, or invalid credentials.
  * Improved recognition of authentication status, login email, authentication method, and active CLI profiles.
  * Added more specific error messages when authentication checks fail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->