### PR TITLE
fix: don't recurse into system directories when building file trees

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -14,7 +14,7 @@ import cors from 'cors';
 import mime from 'mime-types';
 import Database from 'better-sqlite3';
 
-import { AppError, WORKSPACES_ROOT, getOpenCodeDatabasePath, validateWorkspacePath } from '@/shared/utils.js';
+import { AppError, FORBIDDEN_WORKSPACE_PATHS, WORKSPACES_ROOT, getOpenCodeDatabasePath, normalizeProjectPath, validateWorkspacePath } from '@/shared/utils.js';
 import { closeSessionsWatcher, initializeSessionsWatcher } from '@/modules/providers/index.js';
 import { createWebSocketServer } from '@/modules/websocket/index.js';
 
@@ -1512,7 +1512,13 @@ async function getFileTree(dirPath, maxDepth = 3, currentDepth = 0, showHidden =
             item.permissionsRwx = '---------';
         }
 
-        if (entry.isDirectory() && currentDepth < maxDepth) {
+        // Skip recursing into pseudo-filesystems and other system-critical
+        // directories (e.g. /proc, /sys) — they're never valid project roots,
+        // and /proc in particular can contain thousands of virtual entries
+        // that make traversal from a broad root (e.g. "/") pathologically slow.
+        const isForbiddenSystemDir = FORBIDDEN_WORKSPACE_PATHS.includes(normalizeProjectPath(itemPath));
+
+        if (entry.isDirectory() && currentDepth < maxDepth && !isForbiddenSystemDir) {
             // Recurse. Let readdir's own EACCES bubble up through the catch in
             // the recursive call rather than doing a separate access() probe
             // (which doubled the round-trip count on SMB without adding info).


### PR DESCRIPTION
Fixes #1064.

## Problem

`getFileTree` recurses one level into every subdirectory it lists, with no concept of which directories are legitimate project locations. When browsing from a broad root, this means recursing into `/proc`, `/sys`, and other pseudo-filesystems.

This has two consequences:

1. **Log noise (#1064).** Per-process procfs entries like `/proc/<pid>/net`, `/proc/<pid>/attr/apparmor`, and `/proc/<pid>/task/<tid>` are inherently racy to list. The process or thread can exit mid-walk, and some entries aren't real listable directories at all. These fail `scandir` with `EINVAL`/`ENOENT`. The error handler in `getFileTree` only suppresses `EACCES`/`EPERM`, so every one of these dumps a full error object plus stack trace on startup. The app keeps working, but the traces look like crashes and bury real problems.

2. **Performance.** `/proc` alone can contain thousands of virtual entries, each requiring a `stat` call, making the browse-filesystem endpoint pathologically slow from a broad root.

## Fix

Skip recursion into directories listed in `FORBIDDEN_WORKSPACE_PATHS`, which is already the source of truth for which system directories can never be a workspace. Reusing it rather than introducing a second, differently-scoped list means the skip list stays in sync automatically with whatever `FORBIDDEN_WORKSPACE_PATHS` a given deployment configures.

Because this stops the walk at `/proc` itself, it eliminates the entire class of per-PID procfs errors rather than allowlisting the specific subpaths that happen to appear in the report.

## Notes

Single commit, `server/index.js` only (+8/-2). I solved this a while ago for myself and it has been running in a private build since 2026-07-01 without issues.

The error handler still logs full stack traces for `ENOENT`/`EINVAL` from other paths. That's deliberate: outside procfs, `EINVAL` in particular is unusual enough to be worth surfacing, and once `/proc` is off the walk the volume drops to near zero.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved filesystem tree generation by preventing traversal into restricted system and pseudo-filesystem directories.
  * Reduced unnecessary scanning of protected paths while preserving the configured directory depth limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->