### PR TITLE
fix(skills): discover skill directories that are symlinks

### DIFF
--- a/server/shared/utils.ts
+++ b/server/shared/utils.ts
@@ -910,7 +910,9 @@ export async function findProviderSkillMarkdownFiles(
     }
 
     for (const entry of entries) {
-      if (entry.isDirectory()) {
+      // Symlinks to skill directories are common in ~/.cursor/skills; Dirent.isDirectory()
+      // is false for links even when the target is a directory.
+      if (entry.isDirectory() || entry.isSymbolicLink()) {
         await collectRecursive(path.join(dirPath, entry.name));
       }
     }
@@ -925,7 +927,7 @@ export async function findProviderSkillMarkdownFiles(
     const entries = await readdir(rootDir, { withFileTypes: true });
 
     for (const entry of entries) {
-      if (!entry.isDirectory()) {
+      if (!entry.isDirectory() && !entry.isSymbolicLink()) {
         continue;
       }
 


### PR DESCRIPTION
## Summary
- Treat directory symlinks as traversable when discovering provider skill `SKILL.md` files.
- Fixes cases like `~/.cursor/skills` where `Dirent.isDirectory()` is false for symlinks even when the target is a directory.

## Test plan
- [ ] Place a skill behind a symlink under a provider skills root (e.g. `~/.cursor/skills/my-skill` → real dir with `SKILL.md`)
- [ ] Confirm the skill appears in CloudCLI skill discovery / settings
- [ ] Confirm normal (non-symlink) skill directories still discover correctly
- [ ] Confirm broken/non-directory symlinks do not crash discovery


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Skill discovery now supports provider skill directories accessed through symbolic links.
  * Recursive and direct searches can locate `SKILL.md` files within symlinked directories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->