### PR TITLE
fix: render web-UI slash commands compactly instead of leaking prompt

### DIFF
--- a/server/modules/providers/list/claude/claude-sessions.provider.ts
+++ b/server/modules/providers/list/claude/claude-sessions.provider.ts
@@ -246,6 +246,14 @@ type ClaudeLocalCommandPayload = {
  * normal text path continue untouched for unrelated messages.
  */
 function parseLocalCommandPayload(content: string): ClaudeLocalCommandPayload | null {
+  // Only treat the text as a local command when the wrapper opens the payload.
+  // A normal user message that merely mentions a `<command-name>` tag somewhere
+  // in its body must stay untouched — otherwise it would collapse into a compact
+  // bubble and its surrounding prose would be discarded (issue #1009 follow-up).
+  if (!/^\s*<command-(?:name|message|args)>/.test(content)) {
+    return null;
+  }
+
   const commandName = extractTaggedContent(content, 'command-name');
   const commandMessage = extractTaggedContent(content, 'command-message');
   const commandArgs = extractTaggedContent(content, 'command-args');
@@ -267,6 +275,13 @@ function parseLocalCommandPayload(content: string): ClaudeLocalCommandPayload | 
  * We prefer the slash-prefixed command name because that most closely matches
  * what the user actually typed, and only fall back to the message body when the
  * command name is unavailable in older transcript variants.
+ *
+ * INVARIANT (issue #1009): the base+args formatting MUST stay byte-identical to
+ * the frontend `formatLocalCommandDisplayText` in
+ * `src/components/chat/hooks/useChatComposerState.ts`. The optimistic user
+ * bubble is de-duplicated against this replayed value via an exact text
+ * fingerprint; drift between the two produces a duplicate bubble after a run
+ * completes. Keep the trim/spacing rules in sync on both sides.
  */
 function buildLocalCommandDisplayText(payload: ClaudeLocalCommandPayload): string {
   const commandName = payload.commandName.trim();
@@ -342,7 +357,30 @@ export class ClaudeSessionsProvider implements IProviderSessions {
             }));
           } else if (part.type === 'text') {
             const text = part.text || '';
-            if (text && !isInternalContent(text)) {
+            // The SDK persists web-UI prompts as array content, so the tagged
+            // local-command wrapper arrives here rather than in the string
+            // branch below — parse it in both places (issue #1009).
+            const localCommandPayload = parseLocalCommandPayload(text);
+            if (localCommandPayload) {
+              const displayText = buildLocalCommandDisplayText(localCommandPayload);
+              if (displayText) {
+                messages.push(createNormalizedMessage({
+                  id: `${baseId}_cmd_${partIndex}`,
+                  sessionId,
+                  timestamp: ts,
+                  provider: PROVIDER,
+                  kind: 'text',
+                  role: 'user',
+                  content: displayText,
+                  images: !imagesAttached && imageAttachments.length > 0 ? imageAttachments : undefined,
+                  commandName: localCommandPayload.commandName,
+                  commandMessage: localCommandPayload.commandMessage,
+                  commandArgs: localCommandPayload.commandArgs,
+                  isLocalCommand: true,
+                }));
+                imagesAttached = true;
+              }
+            } else if (text && !isInternalContent(text)) {
               messages.push(createNormalizedMessage({
                 id: `${baseId}_text_${partIndex}`,
                 sessionId,
@@ -364,7 +402,9 @@ export class ClaudeSessionsProvider implements IProviderSessions {
             .map((part: AnyRecord) => part.text)
             .filter(Boolean)
             .join('\n');
-          if (textParts && !isInternalContent(textParts)) {
+          // A command payload whose display text came up empty must stay
+          // hidden rather than fall through as raw tagged text.
+          if (textParts && !isInternalContent(textParts) && !parseLocalCommandPayload(textParts)) {
             messages.push(createNormalizedMessage({
               id: `${baseId}_text`,
               sessionId,

--- a/server/modules/providers/tests/claude-local-command-invocation.test.ts
+++ b/server/modules/providers/tests/claude-local-command-invocation.test.ts
@@ -1,0 +1,192 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { ClaudeSessionsProvider } from '@/modules/providers/list/claude/claude-sessions.provider.js';
+
+const SESSION_ID = 'session-1';
+
+const COMMAND_BODY = [
+  'You are performing a production deploy.',
+  '',
+  '1. Run the build',
+  '2. Push the artifacts',
+  '3. Verify <https://example.com/health> responds',
+].join('\n');
+
+// The web UI sends custom commands as the CLI-native tag wrapper followed by
+// the expanded command body in ONE string (issue #1009). The normalizer must
+// surface only the compact command and drop the body.
+test('claude: command tags followed by the expanded body render compactly', () => {
+  const provider = new ClaudeSessionsProvider();
+  const entry = {
+    uuid: 'c1',
+    timestamp: '2026-07-22T10:00:00.000Z',
+    message: {
+      role: 'user',
+      content:
+        '<command-message>deploy</command-message>\n' +
+        '<command-name>/deploy</command-name>\n' +
+        '<command-args>prod eu</command-args>\n\n' +
+        COMMAND_BODY,
+    },
+  };
+
+  const messages = provider.normalizeMessage(entry, SESSION_ID);
+
+  assert.equal(messages.length, 1);
+  assert.equal(messages[0].kind, 'text');
+  assert.equal(messages[0].role, 'user');
+  assert.equal(messages[0].isLocalCommand, true);
+  assert.equal(messages[0].commandName, '/deploy');
+  assert.equal(messages[0].commandArgs, 'prod eu');
+  assert.equal(messages[0].content, '/deploy prod eu');
+  // The expanded prompt body must never leak into the chat.
+  assert.ok(!String(messages[0].content).includes('production deploy'));
+});
+
+// The SDK persists (and live-streams) web-UI prompts as ARRAY content, not as
+// a plain string — the aborted-run leak from manual testing came through this
+// branch. It must render compactly too.
+test('claude: array-form command tags followed by the body render compactly', () => {
+  const provider = new ClaudeSessionsProvider();
+  const entry = {
+    uuid: 'c1a',
+    timestamp: '2026-07-22T10:00:00.000Z',
+    message: {
+      role: 'user',
+      content: [{
+        type: 'text',
+        text:
+          '<command-message>handoff</command-message>\n' +
+          '<command-name>/handoff</command-name>\n' +
+          '<command-args></command-args>\n\n' +
+          COMMAND_BODY,
+      }],
+    },
+  };
+
+  const messages = provider.normalizeMessage(entry, SESSION_ID);
+
+  assert.equal(messages.length, 1);
+  assert.equal(messages[0].isLocalCommand, true);
+  assert.equal(messages[0].role, 'user');
+  assert.equal(messages[0].content, '/handoff');
+  assert.ok(!String(messages[0].content).includes('production deploy'));
+});
+
+test('claude: command tags with empty args show only the command name', () => {
+  const provider = new ClaudeSessionsProvider();
+  const entry = {
+    uuid: 'c2',
+    timestamp: '2026-07-22T10:00:00.000Z',
+    message: {
+      role: 'user',
+      content:
+        '<command-message>deploy</command-message>\n' +
+        '<command-name>/deploy</command-name>\n' +
+        '<command-args></command-args>\n\n' +
+        COMMAND_BODY,
+    },
+  };
+
+  const messages = provider.normalizeMessage(entry, SESSION_ID);
+
+  assert.equal(messages.length, 1);
+  assert.equal(messages[0].isLocalCommand, true);
+  assert.equal(messages[0].content, '/deploy');
+});
+
+// Native CLI transcripts carry the tags without a trailing body; that shape
+// predates this fix and must keep working.
+test('claude: native tag-only command rows keep rendering compactly', () => {
+  const provider = new ClaudeSessionsProvider();
+  const entry = {
+    uuid: 'c3',
+    timestamp: '2026-07-22T10:00:00.000Z',
+    message: {
+      role: 'user',
+      content:
+        '<command-message>investigate-pr</command-message>\n' +
+        '<command-name>/investigate-pr</command-name>\n' +
+        '<command-args>375</command-args>',
+    },
+  };
+
+  const messages = provider.normalizeMessage(entry, SESSION_ID);
+
+  assert.equal(messages.length, 1);
+  assert.equal(messages[0].isLocalCommand, true);
+  assert.equal(messages[0].content, '/investigate-pr 375');
+});
+
+test('claude: ordinary user messages are untouched by command parsing', () => {
+  const provider = new ClaudeSessionsProvider();
+  const entry = {
+    uuid: 'c4',
+    timestamp: '2026-07-22T10:00:00.000Z',
+    message: { role: 'user', content: 'Please run /deploy for me later.' },
+  };
+
+  const messages = provider.normalizeMessage(entry, SESSION_ID);
+
+  assert.equal(messages.length, 1);
+  assert.equal(messages[0].isLocalCommand, undefined);
+  assert.equal(messages[0].content, 'Please run /deploy for me later.');
+});
+
+// A user prose message that merely embeds a command tag mid-text must NOT be
+// collapsed into a compact bubble — the wrapper only counts when it opens the
+// payload, otherwise the surrounding prose is silently discarded.
+test('claude: an embedded command tag inside prose is kept as normal text', () => {
+  const provider = new ClaudeSessionsProvider();
+  const embedded =
+    'Here is what my slash command expands to: <command-name>/deploy</command-name> — is that right?';
+  const entry = {
+    uuid: 'c5',
+    timestamp: '2026-07-22T10:00:00.000Z',
+    message: { role: 'user', content: embedded },
+  };
+
+  const messages = provider.normalizeMessage(entry, SESSION_ID);
+
+  assert.equal(messages.length, 1);
+  assert.equal(messages[0].isLocalCommand, undefined);
+  assert.equal(messages[0].content, embedded);
+});
+
+// A command turn that also carries an image attachment must render as ONE
+// user bubble with the image on it, not a compact command bubble plus a
+// separate image-only bubble.
+test('claude: array-form command with an image renders one bubble with the image', () => {
+  const provider = new ClaudeSessionsProvider();
+  const entry = {
+    uuid: 'c6',
+    timestamp: '2026-07-22T10:00:00.000Z',
+    message: {
+      role: 'user',
+      content: [
+        {
+          type: 'image',
+          source: { type: 'base64', media_type: 'image/png', data: 'AAAA' },
+        },
+        {
+          type: 'text',
+          text:
+            '<command-message>deploy</command-message>\n' +
+            '<command-name>/deploy</command-name>\n' +
+            '<command-args>prod</command-args>\n\n' +
+            COMMAND_BODY,
+        },
+      ],
+    },
+  };
+
+  const messages = provider.normalizeMessage(entry, SESSION_ID);
+
+  assert.equal(messages.length, 1);
+  assert.equal(messages[0].isLocalCommand, true);
+  assert.equal(messages[0].content, '/deploy prod');
+  const images = messages[0].images as Array<{ data: string }> | undefined;
+  assert.equal(images?.length, 1);
+  assert.equal(images?.[0].data, 'data:image/png;base64,AAAA');
+});

--- a/src/components/chat/hooks/useChatComposerState.ts
+++ b/src/components/chat/hooks/useChatComposerState.ts
@@ -150,6 +150,44 @@ const createFakeSubmitEvent = () => {
   return { preventDefault: () => undefined } as unknown as FormEvent<HTMLFormElement>;
 };
 
+/**
+ * Builds the compact command string shown in the optimistic user bubble,
+ * e.g. "/deploy prod".
+ *
+ * INVARIANT (issue #1009): the output MUST stay byte-identical to the
+ * server-side `buildLocalCommandDisplayText` in
+ * `server/modules/providers/list/claude/claude-sessions.provider.ts`. The
+ * optimistic bubble is de-duplicated against the replayed server transcript
+ * via an exact text fingerprint (`hasServerEchoForLocalUser` in
+ * `useSessionStore.ts`); if the two formatters drift, the command resurfaces
+ * as a duplicate bubble once the run completes. Keep the trim/spacing rules
+ * in sync on both sides.
+ */
+export function formatLocalCommandDisplayText(commandName: string, args: string): string {
+  const base = commandName.trim();
+  const trimmedArgs = args.trim();
+  if (!base) {
+    return '';
+  }
+  return trimmedArgs ? `${base} ${trimmedArgs}` : base;
+}
+
+/**
+ * Decouples what a custom slash command shows in chat from what it sends to
+ * the provider. The user bubble renders only the compact `displayText`
+ * (`/name args`) while `promptContent` — the expanded command body — is what
+ * actually goes out as `chat.send.content`, so the internal prompt never
+ * appears as user input (issue #1009).
+ */
+export type CommandSubmitOverride = {
+  /** Compact command string shown as the user bubble, e.g. "/deploy prod". */
+  displayText: string;
+  /** Full prompt sent to the provider (expanded body, tagged for Claude). */
+  promptContent: string;
+  commandName: string;
+  commandArgs: string;
+};
+
 export type QueuedDraft = {
   content: string;
   images: File[];
@@ -159,12 +197,20 @@ export type QueuedDraft = {
    * permission settings while another session is being viewed.
    */
   options?: QueuedSendOptions;
+  /**
+   * For queued custom slash commands, the already-expanded prompt. Only the
+   * app-level auto-send uses it (see `StoredQueuedMessage.promptContent`); the
+   * in-composer flush re-expands the compact `content` instead (issue #1009).
+   */
+  promptContent?: string;
 };
 
 const restoreQueuedDraft = (sessionKey: string): QueuedDraft | null => {
   const saved = readQueuedMessage(sessionKey);
   // Image attachments can't survive a reload; only text and options persist.
-  return saved ? { content: saved.content, images: [], options: saved.options } : null;
+  return saved
+    ? { content: saved.content, images: [], options: saved.options, promptContent: saved.promptContent }
+    : null;
 };
 
 const getNotificationSessionSummary = (
@@ -232,7 +278,10 @@ export function useChatComposerState({
   const textareaLineHeightRef = useRef<number | null>(null);
   const lastAutosizedInputRef = useRef<string | null>(null);
   const handleSubmitRef = useRef<
-    ((event: FormEvent<HTMLFormElement> | MouseEvent | TouchEvent | KeyboardEvent<HTMLTextAreaElement>) => Promise<void>) | null
+    ((
+      event: FormEvent<HTMLFormElement> | MouseEvent | TouchEvent | KeyboardEvent<HTMLTextAreaElement>,
+      commandOverride?: CommandSubmitOverride,
+    ) => Promise<void>) | null
   >(null);
   const inputValueRef = useRef(input);
   const selectedProjectId = selectedProject?.projectId;
@@ -321,7 +370,10 @@ export function useChatComposerState({
     setCommandModalPayload(null);
   }, []);
 
-  const handleCustomCommand = useCallback(async (result: CommandExecutionResult) => {
+  const handleCustomCommand = useCallback(async (
+    result: CommandExecutionResult,
+    invocation: { commandName: string; args: string[] },
+  ) => {
     const { content, hasBashCommands } = result;
 
     if (hasBashCommands) {
@@ -338,17 +390,36 @@ export function useChatComposerState({
       }
     }
 
-    const commandContent = content || '';
-    setInput(commandContent);
-    inputValueRef.current = commandContent;
+    const commandBody = content || '';
+    const slashName = invocation.commandName.startsWith('/')
+      ? invocation.commandName
+      : `/${invocation.commandName}`;
+    const commandArgs = invocation.args.join(' ');
+    const displayText = formatLocalCommandDisplayText(slashName, commandArgs);
 
-    // Defer submit to next tick so the command text is reflected in UI before dispatching.
-    setTimeout(() => {
-      if (handleSubmitRef.current) {
-        handleSubmitRef.current(createFakeSubmitEvent());
-      }
-    }, 0);
-  }, [addMessage]);
+    // Claude transcripts are normalized through `parseLocalCommandPayload`,
+    // which understands the CLI's native <command-name> wrapper. Prefixing the
+    // expanded body with the same tags makes live and history rendering show
+    // the compact command instead of the full prompt (issue #1009).
+    //
+    // Other providers keep receiving the plain body: their transcripts have no
+    // tag-aware normalization, so embedding the tags would only leak them as
+    // literal text on reload. The known trade-off is that the compact live
+    // bubble still expands back to the full body in their reloaded history —
+    // acceptable until those providers gain equivalent normalization.
+    const promptContent = provider === 'claude'
+      ? `<command-message>${slashName.slice(1)}</command-message>\n` +
+        `<command-name>${slashName}</command-name>\n` +
+        `<command-args>${commandArgs}</command-args>\n\n${commandBody}`
+      : commandBody;
+
+    handleSubmitRef.current?.(createFakeSubmitEvent(), {
+      displayText,
+      promptContent,
+      commandName: slashName,
+      commandArgs,
+    });
+  }, [addMessage, provider]);
 
   const executeCommand = useCallback(
     async (command: SlashCommand, rawInput?: string, options?: { preserveInput?: boolean }) => {
@@ -411,7 +482,7 @@ export function useChatComposerState({
             inputValueRef.current = '';
           }
         } else if (result.type === 'custom') {
-          await handleCustomCommand(result);
+          await handleCustomCommand(result, { commandName: command.name, args });
         }
       } catch (error) {
         const message = error instanceof Error ? error.message : 'Unknown error';
@@ -646,9 +717,13 @@ export function useChatComposerState({
   const handleSubmit = useCallback(
     async (
       event: FormEvent<HTMLFormElement> | MouseEvent | TouchEvent | KeyboardEvent<HTMLTextAreaElement>,
+      commandOverride?: CommandSubmitOverride,
     ) => {
       event.preventDefault();
-      const currentInput = inputValueRef.current;
+      const currentInput = commandOverride?.promptContent ?? inputValueRef.current;
+      // What the user bubble (and session summary) shows; identical to the
+      // sent text except for command overrides, which display only "/name args".
+      const displayContent = commandOverride?.displayText ?? currentInput;
       if (!currentInput.trim() || !selectedProject) {
         return;
       }
@@ -659,9 +734,17 @@ export function useChatComposerState({
       if (isLoading) {
         queuedDraftSessionRef.current = sessionKey;
         setQueuedDraft({
-          content: currentInput,
+          // For command overrides, queue the compact "/name args" text: the
+          // flush replays it through slash-command interception, so the
+          // command is re-expanded at send time and the already-expanded
+          // prompt never surfaces as editable draft text.
+          content: commandOverride ? commandOverride.displayText : currentInput,
           images: attachedImages,
-          options: buildSendOptions(currentInput),
+          options: buildSendOptions(displayContent),
+          // The app-level auto-send (fired when this session completes while
+          // unviewed) can't re-intercept the slash command, so carry the
+          // expanded prompt for it to dispatch verbatim (issue #1009).
+          ...(commandOverride ? { promptContent: commandOverride.promptContent } : {}),
         });
         setInput('');
         inputValueRef.current = '';
@@ -680,9 +763,10 @@ export function useChatComposerState({
 
       // Intercept slash commands only when "/" is the first input character.
       // Also accept exact "help" as a convenience alias for users who expect CLI-style help.
+      // Command overrides carry an already-expanded command and must not be re-intercepted.
       const commandInput = currentInput.trimEnd();
-      const isHelpAlias = commandInput.trim().toLowerCase() === 'help';
-      if (commandInput.startsWith('/') || isHelpAlias) {
+      const isHelpAlias = !commandOverride && commandInput.trim().toLowerCase() === 'help';
+      if (!commandOverride && (commandInput.startsWith('/') || isHelpAlias)) {
         const firstSpace = commandInput.indexOf(' ');
         const commandName = isHelpAlias
           ? '/help'
@@ -748,7 +832,7 @@ export function useChatComposerState({
       }
 
       const resolvedProjectPath = selectedProject.fullPath || selectedProject.path || '';
-      const sessionSummary = getNotificationSessionSummary(selectedSession, currentInput);
+      const sessionSummary = getNotificationSessionSummary(selectedSession, displayContent);
 
       // The conversation always has a stable backend-allocated session id
       // BEFORE the first websocket send: brand-new chats allocate one here
@@ -798,9 +882,16 @@ export function useChatComposerState({
 
       const userMessage: ChatMessage = {
         type: 'user',
-        content: currentInput,
+        content: displayContent,
         images: uploadedImages as any,
         timestamp: new Date(),
+        ...(commandOverride
+          ? {
+              isLocalCommand: true,
+              commandName: commandOverride.commandName,
+              commandArgs: commandOverride.commandArgs,
+            }
+          : {}),
       };
 
       addMessage(userMessage);
@@ -823,7 +914,7 @@ export function useChatComposerState({
         sessionId: targetSessionId,
         content: messageContent,
         options: {
-          ...buildSendOptions(messageContent),
+          ...buildSendOptions(displayContent),
           images: uploadedImages,
         },
       });
@@ -975,7 +1066,11 @@ export function useChatComposerState({
       return;
     }
     if (queuedDraft?.content) {
-      writeQueuedMessage(sessionKey, { content: queuedDraft.content, options: queuedDraft.options });
+      writeQueuedMessage(sessionKey, {
+        content: queuedDraft.content,
+        options: queuedDraft.options,
+        promptContent: queuedDraft.promptContent,
+      });
     } else {
       clearQueuedMessage(sessionKey);
     }

--- a/src/components/chat/utils/chatStorage.ts
+++ b/src/components/chat/utils/chatStorage.ts
@@ -54,6 +54,15 @@ export type QueuedSendOptions = Record<string, unknown>;
 export type StoredQueuedMessage = {
   content: string;
   options?: QueuedSendOptions;
+  /**
+   * For queued custom slash commands, the fully expanded prompt to dispatch
+   * verbatim (the tagged wrapper for Claude, the plain body otherwise). The
+   * app-level auto-send has no access to slash-command re-interception, so it
+   * must send this instead of the compact `content` — otherwise the provider
+   * receives an un-expanded "/name args" string. The in-composer flush ignores
+   * this field and re-expands `content` live (issue #1009).
+   */
+  promptContent?: string;
 };
 
 export const queuedMessageKey = (sessionId: string) => `queued_message_${sessionId}`;
@@ -71,8 +80,12 @@ export function readQueuedMessage(sessionId: string): StoredQueuedMessage | null
   try {
     const parsed = JSON.parse(raw) as unknown;
     if (parsed && typeof parsed === 'object' && typeof (parsed as StoredQueuedMessage).content === 'string') {
-      const { content, options } = parsed as StoredQueuedMessage;
-      return content.trim() ? { content, options } : null;
+      const { content, options, promptContent } = parsed as StoredQueuedMessage;
+      // Persisted data is untrusted — drop a malformed promptContent instead
+      // of letting a non-string reach the auto-send dispatch.
+      return content.trim()
+        ? { content, options, promptContent: typeof promptContent === 'string' ? promptContent : undefined }
+        : null;
     }
   } catch {
     // Legacy format: the raw draft text itself.

--- a/src/hooks/useQueuedMessageAutoSend.ts
+++ b/src/hooks/useQueuedMessageAutoSend.ts
@@ -61,7 +61,10 @@ export function useQueuedMessageAutoSend({
       sendMessage({
         type: 'chat.send',
         sessionId,
-        content: queued.content,
+        // Custom slash commands carry their expanded prompt in `promptContent`;
+        // this hook can't re-intercept the compact "/name args" the way the
+        // composer flush does, so it must send the expanded form (issue #1009).
+        content: queued.promptContent ?? queued.content,
         options: { ...(queued.options ?? {}), images: [] },
       });
       markSessionProcessing(sessionId, { statusText: null, canInterrupt: true });


### PR DESCRIPTION
Fixes #1009

## Problem
Custom slash commands were expanded client-side and their full body was sent as the chat message, so the internal prompt showed up as a user bubble both live and after a reload.

## Reproduction
1. Open the web UI with a Claude project and open or start a session.
2. From the composer, invoke a custom slash command with arguments, e.g. `/handoff just the essentials`.
3. Before this change: the whole expanded command body renders as your user message, both live and after reloading the session, instead of the command you typed.
4. After this change: the bubble shows only the compact `/handoff just the essentials`, live and after reload.

## Change
Display text and the sent prompt are now separate. The bubble only shows `/name args`, while Claude receives the expanded body wrapped in the CLI-native `<command-name>` tags. On reload the existing normalization folds that back into the compact form. The array-content branch parses the same wrapper, since aborted and streamed runs deliver the prompt as array text. Other providers keep receiving the plain body.

## Tests
5 new node:test cases: string and array form, empty args, native tag-only, and a negative case. `npm run typecheck`, `npm run lint`, and `npm run build` are all green.

## Review focus
The delicate part is the fingerprint coupling: frontend and backend must format the command identically, otherwise a duplicate bubble appears after the run completes. Please also check the non-Claude path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Custom slash commands now show a compact optimistic command bubble, while the expanded prompt is used for submission.
  - Queued slash-command drafts now preserve and restore the expanded prompt, including when auto-sending.

- **Bug Fixes**
  - Improved Claude “local slash command” handling to better recognize wrapper tags only when they start a message.
  - Prevented accidental local-command collapsing when tags appear mid-sentence.
  - Ensured command turns with image attachments render as a single user bubble.

- **Tests**
  - Added coverage for normalization across wrapper formats, empty arguments, prose immunity, mid-sentence tags, and attachment rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->