### PR TITLE
fix(codex): show provider thread titles in the sidebar

### DIFF
--- a/server/modules/database/migrations.ts
+++ b/server/modules/database/migrations.ts
@@ -58,18 +58,28 @@ const migrateLegacySessionNames = (db: Database): void => {
   if (hasSessionsTable) {
     console.log('Running migration: Merging session_names into sessions');
     db.exec(`
-      INSERT INTO sessions (session_id, provider, custom_name, created_at, updated_at)
+      INSERT INTO sessions (session_id, provider, custom_name, custom_name_source, created_at, updated_at)
       SELECT
         session_id,
         COALESCE(provider, 'claude'),
         custom_name,
+        CASE WHEN custom_name IS NULL OR trim(custom_name) = '' THEN NULL ELSE 'manual' END,
         COALESCE(created_at, CURRENT_TIMESTAMP),
         COALESCE(updated_at, CURRENT_TIMESTAMP)
       FROM session_names
       WHERE true
       ON CONFLICT(session_id) DO UPDATE SET
         provider = excluded.provider,
-        custom_name = COALESCE(excluded.custom_name, sessions.custom_name),
+        custom_name = CASE
+          WHEN excluded.custom_name IS NOT NULL AND trim(excluded.custom_name) <> ''
+            THEN excluded.custom_name
+          ELSE sessions.custom_name
+        END,
+        custom_name_source = CASE
+          WHEN excluded.custom_name IS NOT NULL AND trim(excluded.custom_name) <> ''
+            THEN 'manual'
+          ELSE sessions.custom_name_source
+        END,
         created_at = COALESCE(sessions.created_at, excluded.created_at),
         updated_at = COALESCE(excluded.updated_at, sessions.updated_at)
     `);
@@ -79,6 +89,13 @@ const migrateLegacySessionNames = (db: Database): void => {
 
   console.log('Running migration: Renaming session_names table to sessions');
   db.exec('ALTER TABLE session_names RENAME TO sessions');
+  const columnNames = getTableInfo(db, 'sessions').map((column) => column.name);
+  addColumnToTableIfNotExists(db, 'sessions', columnNames, 'custom_name_source', 'TEXT');
+  db.exec(`
+    UPDATE sessions
+    SET custom_name_source = 'manual'
+    WHERE custom_name IS NOT NULL AND trim(custom_name) <> ''
+  `);
 };
 
 const migrateLegacyWorkspaceTableIntoProjects = (db: Database): void => {
@@ -416,6 +433,19 @@ const addSessionModelColumn = (db: Database): void => {
   addColumnToTableIfNotExists(db, 'sessions', columnNames, 'model', 'TEXT');
 };
 
+const addSessionCustomNameSource = (db: Database): void => {
+  const columnNames = getTableInfo(db, 'sessions').map((column) => column.name);
+  const isLegacySchema = !columnNames.includes('custom_name_source');
+  addColumnToTableIfNotExists(db, 'sessions', columnNames, 'custom_name_source', 'TEXT');
+  if (isLegacySchema) {
+    db.exec(`
+      UPDATE sessions
+      SET custom_name_source = 'manual'
+      WHERE custom_name IS NOT NULL AND trim(custom_name) <> ''
+    `);
+  }
+};
+
 const ensureProjectsForSessionPaths = (db: Database): void => {
   if (!tableExists(db, 'sessions')) {
     return;
@@ -464,6 +494,7 @@ export const runMigrations = (db: Database) => {
 
     migrateLegacyWorkspaceTableIntoProjects(db);
     rebuildSessionsTableWithProjectSchema(db);
+    addSessionCustomNameSource(db);
     migrateLegacySessionNames(db);
     addProviderSessionIdMapping(db);
     addSessionModelColumn(db);

--- a/server/modules/database/migrations.ts
+++ b/server/modules/database/migrations.ts
@@ -63,18 +63,28 @@ const migrateLegacySessionNames = (db: Database): void => {
   if (hasSessionsTable) {
     console.log('Running migration: Merging session_names into sessions');
     db.exec(`
-      INSERT INTO sessions (session_id, provider, custom_name, created_at, updated_at)
+      INSERT INTO sessions (session_id, provider, custom_name, custom_name_source, created_at, updated_at)
       SELECT
         session_id,
         COALESCE(provider, 'claude'),
         custom_name,
+        CASE WHEN custom_name IS NULL OR trim(custom_name) = '' THEN NULL ELSE 'manual' END,
         COALESCE(created_at, CURRENT_TIMESTAMP),
         COALESCE(updated_at, CURRENT_TIMESTAMP)
       FROM session_names
       WHERE true
       ON CONFLICT(session_id) DO UPDATE SET
         provider = excluded.provider,
-        custom_name = COALESCE(excluded.custom_name, sessions.custom_name),
+        custom_name = CASE
+          WHEN excluded.custom_name IS NOT NULL AND trim(excluded.custom_name) <> ''
+            THEN excluded.custom_name
+          ELSE sessions.custom_name
+        END,
+        custom_name_source = CASE
+          WHEN excluded.custom_name IS NOT NULL AND trim(excluded.custom_name) <> ''
+            THEN 'manual'
+          ELSE sessions.custom_name_source
+        END,
         created_at = COALESCE(sessions.created_at, excluded.created_at),
         updated_at = COALESCE(excluded.updated_at, sessions.updated_at)
     `);
@@ -84,6 +94,13 @@ const migrateLegacySessionNames = (db: Database): void => {
 
   console.log('Running migration: Renaming session_names table to sessions');
   db.exec('ALTER TABLE session_names RENAME TO sessions');
+  const columnNames = getTableInfo(db, 'sessions').map((column) => column.name);
+  addColumnToTableIfNotExists(db, 'sessions', columnNames, 'custom_name_source', 'TEXT');
+  db.exec(`
+    UPDATE sessions
+    SET custom_name_source = 'manual'
+    WHERE custom_name IS NOT NULL AND trim(custom_name) <> ''
+  `);
 };
 
 const migrateLegacyWorkspaceTableIntoProjects = (db: Database): void => {
@@ -457,6 +474,19 @@ const addSessionEffortColumn = (db: Database): void => {
   addColumnToTableIfNotExists(db, 'sessions', columnNames, 'effort', 'TEXT');
 };
 
+const addSessionCustomNameSource = (db: Database): void => {
+  const columnNames = getTableInfo(db, 'sessions').map((column) => column.name);
+  const isLegacySchema = !columnNames.includes('custom_name_source');
+  addColumnToTableIfNotExists(db, 'sessions', columnNames, 'custom_name_source', 'TEXT');
+  if (isLegacySchema) {
+    db.exec(`
+      UPDATE sessions
+      SET custom_name_source = 'manual'
+      WHERE custom_name IS NOT NULL AND trim(custom_name) <> ''
+    `);
+  }
+};
+
 const ensureProjectsForSessionPaths = (db: Database): void => {
   if (!tableExists(db, 'sessions')) {
     return;
@@ -514,6 +544,7 @@ export const runMigrations = (db: Database) => {
 
     migrateLegacyWorkspaceTableIntoProjects(db);
     rebuildSessionsTableWithProjectSchema(db);
+    addSessionCustomNameSource(db);
     migrateLegacySessionNames(db);
     addProviderSessionIdMapping(db);
     addSessionModelColumn(db);

--- a/server/modules/database/repositories/sessions.db.ts
+++ b/server/modules/database/repositories/sessions.db.ts
@@ -9,6 +9,7 @@ type SessionRow = {
   project_path: string | null;
   jsonl_path: string | null;
   custom_name: string | null;
+  custom_name_source: string | null;
   /** Model this session runs with; NULL until the app records one for it. */
   model: string | null;
   isArchived: number;
@@ -17,7 +18,7 @@ type SessionRow = {
 };
 
 const SESSION_ROW_COLUMNS =
-  'session_id, provider, provider_session_id, project_path, jsonl_path, custom_name, model, isArchived, created_at, updated_at';
+  'session_id, provider, provider_session_id, project_path, jsonl_path, custom_name, custom_name_source, model, isArchived, created_at, updated_at';
 
 const SQLITE_UTC_TIMESTAMP_REGEX = /^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/;
 
@@ -103,13 +104,22 @@ export const sessionsDb = {
            project_path = ?,
            jsonl_path = ?,
            isArchived = 0,
-           custom_name = COALESCE(?, custom_name)
+           custom_name = CASE
+             WHEN custom_name_source = 'manual' THEN custom_name
+             ELSE COALESCE(?, custom_name)
+           END,
+           custom_name_source = CASE
+             WHEN custom_name_source = 'manual' THEN custom_name_source
+             WHEN ? IS NOT NULL THEN 'provider'
+             ELSE custom_name_source
+           END
          WHERE session_id = ?`
       ).run(
         provider,
         updatedAtValue,
         normalizedProjectPath,
         jsonlPath ?? null,
+        customName ?? null,
         customName ?? null,
         existing.session_id
       );
@@ -121,8 +131,8 @@ export const sessionsDb = {
     // keyed by the provider-native id for both columns. The ON CONFLICT path
     // covers legacy rows that predate the provider_session_id mapping.
     db.prepare(
-      `INSERT INTO sessions (session_id, provider, provider_session_id, custom_name, project_path, jsonl_path, isArchived, created_at, updated_at)
-       VALUES (?, ?, ?, ?, ?, ?, 0, COALESCE(?, CURRENT_TIMESTAMP), COALESCE(?, CURRENT_TIMESTAMP))
+      `INSERT INTO sessions (session_id, provider, provider_session_id, custom_name, custom_name_source, project_path, jsonl_path, isArchived, created_at, updated_at)
+       VALUES (?, ?, ?, ?, CASE WHEN ? IS NULL THEN NULL ELSE 'provider' END, ?, ?, 0, COALESCE(?, CURRENT_TIMESTAMP), COALESCE(?, CURRENT_TIMESTAMP))
        ON CONFLICT(session_id) DO UPDATE SET
          provider = excluded.provider,
          provider_session_id = excluded.provider_session_id,
@@ -130,11 +140,19 @@ export const sessionsDb = {
          project_path = excluded.project_path,
          jsonl_path = excluded.jsonl_path,
          isArchived = 0,
-         custom_name = COALESCE(excluded.custom_name, sessions.custom_name)`
+         custom_name = CASE
+           WHEN sessions.custom_name_source = 'manual' THEN sessions.custom_name
+           ELSE COALESCE(excluded.custom_name, sessions.custom_name)
+         END,
+         custom_name_source = CASE
+           WHEN sessions.custom_name_source = 'manual' THEN sessions.custom_name_source
+           ELSE COALESCE(excluded.custom_name_source, sessions.custom_name_source)
+         END`
     ).run(
       providerSessionId,
       provider,
       providerSessionId,
+      customName ?? null,
       customName ?? null,
       normalizedProjectPath,
       jsonlPath ?? null,
@@ -160,8 +178,8 @@ export const sessionsDb = {
     projectsDb.createProjectPath(normalizedProjectPath);
 
     db.prepare(
-      `INSERT INTO sessions (session_id, provider, provider_session_id, custom_name, project_path, jsonl_path, isArchived, created_at, updated_at)
-       VALUES (?, ?, NULL, NULL, ?, NULL, 0, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)`
+      `INSERT INTO sessions (session_id, provider, provider_session_id, custom_name, custom_name_source, project_path, jsonl_path, isArchived, created_at, updated_at)
+       VALUES (?, ?, NULL, NULL, NULL, ?, NULL, 0, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)`
     ).run(sessionId, provider, normalizedProjectPath);
 
     return sessionId;
@@ -195,10 +213,28 @@ export const sessionsDb = {
           `UPDATE sessions SET
              provider_session_id = ?,
              jsonl_path = COALESCE(jsonl_path, ?),
-             custom_name = COALESCE(custom_name, ?),
+             custom_name = CASE
+               WHEN custom_name_source = 'manual' THEN custom_name
+               WHEN ? = 'manual' THEN ?
+               ELSE COALESCE(custom_name, ?)
+             END,
+             custom_name_source = CASE
+               WHEN custom_name_source = 'manual' THEN custom_name_source
+               WHEN ? = 'manual' THEN 'manual'
+               ELSE COALESCE(custom_name_source, ?)
+             END,
              updated_at = CURRENT_TIMESTAMP
            WHERE session_id = ?`
-        ).run(providerSessionId, duplicate.jsonl_path, duplicate.custom_name, sessionId);
+        ).run(
+          providerSessionId,
+          duplicate.jsonl_path,
+          duplicate.custom_name_source,
+          duplicate.custom_name,
+          duplicate.custom_name,
+          duplicate.custom_name_source,
+          duplicate.custom_name_source,
+          sessionId
+        );
         return;
       }
 
@@ -233,8 +269,17 @@ export const sessionsDb = {
     const db = getConnection();
     db.prepare(
       `UPDATE sessions
-       SET custom_name = ?
+       SET custom_name = ?, custom_name_source = 'manual'
        WHERE session_id = ?`
+    ).run(customName, sessionId);
+  },
+
+  updateSessionProviderName(sessionId: string, customName: string): void {
+    const db = getConnection();
+    db.prepare(
+      `UPDATE sessions
+       SET custom_name = ?, custom_name_source = 'provider'
+       WHERE session_id = ? AND COALESCE(custom_name_source, 'provider') <> 'manual'`
     ).run(customName, sessionId);
   },
 
@@ -321,6 +366,19 @@ export const sessionsDb = {
          WHERE isArchived = 0`
       )
       .all() as SessionRow[];
+
+    return normalizeSessionRows(rows);
+  },
+
+  getSessionsByProvider(provider: string): SessionRow[] {
+    const db = getConnection();
+    const rows = db
+      .prepare(
+        `SELECT ${SESSION_ROW_COLUMNS}
+         FROM sessions
+         WHERE provider = ?`
+      )
+      .all(provider) as SessionRow[];
 
     return normalizeSessionRows(rows);
   },

--- a/server/modules/database/repositories/sessions.db.ts
+++ b/server/modules/database/repositories/sessions.db.ts
@@ -9,6 +9,7 @@ type SessionRow = {
   project_path: string | null;
   jsonl_path: string | null;
   custom_name: string | null;
+  custom_name_source: string | null;
   /** Model this session runs with; NULL until the app records one for it. */
   model: string | null;
   /** Reasoning effort this session runs with; NULL until the app records one. */
@@ -26,7 +27,7 @@ type RecentSessionsPage = {
 };
 
 const SESSION_ROW_COLUMNS =
-  'session_id, provider, provider_session_id, project_path, jsonl_path, custom_name, model, effort, forked_from_session_id, isArchived, created_at, updated_at';
+  'session_id, provider, provider_session_id, project_path, jsonl_path, custom_name, custom_name_source, model, effort, forked_from_session_id, isArchived, created_at, updated_at';
 
 const SQLITE_UTC_TIMESTAMP_REGEX = /^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/;
 
@@ -115,8 +116,15 @@ export const sessionsDb = {
            jsonl_path = ?,
            isArchived = 0,
            custom_name = CASE
+             WHEN custom_name_source = 'manual' THEN custom_name
              WHEN session_id <> provider_session_id AND custom_name IS NOT NULL THEN custom_name
              ELSE COALESCE(?, custom_name)
+           END,
+           custom_name_source = CASE
+             WHEN custom_name_source = 'manual' THEN custom_name_source
+             WHEN session_id <> provider_session_id AND custom_name IS NOT NULL THEN custom_name_source
+             WHEN ? IS NOT NULL THEN 'provider'
+             ELSE custom_name_source
            END
          WHERE session_id = ?`
       ).run(
@@ -124,6 +132,7 @@ export const sessionsDb = {
         updatedAtValue,
         normalizedProjectPath,
         jsonlPath ?? null,
+        customName ?? null,
         customName ?? null,
         existing.session_id
       );
@@ -135,8 +144,8 @@ export const sessionsDb = {
     // keyed by the provider-native id for both columns. The ON CONFLICT path
     // covers legacy rows that predate the provider_session_id mapping.
     db.prepare(
-      `INSERT INTO sessions (session_id, provider, provider_session_id, custom_name, project_path, jsonl_path, isArchived, created_at, updated_at)
-       VALUES (?, ?, ?, ?, ?, ?, 0, COALESCE(?, CURRENT_TIMESTAMP), COALESCE(?, CURRENT_TIMESTAMP))
+      `INSERT INTO sessions (session_id, provider, provider_session_id, custom_name, custom_name_source, project_path, jsonl_path, isArchived, created_at, updated_at)
+       VALUES (?, ?, ?, ?, CASE WHEN ? IS NULL THEN NULL ELSE 'provider' END, ?, ?, 0, COALESCE(?, CURRENT_TIMESTAMP), COALESCE(?, CURRENT_TIMESTAMP))
        ON CONFLICT(session_id) DO UPDATE SET
          provider = excluded.provider,
          provider_session_id = excluded.provider_session_id,
@@ -145,14 +154,22 @@ export const sessionsDb = {
          jsonl_path = excluded.jsonl_path,
          isArchived = 0,
          custom_name = CASE
+           WHEN sessions.custom_name_source = 'manual' THEN sessions.custom_name
            WHEN sessions.session_id <> sessions.provider_session_id AND sessions.custom_name IS NOT NULL
              THEN sessions.custom_name
            ELSE COALESCE(excluded.custom_name, sessions.custom_name)
+         END,
+         custom_name_source = CASE
+           WHEN sessions.custom_name_source = 'manual' THEN sessions.custom_name_source
+           WHEN sessions.session_id <> sessions.provider_session_id AND sessions.custom_name IS NOT NULL
+             THEN sessions.custom_name_source
+           ELSE COALESCE(excluded.custom_name_source, sessions.custom_name_source)
          END`
     ).run(
       providerSessionId,
       provider,
       providerSessionId,
+      customName ?? null,
       customName ?? null,
       normalizedProjectPath,
       jsonlPath ?? null,
@@ -268,10 +285,28 @@ export const sessionsDb = {
           `UPDATE sessions SET
              provider_session_id = ?,
              jsonl_path = COALESCE(jsonl_path, ?),
-             custom_name = COALESCE(custom_name, ?),
+             custom_name = CASE
+               WHEN custom_name_source = 'manual' THEN custom_name
+               WHEN ? = 'manual' THEN ?
+               ELSE COALESCE(custom_name, ?)
+             END,
+             custom_name_source = CASE
+               WHEN custom_name_source = 'manual' THEN custom_name_source
+               WHEN ? = 'manual' THEN 'manual'
+               ELSE COALESCE(custom_name_source, ?)
+             END,
              updated_at = CURRENT_TIMESTAMP
            WHERE session_id = ?`
-        ).run(providerSessionId, duplicate.jsonl_path, duplicate.custom_name, sessionId);
+        ).run(
+          providerSessionId,
+          duplicate.jsonl_path,
+          duplicate.custom_name_source,
+          duplicate.custom_name,
+          duplicate.custom_name,
+          duplicate.custom_name_source,
+          duplicate.custom_name_source,
+          sessionId
+        );
         return;
       }
 
@@ -440,8 +475,17 @@ export const sessionsDb = {
     const db = getConnection();
     db.prepare(
       `UPDATE sessions
-       SET custom_name = ?
+       SET custom_name = ?, custom_name_source = 'manual'
        WHERE session_id = ?`
+    ).run(customName, sessionId);
+  },
+
+  updateSessionProviderName(sessionId: string, customName: string): void {
+    const db = getConnection();
+    db.prepare(
+      `UPDATE sessions
+       SET custom_name = ?, custom_name_source = 'provider'
+       WHERE session_id = ? AND COALESCE(custom_name_source, 'provider') <> 'manual'`
     ).run(customName, sessionId);
   },
 
@@ -528,6 +572,19 @@ export const sessionsDb = {
          WHERE isArchived = 0`
       )
       .all() as SessionRow[];
+
+    return normalizeSessionRows(rows);
+  },
+
+  getSessionsByProvider(provider: string): SessionRow[] {
+    const db = getConnection();
+    const rows = db
+      .prepare(
+        `SELECT ${SESSION_ROW_COLUMNS}
+         FROM sessions
+         WHERE provider = ?`
+      )
+      .all(provider) as SessionRow[];
 
     return normalizeSessionRows(rows);
   },

--- a/server/modules/database/repositories/sessions.db.ts
+++ b/server/modules/database/repositories/sessions.db.ts
@@ -117,12 +117,10 @@ export const sessionsDb = {
            isArchived = 0,
            custom_name = CASE
              WHEN custom_name_source = 'manual' THEN custom_name
-             WHEN session_id <> provider_session_id AND custom_name IS NOT NULL THEN custom_name
              ELSE COALESCE(?, custom_name)
            END,
            custom_name_source = CASE
              WHEN custom_name_source = 'manual' THEN custom_name_source
-             WHEN session_id <> provider_session_id AND custom_name IS NOT NULL THEN custom_name_source
              WHEN ? IS NOT NULL THEN 'provider'
              ELSE custom_name_source
            END
@@ -155,14 +153,10 @@ export const sessionsDb = {
          isArchived = 0,
          custom_name = CASE
            WHEN sessions.custom_name_source = 'manual' THEN sessions.custom_name
-           WHEN sessions.session_id <> sessions.provider_session_id AND sessions.custom_name IS NOT NULL
-             THEN sessions.custom_name
            ELSE COALESCE(excluded.custom_name, sessions.custom_name)
          END,
          custom_name_source = CASE
            WHEN sessions.custom_name_source = 'manual' THEN sessions.custom_name_source
-           WHEN sessions.session_id <> sessions.provider_session_id AND sessions.custom_name IS NOT NULL
-             THEN sessions.custom_name_source
            ELSE COALESCE(excluded.custom_name_source, sessions.custom_name_source)
          END`
     ).run(
@@ -187,7 +181,9 @@ export const sessionsDb = {
    * `session_id` is the stable app-facing id, while `provider_session_id`
    * stays NULL until the provider runtime announces its own id and
    * `assignProviderSessionId` records the mapping. `customName` is derived
-   * from the first visible CloudCLI message by the sessions service.
+   * from the first visible CloudCLI message by the sessions service; when
+   * present, it is treated as an app-owned name so provider indexing cannot
+   * replace it.
    */
   createAppSession(
     sessionId: string,
@@ -201,9 +197,9 @@ export const sessionsDb = {
     projectsDb.createProjectPath(normalizedProjectPath);
 
     db.prepare(
-      `INSERT INTO sessions (session_id, provider, provider_session_id, custom_name, project_path, jsonl_path, isArchived, created_at, updated_at)
-       VALUES (?, ?, NULL, ?, ?, NULL, 0, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)`
-    ).run(sessionId, provider, customName ?? null, normalizedProjectPath);
+      `INSERT INTO sessions (session_id, provider, provider_session_id, custom_name, custom_name_source, project_path, jsonl_path, isArchived, created_at, updated_at)
+       VALUES (?, ?, NULL, ?, CASE WHEN NULLIF(trim(?), '') IS NULL THEN NULL ELSE 'manual' END, ?, NULL, 0, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)`
+    ).run(sessionId, provider, customName ?? null, customName ?? null, normalizedProjectPath);
 
     return sessionId;
   },

--- a/server/modules/database/schema.ts
+++ b/server/modules/database/schema.ts
@@ -107,6 +107,7 @@ CREATE TABLE IF NOT EXISTS sessions (
     -- id mid-run, or equals \`session_id\` for sessions discovered on disk.
     provider_session_id TEXT,
     custom_name TEXT,
+    custom_name_source TEXT,
     project_path TEXT,
     jsonl_path TEXT,
     -- Model this session runs with. Written when the user picks a model for the

--- a/server/modules/database/schema.ts
+++ b/server/modules/database/schema.ts
@@ -131,6 +131,7 @@ CREATE TABLE IF NOT EXISTS sessions (
     -- id mid-run, or equals \`session_id\` for sessions discovered on disk.
     provider_session_id TEXT,
     custom_name TEXT,
+    custom_name_source TEXT,
     project_path TEXT,
     jsonl_path TEXT,
     -- Model and reasoning effort this session runs with. Written when the user

--- a/server/modules/database/tests/sessions-provider-mapping.test.ts
+++ b/server/modules/database/tests/sessions-provider-mapping.test.ts
@@ -98,6 +98,21 @@ test('assignProviderSessionId merges a watcher-created duplicate into the app ro
   });
 });
 
+test('assignProviderSessionId preserves a duplicate manual name over a provider name', async () => {
+  await withIsolatedDatabase(() => {
+    sessionsDb.createAppSession('app-id-3', 'codex', '/workspace/demo');
+    sessionsDb.updateSessionProviderName('app-id-3', 'Provider title');
+    sessionsDb.createSession('provider-manual-race', 'codex', '/workspace/demo', 'Provider duplicate name');
+    sessionsDb.updateSessionCustomName('provider-manual-race', 'Manual duplicate name');
+
+    sessionsDb.assignProviderSessionId('app-id-3', 'provider-manual-race');
+
+    const row = sessionsDb.getSessionById('app-id-3');
+    assert.equal(row?.custom_name, 'Manual duplicate name');
+    assert.equal(row?.custom_name_source, 'manual');
+  });
+});
+
 test('legacy provider-keyed rows stay resolvable through both lookups', async () => {
   await withIsolatedDatabase(() => {
     sessionsDb.createSession('legacy-1', 'opencode', '/workspace/demo');

--- a/server/modules/database/tests/sessions-provider-mapping.test.ts
+++ b/server/modules/database/tests/sessions-provider-mapping.test.ts
@@ -99,6 +99,21 @@ test('assignProviderSessionId merges a watcher-created duplicate into the app ro
   });
 });
 
+test('assignProviderSessionId preserves a duplicate manual name over a provider name', async () => {
+  await withIsolatedDatabase(() => {
+    sessionsDb.createAppSession('app-id-3', 'codex', '/workspace/demo');
+    sessionsDb.updateSessionProviderName('app-id-3', 'Provider title');
+    sessionsDb.createSession('provider-manual-race', 'codex', '/workspace/demo', 'Provider duplicate name');
+    sessionsDb.updateSessionCustomName('provider-manual-race', 'Manual duplicate name');
+
+    sessionsDb.assignProviderSessionId('app-id-3', 'provider-manual-race');
+
+    const row = sessionsDb.getSessionById('app-id-3');
+    assert.equal(row?.custom_name, 'Manual duplicate name');
+    assert.equal(row?.custom_name_source, 'manual');
+  });
+});
+
 test('legacy provider-keyed rows stay resolvable through both lookups', async () => {
   await withIsolatedDatabase(() => {
     sessionsDb.createSession('legacy-1', 'opencode', '/workspace/demo');

--- a/server/modules/database/tests/sessions.db.integration.test.ts
+++ b/server/modules/database/tests/sessions.db.integration.test.ts
@@ -4,17 +4,23 @@ import { tmpdir } from 'node:os';
 import path from 'node:path';
 import test from 'node:test';
 
+import Database from 'better-sqlite3';
+
 import { closeConnection } from '@/modules/database/connection.js';
 import { initializeDatabase } from '@/modules/database/init-db.js';
 import { sessionsDb } from '@/modules/database/repositories/sessions.db.js';
 
-async function withIsolatedDatabase(runTest: () => void | Promise<void>): Promise<void> {
+async function withIsolatedDatabase(
+  runTest: () => void | Promise<void>,
+  prepareDatabase?: (databasePath: string) => void,
+): Promise<void> {
   const previousDatabasePath = process.env.DATABASE_PATH;
   const tempDirectory = await mkdtemp(path.join(tmpdir(), 'sessions-db-'));
   const databasePath = path.join(tempDirectory, 'auth.db');
 
   closeConnection();
   process.env.DATABASE_PATH = databasePath;
+  prepareDatabase?.(databasePath);
   await initializeDatabase();
 
   try {
@@ -29,6 +35,93 @@ async function withIsolatedDatabase(runTest: () => void | Promise<void>): Promis
     await rm(tempDirectory, { recursive: true, force: true });
   }
 }
+
+test('migration preserves legacy session names as manual overrides', async () => {
+  await withIsolatedDatabase(() => {
+    const migrated = sessionsDb.getSessionById('legacy-manual');
+    assert.equal(migrated?.custom_name_source, 'manual');
+
+    sessionsDb.updateSessionProviderName('legacy-manual', 'Codex title');
+    assert.equal(sessionsDb.getSessionById('legacy-manual')?.custom_name, 'My existing name');
+  }, (databasePath) => {
+    const db = new Database(databasePath);
+    db.exec(`
+      CREATE TABLE sessions (
+        session_id TEXT PRIMARY KEY,
+        provider TEXT NOT NULL,
+        custom_name TEXT,
+        project_path TEXT,
+        jsonl_path TEXT,
+        isArchived BOOLEAN DEFAULT 0,
+        created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+        updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+      );
+      INSERT INTO sessions (session_id, provider, custom_name)
+      VALUES ('legacy-manual', 'codex', 'My existing name');
+    `);
+    db.close();
+  });
+});
+
+test('session_names migration preserves custom names as manual overrides', async () => {
+  await withIsolatedDatabase(() => {
+    const migrated = sessionsDb.getSessionById('legacy-session-name');
+    assert.equal(migrated?.custom_name_source, 'manual');
+
+    sessionsDb.updateSessionProviderName('legacy-session-name', 'Provider title');
+    assert.equal(sessionsDb.getSessionById('legacy-session-name')?.custom_name, 'Legacy custom name');
+  }, (databasePath) => {
+    const db = new Database(databasePath);
+    db.exec(`
+      CREATE TABLE session_names (
+        session_id TEXT PRIMARY KEY,
+        provider TEXT,
+        custom_name TEXT,
+        created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+        updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+      );
+      INSERT INTO session_names (session_id, provider, custom_name)
+      VALUES ('legacy-session-name', 'codex', 'Legacy custom name');
+    `);
+    db.close();
+  });
+});
+
+test('session_names migration treats blank names as absent during conflict merge', async () => {
+  await withIsolatedDatabase(() => {
+    const migrated = sessionsDb.getSessionById('existing-provider-name');
+    assert.equal(migrated?.custom_name, 'Existing provider name');
+    assert.equal(migrated?.custom_name_source, 'provider');
+  }, (databasePath) => {
+    const db = new Database(databasePath);
+    db.exec(`
+      CREATE TABLE sessions (
+        session_id TEXT PRIMARY KEY,
+        provider TEXT NOT NULL,
+        provider_session_id TEXT,
+        custom_name TEXT,
+        custom_name_source TEXT,
+        project_path TEXT,
+        jsonl_path TEXT,
+        isArchived BOOLEAN DEFAULT 0,
+        created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+        updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+      );
+      INSERT INTO sessions (session_id, provider, provider_session_id, custom_name, custom_name_source)
+      VALUES ('existing-provider-name', 'codex', 'codex-existing-provider-name', 'Existing provider name', 'provider');
+      CREATE TABLE session_names (
+        session_id TEXT PRIMARY KEY,
+        provider TEXT,
+        custom_name TEXT,
+        created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+        updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+      );
+      INSERT INTO session_names (session_id, provider, custom_name)
+      VALUES ('existing-provider-name', 'codex', '   ');
+    `);
+    db.close();
+  });
+});
 
 test('session archive queries hide archived rows from active project views', async () => {
   await withIsolatedDatabase(() => {

--- a/server/modules/database/tests/sessions.db.integration.test.ts
+++ b/server/modules/database/tests/sessions.db.integration.test.ts
@@ -4,18 +4,24 @@ import { tmpdir } from 'node:os';
 import path from 'node:path';
 import test from 'node:test';
 
+import Database from 'better-sqlite3';
+
 import { closeConnection } from '@/modules/database/connection.js';
 import { initializeDatabase } from '@/modules/database/init-db.js';
 import { projectsDb } from '@/modules/database/repositories/projects.db.js';
 import { sessionsDb } from '@/modules/database/repositories/sessions.db.js';
 
-async function withIsolatedDatabase(runTest: () => void | Promise<void>): Promise<void> {
+async function withIsolatedDatabase(
+  runTest: () => void | Promise<void>,
+  prepareDatabase?: (databasePath: string) => void,
+): Promise<void> {
   const previousDatabasePath = process.env.DATABASE_PATH;
   const tempDirectory = await mkdtemp(path.join(tmpdir(), 'sessions-db-'));
   const databasePath = path.join(tempDirectory, 'auth.db');
 
   closeConnection();
   process.env.DATABASE_PATH = databasePath;
+  prepareDatabase?.(databasePath);
   await initializeDatabase();
 
   try {
@@ -30,6 +36,93 @@ async function withIsolatedDatabase(runTest: () => void | Promise<void>): Promis
     await rm(tempDirectory, { recursive: true, force: true });
   }
 }
+
+test('migration preserves legacy session names as manual overrides', async () => {
+  await withIsolatedDatabase(() => {
+    const migrated = sessionsDb.getSessionById('legacy-manual');
+    assert.equal(migrated?.custom_name_source, 'manual');
+
+    sessionsDb.updateSessionProviderName('legacy-manual', 'Codex title');
+    assert.equal(sessionsDb.getSessionById('legacy-manual')?.custom_name, 'My existing name');
+  }, (databasePath) => {
+    const db = new Database(databasePath);
+    db.exec(`
+      CREATE TABLE sessions (
+        session_id TEXT PRIMARY KEY,
+        provider TEXT NOT NULL,
+        custom_name TEXT,
+        project_path TEXT,
+        jsonl_path TEXT,
+        isArchived BOOLEAN DEFAULT 0,
+        created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+        updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+      );
+      INSERT INTO sessions (session_id, provider, custom_name)
+      VALUES ('legacy-manual', 'codex', 'My existing name');
+    `);
+    db.close();
+  });
+});
+
+test('session_names migration preserves custom names as manual overrides', async () => {
+  await withIsolatedDatabase(() => {
+    const migrated = sessionsDb.getSessionById('legacy-session-name');
+    assert.equal(migrated?.custom_name_source, 'manual');
+
+    sessionsDb.updateSessionProviderName('legacy-session-name', 'Provider title');
+    assert.equal(sessionsDb.getSessionById('legacy-session-name')?.custom_name, 'Legacy custom name');
+  }, (databasePath) => {
+    const db = new Database(databasePath);
+    db.exec(`
+      CREATE TABLE session_names (
+        session_id TEXT PRIMARY KEY,
+        provider TEXT,
+        custom_name TEXT,
+        created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+        updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+      );
+      INSERT INTO session_names (session_id, provider, custom_name)
+      VALUES ('legacy-session-name', 'codex', 'Legacy custom name');
+    `);
+    db.close();
+  });
+});
+
+test('session_names migration treats blank names as absent during conflict merge', async () => {
+  await withIsolatedDatabase(() => {
+    const migrated = sessionsDb.getSessionById('existing-provider-name');
+    assert.equal(migrated?.custom_name, 'Existing provider name');
+    assert.equal(migrated?.custom_name_source, 'provider');
+  }, (databasePath) => {
+    const db = new Database(databasePath);
+    db.exec(`
+      CREATE TABLE sessions (
+        session_id TEXT PRIMARY KEY,
+        provider TEXT NOT NULL,
+        provider_session_id TEXT,
+        custom_name TEXT,
+        custom_name_source TEXT,
+        project_path TEXT,
+        jsonl_path TEXT,
+        isArchived BOOLEAN DEFAULT 0,
+        created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+        updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+      );
+      INSERT INTO sessions (session_id, provider, provider_session_id, custom_name, custom_name_source)
+      VALUES ('existing-provider-name', 'codex', 'codex-existing-provider-name', 'Existing provider name', 'provider');
+      CREATE TABLE session_names (
+        session_id TEXT PRIMARY KEY,
+        provider TEXT,
+        custom_name TEXT,
+        created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+        updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+      );
+      INSERT INTO session_names (session_id, provider, custom_name)
+      VALUES ('existing-provider-name', 'codex', '   ');
+    `);
+    db.close();
+  });
+});
 
 test('session archive queries hide archived rows from active project views', async () => {
   await withIsolatedDatabase(() => {

--- a/server/modules/providers/README.md
+++ b/server/modules/providers/README.md
@@ -205,7 +205,7 @@ Current session sync roots are:
 | Provider | Scan Roots | Metadata Helpers / Notes |
 | --- | --- | --- |
 | Claude | `~/.claude/projects/**/*.jsonl` | Uses `~/.claude/history.jsonl` for name lookup and the trailing `ai-title`, `last-prompt`, or `custom-title` entries for title recovery. |
-| Codex | `~/.codex/sessions/**/*.jsonl` | Uses `~/.codex/session_index.jsonl` for title lookup and the last `task_complete` message for a fallback title. |
+| Codex | `~/.codex/sessions/**/*.jsonl` | Preserves CloudCLI manual names first, then prefers the latest `~/.codex/session_index.jsonl` name over the title from the latest `~/.codex/state_*.sqlite`; app-created sessions use the first user message and other sessions use the last `task_complete` message as fallback. |
 | Cursor | `~/.cursor/projects/**/*.jsonl` | Uses sibling `worker.log` to recover `workspacePath`, then derives the session title from the first user prompt. |
 | OpenCode | `~/.local/share/opencode/opencode.db` | Reads active sessions/messages/parts from OpenCode's shared SQLite database and stores `jsonl_path` as `null` so deleting one app session cannot remove the shared DB. |
 
@@ -376,5 +376,4 @@ alongside the implementation.
 - Forgetting that Claude plugin skills are discovered differently from normal
   user/project skill folders.
 - Assuming one provider's MCP config file format works for the others.
-
 

--- a/server/modules/providers/list/codex/codex-session-synchronizer.provider.ts
+++ b/server/modules/providers/list/codex/codex-session-synchronizer.provider.ts
@@ -1,16 +1,22 @@
+import { createReadStream } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import { readFile } from 'node:fs/promises';
+import { readFile, readdir, stat } from 'node:fs/promises';
+import readline from 'node:readline';
+
+import Database from 'better-sqlite3';
 
 import { sessionsDb } from '@/modules/database/index.js';
 import {
-  buildLookupMap,
   extractFirstValidJsonlData,
   findFilesRecursivelyCreatedAfter,
   normalizeSessionName,
   readFileTimestamps,
 } from '@/shared/utils.js';
-import type { IProviderSessionSynchronizer } from '@/shared/interfaces.js';
+import type {
+  IProviderSessionSynchronizer,
+  SessionSynchronizeOptions,
+} from '@/shared/interfaces.js';
 
 type ParsedSession = {
   sessionId: string;
@@ -24,12 +30,27 @@ type ParsedSession = {
 export class CodexSessionSynchronizer implements IProviderSessionSynchronizer {
   private readonly provider = 'codex' as const;
   private readonly codexHome = path.join(os.homedir(), '.codex');
+  private indexedNameCache: { mtimeMs: number; names: Map<string, string> } | null = null;
+  private synchronizationQueue: Promise<void> = Promise.resolve();
 
   /**
    * Scans ~/.codex/sessions and upserts discovered sessions into DB.
    */
-  async synchronize(since?: Date): Promise<number> {
-    const nameMap = await buildLookupMap(path.join(this.codexHome, 'session_index.jsonl'), 'id', 'thread_name');
+  async synchronize(
+    since?: Date,
+    options: SessionSynchronizeOptions = {},
+  ): Promise<number> {
+    return this.enqueueSynchronization(() => this.synchronizeInternal(since, options));
+  }
+
+  private async synchronizeInternal(
+    since?: Date,
+    options: SessionSynchronizeOptions = {},
+  ): Promise<number> {
+    const nameMap = options.initializing
+      ? await this.buildSessionNameMap()
+      : await this.readIndexedNameMap();
+    this.updateProviderSessionNames(nameMap);
     const files = await findFilesRecursivelyCreatedAfter(
       path.join(this.codexHome, 'sessions'),
       '.jsonl',
@@ -48,7 +69,7 @@ export class CodexSessionSynchronizer implements IProviderSessionSynchronizer {
       if (existingSession) {
         // If session name is untitled and we now have a name, update it
         if (existingSession.custom_name === 'Untitled Codex Session' && parsed.sessionName && parsed.sessionName !== 'Untitled Codex Session') {
-          sessionsDb.updateSessionCustomName(existingSession.session_id, parsed.sessionName);
+          sessionsDb.updateSessionProviderName(existingSession.session_id, parsed.sessionName);
         }
       }
 
@@ -72,11 +93,15 @@ export class CodexSessionSynchronizer implements IProviderSessionSynchronizer {
    * Parses and upserts one Codex session JSONL file.
    */
   async synchronizeFile(filePath: string): Promise<string | null> {
+    return this.enqueueSynchronization(() => this.synchronizeFileInternal(filePath));
+  }
+
+  private async synchronizeFileInternal(filePath: string): Promise<string | null> {
     if (!filePath.endsWith('.jsonl')) {
       return null;
     }
 
-    const nameMap = await buildLookupMap(path.join(this.codexHome, 'session_index.jsonl'), 'id', 'thread_name');
+    const nameMap = await this.readIndexedNameMap();
     const parsed = await this.processSessionFile(filePath, nameMap);
     if (!parsed) {
       return null;
@@ -92,6 +117,127 @@ export class CodexSessionSynchronizer implements IProviderSessionSynchronizer {
       timestamps.updatedAt,
       filePath
     );
+  }
+
+  private enqueueSynchronization<T>(operation: () => Promise<T>): Promise<T> {
+    const previous = this.synchronizationQueue;
+    let release!: () => void;
+    this.synchronizationQueue = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+
+    return previous.then(operation).finally(release);
+  }
+
+  private async buildSessionNameMap(): Promise<Map<string, string>> {
+    const nameMap = await this.readStateTitleMap();
+    const indexedNames = await this.readIndexedNameMap();
+    for (const [sessionId, name] of indexedNames) {
+      if (name.trim()) {
+        nameMap.set(sessionId, name);
+      }
+    }
+    return nameMap;
+  }
+
+  private async readIndexedNameMap(): Promise<Map<string, string>> {
+    const indexPath = path.join(this.codexHome, 'session_index.jsonl');
+    const mtimeMs = await this.readIndexedNameMtime();
+    if (mtimeMs === null) {
+      return new Map();
+    }
+
+    if (this.indexedNameCache?.mtimeMs === mtimeMs) {
+      return this.indexedNameCache.names;
+    }
+
+    const names = await this.loadIndexedNameMap(indexPath);
+    this.indexedNameCache = { mtimeMs, names };
+    return names;
+  }
+
+  private async readIndexedNameMtime(): Promise<number | null> {
+    try {
+      return (await stat(path.join(this.codexHome, 'session_index.jsonl'))).mtimeMs;
+    } catch {
+      return null;
+    }
+  }
+
+  private async loadIndexedNameMap(indexPath: string): Promise<Map<string, string>> {
+    const names = new Map<string, string>();
+    try {
+      const lines = readline.createInterface({
+        input: createReadStream(indexPath),
+        crlfDelay: Infinity,
+      });
+      for await (const line of lines) {
+        try {
+          const entry = JSON.parse(line) as Record<string, unknown>;
+          if (typeof entry.id === 'string' && typeof entry.thread_name === 'string') {
+            names.set(entry.id, entry.thread_name);
+          }
+        } catch {
+          // A malformed entry must not hide newer names later in the append-only index.
+        }
+      }
+    } catch {
+      // The index is optional; state titles and transcript fallbacks remain available.
+    }
+    return names;
+  }
+
+  private updateProviderSessionNames(nameMap: Map<string, string>): void {
+    const sessions = sessionsDb.getSessionsByProvider(this.provider);
+    const sessionsByLookupId = new Map<string, (typeof sessions)[number]>();
+    for (const session of sessions) {
+      if (session.provider_session_id) {
+        sessionsByLookupId.set(session.provider_session_id, session);
+      }
+    }
+    for (const session of sessions) {
+      if (!sessionsByLookupId.has(session.session_id)) {
+        sessionsByLookupId.set(session.session_id, session);
+      }
+    }
+
+    for (const [providerSessionId, name] of nameMap) {
+      const existingSession = sessionsByLookupId.get(providerSessionId);
+      if (!existingSession) {
+        continue;
+      }
+
+      const normalizedName = normalizeSessionName(name, 'Untitled Codex Session');
+      if (normalizedName !== existingSession.custom_name) {
+        sessionsDb.updateSessionProviderName(existingSession.session_id, normalizedName);
+      }
+    }
+  }
+
+  private async readStateTitleMap(): Promise<Map<string, string>> {
+    try {
+      const stateFile = (await readdir(this.codexHome))
+        .map((fileName) => ({ fileName, match: /^state_(\d+)\.sqlite$/.exec(fileName) }))
+        .filter((entry): entry is { fileName: string; match: RegExpExecArray } => entry.match !== null)
+        .sort((a, b) => Number(b.match[1]) - Number(a.match[1]))[0]?.fileName;
+      if (!stateFile) {
+        return new Map();
+      }
+
+      const db = new Database(path.join(this.codexHome, stateFile), {
+        readonly: true,
+        fileMustExist: true,
+      });
+      try {
+        const rows = db.prepare('SELECT id, title FROM threads WHERE trim(title) <> \'\'')
+          .all() as Array<{ id: string; title: string }>;
+        return new Map(rows.map((row) => [row.id, row.title]));
+      } finally {
+        db.close();
+      }
+    } catch {
+      return new Map();
+    }
   }
 
   /**
@@ -126,6 +272,21 @@ export class CodexSessionSynchronizer implements IProviderSessionSynchronizer {
     // ids must be resolved through the provider-id mapping first.
     const existingSession = sessionsDb.getSessionByProviderSessionId(parsed.sessionId)
       ?? sessionsDb.getSessionById(parsed.sessionId);
+    if (existingSession?.custom_name_source === 'manual' && existingSession.custom_name?.trim()) {
+      return {
+        ...parsed,
+        sessionName: normalizeSessionName(existingSession.custom_name, 'Untitled Codex Session'),
+      };
+    }
+
+    const indexedSessionName = nameMap.get(parsed.sessionId);
+    if (indexedSessionName?.trim()) {
+      return {
+        ...parsed,
+        sessionName: normalizeSessionName(indexedSessionName, 'Untitled Codex Session'),
+      };
+    }
+
     const existingSessionName = existingSession?.custom_name;
     if (existingSessionName && existingSessionName !== 'Untitled Codex Session') {
       return {
@@ -135,11 +296,8 @@ export class CodexSessionSynchronizer implements IProviderSessionSynchronizer {
     }
 
     // Sessions started by sending a message from cloudcli carry a distinct
-    // app-allocated session_id mapped to the provider id. For these we title the
-    // conversation from the first user message the user typed, instead of the
-    // generic "Untitled Codex Session" placeholder. Sessions discovered purely
-    // by indexing (session_id === provider_session_id) keep the existing
-    // thread_name/last-agent-message setup below.
+    // app-allocated session_id mapped to the provider id. When Codex has not
+    // assigned a thread name yet, use the first user message as the fallback.
     const isAppCreated =
       existingSession != null &&
       existingSession.provider_session_id != null &&
@@ -148,9 +306,6 @@ export class CodexSessionSynchronizer implements IProviderSessionSynchronizer {
     let sessionName = isAppCreated
       ? await this.extractFirstUserMessageFromStart(filePath)
       : undefined;
-    if (!sessionName) {
-      sessionName = nameMap.get(parsed.sessionId);
-    }
     if (!sessionName) {
       sessionName = await this.extractLastAgentMessageFromEnd(filePath);
     }

--- a/server/modules/providers/list/codex/codex-session-synchronizer.provider.ts
+++ b/server/modules/providers/list/codex/codex-session-synchronizer.provider.ts
@@ -1,16 +1,22 @@
+import { createReadStream } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import { readFile } from 'node:fs/promises';
+import { readFile, readdir, stat } from 'node:fs/promises';
+import readline from 'node:readline';
+
+import Database from 'better-sqlite3';
 
 import { sessionsDb } from '@/modules/database/index.js';
 import {
-  buildLookupMap,
   extractFirstValidJsonlData,
   findFilesRecursivelyCreatedAfter,
   normalizeSessionName,
   readFileTimestamps,
 } from '@/shared/utils.js';
-import type { IProviderSessionSynchronizer } from '@/shared/interfaces.js';
+import type {
+  IProviderSessionSynchronizer,
+  SessionSynchronizeOptions,
+} from '@/shared/interfaces.js';
 
 type ParsedSession = {
   sessionId: string;
@@ -24,12 +30,27 @@ type ParsedSession = {
 export class CodexSessionSynchronizer implements IProviderSessionSynchronizer {
   private readonly provider = 'codex' as const;
   private readonly codexHome = path.join(os.homedir(), '.codex');
+  private indexedNameCache: { mtimeMs: number; names: Map<string, string> } | null = null;
+  private synchronizationQueue: Promise<void> = Promise.resolve();
 
   /**
    * Scans ~/.codex/sessions and upserts discovered sessions into DB.
    */
-  async synchronize(since?: Date): Promise<number> {
-    const nameMap = await buildLookupMap(path.join(this.codexHome, 'session_index.jsonl'), 'id', 'thread_name');
+  async synchronize(
+    since?: Date,
+    options: SessionSynchronizeOptions = {},
+  ): Promise<number> {
+    return this.enqueueSynchronization(() => this.synchronizeInternal(since, options));
+  }
+
+  private async synchronizeInternal(
+    since?: Date,
+    options: SessionSynchronizeOptions = {},
+  ): Promise<number> {
+    const nameMap = options.initializing
+      ? await this.buildSessionNameMap()
+      : await this.readIndexedNameMap();
+    this.updateProviderSessionNames(nameMap);
     const files = await findFilesRecursivelyCreatedAfter(
       path.join(this.codexHome, 'sessions'),
       '.jsonl',
@@ -48,7 +69,7 @@ export class CodexSessionSynchronizer implements IProviderSessionSynchronizer {
       if (existingSession) {
         // If session name is untitled and we now have a name, update it
         if (existingSession.custom_name === 'Untitled Codex Session' && parsed.sessionName && parsed.sessionName !== 'Untitled Codex Session') {
-          sessionsDb.updateSessionCustomName(existingSession.session_id, parsed.sessionName);
+          sessionsDb.updateSessionProviderName(existingSession.session_id, parsed.sessionName);
         }
       }
 
@@ -72,11 +93,15 @@ export class CodexSessionSynchronizer implements IProviderSessionSynchronizer {
    * Parses and upserts one Codex session JSONL file.
    */
   async synchronizeFile(filePath: string): Promise<string | null> {
+    return this.enqueueSynchronization(() => this.synchronizeFileInternal(filePath));
+  }
+
+  private async synchronizeFileInternal(filePath: string): Promise<string | null> {
     if (!filePath.endsWith('.jsonl')) {
       return null;
     }
 
-    const nameMap = await buildLookupMap(path.join(this.codexHome, 'session_index.jsonl'), 'id', 'thread_name');
+    const nameMap = await this.readIndexedNameMap();
     const parsed = await this.processSessionFile(filePath, nameMap);
     if (!parsed) {
       return null;
@@ -92,6 +117,127 @@ export class CodexSessionSynchronizer implements IProviderSessionSynchronizer {
       timestamps.updatedAt,
       filePath
     );
+  }
+
+  private enqueueSynchronization<T>(operation: () => Promise<T>): Promise<T> {
+    const previous = this.synchronizationQueue;
+    let release!: () => void;
+    this.synchronizationQueue = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+
+    return previous.then(operation).finally(release);
+  }
+
+  private async buildSessionNameMap(): Promise<Map<string, string>> {
+    const nameMap = await this.readStateTitleMap();
+    const indexedNames = await this.readIndexedNameMap();
+    for (const [sessionId, name] of indexedNames) {
+      if (name.trim()) {
+        nameMap.set(sessionId, name);
+      }
+    }
+    return nameMap;
+  }
+
+  private async readIndexedNameMap(): Promise<Map<string, string>> {
+    const indexPath = path.join(this.codexHome, 'session_index.jsonl');
+    const mtimeMs = await this.readIndexedNameMtime();
+    if (mtimeMs === null) {
+      return new Map();
+    }
+
+    if (this.indexedNameCache?.mtimeMs === mtimeMs) {
+      return this.indexedNameCache.names;
+    }
+
+    const names = await this.loadIndexedNameMap(indexPath);
+    this.indexedNameCache = { mtimeMs, names };
+    return names;
+  }
+
+  private async readIndexedNameMtime(): Promise<number | null> {
+    try {
+      return (await stat(path.join(this.codexHome, 'session_index.jsonl'))).mtimeMs;
+    } catch {
+      return null;
+    }
+  }
+
+  private async loadIndexedNameMap(indexPath: string): Promise<Map<string, string>> {
+    const names = new Map<string, string>();
+    try {
+      const lines = readline.createInterface({
+        input: createReadStream(indexPath),
+        crlfDelay: Infinity,
+      });
+      for await (const line of lines) {
+        try {
+          const entry = JSON.parse(line) as Record<string, unknown>;
+          if (typeof entry.id === 'string' && typeof entry.thread_name === 'string') {
+            names.set(entry.id, entry.thread_name);
+          }
+        } catch {
+          // A malformed entry must not hide newer names later in the append-only index.
+        }
+      }
+    } catch {
+      // The index is optional; state titles and transcript fallbacks remain available.
+    }
+    return names;
+  }
+
+  private updateProviderSessionNames(nameMap: Map<string, string>): void {
+    const sessions = sessionsDb.getSessionsByProvider(this.provider);
+    const sessionsByLookupId = new Map<string, (typeof sessions)[number]>();
+    for (const session of sessions) {
+      if (session.provider_session_id) {
+        sessionsByLookupId.set(session.provider_session_id, session);
+      }
+    }
+    for (const session of sessions) {
+      if (!sessionsByLookupId.has(session.session_id)) {
+        sessionsByLookupId.set(session.session_id, session);
+      }
+    }
+
+    for (const [providerSessionId, name] of nameMap) {
+      const existingSession = sessionsByLookupId.get(providerSessionId);
+      if (!existingSession) {
+        continue;
+      }
+
+      const normalizedName = normalizeSessionName(name, 'Untitled Codex Session');
+      if (normalizedName !== existingSession.custom_name) {
+        sessionsDb.updateSessionProviderName(existingSession.session_id, normalizedName);
+      }
+    }
+  }
+
+  private async readStateTitleMap(): Promise<Map<string, string>> {
+    try {
+      const stateFile = (await readdir(this.codexHome))
+        .map((fileName) => ({ fileName, match: /^state_(\d+)\.sqlite$/.exec(fileName) }))
+        .filter((entry): entry is { fileName: string; match: RegExpExecArray } => entry.match !== null)
+        .sort((a, b) => Number(b.match[1]) - Number(a.match[1]))[0]?.fileName;
+      if (!stateFile) {
+        return new Map();
+      }
+
+      const db = new Database(path.join(this.codexHome, stateFile), {
+        readonly: true,
+        fileMustExist: true,
+      });
+      try {
+        const rows = db.prepare('SELECT id, title FROM threads WHERE trim(title) <> \'\'')
+          .all() as Array<{ id: string; title: string }>;
+        return new Map(rows.map((row) => [row.id, row.title]));
+      } finally {
+        db.close();
+      }
+    } catch {
+      return new Map();
+    }
   }
 
   /**
@@ -135,6 +281,21 @@ export class CodexSessionSynchronizer implements IProviderSessionSynchronizer {
     // ids must be resolved through the provider-id mapping first.
     const existingSession = sessionsDb.getSessionByProviderSessionId(parsed.sessionId)
       ?? sessionsDb.getSessionById(parsed.sessionId);
+    if (existingSession?.custom_name_source === 'manual' && existingSession.custom_name?.trim()) {
+      return {
+        ...parsed,
+        sessionName: normalizeSessionName(existingSession.custom_name, 'Untitled Codex Session'),
+      };
+    }
+
+    const indexedSessionName = nameMap.get(parsed.sessionId);
+    if (indexedSessionName?.trim()) {
+      return {
+        ...parsed,
+        sessionName: normalizeSessionName(indexedSessionName, 'Untitled Codex Session'),
+      };
+    }
+
     const existingSessionName = existingSession?.custom_name;
     if (existingSessionName && existingSessionName !== 'Untitled Codex Session') {
       return {
@@ -143,7 +304,17 @@ export class CodexSessionSynchronizer implements IProviderSessionSynchronizer {
       };
     }
 
-    let sessionName = nameMap.get(parsed.sessionId);
+    // Sessions started by sending a message from cloudcli carry a distinct
+    // app-allocated session_id mapped to the provider id. When Codex has not
+    // assigned a thread name yet, use the first user message as the fallback.
+    const isAppCreated =
+      existingSession != null &&
+      existingSession.provider_session_id != null &&
+      existingSession.session_id !== existingSession.provider_session_id;
+
+    let sessionName = isAppCreated
+      ? await this.extractFirstUserMessageFromStart(filePath)
+      : undefined;
     if (!sessionName) {
       sessionName = await this.extractLastAgentMessageFromEnd(filePath);
     }

--- a/server/modules/providers/list/codex/codex-session-synchronizer.provider.ts
+++ b/server/modules/providers/list/codex/codex-session-synchronizer.provider.ts
@@ -203,7 +203,7 @@ export class CodexSessionSynchronizer implements IProviderSessionSynchronizer {
 
     for (const [providerSessionId, name] of nameMap) {
       const existingSession = sessionsByLookupId.get(providerSessionId);
-      if (!existingSession) {
+      if (!existingSession || !name.trim()) {
         continue;
       }
 
@@ -342,6 +342,49 @@ export class CodexSessionSynchronizer implements IProviderSessionSynchronizer {
 
     const source = payload.source;
     return typeof source === 'object' && source !== null && 'subagent' in source;
+  }
+
+  /**
+   * Returns the first user message text in a Codex transcript, used to title
+   * app-created sessions from the prompt the user sent from cloudcli.
+   *
+   * Reads the `event_msg`/`user_message` payload rather than the raw
+   * `response_item` user turn so injected `<environment_context>` boilerplate
+   * is never mistaken for the user's prompt.
+   */
+  private async extractFirstUserMessageFromStart(filePath: string): Promise<string | undefined> {
+    try {
+      const content = await readFile(filePath, 'utf8');
+      const lines = content.split(/\r?\n/);
+
+      for (const rawLine of lines) {
+        const line = rawLine.trim();
+        if (!line) {
+          continue;
+        }
+
+        let parsed: unknown;
+        try {
+          parsed = JSON.parse(line);
+        } catch {
+          continue;
+        }
+
+        const data = parsed as Record<string, unknown>;
+        const eventType = typeof data.type === 'string' ? data.type : undefined;
+        const payload = data.payload as Record<string, unknown> | undefined;
+        const payloadType = typeof payload?.type === 'string' ? payload.type : undefined;
+        const message = typeof payload?.message === 'string' ? payload.message : undefined;
+
+        if (eventType === 'event_msg' && payloadType === 'user_message' && message?.trim()) {
+          return message;
+        }
+      }
+    } catch {
+      // Ignore missing/unreadable files so sync can continue.
+    }
+
+    return undefined;
   }
 
   private async extractLastAgentMessageFromEnd(filePath: string): Promise<string | undefined> {

--- a/server/modules/providers/services/session-synchronizer.service.ts
+++ b/server/modules/providers/services/session-synchronizer.service.ts
@@ -1,5 +1,6 @@
 import { scanStateDb } from '@/modules/database/index.js';
 import { providerRegistry } from '@/modules/providers/provider.registry.js';
+import type { SessionSynchronizeOptions } from '@/shared/interfaces.js';
 import type { LLMProvider } from '@/shared/types.js';
 
 type SessionSynchronizeResult = {
@@ -14,7 +15,7 @@ export const sessionSynchronizerService = {
   /**
    * Runs all provider synchronizers and updates scan_state.last_scanned_at.
    */
-  async synchronizeSessions(): Promise<SessionSynchronizeResult> {
+  async synchronizeSessions(options: SessionSynchronizeOptions = {}): Promise<SessionSynchronizeResult> {
     const lastScanAt = scanStateDb.getLastScannedAt();
     const scanBoundary = new Date();
     const processedByProvider: Record<LLMProvider, number> = {
@@ -28,7 +29,7 @@ export const sessionSynchronizerService = {
     const results = await Promise.allSettled(
       providerRegistry.listProviders().map(async (provider) => ({
         provider: provider.id,
-        processed: await provider.sessionSynchronizer.synchronize(lastScanAt ?? undefined),
+        processed: await provider.sessionSynchronizer.synchronize(lastScanAt ?? undefined, options),
       }))
     );
 

--- a/server/modules/providers/services/session-synchronizer.service.ts
+++ b/server/modules/providers/services/session-synchronizer.service.ts
@@ -3,6 +3,7 @@ import { access } from 'node:fs/promises';
 
 import { scanStateDb, sessionsDb } from '@/modules/database/index.js';
 import { providerRegistry } from '@/modules/providers/provider.registry.js';
+import type { SessionSynchronizeOptions } from '@/shared/interfaces.js';
 import type { LLMProvider } from '@/shared/types.js';
 
 type SessionSynchronizeResult = {
@@ -76,7 +77,7 @@ let inFlightSynchronization: Promise<SessionSynchronizeResult> | null = null;
 /**
  * Runs all provider synchronizers and updates scan_state.last_scanned_at.
  */
-async function runSessionSynchronization(): Promise<SessionSynchronizeResult> {
+async function runSessionSynchronization(options: SessionSynchronizeOptions = {}): Promise<SessionSynchronizeResult> {
   const lastScanAt = scanStateDb.getLastScannedAt();
   const scanBoundary = new Date();
   const processedByProvider: Record<LLMProvider, number> = {
@@ -90,7 +91,7 @@ async function runSessionSynchronization(): Promise<SessionSynchronizeResult> {
   const results = await Promise.allSettled(
     providerRegistry.listProviders().map(async (provider) => ({
       provider: provider.id,
-      processed: await provider.sessionSynchronizer.synchronize(lastScanAt ?? undefined),
+      processed: await provider.sessionSynchronizer.synchronize(lastScanAt ?? undefined, options),
     }))
   );
 
@@ -131,12 +132,12 @@ export const sessionSynchronizerService = {
    * Scans every provider for new or changed sessions, coalescing concurrent
    * callers onto a single scan.
    */
-  async synchronizeSessions(): Promise<SessionSynchronizeResult> {
+  async synchronizeSessions(options: SessionSynchronizeOptions = {}): Promise<SessionSynchronizeResult> {
     if (inFlightSynchronization) {
       return inFlightSynchronization;
     }
 
-    inFlightSynchronization = runSessionSynchronization().finally(() => {
+    inFlightSynchronization = runSessionSynchronization(options).finally(() => {
       inFlightSynchronization = null;
     });
 

--- a/server/modules/providers/services/sessions-watcher.service.ts
+++ b/server/modules/providers/services/sessions-watcher.service.ts
@@ -259,7 +259,7 @@ async function onUpdate(
 export async function initializeSessionsWatcher(): Promise<void> {
   console.log('Setting up session watchers');
 
-  const initialSync = await sessionSynchronizerService.synchronizeSessions();
+  const initialSync = await sessionSynchronizerService.synchronizeSessions({ initializing: true });
   console.log('Initial session synchronization complete', {
     processedByProvider: initialSync.processedByProvider,
     failures: initialSync.failures,

--- a/server/modules/providers/services/sessions-watcher.service.ts
+++ b/server/modules/providers/services/sessions-watcher.service.ts
@@ -197,7 +197,7 @@ async function onUpdate(
 export async function initializeSessionsWatcher(): Promise<void> {
   console.log('Setting up session watchers');
 
-  const initialSync = await sessionSynchronizerService.synchronizeSessions();
+  const initialSync = await sessionSynchronizerService.synchronizeSessions({ initializing: true });
   console.log('Initial session synchronization complete', {
     processedByProvider: initialSync.processedByProvider,
     prunedOrphans: initialSync.prunedOrphans,

--- a/server/modules/providers/tests/codex-sessions.test.ts
+++ b/server/modules/providers/tests/codex-sessions.test.ts
@@ -1,8 +1,10 @@
 import assert from 'node:assert/strict';
-import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, rm, utimes, writeFile } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 import test from 'node:test';
+
+import Database from 'better-sqlite3';
 
 import { closeConnection, initializeDatabase, sessionsDb } from '@/modules/database/index.js';
 import { CodexSessionSynchronizer } from '@/modules/providers/list/codex/codex-session-synchronizer.provider.js';
@@ -64,10 +66,16 @@ const writeCodexTranscript = async (
   return filePath;
 };
 
-test('Codex synchronizer titles app-created sessions from the first user message', { concurrency: false }, async () => {
+test('Codex synchronizer titles app-created sessions from the first user message when the indexed title is blank', { concurrency: false }, async () => {
   const tempRoot = await mkdtemp(path.join(os.tmpdir(), 'codex-session-sync-app-'));
   const workspacePath = path.join(tempRoot, 'workspace');
   await mkdir(workspacePath, { recursive: true });
+  await mkdir(path.join(tempRoot, '.codex'), { recursive: true });
+  await writeFile(
+    path.join(tempRoot, '.codex', 'session_index.jsonl'),
+    `${JSON.stringify({ id: 'codex-app-1', thread_name: '   ' })}\n`,
+    'utf8'
+  );
   const restoreHomeDir = patchHomeDir(tempRoot);
 
   try {
@@ -82,6 +90,323 @@ test('Codex synchronizer titles app-created sessions from the first user message
       await synchronizer.synchronize();
 
       assert.equal(sessionsDb.getSessionById('app-1')?.custom_name, 'Fix the login redirect bug');
+    });
+  } finally {
+    restoreHomeDir();
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test('Codex synchronizer replaces an app-created fallback with the indexed thread name', { concurrency: false }, async () => {
+  const tempRoot = await mkdtemp(path.join(os.tmpdir(), 'codex-session-sync-title-'));
+  const workspacePath = path.join(tempRoot, 'workspace');
+  await mkdir(workspacePath, { recursive: true });
+  await mkdir(path.join(tempRoot, '.codex'), { recursive: true });
+  await writeFile(
+    path.join(tempRoot, '.codex', 'session_index.jsonl'),
+    `${JSON.stringify({ id: 'codex-app-titled', thread_name: '   ' })}\n`,
+    'utf8'
+  );
+  const restoreHomeDir = patchHomeDir(tempRoot);
+
+  try {
+    const transcriptPath = await writeCodexTranscript(
+      tempRoot,
+      'codex-app-titled',
+      workspacePath,
+      'First prompt fallback',
+    );
+    await withIsolatedDatabase(async () => {
+      sessionsDb.createAppSession('app-titled', 'codex', workspacePath);
+      sessionsDb.assignProviderSessionId('app-titled', 'codex-app-titled');
+
+      const synchronizer = new CodexSessionSynchronizer();
+      await synchronizer.synchronize();
+      assert.equal(sessionsDb.getSessionById('app-titled')?.custom_name, 'First prompt fallback');
+
+      await writeFile(
+        path.join(tempRoot, '.codex', 'session_index.jsonl'),
+        `${JSON.stringify({ id: 'codex-app-titled', thread_name: 'Old title' })}\n${JSON.stringify({ id: 'codex-app-titled', thread_name: 'Fix login redirect' })}\n`,
+        'utf8'
+      );
+      await synchronizer.synchronizeFile(transcriptPath);
+
+      assert.equal(sessionsDb.getSessionById('app-titled')?.custom_name, 'Fix login redirect');
+    });
+  } finally {
+    restoreHomeDir();
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test('Codex file synchronization does not persist a stale index title after a newer sync', { concurrency: false }, async () => {
+  const tempRoot = await mkdtemp(path.join(os.tmpdir(), 'codex-session-sync-index-race-'));
+  const workspacePath = path.join(tempRoot, 'workspace');
+  const indexPath = path.join(tempRoot, '.codex', 'session_index.jsonl');
+  await mkdir(workspacePath, { recursive: true });
+  await mkdir(path.dirname(indexPath), { recursive: true });
+  await writeFile(indexPath, '{}\n', 'utf8');
+  const restoreHomeDir = patchHomeDir(tempRoot);
+
+  try {
+    const transcriptPath = await writeCodexTranscript(
+      tempRoot,
+      'codex-index-race',
+      workspacePath,
+      'First prompt fallback',
+    );
+    await withIsolatedDatabase(async () => {
+      let loadCount = 0;
+      let markFirstLoadStarted!: () => void;
+      let releaseFirstLoad!: () => void;
+      const firstLoadStarted = new Promise<void>((resolve) => {
+        markFirstLoadStarted = resolve;
+      });
+      const firstLoadRelease = new Promise<void>((resolve) => {
+        releaseFirstLoad = resolve;
+      });
+
+      const synchronizer = new CodexSessionSynchronizer();
+      (synchronizer as any).loadIndexedNameMap = async () => {
+        loadCount += 1;
+        if (loadCount === 1) {
+          markFirstLoadStarted();
+          await firstLoadRelease;
+          return new Map([['codex-index-race', 'Old indexed title']]);
+        }
+        return new Map([['codex-index-race', 'New indexed title']]);
+      };
+
+      const firstSync = synchronizer.synchronizeFile(transcriptPath);
+      await firstLoadStarted;
+
+      await writeFile(indexPath, '{"updated":true}\n', 'utf8');
+      const nextMtime = new Date(Date.now() + 60_000);
+      await utimes(indexPath, nextMtime, nextMtime);
+      const secondSync = synchronizer.synchronizeFile(transcriptPath);
+
+      releaseFirstLoad();
+      await Promise.all([firstSync, secondSync]);
+
+      assert.equal(loadCount, 2);
+      assert.equal(
+        sessionsDb.getSessionById('codex-index-race')?.custom_name,
+        'New indexed title',
+      );
+    });
+  } finally {
+    restoreHomeDir();
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test('Codex full synchronization serializes with a watcher update', { concurrency: false }, async () => {
+  const tempRoot = await mkdtemp(path.join(os.tmpdir(), 'codex-session-sync-full-race-'));
+  const workspacePath = path.join(tempRoot, 'workspace');
+  const indexPath = path.join(tempRoot, '.codex', 'session_index.jsonl');
+  await mkdir(workspacePath, { recursive: true });
+  await mkdir(path.dirname(indexPath), { recursive: true });
+  await writeFile(
+    indexPath,
+    `${JSON.stringify({ id: 'codex-full-race', thread_name: 'Old indexed title' })}\n`,
+    'utf8',
+  );
+  const restoreHomeDir = patchHomeDir(tempRoot);
+
+  try {
+    const transcriptPath = await writeCodexTranscript(
+      tempRoot,
+      'codex-full-race',
+      workspacePath,
+      'First prompt fallback',
+    );
+    await withIsolatedDatabase(async () => {
+      let markOldSessionParsed!: () => void;
+      let releaseFullSync!: () => void;
+      const oldSessionParsed = new Promise<void>((resolve) => {
+        markOldSessionParsed = resolve;
+      });
+      const fullSyncRelease = new Promise<void>((resolve) => {
+        releaseFullSync = resolve;
+      });
+
+      const synchronizer = new CodexSessionSynchronizer();
+      const originalProcessSessionFile = (synchronizer as any).processSessionFile;
+      (synchronizer as any).processSessionFile = async (filePath: string, nameMap: Map<string, string>) => {
+        const parsed = await originalProcessSessionFile.call(synchronizer, filePath, nameMap);
+        if (nameMap.get('codex-full-race') === 'Old indexed title') {
+          markOldSessionParsed();
+          await fullSyncRelease;
+        }
+        return parsed;
+      };
+
+      const fullSync = synchronizer.synchronize();
+      await oldSessionParsed;
+
+      await writeFile(
+        indexPath,
+        `${JSON.stringify({ id: 'codex-full-race', thread_name: 'New indexed title' })}\n`,
+        'utf8',
+      );
+      const nextMtime = new Date(Date.now() + 60_000);
+      await utimes(indexPath, nextMtime, nextMtime);
+
+      const watcherSync = synchronizer.synchronizeFile(transcriptPath);
+      releaseFullSync();
+      await Promise.all([fullSync, watcherSync]);
+      assert.equal(
+        sessionsDb.getSessionById('codex-full-race')?.custom_name,
+        'New indexed title',
+      );
+    });
+  } finally {
+    restoreHomeDir();
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test('Codex synchronizer preserves a CloudCLI manual name over a Codex title', { concurrency: false }, async () => {
+  const tempRoot = await mkdtemp(path.join(os.tmpdir(), 'codex-session-sync-manual-title-'));
+  const workspacePath = path.join(tempRoot, 'workspace');
+  await mkdir(workspacePath, { recursive: true });
+  await mkdir(path.join(tempRoot, '.codex'), { recursive: true });
+  await writeFile(
+    path.join(tempRoot, '.codex', 'session_index.jsonl'),
+    `${JSON.stringify({ id: 'codex-manual-title', thread_name: 'Codex title' })}\n`,
+    'utf8'
+  );
+  const restoreHomeDir = patchHomeDir(tempRoot);
+
+  try {
+    await writeCodexTranscript(tempRoot, 'codex-manual-title', workspacePath, 'First prompt fallback');
+    await withIsolatedDatabase(async () => {
+      sessionsDb.createAppSession('app-manual-title', 'codex', workspacePath);
+      sessionsDb.assignProviderSessionId('app-manual-title', 'codex-manual-title');
+      sessionsDb.updateSessionCustomName('app-manual-title', 'My CloudCLI name');
+
+      await new CodexSessionSynchronizer().synchronize();
+
+      assert.equal(sessionsDb.getSessionById('app-manual-title')?.custom_name, 'My CloudCLI name');
+    });
+  } finally {
+    restoreHomeDir();
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test('Codex synchronizer replaces a fallback with the Codex state database title', { concurrency: false }, async () => {
+  const tempRoot = await mkdtemp(path.join(os.tmpdir(), 'codex-session-sync-state-title-'));
+  const workspacePath = path.join(tempRoot, 'workspace');
+  await mkdir(workspacePath, { recursive: true });
+  const restoreHomeDir = patchHomeDir(tempRoot);
+
+  try {
+    await writeCodexTranscript(tempRoot, 'codex-state-titled', workspacePath, 'First prompt fallback');
+    await withIsolatedDatabase(async () => {
+      const synchronizer = new CodexSessionSynchronizer();
+      await synchronizer.synchronize();
+      assert.equal(sessionsDb.getSessionById('codex-state-titled')?.custom_name, 'Untitled Codex Session');
+      sessionsDb.updateSessionIsArchived('codex-state-titled', true);
+
+      const stateDb = new Database(path.join(tempRoot, '.codex', 'state_5.sqlite'));
+      stateDb.exec('CREATE TABLE threads (id TEXT PRIMARY KEY, title TEXT NOT NULL)');
+      stateDb.prepare('INSERT INTO threads (id, title) VALUES (?, ?)')
+        .run('codex-state-titled', 'Fix login redirect');
+      stateDb.close();
+
+      await synchronizer.synchronize(
+        new Date(Date.now() + 60_000),
+        { initializing: true },
+      );
+      assert.equal(sessionsDb.getSessionById('codex-state-titled')?.custom_name, 'Fix login redirect');
+      assert.equal(sessionsDb.getSessionById('codex-state-titled')?.isArchived, 1);
+    });
+  } finally {
+    restoreHomeDir();
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test('Codex file synchronization does not reload the full state title database', { concurrency: false }, async () => {
+  const tempRoot = await mkdtemp(path.join(os.tmpdir(), 'codex-session-file-sync-state-title-'));
+  const workspacePath = path.join(tempRoot, 'workspace');
+  await mkdir(workspacePath, { recursive: true });
+  const restoreHomeDir = patchHomeDir(tempRoot);
+
+  try {
+    const transcriptPath = await writeCodexTranscript(
+      tempRoot,
+      'codex-state-file-sync',
+      workspacePath,
+      'First prompt fallback',
+    );
+    await withIsolatedDatabase(async () => {
+      const stateDb = new Database(path.join(tempRoot, '.codex', 'state_5.sqlite'));
+      stateDb.exec('CREATE TABLE threads (id TEXT PRIMARY KEY, title TEXT NOT NULL)');
+      stateDb.prepare('INSERT INTO threads (id, title) VALUES (?, ?)')
+        .run('codex-state-file-sync', 'Initial state title');
+
+      const synchronizer = new CodexSessionSynchronizer();
+      await synchronizer.synchronize(undefined, { initializing: true });
+      assert.equal(
+        sessionsDb.getSessionById('codex-state-file-sync')?.custom_name,
+        'Initial state title',
+      );
+
+      stateDb.prepare('UPDATE threads SET title = ? WHERE id = ?')
+        .run('Changed state title', 'codex-state-file-sync');
+      stateDb.close();
+
+      await synchronizer.synchronizeFile(transcriptPath);
+
+      assert.equal(
+        sessionsDb.getSessionById('codex-state-file-sync')?.custom_name,
+        'Initial state title',
+      );
+    });
+  } finally {
+    restoreHomeDir();
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test('Codex full synchronization does not reload state titles after initialization', { concurrency: false }, async () => {
+  const tempRoot = await mkdtemp(path.join(os.tmpdir(), 'codex-session-full-sync-state-title-'));
+  const workspacePath = path.join(tempRoot, 'workspace');
+  await mkdir(workspacePath, { recursive: true });
+  const restoreHomeDir = patchHomeDir(tempRoot);
+
+  try {
+    await writeCodexTranscript(
+      tempRoot,
+      'codex-state-full-sync',
+      workspacePath,
+      'First prompt fallback',
+    );
+    await withIsolatedDatabase(async () => {
+      const stateDb = new Database(path.join(tempRoot, '.codex', 'state_5.sqlite'));
+      stateDb.exec('CREATE TABLE threads (id TEXT PRIMARY KEY, title TEXT NOT NULL)');
+      stateDb.prepare('INSERT INTO threads (id, title) VALUES (?, ?)')
+        .run('codex-state-full-sync', 'Initial state title');
+
+      const synchronizer = new CodexSessionSynchronizer();
+      await synchronizer.synchronize(undefined, { initializing: true });
+      assert.equal(
+        sessionsDb.getSessionById('codex-state-full-sync')?.custom_name,
+        'Initial state title',
+      );
+
+      stateDb.prepare('UPDATE threads SET title = ? WHERE id = ?')
+        .run('Changed state title', 'codex-state-full-sync');
+      stateDb.close();
+
+      await synchronizer.synchronize();
+
+      assert.equal(
+        sessionsDb.getSessionById('codex-state-full-sync')?.custom_name,
+        'Initial state title',
+      );
     });
   } finally {
     restoreHomeDir();

--- a/server/modules/providers/tests/codex-sessions.test.ts
+++ b/server/modules/providers/tests/codex-sessions.test.ts
@@ -1,8 +1,10 @@
 import assert from 'node:assert/strict';
-import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, rm, utimes, writeFile } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 import test from 'node:test';
+
+import Database from 'better-sqlite3';
 
 import { closeConnection, initializeDatabase, sessionsDb } from '@/modules/database/index.js';
 import { CodexSessionSynchronizer } from '@/modules/providers/list/codex/codex-session-synchronizer.provider.js';
@@ -68,6 +70,12 @@ test('Codex synchronizer preserves the title assigned when CloudCLI creates a se
   const tempRoot = await mkdtemp(path.join(os.tmpdir(), 'codex-session-sync-app-'));
   const workspacePath = path.join(tempRoot, 'workspace');
   await mkdir(workspacePath, { recursive: true });
+  await mkdir(path.join(tempRoot, '.codex'), { recursive: true });
+  await writeFile(
+    path.join(tempRoot, '.codex', 'session_index.jsonl'),
+    `${JSON.stringify({ id: 'codex-app-1', thread_name: '   ' })}\n`,
+    'utf8'
+  );
   const restoreHomeDir = patchHomeDir(tempRoot);
 
   try {
@@ -82,6 +90,323 @@ test('Codex synchronizer preserves the title assigned when CloudCLI creates a se
       await synchronizer.synchronize();
 
       assert.equal(sessionsDb.getSessionById('app-1')?.custom_name, 'Fix the login redirect');
+    });
+  } finally {
+    restoreHomeDir();
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test('Codex synchronizer replaces an app-created fallback with the indexed thread name', { concurrency: false }, async () => {
+  const tempRoot = await mkdtemp(path.join(os.tmpdir(), 'codex-session-sync-title-'));
+  const workspacePath = path.join(tempRoot, 'workspace');
+  await mkdir(workspacePath, { recursive: true });
+  await mkdir(path.join(tempRoot, '.codex'), { recursive: true });
+  await writeFile(
+    path.join(tempRoot, '.codex', 'session_index.jsonl'),
+    `${JSON.stringify({ id: 'codex-app-titled', thread_name: '   ' })}\n`,
+    'utf8'
+  );
+  const restoreHomeDir = patchHomeDir(tempRoot);
+
+  try {
+    const transcriptPath = await writeCodexTranscript(
+      tempRoot,
+      'codex-app-titled',
+      workspacePath,
+      'First prompt fallback',
+    );
+    await withIsolatedDatabase(async () => {
+      sessionsDb.createAppSession('app-titled', 'codex', workspacePath);
+      sessionsDb.assignProviderSessionId('app-titled', 'codex-app-titled');
+
+      const synchronizer = new CodexSessionSynchronizer();
+      await synchronizer.synchronize();
+      assert.equal(sessionsDb.getSessionById('app-titled')?.custom_name, 'First prompt fallback');
+
+      await writeFile(
+        path.join(tempRoot, '.codex', 'session_index.jsonl'),
+        `${JSON.stringify({ id: 'codex-app-titled', thread_name: 'Old title' })}\n${JSON.stringify({ id: 'codex-app-titled', thread_name: 'Fix login redirect' })}\n`,
+        'utf8'
+      );
+      await synchronizer.synchronizeFile(transcriptPath);
+
+      assert.equal(sessionsDb.getSessionById('app-titled')?.custom_name, 'Fix login redirect');
+    });
+  } finally {
+    restoreHomeDir();
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test('Codex file synchronization does not persist a stale index title after a newer sync', { concurrency: false }, async () => {
+  const tempRoot = await mkdtemp(path.join(os.tmpdir(), 'codex-session-sync-index-race-'));
+  const workspacePath = path.join(tempRoot, 'workspace');
+  const indexPath = path.join(tempRoot, '.codex', 'session_index.jsonl');
+  await mkdir(workspacePath, { recursive: true });
+  await mkdir(path.dirname(indexPath), { recursive: true });
+  await writeFile(indexPath, '{}\n', 'utf8');
+  const restoreHomeDir = patchHomeDir(tempRoot);
+
+  try {
+    const transcriptPath = await writeCodexTranscript(
+      tempRoot,
+      'codex-index-race',
+      workspacePath,
+      'First prompt fallback',
+    );
+    await withIsolatedDatabase(async () => {
+      let loadCount = 0;
+      let markFirstLoadStarted!: () => void;
+      let releaseFirstLoad!: () => void;
+      const firstLoadStarted = new Promise<void>((resolve) => {
+        markFirstLoadStarted = resolve;
+      });
+      const firstLoadRelease = new Promise<void>((resolve) => {
+        releaseFirstLoad = resolve;
+      });
+
+      const synchronizer = new CodexSessionSynchronizer();
+      (synchronizer as any).loadIndexedNameMap = async () => {
+        loadCount += 1;
+        if (loadCount === 1) {
+          markFirstLoadStarted();
+          await firstLoadRelease;
+          return new Map([['codex-index-race', 'Old indexed title']]);
+        }
+        return new Map([['codex-index-race', 'New indexed title']]);
+      };
+
+      const firstSync = synchronizer.synchronizeFile(transcriptPath);
+      await firstLoadStarted;
+
+      await writeFile(indexPath, '{"updated":true}\n', 'utf8');
+      const nextMtime = new Date(Date.now() + 60_000);
+      await utimes(indexPath, nextMtime, nextMtime);
+      const secondSync = synchronizer.synchronizeFile(transcriptPath);
+
+      releaseFirstLoad();
+      await Promise.all([firstSync, secondSync]);
+
+      assert.equal(loadCount, 2);
+      assert.equal(
+        sessionsDb.getSessionById('codex-index-race')?.custom_name,
+        'New indexed title',
+      );
+    });
+  } finally {
+    restoreHomeDir();
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test('Codex full synchronization serializes with a watcher update', { concurrency: false }, async () => {
+  const tempRoot = await mkdtemp(path.join(os.tmpdir(), 'codex-session-sync-full-race-'));
+  const workspacePath = path.join(tempRoot, 'workspace');
+  const indexPath = path.join(tempRoot, '.codex', 'session_index.jsonl');
+  await mkdir(workspacePath, { recursive: true });
+  await mkdir(path.dirname(indexPath), { recursive: true });
+  await writeFile(
+    indexPath,
+    `${JSON.stringify({ id: 'codex-full-race', thread_name: 'Old indexed title' })}\n`,
+    'utf8',
+  );
+  const restoreHomeDir = patchHomeDir(tempRoot);
+
+  try {
+    const transcriptPath = await writeCodexTranscript(
+      tempRoot,
+      'codex-full-race',
+      workspacePath,
+      'First prompt fallback',
+    );
+    await withIsolatedDatabase(async () => {
+      let markOldSessionParsed!: () => void;
+      let releaseFullSync!: () => void;
+      const oldSessionParsed = new Promise<void>((resolve) => {
+        markOldSessionParsed = resolve;
+      });
+      const fullSyncRelease = new Promise<void>((resolve) => {
+        releaseFullSync = resolve;
+      });
+
+      const synchronizer = new CodexSessionSynchronizer();
+      const originalProcessSessionFile = (synchronizer as any).processSessionFile;
+      (synchronizer as any).processSessionFile = async (filePath: string, nameMap: Map<string, string>) => {
+        const parsed = await originalProcessSessionFile.call(synchronizer, filePath, nameMap);
+        if (nameMap.get('codex-full-race') === 'Old indexed title') {
+          markOldSessionParsed();
+          await fullSyncRelease;
+        }
+        return parsed;
+      };
+
+      const fullSync = synchronizer.synchronize();
+      await oldSessionParsed;
+
+      await writeFile(
+        indexPath,
+        `${JSON.stringify({ id: 'codex-full-race', thread_name: 'New indexed title' })}\n`,
+        'utf8',
+      );
+      const nextMtime = new Date(Date.now() + 60_000);
+      await utimes(indexPath, nextMtime, nextMtime);
+
+      const watcherSync = synchronizer.synchronizeFile(transcriptPath);
+      releaseFullSync();
+      await Promise.all([fullSync, watcherSync]);
+      assert.equal(
+        sessionsDb.getSessionById('codex-full-race')?.custom_name,
+        'New indexed title',
+      );
+    });
+  } finally {
+    restoreHomeDir();
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test('Codex synchronizer preserves a CloudCLI manual name over a Codex title', { concurrency: false }, async () => {
+  const tempRoot = await mkdtemp(path.join(os.tmpdir(), 'codex-session-sync-manual-title-'));
+  const workspacePath = path.join(tempRoot, 'workspace');
+  await mkdir(workspacePath, { recursive: true });
+  await mkdir(path.join(tempRoot, '.codex'), { recursive: true });
+  await writeFile(
+    path.join(tempRoot, '.codex', 'session_index.jsonl'),
+    `${JSON.stringify({ id: 'codex-manual-title', thread_name: 'Codex title' })}\n`,
+    'utf8'
+  );
+  const restoreHomeDir = patchHomeDir(tempRoot);
+
+  try {
+    await writeCodexTranscript(tempRoot, 'codex-manual-title', workspacePath, 'First prompt fallback');
+    await withIsolatedDatabase(async () => {
+      sessionsDb.createAppSession('app-manual-title', 'codex', workspacePath);
+      sessionsDb.assignProviderSessionId('app-manual-title', 'codex-manual-title');
+      sessionsDb.updateSessionCustomName('app-manual-title', 'My CloudCLI name');
+
+      await new CodexSessionSynchronizer().synchronize();
+
+      assert.equal(sessionsDb.getSessionById('app-manual-title')?.custom_name, 'My CloudCLI name');
+    });
+  } finally {
+    restoreHomeDir();
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test('Codex synchronizer replaces a fallback with the Codex state database title', { concurrency: false }, async () => {
+  const tempRoot = await mkdtemp(path.join(os.tmpdir(), 'codex-session-sync-state-title-'));
+  const workspacePath = path.join(tempRoot, 'workspace');
+  await mkdir(workspacePath, { recursive: true });
+  const restoreHomeDir = patchHomeDir(tempRoot);
+
+  try {
+    await writeCodexTranscript(tempRoot, 'codex-state-titled', workspacePath, 'First prompt fallback');
+    await withIsolatedDatabase(async () => {
+      const synchronizer = new CodexSessionSynchronizer();
+      await synchronizer.synchronize();
+      assert.equal(sessionsDb.getSessionById('codex-state-titled')?.custom_name, 'Untitled Codex Session');
+      sessionsDb.updateSessionIsArchived('codex-state-titled', true);
+
+      const stateDb = new Database(path.join(tempRoot, '.codex', 'state_5.sqlite'));
+      stateDb.exec('CREATE TABLE threads (id TEXT PRIMARY KEY, title TEXT NOT NULL)');
+      stateDb.prepare('INSERT INTO threads (id, title) VALUES (?, ?)')
+        .run('codex-state-titled', 'Fix login redirect');
+      stateDb.close();
+
+      await synchronizer.synchronize(
+        new Date(Date.now() + 60_000),
+        { initializing: true },
+      );
+      assert.equal(sessionsDb.getSessionById('codex-state-titled')?.custom_name, 'Fix login redirect');
+      assert.equal(sessionsDb.getSessionById('codex-state-titled')?.isArchived, 1);
+    });
+  } finally {
+    restoreHomeDir();
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test('Codex file synchronization does not reload the full state title database', { concurrency: false }, async () => {
+  const tempRoot = await mkdtemp(path.join(os.tmpdir(), 'codex-session-file-sync-state-title-'));
+  const workspacePath = path.join(tempRoot, 'workspace');
+  await mkdir(workspacePath, { recursive: true });
+  const restoreHomeDir = patchHomeDir(tempRoot);
+
+  try {
+    const transcriptPath = await writeCodexTranscript(
+      tempRoot,
+      'codex-state-file-sync',
+      workspacePath,
+      'First prompt fallback',
+    );
+    await withIsolatedDatabase(async () => {
+      const stateDb = new Database(path.join(tempRoot, '.codex', 'state_5.sqlite'));
+      stateDb.exec('CREATE TABLE threads (id TEXT PRIMARY KEY, title TEXT NOT NULL)');
+      stateDb.prepare('INSERT INTO threads (id, title) VALUES (?, ?)')
+        .run('codex-state-file-sync', 'Initial state title');
+
+      const synchronizer = new CodexSessionSynchronizer();
+      await synchronizer.synchronize(undefined, { initializing: true });
+      assert.equal(
+        sessionsDb.getSessionById('codex-state-file-sync')?.custom_name,
+        'Initial state title',
+      );
+
+      stateDb.prepare('UPDATE threads SET title = ? WHERE id = ?')
+        .run('Changed state title', 'codex-state-file-sync');
+      stateDb.close();
+
+      await synchronizer.synchronizeFile(transcriptPath);
+
+      assert.equal(
+        sessionsDb.getSessionById('codex-state-file-sync')?.custom_name,
+        'Initial state title',
+      );
+    });
+  } finally {
+    restoreHomeDir();
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test('Codex full synchronization does not reload state titles after initialization', { concurrency: false }, async () => {
+  const tempRoot = await mkdtemp(path.join(os.tmpdir(), 'codex-session-full-sync-state-title-'));
+  const workspacePath = path.join(tempRoot, 'workspace');
+  await mkdir(workspacePath, { recursive: true });
+  const restoreHomeDir = patchHomeDir(tempRoot);
+
+  try {
+    await writeCodexTranscript(
+      tempRoot,
+      'codex-state-full-sync',
+      workspacePath,
+      'First prompt fallback',
+    );
+    await withIsolatedDatabase(async () => {
+      const stateDb = new Database(path.join(tempRoot, '.codex', 'state_5.sqlite'));
+      stateDb.exec('CREATE TABLE threads (id TEXT PRIMARY KEY, title TEXT NOT NULL)');
+      stateDb.prepare('INSERT INTO threads (id, title) VALUES (?, ?)')
+        .run('codex-state-full-sync', 'Initial state title');
+
+      const synchronizer = new CodexSessionSynchronizer();
+      await synchronizer.synchronize(undefined, { initializing: true });
+      assert.equal(
+        sessionsDb.getSessionById('codex-state-full-sync')?.custom_name,
+        'Initial state title',
+      );
+
+      stateDb.prepare('UPDATE threads SET title = ? WHERE id = ?')
+        .run('Changed state title', 'codex-state-full-sync');
+      stateDb.close();
+
+      await synchronizer.synchronize();
+
+      assert.equal(
+        sessionsDb.getSessionById('codex-state-full-sync')?.custom_name,
+        'Initial state title',
+      );
     });
   } finally {
     restoreHomeDir();

--- a/server/modules/providers/tests/codex-sessions.test.ts
+++ b/server/modules/providers/tests/codex-sessions.test.ts
@@ -129,9 +129,38 @@ test('Codex synchronizer replaces an app-created fallback with the indexed threa
         `${JSON.stringify({ id: 'codex-app-titled', thread_name: 'Old title' })}\n${JSON.stringify({ id: 'codex-app-titled', thread_name: 'Fix login redirect' })}\n`,
         'utf8'
       );
+      const nextIndexMtime = new Date(Date.now() + 60_000);
+      await utimes(path.join(tempRoot, '.codex', 'session_index.jsonl'), nextIndexMtime, nextIndexMtime);
       await synchronizer.synchronizeFile(transcriptPath);
 
       assert.equal(sessionsDb.getSessionById('app-titled')?.custom_name, 'Fix login redirect');
+    });
+  } finally {
+    restoreHomeDir();
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test('Codex synchronizer preserves an existing title when the indexed name is blank', { concurrency: false }, async () => {
+  const tempRoot = await mkdtemp(path.join(os.tmpdir(), 'codex-session-sync-blank-title-'));
+  const workspacePath = path.join(tempRoot, 'workspace');
+  await mkdir(workspacePath, { recursive: true });
+  await mkdir(path.join(tempRoot, '.codex'), { recursive: true });
+  await writeFile(
+    path.join(tempRoot, '.codex', 'session_index.jsonl'),
+    `${JSON.stringify({ id: 'codex-blank-title', thread_name: '   ' })}\n`,
+    'utf8',
+  );
+  const restoreHomeDir = patchHomeDir(tempRoot);
+
+  try {
+    await writeCodexTranscript(tempRoot, 'codex-blank-title', workspacePath);
+    await withIsolatedDatabase(async () => {
+      sessionsDb.createSession('codex-blank-title', 'codex', workspacePath, 'Existing title');
+
+      await new CodexSessionSynchronizer().synchronize();
+
+      assert.equal(sessionsDb.getSessionById('codex-blank-title')?.custom_name, 'Existing title');
     });
   } finally {
     restoreHomeDir();

--- a/server/modules/providers/tests/provider-token-usage.service.test.ts
+++ b/server/modules/providers/tests/provider-token-usage.service.test.ts
@@ -17,6 +17,7 @@ function createSessionRow(overrides: Record<string, unknown> = {}) {
     project_path: null,
     jsonl_path: null,
     custom_name: null,
+    custom_name_source: null,
     model: null,
     isArchived: 0,
     created_at: '2026-01-01T00:00:00.000Z',

--- a/server/modules/providers/tests/provider-token-usage.service.test.ts
+++ b/server/modules/providers/tests/provider-token-usage.service.test.ts
@@ -20,6 +20,7 @@ function createSessionRow(overrides: Record<string, unknown> = {}) {
     project_path: null,
     jsonl_path: null,
     custom_name: null,
+    custom_name_source: null,
     model: null,
     effort: null,
     forked_from_session_id: null,

--- a/server/shared/interfaces.ts
+++ b/server/shared/interfaces.ts
@@ -168,11 +168,15 @@ export interface IProviderSessions {
  * interface for both full rescans and single-file incremental sync triggered
  * by filesystem watcher events.
  */
+export type SessionSynchronizeOptions = {
+  initializing?: boolean;
+};
+
 export interface IProviderSessionSynchronizer {
   /**
    * Scans provider session artifacts and upserts discovered sessions into DB.
    */
-  synchronize(since?: Date): Promise<number>;
+  synchronize(since?: Date, options?: SessionSynchronizeOptions): Promise<number>;
 
   /**
    * Parses and upserts one provider artifact file without running a full scan.

--- a/server/shared/interfaces.ts
+++ b/server/shared/interfaces.ts
@@ -228,11 +228,15 @@ export interface IProviderSessions {
  * interface for both full rescans and single-file incremental sync triggered
  * by filesystem watcher events.
  */
+export type SessionSynchronizeOptions = {
+  initializing?: boolean;
+};
+
 export interface IProviderSessionSynchronizer {
   /**
    * Scans provider session artifacts and upserts discovered sessions into DB.
    */
-  synchronize(since?: Date): Promise<number>;
+  synchronize(since?: Date, options?: SessionSynchronizeOptions): Promise<number>;
 
   /**
    * Parses and upserts one provider artifact file without running a full scan.


### PR DESCRIPTION
## Summary

- read Codex-generated thread titles from the newest `~/.codex/state_*.sqlite`
- treat `session_index.jsonl` as append-only and prefer its latest manual name
- refresh title metadata even when the transcript was already indexed
- load the full Codex state title database only during startup; watcher updates reuse an mtime-keyed index cache
- preserve CloudCLI manual names above provider titles via explicit name provenance

Displayed title precedence is:

1. CloudCLI manual name
2. Codex `session_index.jsonl` name
3. Codex state database title
4. existing transcript-derived fallback

## Migration safety

Existing non-empty session names are conservatively marked as manual during upgrade because older releases did not record provenance. This prevents an upgrade from overwriting a name the user entered in CloudCLI. Newly synchronized names are marked as provider-derived and can be refreshed by later Codex metadata.

## Testing

- 124 server tests pass
- typecheck passes
- targeted ESLint passes
- production build passes
- local restart stayed below 470 MB RSS instead of growing toward the 4 GB Node heap limit
- migration tests cover both legacy `sessions` and `session_names` layouts

Fixes #1060


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Session names now retain their source, distinguishing manually assigned names from provider-generated names.
  * Added provider-based session lookup.
* **Bug Fixes**
  * Preserved manual session names during migrations, merges, and synchronization.
  * Improved title selection using indexed and stored titles with reliable fallbacks.
  * Prevented blank or outdated provider data from replacing valid session names.
* **Documentation**
  * Updated Codex session synchronization guidance and title-source priorities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
