### PR TITLE
fix: don't recurse into system directories when building file trees

### DIFF
--- a/server/modules/file-tree/file-tree.service.ts
+++ b/server/modules/file-tree/file-tree.service.ts
@@ -8,7 +8,7 @@ import type {
   FileTreeServices,
   FileTreeUploadedFile,
 } from '@/shared/types.js';
-import { AppError } from '@/shared/utils.js';
+import { AppError, FORBIDDEN_WORKSPACE_PATHS, normalizeProjectPath } from '@/shared/utils.js';
 
 const IGNORED_DIRECTORY_NAMES = new Set([
   'node_modules', 'dist', 'build', '.next', '.nuxt', '.cache', '.parcel-cache',
@@ -233,7 +233,13 @@ export function createFileTreeService(dependencies: FileTreeServiceDependencies)
         // Metadata failures should not hide an otherwise readable tree entry.
       }
 
-      if (entry.isDirectory() && currentDepth < maximumDepth) {
+      // Skip recursing into pseudo-filesystems and other system-critical
+      // directories (e.g. /proc, /sys) — they're never valid project roots,
+      // and /proc in particular can contain thousands of virtual entries
+      // that make traversal from a broad root (e.g. "/") pathologically slow.
+      const isForbiddenSystemDir = FORBIDDEN_WORKSPACE_PATHS.includes(normalizeProjectPath(itemPath));
+
+      if (entry.isDirectory() && currentDepth < maximumDepth && !isForbiddenSystemDir) {
         item.children = await buildFileTree(
           itemPath,
           maximumDepth,


### PR DESCRIPTION
Fixes #1064

Supersedes #1065, which was opened against the pre-refactor tree. #1037 moved
file-tree handling out of the monolithic `server/index.js` and into
`server/modules/file-tree/file-tree.service.ts`, so `getFileTree` no longer
exists under that name and the original patch no longer applies. This is the
same fix, rewritten against the new module. I'll close #1065 once this is up.

## Problem

`buildFileTree` (`server/modules/file-tree/file-tree.service.ts`) recurses into
every subdirectory it lists, with no concept of which directories are
legitimate project locations. `listProjectFiles` walks the project root to
depth 10, and `resolveProjectRoot` returns the stored `project_path` verbatim:
it never validates it. That's the gap. The folder-browser endpoint
(`browseWorkspace`) does validate, rejecting system paths via
`validateWorkspacePath` before it walks anything, but the project file-tree
path has no equivalent check.

### Working theory for the errors in #1064

I can't confirm the reporter's setup, so treat this as the current best
explanation rather than established fact. The fix stops the errors either way,
since it removes procfs from the walk regardless of how the walk was triggered.

Running `claude` from a terminal sitting in `/` produces a perfectly ordinary
session whose cwd is `/`. Session discovery registers that cwd as a project path
as-is, so a project rooted at `/` can exist without anyone having browsed to it
or typed it into the UI.

From there it needs no further interaction. The chat pane requests the
mentionable-file list from a mount effect, before any `@` is typed, so simply
having that project selected walks the root. And selection is restored from the
`/session/<id>` URL, so a reopened tab reproduces it on every startup. That
would account for a scan appearing unprompted at launch on a machine whose
owner never intentionally opened `/`.

### What the walk then does

Sweeping `/` at depth 10 descends into `/proc`. Per-process entries are
inherently racy to list: a thread can exit between the parent's `readdir` and
the child's, and some entries aren't listable directories at all. These fail
`scandir` with `ENOENT`/`EINVAL`. The handler in `buildFileTree` only suppresses
`EACCES`/`EPERM`, so each one dumps a full error object and stack trace. The app
keeps working, but the traces look like crashes and bury real problems.

The paths in the report do pin down which walk is responsible:
`/proc/801039/task/914688` is four levels below `/`, which a depth-1 listing
cannot reach. So it's the depth-10 project sweep, not the shallow browse.

## Fix

Skip recursion into directories listed in `FORBIDDEN_WORKSPACE_PATHS`, already
the source of truth for which directories can never be a workspace. Reusing it
rather than adding a second, differently-scoped list keeps the two in sync with
whatever a given deployment configures.

The match is on the exact normalised path, not a prefix. That prunes `/proc`
when the walk root is `/`, while leaving a project that merely contains a
directory named `proc` alone. Prefix matching would also be awkward here, since
`/` is itself in the list and would match everything.

Because the walk stops at `/proc` itself, this eliminates the whole class of
per-PID procfs errors rather than allowlisting the specific subpaths that
happen to appear in the report.

Single commit, `server/modules/file-tree/file-tree.service.ts` only (+8/-2). The
pre-refactor version of this patch has been running in a private build since
2026-07-01 without issues.

## Out of scope, but worth flagging

`buildFileTree` has no size limit. It materialises every node in memory, and
`Promise.all` holds each completed subtree alive until the root resolves, so a
large enough root exhausts the heap. I hit this while testing: a walk rooted at
`/` on my machine OOM'd the server (~4 GB, `Reached heap limit`) because a large
mounted volume sat beneath it, several million entries. Skipping
pseudo-filesystems doesn't prevent that, since the entries were ordinary files.
A node budget with a `truncated` flag on the response would make any root safe
regardless of what's mounted below it. Happy to open that separately if it's
wanted.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file-tree scanning to skip restricted system directories.
  * Prevented traversal beyond protected workspace paths, enhancing safety and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->