### PR TITLE
feat(omp): add Oh My Pi (omp) as a first-class agent provider

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -162,6 +162,7 @@ export default tseslint.config(
             "server/shared/frontmatter.ts",
             "server/shared/claude-cli-path.ts",
             "server/shared/image-attachments.ts",
+            "server/shared/tool-approval-registry.ts",
           ], // classify shared utility files so modules can depend on them explicitly
           mode: "file",
         },

--- a/public/api-docs.html
+++ b/public/api-docs.html
@@ -489,7 +489,7 @@
                                 <span class="endpoint-path"><span class="api-url">http://localhost:3001</span>/api/agent</span>
                             </div>
 
-                            <p>Trigger an AI agent (Claude, Cursor, Codex, or OpenCode) to work on a project.</p>
+                            <p>Trigger an AI agent (Claude, Cursor, Codex, OpenCode, or omp) to work on a project.</p>
 
                             <h4>Request Body Parameters</h4>
                             <table>
@@ -524,7 +524,7 @@
                                         <td><code>provider</code></td>
                                         <td>string</td>
                                         <td><span class="badge badge-optional">Optional</span></td>
-                                        <td><code>claude</code>, <code>cursor</code>, <code>codex</code>, or <code>opencode</code> (default: <code>claude</code>)</td>
+                                        <td><code>claude</code>, <code>cursor</code>, <code>codex</code>, <code>opencode</code>, or <code>omp</code> (default: <code>claude</code>)</td>
                                     </tr>
                                     <tr>
                                         <td><code>stream</code></td>
@@ -839,6 +839,7 @@ data: {"type":"done"}</code></pre>
             { id: 'codex',    name: 'OpenAI' },
             { id: 'cursor',   name: 'Cursor' },
             { id: 'opencode', name: 'OpenCode' },
+            { id: 'omp',      name: 'omp' },
         ];
 
         async function populateModels() {

--- a/server/index.ts
+++ b/server/index.ts
@@ -83,6 +83,7 @@ const queryClaude = providerRuntimeService.getRunner('claude');
 const queryCursor = providerRuntimeService.getRunner('cursor');
 const queryCodex = providerRuntimeService.getRunner('codex');
 const queryOpenCode = providerRuntimeService.getRunner('opencode');
+const queryOmp = providerRuntimeService.getRunner('omp');
 const gitRoutes = createGitModule({
     queryClaude,
     queryCursor,
@@ -92,6 +93,7 @@ const agentRoutes = createAgentModule({
     queryCursor,
     queryCodex,
     queryOpenCode,
+    queryOmp,
 });
 
 // Single WebSocket server that handles chat, shell, and plugin proxy paths.

--- a/server/modules/agent/agent.module.ts
+++ b/server/modules/agent/agent.module.ts
@@ -17,7 +17,7 @@ import { createAgentRouter } from './agent.routes.js';
 
 type AgentExternalDependencies = Pick<
   Parameters<typeof createAgentRouter>[0],
-  'queryClaude' | 'queryCursor' | 'queryCodex' | 'queryOpenCode'
+  'queryClaude' | 'queryCursor' | 'queryCodex' | 'queryOpenCode' | 'queryOmp'
 >;
 
 /**

--- a/server/modules/agent/agent.routes.ts
+++ b/server/modules/agent/agent.routes.ts
@@ -22,6 +22,7 @@ type AgentRouterDependencies = {
   queryCursor: ProviderRunFunction;
   queryCodex: ProviderRunFunction;
   queryOpenCode: ProviderRunFunction;
+  queryOmp: ProviderRunFunction;
   GithubClient: typeof import('@octokit/rest').Octokit;
 };
 
@@ -44,6 +45,7 @@ export function createAgentRouter(dependencies: AgentRouterDependencies): expres
   const spawnCursor = dependencies.queryCursor;
   const queryCodex = dependencies.queryCodex;
   const spawnOpenCode = dependencies.queryOpenCode;
+  const spawnOmp = dependencies.queryOmp;
   const Octokit = dependencies.GithubClient;
   const router = express.Router();
 
@@ -662,7 +664,7 @@ export function createAgentRouter(dependencies: AgentRouterDependencies): expres
    *                          - Source for auto-generated branch names (if createBranch=true and no branchName)
    *                          - Fallback for PR title if no commits are made
    *
-   * @param {string} provider - (Optional) AI provider to use. Options: 'claude' | 'cursor' | 'codex' | 'opencode'
+   * @param {string} provider - (Optional) AI provider to use. Options: 'claude' | 'cursor' | 'codex' | 'opencode' | 'omp'
    *                           Default: 'claude'
    *
    * @param {boolean} stream - (Optional) Enable Server-Sent Events (SSE) streaming for real-time updates.
@@ -785,7 +787,7 @@ export function createAgentRouter(dependencies: AgentRouterDependencies): expres
    * Input Validations (400 Bad Request):
    *   - Either githubUrl OR projectPath must be provided (not neither)
    *   - message must be non-empty string
-   *   - provider must be 'claude', 'cursor', 'codex', or 'opencode'
+   *   - provider must be 'claude', 'cursor', 'codex', 'opencode', or 'omp'
    *   - createBranch/createPR requires githubUrl OR projectPath (not neither)
    *   - branchName must pass Git naming rules (if provided)
    *
@@ -896,8 +898,8 @@ export function createAgentRouter(dependencies: AgentRouterDependencies): expres
       return res.status(400).json({ error: 'message is required' });
     }
 
-    if (!['claude', 'cursor', 'codex', 'opencode'].includes(provider)) {
-      return res.status(400).json({ error: 'provider must be "claude", "cursor", "codex", or "opencode"' });
+    if (!['claude', 'cursor', 'codex', 'opencode', 'omp'].includes(provider)) {
+      return res.status(400).json({ error: 'provider must be "claude", "cursor", "codex", "opencode", or "omp"' });
     }
 
     // Validate GitHub branch/PR creation requirements
@@ -1025,6 +1027,21 @@ export function createAgentRouter(dependencies: AgentRouterDependencies): expres
           model: model || opencodeModels.DEFAULT,
           effort,
           permissionMode: 'bypassPermissions' // Agent runs are non-interactive, like the other providers above
+        }, writer);
+      } else if (provider === 'omp') {
+        console.log('Starting omp ACP session');
+
+        await spawnOmp(message.trim(), {
+          projectPath: finalProjectPath,
+          cwd: finalProjectPath,
+          sessionId: sessionId || null,
+          // No catalog default here: omp resolves its own configured model when the
+          // caller doesn't name one (OMP_CONFIGURED_MODEL_SENTINEL).
+          model,
+          effort,
+          // Agent runs are non-interactive: the mode drives per-session approval,
+          // so bypass auto-allows instead of stalling on a prompt nobody answers.
+          permissionMode: 'bypassPermissions'
         }, writer);
       }
 

--- a/server/modules/agent/tests/agent.routes.test.ts
+++ b/server/modules/agent/tests/agent.routes.test.ts
@@ -34,6 +34,7 @@ function createDependencies(
     queryCursor: unexpectedProviderCall as AgentDependencies['queryCursor'],
     queryCodex: unexpectedProviderCall as AgentDependencies['queryCodex'],
     queryOpenCode: unexpectedProviderCall as AgentDependencies['queryOpenCode'],
+    queryOmp: unexpectedProviderCall as AgentDependencies['queryOmp'],
     GithubClient: class {} as unknown as AgentDependencies['GithubClient'],
     ...overrides,
   };

--- a/server/modules/commands/commands.routes.ts
+++ b/server/modules/commands/commands.routes.ts
@@ -28,13 +28,14 @@ const providerModelsService = dependencies.models;
 const process = dependencies.runtime;
 const router = express.Router();
 
-const MODEL_PROVIDERS = ["claude", "cursor", "codex", "opencode"];
+const MODEL_PROVIDERS = ["claude", "cursor", "codex", "opencode", "omp"];
 
 const MODEL_PROVIDER_LABELS = {
   claude: "Claude",
   cursor: "Cursor",
   codex: "Codex",
   opencode: "OpenCode",
+  omp: "omp",
 };
 
 const readModelProvider = (value) => {
@@ -59,6 +60,40 @@ const resolveCommandModel = async (modelsService, provider, context) => {
     requestedModel: context?.model,
   });
   return resolved.model;
+};
+
+/**
+ * Resolves the model `/cost` reports.
+ *
+ * The panel answers "what did this session's last turn actually run on", and
+ * the transcript already knows: the client reads it out of the token-usage
+ * payload and sends it back in `tokenUsage.model`. The session's recorded
+ * model cannot answer that question - omp records a "use my own configured
+ * model" sentinel there, and the sentinel outranks everything else in
+ * `resolveSessionModel` - so it is only the fallback. A fallback that lands
+ * back on the catalog default is reported by its catalog label, because that
+ * default is a placeholder value the user never chose by name.
+ */
+const resolveCostModel = async (modelsService, provider, context) => {
+  const turnModel = typeof context?.tokenUsage?.model === 'string'
+    ? context.tokenUsage.model.trim()
+    : '';
+  if (turnModel) {
+    return turnModel;
+  }
+
+  // Both reads are needed and neither depends on the other, and the models service
+  // keeps no cache or in-flight dedupe — so overlap them instead of paying twice in
+  // sequence.
+  const [resolved, catalog] = await Promise.all([
+    resolveCommandModel(modelsService, provider, context),
+    modelsService.getProviderModels(provider),
+  ]);
+  if (resolved !== catalog.DEFAULT) {
+    return resolved;
+  }
+
+  return catalog.OPTIONS.find((option) => option.value === resolved)?.label || resolved;
 };
 
 const executeModelsCommand = async (args, context, modelsService) => {
@@ -263,7 +298,7 @@ Custom commands can be created in:
   "/cost": async (args, context) => {
     const tokenUsage = context?.tokenUsage || {};
     const provider = readModelProvider(context?.provider);
-    const model = await resolveCommandModel(providerModelsService, provider, context);
+    const model = await resolveCostModel(providerModelsService, provider, context);
 
     const reportedUsed =
       Number(

--- a/server/modules/commands/tests/commands.test.ts
+++ b/server/modules/commands/tests/commands.test.ts
@@ -112,3 +112,23 @@ test('cost and status commands report the same resolved model as /models', async
   assert.equal((cost.data as { model: string }).model, 'haiku');
   assert.equal((status.data as { model: string }).model, 'haiku');
 });
+
+test('cost command reports the model the last turn ran on, not the recorded sentinel', async () => {
+  // omp records a "use my own configured model" sentinel against the session,
+  // so the recorded value can never name the model a turn ran on. The client
+  // reads that out of the transcript and sends it back in `tokenUsage.model`.
+  const result = await executeCommand('/cost', {
+    provider: 'omp',
+    sessionId: 'session-1',
+    model: '__omp_configured_model__',
+    tokenUsage: { used: 100, total: 1000, model: 'claude-opus-5' },
+  }, { 'session-1': '__omp_configured_model__' });
+
+  assert.equal((result.data as { model: string }).model, 'claude-opus-5');
+});
+
+test('cost command labels a catalog default rather than reporting its raw value', async () => {
+  const result = await executeCommand('/cost', { provider: 'omp', sessionId: 'session-2' });
+
+  assert.equal((result.data as { model: string }).model, 'Default');
+});

--- a/server/modules/notifications/services/notification-orchestrator.service.js
+++ b/server/modules/notifications/services/notification-orchestrator.service.js
@@ -246,6 +246,10 @@ function notifyUserIfEnabled({ userId, event }) {
   }
 }
 
+/**
+ * @param {{ userId?: string | number | null, provider: string, sessionId?: string | null,
+ *   stopReason?: string, sessionName?: string | null }} input
+ */
 function notifyRunStopped({ userId, provider, sessionId = null, stopReason = 'completed', sessionName = null }) {
   notifyUserIfEnabled({
     userId,
@@ -261,6 +265,10 @@ function notifyRunStopped({ userId, provider, sessionId = null, stopReason = 'co
   });
 }
 
+/**
+ * @param {{ userId?: string | number | null, provider: string, sessionId?: string | null,
+ *   error: unknown, sessionName?: string | null }} input
+ */
 function notifyRunFailed({ userId, provider, sessionId = null, error, sessionName = null }) {
   const errorMessage = normalizeErrorMessage(error);
 

--- a/server/modules/providers/list/claude/claude-runtime.provider.js
+++ b/server/modules/providers/list/claude/claude-runtime.provider.js
@@ -33,9 +33,14 @@ import {
   notifyUserIfEnabled
 } from '@/modules/notifications/index.js';
 import { createCompleteMessage, createNormalizedMessage } from '@/shared/utils.js';
+import {
+  getPendingApprovalsForSession,
+  registerApproval,
+  resolveToolApproval,
+  unregisterApproval,
+} from '@/shared/tool-approval-registry.js';
 
 const activeSessions = new Map();
-const pendingToolApprovals = new Map();
 // Sessions cancelled via abort-session. The abort handler already sent the
 // terminal `complete` (aborted: true) to the client, so the run loop must not
 // emit a second one when its generator winds down.
@@ -77,7 +82,7 @@ function waitForToolApproval(requestId, options = {}) {
     let timeout;
 
     const cleanup = () => {
-      pendingToolApprovals.delete(requestId);
+      unregisterApproval(requestId);
       if (timeout) clearTimeout(timeout);
       if (signal && abortHandler) {
         signal.removeEventListener('abort', abortHandler);
@@ -109,19 +114,13 @@ function waitForToolApproval(requestId, options = {}) {
     const resolver = (decision) => {
       finalize(decision);
     };
-    // Attach metadata for getPendingApprovalsForSession lookup
-    if (metadata) {
-      Object.assign(resolver, metadata);
-    }
-    pendingToolApprovals.set(requestId, resolver);
+    registerApproval(requestId, {
+      resolver,
+      sessionId: metadata?._sessionId ?? null,
+      provider: 'claude',
+      meta: metadata ?? {},
+    });
   });
-}
-
-function resolveToolApproval(requestId, decision) {
-  const resolver = pendingToolApprovals.get(requestId);
-  if (resolver) {
-    resolver(decision);
-  }
 }
 
 // Match stored permission entries against a tool + input combo.
@@ -787,28 +786,6 @@ function isClaudeSDKSessionActive(sessionId) {
  */
 function getActiveClaudeSDKSessions() {
   return getAllSessions();
-}
-
-/**
- * Get pending tool approvals for a specific session.
- * @param {string} sessionId - The session ID
- * @returns {Array} Array of pending permission request objects
- */
-function getPendingApprovalsForSession(sessionId) {
-  const pending = [];
-  for (const [requestId, resolver] of pendingToolApprovals.entries()) {
-    if (resolver._sessionId === sessionId) {
-      pending.push({
-        requestId,
-        toolName: resolver._toolName || 'UnknownTool',
-        input: resolver._input,
-        context: resolver._context,
-        sessionId,
-        receivedAt: resolver._receivedAt || new Date(),
-      });
-    }
-  }
-  return pending;
 }
 
 /**

--- a/server/modules/providers/list/claude/claude-skills.provider.ts
+++ b/server/modules/providers/list/claude/claude-skills.provider.ts
@@ -1,74 +1,15 @@
-import { readFile, readdir, stat } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 
+import { listClaudePluginSkills } from '@/modules/providers/shared/skills/claude-plugin-skills.js';
 import { SkillsProvider } from '@/modules/providers/shared/skills/skills.provider.js';
-import { parseFrontMatter } from '@/shared/frontmatter.js';
 import type {
   ProviderSkill,
   ProviderSkillListOptions,
   ProviderSkillSource,
 } from '@/shared/types.js';
-import {
-  findProviderSkillMarkdownFiles,
-  readJsonConfig,
-  readObjectRecord,
-  readOptionalString,
-  readProviderSkillMarkdownDefinition,
-} from '@/shared/utils.js';
 
 const getClaudeHomePath = (): string => path.join(os.homedir(), '.claude');
-
-const getClaudePluginName = (pluginId: string): string | null => {
-  const normalizedPluginId = pluginId.trim();
-  if (!normalizedPluginId || normalizedPluginId === '@') {
-    return null;
-  }
-
-  const [pluginName] = normalizedPluginId.split('@');
-  return readOptionalString(pluginName) ?? null;
-};
-
-const stripMarkdownExtension = (filename: string): string =>
-  filename.replace(/\.md$/i, '');
-
-const pathExistsAsDirectory = async (directoryPath: string): Promise<boolean> => {
-  try {
-    const directoryStats = await stat(directoryPath);
-    return directoryStats.isDirectory();
-  } catch {
-    return false;
-  }
-};
-
-const listChildDirectories = async (directoryPath: string): Promise<string[]> => {
-  try {
-    const entries = await readdir(directoryPath, { withFileTypes: true });
-    return entries
-      .filter((entry) => entry.isDirectory())
-      .map((entry) => path.join(directoryPath, entry.name))
-      .sort((left, right) => left.localeCompare(right));
-  } catch {
-    return [];
-  }
-};
-
-const readClaudePluginName = async (
-  installPath: string,
-  pluginId: string,
-): Promise<string | null> => {
-  try {
-    const pluginConfig = await readJsonConfig(
-      path.join(installPath, '.claude-plugin', 'plugin.json'),
-    );
-
-    // Older or partial plugin installs may not have plugin.json yet. Falling
-    // back keeps discovery useful without inventing a separate namespace.
-    return readOptionalString(pluginConfig.name) ?? getClaudePluginName(pluginId);
-  } catch {
-    return getClaudePluginName(pluginId);
-  }
-};
 
 export class ClaudeSkillsProvider extends SkillsProvider {
   constructor() {
@@ -78,7 +19,7 @@ export class ClaudeSkillsProvider extends SkillsProvider {
   async listSkills(options?: ProviderSkillListOptions): Promise<ProviderSkill[]> {
     return [
       ...(await super.listSkills(options)),
-      ...(await this.listPluginSkills(getClaudeHomePath())),
+      ...(await listClaudePluginSkills(this.provider, getClaudeHomePath())),
     ];
   }
 
@@ -105,161 +46,5 @@ export class ClaudeSkillsProvider extends SkillsProvider {
       rootDir: path.join(getClaudeHomePath(), 'skills'),
       commandPrefix: '/',
     };
-  }
-
-  private async listPluginSkills(claudeHomePath: string): Promise<ProviderSkill[]> {
-    const settings = await readJsonConfig(path.join(claudeHomePath, 'settings.json'));
-    const enabledPlugins = readObjectRecord(settings.enabledPlugins);
-    if (!enabledPlugins) {
-      return [];
-    }
-
-    const installedConfig = await readJsonConfig(
-      path.join(claudeHomePath, 'plugins', 'installed_plugins.json'),
-    );
-    const installedPlugins = readObjectRecord(installedConfig.plugins);
-    if (!installedPlugins) {
-      return [];
-    }
-
-    const skills: ProviderSkill[] = [];
-    const visitedPluginFolders = new Set<string>();
-    const pluginEntries = Object.entries(enabledPlugins)
-      .sort(([left], [right]) => left.localeCompare(right));
-    for (const [pluginId, enabled] of pluginEntries) {
-      if (enabled !== true) {
-        continue;
-      }
-
-      const installs = installedPlugins[pluginId];
-      if (!Array.isArray(installs)) {
-        continue;
-      }
-
-      for (const install of installs) {
-        const installRecord = readObjectRecord(install);
-        const installPath = readOptionalString(installRecord?.installPath);
-        if (!installPath) {
-          continue;
-        }
-
-        // Claude's installed path points at one version folder; the usable
-        // plugin payloads live in the direct child folders beside it.
-        const pluginFolders = await listChildDirectories(path.dirname(installPath));
-        for (const pluginFolder of pluginFolders) {
-          const pluginFolderKey = `${pluginId}:${path.resolve(pluginFolder)}`;
-          if (visitedPluginFolders.has(pluginFolderKey)) {
-            continue;
-          }
-          visitedPluginFolders.add(pluginFolderKey);
-
-          const pluginName = await readClaudePluginName(pluginFolder, pluginId);
-          if (!pluginName) {
-            continue;
-          }
-
-          const commandsPath = path.join(pluginFolder, 'commands');
-          if (await pathExistsAsDirectory(commandsPath)) {
-            skills.push(
-              ...(await this.listPluginCommandSkills(commandsPath, pluginId, pluginName)),
-            );
-            continue;
-          }
-
-          const skillsPath = path.join(pluginFolder, 'skills');
-          if (!(await pathExistsAsDirectory(skillsPath))) {
-            continue;
-          }
-
-          skills.push(
-            ...(await this.listPluginSkillMarkdowns(pluginFolder, pluginId, pluginName)),
-          );
-        }
-      }
-    }
-
-    return skills;
-  }
-
-  private async listPluginCommandSkills(
-    commandsPath: string,
-    pluginId: string,
-    pluginName: string,
-  ): Promise<ProviderSkill[]> {
-    const skills: ProviderSkill[] = [];
-
-    try {
-      const entries = await readdir(commandsPath, { withFileTypes: true });
-      const commandFiles = entries
-        .filter((entry) => entry.isFile() && entry.name.toLowerCase().endsWith('.md'))
-        .sort((left, right) => left.name.localeCompare(right.name));
-
-      for (const commandFile of commandFiles) {
-        const sourcePath = path.join(commandsPath, commandFile.name);
-        try {
-          const definition = await this.readPluginCommandDefinition(sourcePath);
-          skills.push({
-            provider: this.provider,
-            name: definition.name,
-            description: definition.description,
-            command: `/${pluginName}:${definition.name}`,
-            scope: 'plugin',
-            sourcePath,
-            pluginName,
-            pluginId,
-          });
-        } catch {
-          // Malformed command markdown should not block sibling plugin commands.
-        }
-      }
-    } catch {
-      // Missing or unreadable command folders are treated as empty plugin command sets.
-    }
-
-    return skills;
-  }
-
-  private async readPluginCommandDefinition(
-    commandPath: string,
-  ): Promise<{ name: string; description: string }> {
-    const content = await readFile(commandPath, 'utf8');
-    const parsed = parseFrontMatter(content);
-    const data = readObjectRecord(parsed.data) ?? {};
-
-    return {
-      name: stripMarkdownExtension(path.basename(commandPath)),
-      description: readOptionalString(data.description) ?? '',
-    };
-  }
-
-  private async listPluginSkillMarkdowns(
-    installPath: string,
-    pluginId: string,
-    pluginName: string,
-  ): Promise<ProviderSkill[]> {
-    const skillFiles = await findProviderSkillMarkdownFiles(path.join(installPath, 'skills'), {
-      recursive: true,
-    });
-    const skills: ProviderSkill[] = [];
-
-    for (const skillPath of skillFiles) {
-      try {
-        const definition = await readProviderSkillMarkdownDefinition(skillPath);
-        skills.push({
-          provider: this.provider,
-          name: definition.name,
-          description: definition.description,
-          command: `/${pluginName}:${definition.name}`,
-          scope: 'plugin',
-          sourcePath: skillPath,
-          pluginName,
-          pluginId,
-        });
-      } catch {
-        // A bad plugin skill file should not block other installed plugin skills.
-      }
-    }
-
-    return skills;
   }
 }

--- a/server/modules/providers/list/omp/omp-auth.provider.ts
+++ b/server/modules/providers/list/omp/omp-auth.provider.ts
@@ -1,0 +1,85 @@
+import { spawn } from 'node:child_process';
+import os from 'node:os';
+import path from 'node:path';
+
+import Database from 'better-sqlite3';
+import crossSpawn from 'cross-spawn';
+
+import type { IProviderAuth } from '@/shared/interfaces.js';
+import type { ProviderAuthStatus } from '@/shared/types.js';
+
+const spawnFn = process.platform === 'win32' ? crossSpawn : spawn;
+
+// Env keys that would let omp run even without a persisted agent.db credential.
+const OMP_CREDENTIAL_ENV_KEYS = ['PI_API_KEY', 'ANTHROPIC_API_KEY', 'OPENAI_API_KEY'];
+
+/**
+ * Auth status for omp (P7). `installed` = async `omp --version` (never blocks
+ * the event loop, per the Kiro PR's async conversion). `authenticated` =
+ * `~/.omp/agent/agent.db` `auth_credentials` row count > 0 (readonly), with an
+ * env-key fallback so a configured-but-no-db setup isn't reported as false.
+ */
+export class OmpProviderAuth implements IProviderAuth {
+  private checkInstalled(): Promise<boolean> {
+    // Read OMP_PATH at call time so it stays overridable (e.g. in tests).
+    const bin = process.env.OMP_PATH ?? 'omp';
+    return new Promise((resolve) => {
+      let settled = false;
+      let child: ReturnType<typeof spawnFn> | undefined;
+      const finish = (value: boolean) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timeout);
+        resolve(value);
+      };
+      const timeout = setTimeout(() => { child?.kill(); finish(false); }, 5000);
+      try {
+        child = spawnFn(bin, ['--version'], { stdio: 'ignore' });
+      } catch {
+        finish(false);
+        return;
+      }
+      child.on('close', (code) => finish(code === 0));
+      child.on('error', () => finish(false));
+    });
+  }
+
+  private checkAuthenticated(): { authenticated: boolean; error?: string } {
+    const dbPath = path.join(os.homedir(), '.omp', 'agent', 'agent.db');
+    let db: Database.Database | undefined;
+    try {
+      db = new Database(dbPath, { readonly: true, fileMustExist: true });
+      // ponytail: counts all credentials, including any disabled ones — "has
+      // credentials configured" is the signal the UI needs; tighten with a
+      // `disabled_cause IS NULL` filter if the pane must show only usable creds.
+      const row = db.prepare('SELECT COUNT(*) AS count FROM auth_credentials').get() as { count: number } | undefined;
+      if ((row?.count ?? 0) > 0) {
+        return { authenticated: true };
+      }
+    } catch {
+      // agent.db or the table is absent — fall through to the env-key fallback
+      // rather than hard-failing to false.
+    } finally {
+      try { db?.close(); } catch { /* already closed */ }
+    }
+
+    const hasEnvKey = OMP_CREDENTIAL_ENV_KEYS.some((key) => (process.env[key] ?? '').trim().length > 0);
+    return hasEnvKey ? { authenticated: true } : { authenticated: false, error: 'No omp credentials found' };
+  }
+
+  async getStatus(): Promise<ProviderAuthStatus> {
+    const installed = await this.checkInstalled();
+    if (!installed) {
+      return { installed, provider: 'omp', authenticated: false, email: null, method: null, error: 'omp is not installed' };
+    }
+    const { authenticated, error } = this.checkAuthenticated();
+    return {
+      installed,
+      provider: 'omp',
+      authenticated,
+      email: null,
+      method: authenticated ? 'agent' : null,
+      error: authenticated ? undefined : (error ?? 'Not authenticated'),
+    };
+  }
+}

--- a/server/modules/providers/list/omp/omp-mcp.provider.ts
+++ b/server/modules/providers/list/omp/omp-mcp.provider.ts
@@ -1,0 +1,43 @@
+import type { IProviderMcp } from '@/shared/interfaces.js';
+import type { LLMProvider, McpScope, ProviderMcpServer, UpsertProviderMcpServerInput } from '@/shared/types.js';
+import { AppError } from '@/shared/utils.js';
+
+const NOT_SUPPORTED = () =>
+  new AppError('MCP management for omp is not supported yet', {
+    code: 'MCP_NOT_SUPPORTED',
+    statusCode: 501,
+  });
+
+/**
+ * MCP stub for omp — reading returns no servers; mutating throws 501.
+ *
+ * Listing must stay non-throwing so the global MCP list/read paths and the
+ * settings UI render omp cleanly; only direct writes are rejected. The global
+ * add/remove helpers in mcp.service.ts skip providers with no writable scopes, so
+ * omp is absent from those results rather than reported as a failure.
+ */
+export class OmpMcpProvider implements IProviderMcp {
+  // Empty → MCP management is unsupported; the global add/remove helpers skip omp.
+  readonly supportedScopes: McpScope[] = [];
+
+  async listServers(_options?: { workspacePath?: string }): Promise<Record<McpScope, ProviderMcpServer[]>> {
+    return { user: [], local: [], project: [] };
+  }
+
+  async listServersForScope(
+    _scope: McpScope,
+    _options?: { workspacePath?: string },
+  ): Promise<ProviderMcpServer[]> {
+    return [];
+  }
+
+  async upsertServer(_input: UpsertProviderMcpServerInput): Promise<ProviderMcpServer> {
+    throw NOT_SUPPORTED();
+  }
+
+  async removeServer(
+    _input: { name: string; scope?: McpScope; workspacePath?: string },
+  ): Promise<{ removed: boolean; provider: LLMProvider; name: string; scope: McpScope }> {
+    throw NOT_SUPPORTED();
+  }
+}

--- a/server/modules/providers/list/omp/omp-models.provider.ts
+++ b/server/modules/providers/list/omp/omp-models.provider.ts
@@ -1,0 +1,170 @@
+import crossSpawn from 'cross-spawn';
+
+import type { IProviderModels } from '@/shared/interfaces.js';
+import type {
+  ProviderCurrentActiveModel,
+  ProviderModelOption,
+  ProviderModelsDefinition,
+} from '@/shared/types.js';
+import { readObjectRecord } from '@/shared/utils.js';
+
+/**
+ * Sentinel meaning "whatever omp's own config selects" — omp resolves the
+ * effective model at runtime via `session/set_config_option`, so a user who
+ * never picks a concrete model just lets omp decide.
+ *
+ * Consumed by the omp runtime provider and by `@/modules/agent`, both of which
+ * must send no explicit model when the session carries the sentinel.
+ */
+export const OMP_CONFIGURED_MODEL_SENTINEL = '__omp_configured_model__';
+
+const OMP_MODELS_TIMEOUT_MS = 15_000;
+
+const SENTINEL_OPTION: ProviderModelOption = { value: OMP_CONFIGURED_MODEL_SENTINEL, label: 'Use omp default' };
+
+// The catalog served when `omp models --json` cannot be read: omp still resolves
+// a model itself, so the sentinel alone is a working catalog.
+const OMP_FALLBACK_MODELS: ProviderModelsDefinition = {
+  OPTIONS: [SENTINEL_OPTION],
+  DEFAULT: OMP_CONFIGURED_MODEL_SENTINEL,
+};
+
+const runOmpModelsCommand = (): Promise<string> => new Promise((resolve, reject) => {
+  // Read OMP_PATH at call time so it stays overridable (matches the auth provider).
+  const child = crossSpawn(process.env.OMP_PATH ?? 'omp', ['models', '--json'], { cwd: process.cwd(), env: { ...process.env } });
+  let stdout = '';
+  let settled = false;
+  const finish = (error: Error | null) => {
+    if (settled) return;
+    settled = true;
+    clearTimeout(timer);
+    if (error) reject(error); else resolve(stdout);
+  };
+  const timer = setTimeout(() => { child.kill('SIGTERM'); finish(new Error('omp models timed out')); }, OMP_MODELS_TIMEOUT_MS);
+  child.stdout?.on('data', (c: Buffer) => { stdout += c.toString(); });
+  child.on('error', (e) => finish(e));
+  child.on('close', (code) => finish(code === 0 ? null : new Error(`omp models exited with code ${code}`)));
+});
+
+/**
+ * Parses `omp models --json` → catalog options (sentinel first).
+ *
+ * Exported as a test seam so the parse is asserted without spawning omp.
+ */
+export function parseOmpModels(stdout: string): ProviderModelsDefinition {
+  const parsed = readObjectRecord(JSON.parse(stdout));
+  const models = parsed && Array.isArray(parsed.models) ? parsed.models : [];
+  const options: ProviderModelOption[] = [SENTINEL_OPTION];
+  const seen = new Set<string>([OMP_CONFIGURED_MODEL_SENTINEL]);
+
+  for (const raw of models) {
+    const model = readObjectRecord(raw);
+    const value = typeof model?.selector === 'string'
+      ? model.selector
+      : (typeof model?.id === 'string' ? model.id : null);
+    if (!value || seen.has(value)) {
+      continue;
+    }
+    seen.add(value);
+    // `thinking` is null OR this model's own level list, e.g. ["low","medium","high","max"].
+    const thinking = Array.isArray(model?.thinking) ? model.thinking : [];
+    options.push({
+      value,
+      label: typeof model?.name === 'string' ? model.name : value,
+      description: value,
+      ...(thinking.length > 0 ? { effort: { values: thinking.map((v) => ({ value: String(v) })) } } : {}),
+    });
+  }
+
+  return { OPTIONS: options, DEFAULT: OMP_CONFIGURED_MODEL_SENTINEL };
+}
+
+/**
+ * Reported when the catalog cannot say — omp absent, or a model it no longer lists.
+ *
+ * Consumed by the providers module's token-usage service, which must still
+ * report a context window when the catalog read fails.
+ */
+export const OMP_FALLBACK_CONTEXT_WINDOW = 200_000;
+
+/**
+ * Per-model context windows from the same catalog, keyed `provider/id`.
+ *
+ * The bare model id is NOT unique across providers, and the difference is not
+ * cosmetic: `claude-opus-5` is 1M through `anthropic` and 264k through
+ * `github-copilot`. omp writes both fields on every assistant message it
+ * records, so the key it is looked up by carries the provider too.
+ */
+function parseOmpContextWindows(stdout: string): Map<string, number> {
+  const parsed = readObjectRecord(JSON.parse(stdout));
+  const models = parsed && Array.isArray(parsed.models) ? parsed.models : [];
+  const windows = new Map<string, number>();
+
+  for (const raw of models) {
+    const model = readObjectRecord(raw);
+    const contextWindow = typeof model?.contextWindow === 'number' ? model.contextWindow : 0;
+    if (contextWindow <= 0) continue;
+    if (typeof model?.provider === 'string' && typeof model?.id === 'string') {
+      windows.set(`${model.provider}/${model.id}`, contextWindow);
+    }
+    // Also by selector: `kilo/anthropic/claude-opus-5` has an id containing a
+    // slash, so `provider/id` and the selector are the same string there, but
+    // for the rest this is the key a caller holding a selector would use.
+    if (typeof model?.selector === 'string') {
+      windows.set(model.selector, contextWindow);
+    }
+  }
+
+  return windows;
+}
+
+// The catalog only changes with the omp binary, and the exec costs ~1s, so it is
+// read once per process. A failure is held for a short window rather than
+// cleared: this runs at every turn end and on every REST token-usage read, and
+// clearing it made an omp that is missing or hanging cost the full
+// OMP_MODELS_TIMEOUT_MS on each one of them.
+const CONTEXT_WINDOW_RETRY_MS = 60_000;
+let contextWindowCache: Promise<Map<string, number>> | null = null;
+let contextWindowRetryAt = 0;
+
+/**
+ * Context window for the model a recorded turn ran on; null when unlisted.
+ *
+ * Consumed by the providers module's token-usage service and by the omp runtime,
+ * which reports the live context window at end of turn.
+ */
+export async function readOmpContextWindow(provider: string | null, model: string | null): Promise<number | null> {
+  if (!provider || !model) return null;
+  if (contextWindowRetryAt && Date.now() >= contextWindowRetryAt) {
+    contextWindowCache = null;
+    contextWindowRetryAt = 0;
+  }
+  if (!contextWindowCache) {
+    contextWindowCache = runOmpModelsCommand()
+      .then(parseOmpContextWindows)
+      .catch(() => {
+        contextWindowRetryAt = Date.now() + CONTEXT_WINDOW_RETRY_MS;
+        return new Map<string, number>();
+      });
+  }
+  return (await contextWindowCache).get(`${provider}/${model}`) ?? null;
+}
+
+// The IProviderModels half of the omp provider, consumed by `omp.provider.ts`.
+export class OmpProviderModels implements IProviderModels {
+  async getSupportedModels(): Promise<ProviderModelsDefinition> {
+    try {
+      const definition = parseOmpModels(await runOmpModelsCommand());
+      return definition.OPTIONS.length > 1 ? definition : OMP_FALLBACK_MODELS;
+    } catch {
+      return OMP_FALLBACK_MODELS;
+    }
+  }
+
+  // omp's live current model comes from session/new configOptions (read by the
+  // runtime). Statelessly here, just return the sentinel ("use omp default") —
+  // no `omp models` exec needed.
+  async getCurrentActiveModel(): Promise<ProviderCurrentActiveModel> {
+    return { model: OMP_CONFIGURED_MODEL_SENTINEL };
+  }
+}

--- a/server/modules/providers/list/omp/omp-runtime.provider.ts
+++ b/server/modules/providers/list/omp/omp-runtime.provider.ts
@@ -1,0 +1,1233 @@
+// omp runtime adapter — drives `omp acp` (Agent Client Protocol, JSON-RPC 2.0
+// over stdio) for live chat turns. Built against omp v17.0.6; behaviour re-verified
+// against v17.2.2 (see the session/load note below — it changed between them).
+//
+// Structure follows the Hermes ACP adapter (persistent per-cwd connection,
+// complete-on-prompt-resolve, session/cancel abort coordinated with
+// handleChatAbort) but talks through the P2 StdioJsonRpcClient (from Kiro #760)
+// instead of a bespoke ACP client.
+//
+// Multiplexing: one `omp acp` child per (cwd, approval profile) hosts MANY ACP
+// sessions (two chats in the same folder and mode share it). SINGLE
+// connection-level handlers route each
+// `session/update` notification AND each inbound `session/request_permission`
+// request to the owning run by session id, so runs never clobber one another.
+// Native session ids come ONLY from session/new and session/load results.
+//
+// Approvals: the config overlay depends on the run's permission mode (see
+// APPROVAL_PROFILES). EVERY profile uses `always-ask`, so omp asks over ACP and the
+// run gates client-side through the shared tool-approval registry (same path as
+// Claude) — bypassPermissions is auto-allowed there rather than handed omp's
+// `yolo`, which would drop omp's own destructive-command backstop.
+//
+// session/load: on v17.0.6 it was in-memory per child and threw for any session
+// this child had not created, which is why the session/fork fallback exists. On
+// v17.2.2 it resumes from disk WITH history, across processes — measured. So a
+// resume normally stays in-place on the same id, and fork is now the rare path.
+// It reads disk ONLY for a session the child does not already hold, though: a
+// re-load of a session already in memory replays the child's own frozen copy.
+// connectionInSyncWith is what keeps a warm child from answering from a snapshot
+// the user's terminal has since moved past.
+import { spawn } from 'node:child_process';
+import type { ChildProcess, ChildProcessWithoutNullStreams } from 'node:child_process';
+import crypto from 'node:crypto';
+import { mkdtempSync, writeFileSync, existsSync, realpathSync, constants as fsConstants, promises as fsp } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import crossSpawn from 'cross-spawn';
+
+import { sessionsDb } from '@/modules/database/index.js';
+import { OMP_CONFIGURED_MODEL_SENTINEL, OMP_FALLBACK_CONTEXT_WINDOW, readOmpContextWindow } from '@/modules/providers/list/omp/omp-models.provider.js';
+import { notifyRunFailed, notifyRunStopped } from '@/modules/notifications/index.js';
+import { createCompleteMessage, createNormalizedMessage } from '@/shared/utils.js';
+import { buildAcpPromptBlocks } from '@/shared/image-attachments.js';
+import { locateOmpSessionFile } from '@/modules/providers/list/omp/omp-session-files.js';
+import { StdioJsonRpcClient } from '@/modules/providers/list/omp/stdio-jsonrpc-client.js';
+import {
+  getPendingApprovalsForSession,
+  registerApproval,
+  resolveToolApproval,
+  unregisterApproval,
+} from '@/shared/tool-approval-registry.js';
+import type {
+  AnyRecord,
+  NormalizedMessage,
+  ProviderRuntimeContext,
+  ProviderRuntimeWriter,
+} from '@/shared/types.js';
+
+/**
+ * One `omp acp` child plus its JSON-RPC client, shared by every run in a cwd.
+ *
+ * Exported as a test seam: the provider tests substitute a fake connection
+ * factory through `__setConnectionFactoryForTest`, which needs this shape.
+ */
+export type OmpConnection = {
+  child: ChildProcess;
+  client: StdioJsonRpcClient;
+  initializeResult: AnyRecord | null;
+  ready?: Promise<OmpConnection>;
+  /**
+   * Session id → the jsonl fingerprint this child was last in sync with. A child
+   * that already holds a session in memory IGNORES a later `session/load` (see
+   * staleness note below), so this is how we notice it has gone stale.
+   * Created on demand — a test's fake connection factory need not supply it.
+   */
+  loadedSessions?: Map<string, string | null>;
+};
+
+/** Run options the chat/REST dispatchers hand to the runtime. */
+type OmpRunOptions = {
+  sessionId?: string | null;
+  projectPath?: string;
+  cwd?: string;
+  sessionSummary?: string;
+  permissionMode?: string;
+  model?: string | null;
+  effort?: string;
+  images?: unknown;
+};
+
+/** One in-flight run, keyed in activeOmpSessions by omp's native session id. */
+type OmpSessionEntry = {
+  connection: OmpConnection;
+  /**
+   * omp's own session id. Keys `activeOmpSessions` because every inbound ACP
+   * frame (`session/update`, `session/request_permission`) identifies its
+   * session by this id, and it is what `session/cancel` accepts.
+   */
+  sessionId: string;
+  /**
+   * The stable app-facing id the client knows, or null for direct API callers
+   * that address omp natively. Client-bound frames and the approval registry
+   * use it, because the chat gateway looks approvals up by app id and clients
+   * abort with it.
+   */
+  appSessionId: string | null;
+  writer: ProviderRuntimeWriter;
+  sessionSummary?: string;
+  permissionMode: string;
+  aborted: boolean;
+  acceptingUpdates: boolean;
+  normalizeMessage: (raw: AnyRecord, sid: string | null) => NormalizedMessage[];
+};
+
+/** ACP `session/request_permission` response. */
+type AcpPermissionOutcome = { outcome: { outcome: string; optionId?: string } };
+
+const spawnFunction = process.platform === 'win32' ? crossSpawn : spawn;
+const PROVIDER = 'omp';
+
+// ACP `session/prompt` resolves only at end-of-turn (routinely minutes), so it
+// opts out of the client's 2-minute default with a large bounded ceiling.
+// The 30-minute cap frees a wedged turn eventually; raise it if real turns exceed it.
+const PROMPT_REQUEST_TIMEOUT_MS = 30 * 60 * 1000;
+
+// omp only emits session/request_permission over ACP when BOTH (a) tools.approvalMode
+// is not 'yolo' and (b) the client advertises fs capabilities (verified against omp
+// v17.0.6: writeTextFile:false or yolo → omp silently auto-runs tools and never
+// asks). initialize always advertises fs; whether omp asks at all is then decided
+// by the per-mode overlay below.
+/**
+ * omp gates some tools twice: once over ACP (our UI prompt) and once internally,
+ * where only a TTY can answer — headless, that inner gate fails as "Tool call
+ * denied by user: <tool>". `tools.approval.<tool>: allow` satisfies the inner gate
+ * without suppressing the ACP request, so approve/deny still flows through our UI.
+ *
+ * The right policy depends on the run's permission mode, so each mode gets its own
+ * overlay (and its own omp child — see connection keying below).
+ *
+ * Both profiles use `always-ask`, deliberately. omp's own `yolo` would skip its
+ * gate entirely, which is tempting for bypassPermissions — but it also DROPS omp's
+ * destructive-command backstop: under always-ask, "override" tools (rm -rf /, sudo
+ * rm, mkfs, dd of=/dev/, curl|bash, fork bombs) ignore a per-tool `allow` and stay
+ * denied headlessly, whereas yolo auto-approves even those. That matters because
+ * bypassPermissions is not always a deliberate choice: readOmpDefaultPermissionMode
+ * derives it from a user's `approvalMode: yolo` config, so it can be the DEFAULT
+ * composer mode for someone who never touched the mode picker. Keeping always-ask
+ * costs nothing — routePermissionRequest auto-allows a bypass run without a prompt.
+ *
+ * - `gated` (default AND bypassPermissions): our client gates what omp asks about,
+ *   and the tools omp never asks about are pre-allowed so they can run at all. Those
+ *   run UNPROMPTED — the choice is "unprompted" or "always denied", not "prompted".
+ *   The renderer shows eval's code so unprompted is at least not invisible.
+ * - `plan`: the ACP-gated tools only. Withholding the unprompted mutators is what
+ *   keeps plan read-only, alongside routePermissionRequest's plan arm and the
+ *   fs/write guard.
+ *
+ * This pins omp's known sensitive set; add tools here if omp starts gating more.
+ */
+// omp gates a tool by capability tier (read/write/exec) but the config allowlist is
+// per TOOL NAME, and omp only routes bash/edit/delete/move through the ACP gate our
+// UI answers. Every other gated tool hits omp's internal, TTY-only prompt instead —
+// which headless fails as "Tool call denied by user: <tool>", blaming a user who was
+// never asked. So each one needs an explicit `allow` here or it simply cannot run.
+// Enumerated from `omp -p "List every tool you can call"` on v17.2.2 rather than
+// guessed: eval and write were each discovered the hard way, one bug report apiece.
+//
+// ACP-gated: omp asks, our client decides (auto-allow on bypass, prompt on default,
+// deny on plan). Safe in every profile — `allow` only satisfies the inner gate.
+const ACP_GATED_TOOLS = ['bash', 'edit', 'delete', 'move'];
+// NOT ACP-gated: omp never asks the client about these, so `allow` means they run
+// UNPROMPTED while its absence means they fail silently. They are therefore withheld
+// from the plan profile, which is what keeps plan read-only.
+const UNPROMPTED_MUTATORS = ['write', 'eval', 'ast_edit', 'memory_edit', 'manage_skill', 'browser', 'task'];
+
+const toolAllowList = (tools: readonly string[]) =>
+  '  approval:\n' + tools.map((tool: string) => '    ' + tool + ': allow\n').join('');
+// Exported as a test seam: the provider tests assert the overlay each permission
+// mode produces, which is what keeps plan mode read-only.
+export const APPROVAL_PROFILES = {
+  plan: `tools:\n  approvalMode: always-ask\n${toolAllowList(ACP_GATED_TOOLS)}`,
+  gated: `tools:\n  approvalMode: always-ask\n${toolAllowList([...ACP_GATED_TOOLS, ...UNPROMPTED_MUTATORS])}`,
+};
+
+type ApprovalProfile = keyof typeof APPROVAL_PROFILES;
+
+/**
+ * Which overlay a run needs, from its permission mode.
+ *
+ * Exported as a test seam so the mode-to-profile mapping is asserted directly.
+ */
+export function approvalProfileFor(permissionMode: string): ApprovalProfile {
+  return permissionMode === 'plan' ? 'plan' : 'gated';
+}
+
+const approvalOverlayPaths = new Map<ApprovalProfile, string>();
+let approvalOverlayDir: string | null = null;
+function getApprovalOverlayPath(profile: ApprovalProfile) {
+  const cached = approvalOverlayPaths.get(profile);
+  // Re-create if never made OR the tmp file was reaped (systemd-tmpfiles clears
+  // /tmp ~10d), else a long-lived server spawns `omp acp --config <missing>`.
+  if (!cached || !existsSync(cached)) {
+    // One dir, one file per profile — the profiles differ only in content.
+    if (!approvalOverlayDir || !existsSync(approvalOverlayDir)) {
+      approvalOverlayDir = mkdtempSync(path.join(os.tmpdir(), 'omp-acp-'));
+    }
+    const overlayPath = path.join(approvalOverlayDir, `${profile}.yml`);
+    // See APPROVAL_PROFILES for what each overlay buys and what it costs.
+    // NOTE (always-ask profiles only): omp's bash approval is INPUT-dependent —
+    // destructive commands (rm -rf /, sudo rm, mkfs, dd of=/dev/, curl|bash,
+    // shutdown, fork-bombs, …) are "override" tools where omp IGNORES per-tool
+    // `allow` (only `deny` is honored), so the inner gate still fires headlessly
+    // and such a command is denied even after the user clicks Allow. This FAILS
+    // CLOSED (desirable) — don't debug it as a regression. This backstop is
+    // precisely why no profile uses omp's `yolo`, which auto-approves them.
+    // INFO: --config deep-merges OVER user config, so a user's own
+    // `tools.approval.bash: deny` becomes allow for the session; acceptable
+    // because our ACP prompt still gates interactively.
+    writeFileSync(overlayPath, APPROVAL_PROFILES[profile]);
+    approvalOverlayPaths.set(profile, overlayPath);
+    return overlayPath;
+  }
+  return cached;
+}
+
+// Max bytes for a single delegated fs read/write.
+// 10MB covers source files; raise it if real edits exceed it.
+const FS_MAX_BYTES = 10 * 1024 * 1024;
+
+// The given base plus its realpath (like the image guard's getDirectoryPathVariants):
+// omp may send kernel-canonical paths (macOS /tmp → /private/tmp), so a legit
+// in-cwd target must be accepted under EITHER form.
+function baseDirVariants(baseDir: string) {
+  const resolved = path.resolve(baseDir);
+  try {
+    const canonical = path.resolve(realpathSync(baseDir));
+    return canonical === resolved ? [resolved] : [resolved, canonical];
+  } catch {
+    return [resolved];
+  }
+}
+
+// Cheap string-level containment pre-check (no per-target symlink resolution —
+// that's safeRead/WriteTarget's job). Tolerant of canonical-vs-given base.
+function resolveWithinDir(baseDir: string, target: string) {
+  if (typeof target !== 'string' || !target) {
+    return null;
+  }
+  const resolved = path.resolve(baseDir, target);
+  return baseDirVariants(baseDir).some((b) => resolved === b || resolved.startsWith(b + path.sep))
+    ? resolved
+    : null;
+}
+
+function withinBase(realBase: string, candidate: string) {
+  return candidate === realBase || candidate.startsWith(realBase + path.sep);
+}
+
+// Resolves a delegated READ target to a realpath guaranteed inside baseDir,
+// following symlinks and failing closed (mirrors the image guard's realpath
+// re-check, image-attachments.ts:isAllowedImageSourcePath). Blocks a symlink
+// inside cwd from exfiltrating e.g. ~/.ssh/id_rsa.
+async function safeReadTarget(baseDir: string, target: string) {
+  const resolved = resolveWithinDir(baseDir, target);
+  if (!resolved) {
+    throw new Error('path escapes working directory refused');
+  }
+  const realBase = await fsp.realpath(baseDir);
+  const real = await fsp.realpath(resolved); // throws if missing → fail closed
+  if (!withinBase(realBase, real)) {
+    throw new Error('symlinked path escapes working directory refused');
+  }
+  return real;
+}
+
+// Resolves a delegated WRITE target (which may not exist yet): the PARENT dir's
+// realpath must stay inside baseDir (blocks a parent-dir symlink like
+// <cwd>/sub → /etc), and the final component must not be an existing symlink
+// (blocks <cwd>/link → ~/.bashrc clobber).
+async function safeWriteTarget(baseDir: string, target: string) {
+  const resolved = resolveWithinDir(baseDir, target);
+  if (!resolved) {
+    throw new Error('path escapes working directory refused');
+  }
+  const realBase = await fsp.realpath(baseDir);
+  const realParent = await fsp.realpath(path.dirname(resolved));
+  if (!withinBase(realBase, realParent)) {
+    throw new Error('symlinked path escapes working directory refused');
+  }
+  try {
+    const st = await fsp.lstat(resolved);
+    if (st.isSymbolicLink()) {
+      throw new Error('refusing to write through a symlink');
+    }
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException)?.code !== 'ENOENT') {
+      throw error; // ENOENT = new file (fine); anything else fails closed
+    }
+  }
+  return path.join(realParent, path.basename(resolved));
+}
+
+/**
+ * Writes `content` to an already-guarded path without ever following a symlink.
+ *
+ * safeWriteTarget's lstat is a check-then-use, so a symlink planted between the
+ * check and the write would otherwise be followed straight out of the working
+ * directory. `noFollow` is injectable so the flagless path (Windows, where
+ * O_NOFOLLOW does not exist) is testable on POSIX — which is also why the
+ * provider tests import this directly rather than only through a run.
+ */
+export async function writeFileNoFollow(
+  targetPath: string,
+  content: string,
+  noFollow: number = fsConstants.O_NOFOLLOW ?? 0,
+): Promise<void> {
+  // Truncating at open would zero a planted symlink's victim before anything
+  // could be checked, so without the flag truncation waits for the check below.
+  const truncateAtOpen = noFollow ? fsConstants.O_TRUNC : 0;
+  let handle;
+  try {
+    handle = await fsp.open(targetPath, fsConstants.O_WRONLY | fsConstants.O_CREAT | truncateAtOpen | noFollow);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException)?.code === 'ELOOP') {
+      throw new Error('refusing to write through a symlink');
+    }
+    throw error;
+  }
+  try {
+    if (!noFollow) {
+      // open() may already have resolved a symlink, and the path can change again
+      // afterwards — so checking the path alone proves nothing about what this
+      // descriptor points at. The opened file must BE the file the path names
+      // right now; a symlink's lstat reports the link's own inode, so it can never
+      // match its target. Unresolvable identity (ino 0) fails closed.
+      const [viaHandle, viaPath] = await Promise.all([handle.stat(), fsp.lstat(targetPath)]);
+      const sameFile = viaPath.ino !== 0
+        && viaHandle.ino === viaPath.ino
+        && viaHandle.dev === viaPath.dev;
+      if (viaPath.isSymbolicLink() || !sameFile) {
+        throw new Error('refusing to write through a symlink');
+      }
+      await handle.truncate(0);
+    }
+    await handle.writeFile(content);
+  } finally {
+    await handle.close();
+  }
+}
+
+// Active runs keyed by native session id. Value:
+// { connection, sessionId, writer, sessionSummary, permissionMode, aborted, acceptingUpdates }.
+// Abortedness lives ONLY on the per-run entry (`entry.aborted`); spawnOmp holds
+// the entry by reference so it survives map deletion. (No separate id Set — that
+// leaked ids across resumed turns and spuriously suppressed later completes.)
+const activeOmpSessions = new Map<string, OmpSessionEntry>();
+
+function createRequestId() {
+  return typeof crypto.randomUUID === 'function'
+    ? crypto.randomUUID()
+    : crypto.randomBytes(16).toString('hex');
+}
+
+function readSessionId(result: AnyRecord | null | undefined) {
+  if (!result || typeof result !== 'object') {
+    return null;
+  }
+  return result.sessionId || result.session_id || result.id || null;
+}
+
+function readStopReason(result: AnyRecord | null | undefined) {
+  if (!result || typeof result !== 'object') {
+    return null;
+  }
+  return result.stopReason || result.stop_reason || result.reason || null;
+}
+
+function canLoadSession(connection: OmpConnection) {
+  return connection?.initializeResult?.agentCapabilities?.loadSession === true;
+}
+
+/**
+ * Cheap identity of a session's on-disk jsonl (`size:mtime`), or null when the
+ * file cannot be found. Compared across turns to detect that ANOTHER omp process
+ * — the user's own terminal — appended to a session this child already holds.
+ * Safe as a baseline: omp has fully flushed the jsonl by the time session/prompt
+ * resolves (measured: byte-identical from t+0 to t+2s after the turn).
+ */
+async function sessionFileFingerprint(sessionId: string) {
+  // Filename scan only, deliberately: the sessions DB would be a faster lookup, but
+  // this runs twice per turn and a synchronous SQLite read can block on a lock held
+  // by another process. The scan is a handful of readdirs and never blocks.
+  try {
+    const filePath = await locateOmpSessionFile(sessionId);
+    if (!filePath) return null;
+    const stat = await fsp.stat(filePath);
+    return `${stat.size}:${stat.mtimeMs}`;
+  } catch {
+    return null;
+  }
+}
+
+// Reads the LAST assistant message's raw usage from a session jsonl
+// (`{input,output,cacheRead,cacheWrite,totalTokens}`) together with the model
+// that turn ran on — `provider`/`model` decide the context window, and only the
+// transcript knows them (the session's configured model is often the "use omp
+// default" sentinel). Prefers the synchronizer's stored path (DB), then a
+// filename lookup (live turns before sync). Shared by the live token_budget
+// status and the REST token-usage endpoint. Best-effort.
+// Reads the whole jsonl each call — fine at chat scale; tail the stream instead if
+// transcripts grow huge.
+// Consumed by the providers module's token-usage service, which serves both the
+// live `token_budget` status and the REST token-usage endpoint.
+export async function readOmpSessionUsage(sessionId: string, knownPath: string | null = null) {
+  try {
+    const filePath = knownPath
+      ?? sessionsDb.getSessionByProviderSessionId(sessionId)?.jsonl_path
+      ?? await locateOmpSessionFile(sessionId);
+    if (!filePath) return null;
+
+    let usage = null;
+    let model = null;
+    let provider = null;
+    for (const line of (await fsp.readFile(filePath, 'utf8')).split('\n')) {
+      const t = line.trim();
+      if (!t) continue;
+      let e;
+      try { e = JSON.parse(t); } catch { continue; }
+      if (e?.type === 'message' && e.message?.role === 'assistant' && e.message?.usage) {
+        usage = e.message.usage; // keep the latest
+        model = typeof e.message.model === 'string' ? e.message.model : null;
+        provider = typeof e.message.provider === 'string' ? e.message.provider : null;
+      }
+    }
+    return usage ? { usage, model, provider } : null;
+  } catch {
+    return null;
+  }
+}
+
+// Maps the last assistant usage to the tokenBudget shape (frontend
+// TokenUsageSummary reads `inputTokens`/`used`). null when no usage found.
+async function readOmpTokenUsage(sessionId: string) {
+  const record = await readOmpSessionUsage(sessionId);
+  if (!record) return null;
+  const { usage } = record;
+  return {
+    // inputTokens folds cacheRead in, matching the REST token-usage branch (index.js).
+    inputTokens: Number(usage.input || 0) + Number(usage.cacheRead || 0),
+    outputTokens: usage.output,
+    used: usage.totalTokens,
+    total: await readOmpContextWindow(record.provider, record.model) ?? OMP_FALLBACK_CONTEXT_WINDOW,
+    // The model this turn actually ran on. A session's configured model is
+    // usually the "use omp default" sentinel, so this is the only honest
+    // answer the UI can show — and it is already resolved for the window.
+    model: record.model ?? undefined,
+    cacheRead: usage.cacheRead,
+    cacheWrite: usage.cacheWrite,
+  };
+}
+
+/**
+ * Routes ONE `session/update` notification to its owning run's writer, keyed by
+ * the native session id in the params. Updates for a run that is still replaying
+ * history (resume) or has already finished are dropped.
+ */
+function routeSessionUpdate(sessions: Map<string, OmpSessionEntry>, params: AnyRecord) {
+  const sid = readSessionId(params);
+  if (!sid) {
+    return;
+  }
+  const entry = sessions.get(sid);
+  if (!entry || !entry.acceptingUpdates) {
+    return;
+  }
+  // Normalization rides on the run's entry: the runtime context is per-run, and
+  // importing sessionsService here would cycle back through the provider registry.
+  const normalized = entry.normalizeMessage(params, sid);
+  for (const msg of normalized) {
+    entry.writer.send(msg);
+  }
+}
+
+// --- ACP permission decision mapping (copied from Hermes hermes-cli.js) ------
+function findPermissionOption(options: unknown, kinds: string[], fallbackOptionIds: string[] = []) {
+  if (!Array.isArray(options)) {
+    return null;
+  }
+  for (const kind of kinds) {
+    const match = options.find((option) => option?.kind === kind);
+    if (match?.optionId) {
+      return match.optionId;
+    }
+  }
+  for (const optionId of fallbackOptionIds) {
+    const match = options.find((option) => option?.optionId === optionId);
+    if (match?.optionId) {
+      return match.optionId;
+    }
+  }
+  return null;
+}
+
+function createPermissionDecision(
+  decision: AnyRecord | null | undefined,
+  options: unknown = [],
+): AcpPermissionOutcome {
+  if (!decision || decision.cancelled) {
+    return { outcome: { outcome: 'cancelled' } };
+  }
+  if (decision.allow) {
+    const optionId = decision.rememberEntry
+      ? findPermissionOption(options, ['allow_always', 'allow_session'], ['allow_always', 'allow_session'])
+      : findPermissionOption(options, ['allow_once'], ['allow_once']);
+    if (!optionId) {
+      return { outcome: { outcome: 'cancelled' } };
+    }
+    return { outcome: { outcome: 'selected', optionId } };
+  }
+  const denyOptionId = findPermissionOption(
+    options,
+    ['reject_once', 'deny', 'reject_always'],
+    ['deny', 'reject_once', 'reject_always'],
+  );
+  if (denyOptionId) {
+    return { outcome: { outcome: 'selected', optionId: denyOptionId } };
+  }
+  return { outcome: { outcome: 'cancelled' } };
+}
+
+function readPermissionTool(params: AnyRecord) {
+  const toolCall = (params && (params.toolCall || params.tool_call)) || {};
+  const toolName = params?.toolName || params?.tool_name || params?.name
+    || params?.tool?.name || toolCall.title || 'tool';
+  const input = params?.input ?? params?.arguments ?? params?.toolInput ?? params?.tool_input
+    ?? toolCall.rawInput ?? toolCall.raw_input ?? toolCall;
+  return { toolName, input };
+}
+
+/**
+ * Answers ONE inbound `session/request_permission` by routing it to the owning
+ * run and applying that run's permission mode. Returns the ACP decision the
+ * client writes back as the JSON-RPC response.
+ */
+function routePermissionRequest(sessions: Map<string, OmpSessionEntry>, params: AnyRecord) {
+  const sid = params?.sessionId || params?.session_id || null;
+  const entry = sid ? sessions.get(sid) : null;
+  if (!entry) {
+    // No owning run (finished/unknown session) — decline safely. omp surfaces this
+    // to the user as a rejection, so say why: a silent "rejected by user" with no
+    // prompt is otherwise indistinguishable from a real denial.
+    console.warn(`omp approval: no live run for session ${sid} — declining `
+      + `(${sessions.size} live run(s))`);
+    return { outcome: { outcome: 'cancelled' } };
+  }
+
+  const options = Array.isArray(params?.options) ? params.options : [];
+  const { toolName, input } = readPermissionTool(params);
+
+  // bypassPermissions: auto-allow without a UI prompt. This IS the path a bypass
+  // run takes — it stays on an always-ask child so omp keeps its destructive-command
+  // backstop (see APPROVAL_PROFILES), and the auto-allow happens here instead.
+  if (entry.permissionMode === 'bypassPermissions') {
+    return createPermissionDecision({ allow: true }, options);
+  }
+
+  // plan: read-only. omp only hard-guards edit/write/move/delete in plan mode —
+  // NOT bash — so any tool reaching this gate in plan mode is auto-DENIED (no UI
+  // prompt). Plan-file writes go through omp's `write` tool to a local:// sandbox,
+  // which isn't sensitive and never triggers session/request_permission, so
+  // planning is unaffected. (Deny → omp throws "rejected by user" before execute.)
+  if (entry.permissionMode === 'plan') {
+    console.warn(`omp approval: plan mode auto-denied ${toolName} for session ${sid} `
+      + '(no UI prompt — omp reports this as rejected by the user)');
+    return createPermissionDecision({ allow: false }, options);
+  }
+
+  // default: surface a UI approval prompt and await the user's decision,
+  // routed back through chat.permission-response → resolveToolApproval.
+  const requestId = createRequestId();
+  // The client only knows the app id, so prompts and the registry entry are
+  // labelled with it; omp's own id would never match a chat.permission-response.
+  const clientSessionId = entry.appSessionId ?? entry.sessionId;
+  entry.writer.send(createNormalizedMessage({
+    kind: 'permission_request',
+    requestId,
+    toolName,
+    input,
+    sessionId: clientSessionId,
+    provider: PROVIDER,
+  }));
+  const receivedAt = new Date();
+  // Executor form: this file compiles against ES2022 (server/tsconfig.json),
+  // which predates Promise.withResolvers.
+  return new Promise<AcpPermissionOutcome>((resolve) => {
+    registerApproval(requestId, {
+      sessionId: clientSessionId,
+      provider: PROVIDER,
+      // getPendingApprovalsForSession reads these plain keys (reconnect replay).
+      meta: { toolName, input, receivedAt },
+      resolver: (decision) => {
+        unregisterApproval(requestId);
+        resolve(createPermissionDecision(decision, options));
+      },
+    });
+  });
+}
+
+// --- per-cwd persistent connection manager ---------------------------------
+// A dead child is evicted so the next turn respawns.
+// No idle reaper: children accumulate per project. Acceptable because each is
+// idle and cheap; add a reaper if long-lived servers pile them up.
+// Keyed by cwd AND approval profile: the overlay is fixed when the child spawns,
+// so a plan run cannot share a child with a gated one. Cost: up to one child per
+// PROFILE per cwd — two, since default and bypassPermissions share `gated` (the
+// no-reaper note above applies per child). Switching mode
+// mid-thread is cheap though — v17.2.2 session/load resumes the same session id on
+// the other child, in place and with history (measured), so no fork is minted.
+const connectionsByKey = new Map<string, OmpConnection>();
+const connectionKey = (workingDir: string, profile: ApprovalProfile) => `${profile}\u0000${workingDir}`;
+
+function createConnection(workingDir: string, profile: ApprovalProfile): OmpConnection {
+  // --config carries this profile's overlay (APPROVAL_PROFILES). Both profiles are
+  // always-ask, so omp emits session/request_permission and the run gates
+  // client-side. Without any overlay omp follows the user's own config, which may
+  // be `yolo` — i.e. no gate at all.
+  // Read OMP_PATH at call time so it stays overridable (e.g. tests point it at a fake).
+  const bin = process.env.OMP_PATH ?? 'omp';
+  // omp derives a session's on-disk slug dir by relativizing cwd against $HOME.
+  // Dev isolation runs the *app* under a fake HOME, which makes omp store sessions
+  // under an absolute-path slug that the user's real-HOME terminal omp can't see.
+  // OMP_CHILD_HOME lets the isolated dev launcher give the omp child the REAL home
+  // so slugs match the terminal. Unset in production → normal inherited HOME.
+  const childEnv = { ...process.env };
+  if (process.env.OMP_CHILD_HOME) childEnv.HOME = process.env.OMP_CHILD_HOME;
+  const child = spawnFunction(bin, ['acp', '--config', getApprovalOverlayPath(profile)], {
+    cwd: workingDir,
+    stdio: ['pipe', 'pipe', 'pipe'],
+    env: childEnv,
+  });
+  // stdio is all "pipe" above, so the streams are non-null.
+  const client = new StdioJsonRpcClient(child as ChildProcessWithoutNullStreams, {
+    onStderr: (line) => console.error('omp acp stderr:', line),
+    onParseError: (rawLine) => console.warn('omp acp non-JSON line:', rawLine.slice(0, 200)),
+  });
+  const connection: OmpConnection = { child, client, initializeResult: null };
+
+  const key = connectionKey(workingDir, profile);
+  const evict = () => {
+    if (connectionsByKey.get(key) === connection) {
+      connectionsByKey.delete(key);
+    }
+  };
+  child.on('close', evict);
+  child.on('error', evict);
+
+  connection.ready = client
+    .request('initialize', {
+      protocolVersion: 1,
+      // fs caps MUST be advertised — omp only asks permission for a tool when it
+      // believes the client can handle fs; with both false it never asks. We
+      // honor the delegation via the fs/* handlers in attachConnectionHandlers.
+      clientCapabilities: { fs: { readTextFile: true, writeTextFile: true } },
+    })
+    .then((result) => {
+      connection.initializeResult = result as AnyRecord;
+      return connection;
+    })
+    .catch((error) => {
+      evict();
+      throw error;
+    });
+
+  return connection;
+}
+
+// Swappable so tests can inject a fake connection (see omp-runtime.test.ts).
+let connectionFactory: (workingDir: string, profile: ApprovalProfile) => OmpConnection = createConnection;
+export function __setConnectionFactoryForTest(
+  factory: ((workingDir: string, profile: ApprovalProfile) => OmpConnection) | null,
+) {
+  connectionFactory = factory ?? createConnection;
+}
+
+// Tests spawn real fake-omp children via the connection manager; without this
+// the persistent children keep the event loop alive and hang the test runner.
+export function __closeConnectionsForTest() {
+  for (const connection of [...connectionsByKey.values(), ...retiringConnections]) {
+    try { connection.child?.kill('SIGKILL'); } catch { /* already gone */ }
+  }
+  connectionsByKey.clear();
+  retiringConnections.clear();
+  runsByConnection.clear();
+}
+
+function attachConnectionHandlers(connection: OmpConnection, workingDir: string) {
+  const c = connection.client;
+  c.onNotification('session/update', (params: AnyRecord) => {
+    routeSessionUpdate(activeOmpSessions, params);
+  });
+  c.registerRequestHandler('session/request_permission', (params: AnyRecord) => {
+    return routePermissionRequest(activeOmpSessions, params);
+  });
+  // We advertised fs caps (so omp asks) — honor the delegated ops it may send
+  // back, symlink-guarded to the run's working dir and size-capped. Errors throw
+  // (handleInboundRequest converts them to a JSON-RPC error, never crashes).
+  c.registerRequestHandler('fs/read_text_file', async (params: AnyRecord) => {
+    const p = await safeReadTarget(workingDir, params?.path);
+    const st = await fsp.stat(p);
+    if (st.size > FS_MAX_BYTES) {
+      throw new Error(`fs/read_text_file: file exceeds ${FS_MAX_BYTES}-byte limit`);
+    }
+    let content = await fsp.readFile(p, 'utf8');
+    // Honor the optional ACP `line` (1-based start) / `limit` (max lines) slice.
+    const line = Number.isInteger(params?.line) ? params.line : null;
+    const limit = Number.isInteger(params?.limit) ? params.limit : null;
+    if (line !== null || limit !== null) {
+      const lines = content.split('\n');
+      const start = line !== null ? Math.max(0, line - 1) : 0;
+      const end = limit !== null ? start + limit : lines.length;
+      content = lines.slice(start, end).join('\n');
+    }
+    return { content };
+  });
+  c.registerRequestHandler('fs/write_text_file', async (params: AnyRecord) => {
+    const content = params?.content;
+    if (typeof content !== 'string') {
+      throw new Error('fs/write_text_file: content must be a string');
+    }
+    if (Buffer.byteLength(content, 'utf8') > FS_MAX_BYTES) {
+      throw new Error(`fs/write_text_file: content exceeds ${FS_MAX_BYTES}-byte limit`);
+    }
+    // Path guard first (always applies, session-independent).
+    const p = await safeWriteTarget(workingDir, params?.path);
+    // Then attribute to a live run and honor its mode. Fail closed: an unknown
+    // session must not bypass plan-read-only (F1) — mirror routePermissionRequest.
+    const entry = params?.sessionId ? activeOmpSessions.get(params.sessionId) : null;
+    if (!entry) {
+      throw new Error('fs/write_text_file: no live session for this write');
+    }
+    if (entry.permissionMode === 'plan') {
+      throw new Error('plan mode is read-only; write refused');
+    }
+    await writeFileNoFollow(p, content);
+    return null;
+  });
+}
+
+async function getConnection(workingDir: string, profile: ApprovalProfile) {
+  const key = connectionKey(workingDir, profile);
+  let connection = connectionsByKey.get(key);
+  if (!connection || connection.client.isClosed()) {
+    connection = connectionFactory(workingDir, profile);
+    attachConnectionHandlers(connection, workingDir);
+    connectionsByKey.set(key, connection);
+  }
+  // Concurrent same-cwd runs are fine — each gets its own ACP session
+  // on the shared child; a shared `ready` promise dedupes the spawn.
+  // The claim goes up BEFORE the await: a run that is still waiting on `ready` (or
+  // on anything else in setup) has no entry in activeOmpSessions yet, and the
+  // reaper must still see it. EVERY successful call hands the caller a claim to
+  // release — spawnOmp releases in its finally, connectionInSyncWith on the swap.
+  claimConnection(connection);
+  try {
+    await connection.ready;
+  } catch (error) {
+    releaseConnection(connection);
+    throw error;
+  }
+  return connection;
+}
+
+const loadedSessionsOf = (connection: OmpConnection) => (connection.loadedSessions ??= new Map());
+
+// Runs holding a connection right now, INCLUDING the ones still in setup. Reaping
+// on activeOmpSessions alone is not enough: a new-session run has no entry there
+// until session/new resolves, so a sibling run that retires the shared child in
+// that window would SIGTERM it and reject the first run's in-flight request.
+const runsByConnection = new Map<OmpConnection, number>();
+
+function claimConnection(connection: OmpConnection) {
+  runsByConnection.set(connection, (runsByConnection.get(connection) ?? 0) + 1);
+}
+
+function releaseConnection(connection: OmpConnection) {
+  const left = (runsByConnection.get(connection) ?? 1) - 1;
+  if (left > 0) {
+    runsByConnection.set(connection, left);
+  } else {
+    runsByConnection.delete(connection);
+  }
+}
+
+/**
+ * Detaches a connection so the NEXT getConnection spawns a fresh child, and kills
+ * it once it has no runs left. It is not killed on the spot: one child hosts every
+ * session in its (cwd, profile), so an immediate SIGTERM would abort another chat's
+ * running turn. Retired children are reaped again at the end of each run.
+ */
+const retiringConnections = new Set<OmpConnection>();
+
+function retireConnection(workingDir: string, profile: ApprovalProfile, connection: OmpConnection) {
+  const key = connectionKey(workingDir, profile);
+  if (connectionsByKey.get(key) === connection) {
+    connectionsByKey.delete(key);
+  }
+  retiringConnections.add(connection);
+  reapRetiredConnections();
+}
+
+function reapRetiredConnections() {
+  for (const connection of retiringConnections) {
+    if (runsByConnection.has(connection)) {
+      continue; // still serving another chat's run, setup included
+    }
+    retiringConnections.delete(connection);
+    // SIGKILL, NOT SIGTERM, and this is the crux of the whole fix. An omp process
+    // that exits GRACEFULLY appends `custom/session_exit` under the head it held —
+    // for a retired child that head is the abandoned branch — and a later
+    // `session/load` resumes from the file's last entry. So a polite kill makes the
+    // replacement child resume on the stale branch: exactly the drift we retired it
+    // for, re-created by the retirement. Measured end to end: with SIGTERM the web
+    // turn after a terminal turn still answered from the pre-terminal snapshot.
+    // Nothing is lost by the hard kill — reap only runs when no run holds the child.
+    try { connection.child?.kill('SIGKILL'); } catch { /* already gone */ }
+  }
+}
+
+/**
+ * Returns a connection whose in-memory copy of `sessionId` matches the jsonl.
+ *
+ * `session/load` is a no-op on a child that ALREADY holds that session: it replays
+ * its own frozen copy and re-reads nothing (measured on v17.2.2 — a second child
+ * appended a turn, the first child's re-load did not see it). So a warm child that
+ * loaded a session hours ago keeps answering from that snapshot, and its next turn
+ * is written as a SECOND BRANCH off the old head — which is what "I continued my
+ * terminal session in the web and it had forgotten the last hour" looks like.
+ * The only cure is a fresh process, so retire the stale one (~1s to respawn+load,
+ * paid only on a real handover).
+ *
+ * Known ceiling: the baseline is the file as it stood when OUR turn ended, so a
+ * foreign write that lands inside our turn folds into it and the next turn compares
+ * equal. The window is the milliseconds between omp's flush and our stat, and the
+ * terminal's next write re-opens the drift, so it self-heals — but a truly
+ * simultaneous two-way session is not what this detects.
+ */
+async function connectionInSyncWith(
+  connection: OmpConnection,
+  workingDir: string,
+  profile: ApprovalProfile,
+  sessionId: string,
+) {
+  const loaded = loadedSessionsOf(connection);
+  if (!loaded.has(sessionId)) {
+    return connection; // this child never held it — its session/load will read disk
+  }
+  const current = await sessionFileFingerprint(sessionId);
+  if (current === loaded.get(sessionId)) {
+    return connection;
+  }
+  console.log(`omp resume: session ${sessionId} changed on disk since this child loaded it `
+    + '— respawning so the turn continues from the real transcript');
+  retireConnection(workingDir, profile, connection);
+  return getConnection(workingDir, profile);
+}
+
+// Consumed by `ompRuntime` below (the contract the provider registry calls),
+// by `@/modules/agent` for its headless OMP dispatch, and by the provider tests.
+export async function spawnOmp(
+  command: string,
+  options: OmpRunOptions = {},
+  writer: ProviderRuntimeWriter,
+  context: ProviderRuntimeContext,
+) {
+  // The runtime context supplies the registry-backed model/session/auth lookups.
+  // Adapters must not import those services directly — they resolve back through
+  // the provider registry, which imports this module (cycle).
+  const normalizeMessage = (raw: AnyRecord, sid: string | null) => context.normalizeMessage(raw, sid);
+  const { sessionId: appSessionId, projectPath, cwd, sessionSummary } = options;
+  // Callers hand runtimes the stable app session id; ACP only understands the
+  // native id recorded on the session row. It is null until omp announces one,
+  // which is exactly what makes a brand-new session start with session/new
+  // instead of a load that could never have matched.
+  const providerSessionId = context.resolveProviderSessionId(appSessionId ?? null);
+  const workingDir = cwd || projectPath || process.cwd();
+  const permissionMode = options.permissionMode || 'default';
+  const approvalProfile = approvalProfileFor(permissionMode);
+  let capturedSessionId = providerSessionId || null;
+  let completeSent = false;
+  // Held outside the try so the finally can re-baseline this child's copy of the
+  // session against the jsonl it just wrote.
+  let runConnection: OmpConnection | null = null;
+  // The run's entry in activeOmpSessions (created once we have a native id).
+  let entry = null;
+
+  const notifyTerminalState = (
+    { error = null, stopReason = 'completed' }: { error?: unknown; stopReason?: string } = {},
+  ) => {
+    const finalSessionId = capturedSessionId || providerSessionId || null;
+    if (!error) {
+      notifyRunStopped({
+        userId: writer?.userId || null,
+        provider: PROVIDER,
+        sessionId: finalSessionId,
+        sessionName: sessionSummary,
+        stopReason,
+      });
+      return;
+    }
+    notifyRunFailed({
+      userId: writer?.userId || null,
+      provider: PROVIDER,
+      sessionId: finalSessionId,
+      sessionName: sessionSummary,
+      error,
+    });
+  };
+
+  try {
+    let connection = await getConnection(workingDir, approvalProfile);
+    runConnection = connection; // claimed by getConnection; the finally releases it
+    if (providerSessionId) {
+      // A warm child ignores session/load for a session it already holds, so make
+      // sure this one is not answering from a snapshot the terminal has moved past.
+      const inSync = await connectionInSyncWith(connection, workingDir, approvalProfile, providerSessionId);
+      if (inSync !== connection) {
+        releaseConnection(connection); // this run's claim moves to the fresh child
+        connection = inSync;
+        runConnection = connection;
+        reapRetiredConnections(); // the retired one may be free to kill now
+      }
+    }
+
+    // Resume: register the run up front (so an abort during load can find it)
+    // but drop replayed history — ACP re-streams the whole prior conversation
+    // as `session/update` notifications BEFORE `session/load` resolves.
+    if (providerSessionId) {
+      entry = {
+        connection,
+        sessionId: providerSessionId,
+        appSessionId: appSessionId ?? null,
+        writer,
+        sessionSummary,
+        permissionMode,
+        aborted: false,
+        acceptingUpdates: false,
+        normalizeMessage,
+      };
+      activeOmpSessions.set(providerSessionId, entry);
+    }
+
+    let sessionResult;
+    // Which branch a resume takes decides whether the model keeps its history, so
+    // it is logged: without this the server records nothing about the resume path
+    // and a "it forgot everything" report cannot be told apart from a silent
+    // fallback to a blank session.
+    let resumePath = providerSessionId ? 'load' : 'new';
+    if (providerSessionId && canLoadSession(connection)) {
+      try {
+        sessionResult = await connection.client.request('session/load', {
+          sessionId: providerSessionId,
+          cwd: workingDir,
+          mcpServers: [],
+        });
+      } catch (loadError) {
+        console.warn(`omp resume: session/load failed for ${providerSessionId} —`,
+          (loadError as { message?: string })?.message ?? loadError);
+        // On v17.2.2 session/load resumes from disk across processes, so reaching
+        // here means something else went wrong (unknown id, unreadable jsonl, a
+        // cwd mismatch) — or the agent is an older build where load WAS in-memory
+        // only. session/fork resumes FROM DISK: the new session inherits the FULL
+        // history + a `parentSession` link, giving true model continuity and a
+        // terminal-navigable branch. Falls back to a fresh session if fork fails.
+        try {
+          sessionResult = await connection.client.request('session/fork', {
+            sessionId: providerSessionId,
+            cwd: workingDir,
+            mcpServers: [],
+          });
+          resumePath = 'fork';
+        } catch (forkError) {
+          console.warn(`omp resume: session/fork failed for ${providerSessionId} —`,
+            (forkError as { message?: string })?.message ?? forkError);
+          sessionResult = await connection.client.request('session/new', { cwd: workingDir, mcpServers: [] });
+          resumePath = 'new (history lost)';
+        }
+      }
+    } else {
+      if (providerSessionId) {
+        resumePath = 'new (history lost: agent did not advertise loadSession)';
+      }
+      sessionResult = await connection.client.request('session/new', {
+        cwd: workingDir,
+        mcpServers: [],
+      });
+    }
+
+    const resolvedId = readSessionId(sessionResult as AnyRecord) || providerSessionId;
+    console.log(`omp run: cwd=${workingDir} requested=${providerSessionId ?? '(new)'} resolved=${resolvedId} `
+      + `path=${resumePath} permissionMode=${permissionMode} approvalProfile=${approvalProfile}`);
+    if (!resolvedId) {
+      throw new Error('omp ACP did not return a session id.');
+    }
+    capturedSessionId = resolvedId;
+
+    if (entry) {
+      // Resume: adopt any rewritten id, then start accepting live updates.
+      if (resolvedId !== entry.sessionId) {
+        // session/fork minted a new branch id (session/load keeps the same id).
+        // The branch jsonl already contains the full inherited history, so no
+        // fork-parent link / display-merge is needed — fetchHistory reads it whole.
+        activeOmpSessions.delete(entry.sessionId);
+        entry.sessionId = resolvedId;
+        activeOmpSessions.set(resolvedId, entry);
+        // SF-2: the run registry must learn the rewritten id, else handleChatAbort
+        // targets the stale id and the abort misses while the turn keeps running.
+        if (typeof writer.setSessionId === 'function') {
+          writer.setSessionId(resolvedId);
+        }
+      }
+      entry.acceptingUpdates = true;
+    } else {
+      // New session: create the entry keyed by omp's own id and announce it.
+      entry = {
+        connection,
+        sessionId: resolvedId,
+        appSessionId: appSessionId ?? null,
+        writer,
+        sessionSummary,
+        permissionMode,
+        aborted: false,
+        acceptingUpdates: true,
+        normalizeMessage,
+      };
+      activeOmpSessions.set(resolvedId, entry);
+      if (typeof writer.setSessionId === 'function') {
+        writer.setSessionId(resolvedId);
+      }
+      writer.send(createNormalizedMessage({
+        kind: 'session_created',
+        newSessionId: resolvedId,
+        cwd: workingDir,
+        sessionId: resolvedId,
+        provider: PROVIDER,
+      }));
+    }
+
+    // SF-1: an abort that landed during the session-setup window must not start
+    // a turn. Checked here (before the prompt) so a re-keyed resume entry can't
+    // be resurrected into a running turn either. handleChatAbort sends the
+    // terminal complete; we just notify the aborted stop for consistency.
+    if (entry.aborted) {
+      activeOmpSessions.delete(entry.sessionId);
+      notifyTerminalState({ stopReason: 'aborted' });
+      return;
+    }
+
+    // Apply per-session config (model / thinking / mode). omp config is per ACP
+    // session (not persisted by us), so this runs for both new sessions AND
+    // resume. session/new|load return configOptions with currentValues — skip a
+    // set when the session already has that value (avoids a round-trip). Each set
+    // is best-effort (non-fatal; the turn still runs if omp rejects one).
+    const initResult = sessionResult as AnyRecord | null | undefined;
+    const configOptions = Array.isArray(initResult?.configOptions) ? initResult.configOptions : [];
+    const currentConfig = (id: string) => configOptions.find((o: AnyRecord) => o?.id === id)?.currentValue;
+    const setConfig = async (configId: string, value: unknown, label: string) => {
+      try {
+        await connection.client.request('session/set_config_option', { sessionId: resolvedId, configId, value });
+      } catch (configError) {
+        console.warn(`omp: failed to set ${label}:`, configError instanceof Error ? configError.message : configError);
+      }
+    };
+
+    const resolvedModel = await context.resolveResumeModel(appSessionId ?? undefined, options.model ?? undefined);
+    if (resolvedModel && resolvedModel !== OMP_CONFIGURED_MODEL_SENTINEL && resolvedModel !== currentConfig('model')) {
+      await setConfig('model', resolvedModel, 'model');
+    }
+    // Skip 'default' — omp rejects it ("Unknown ACP thinking level: default"),
+    // matching the codex/opencode effort handling.
+    const effort = typeof options.effort === 'string' ? options.effort.trim() : '';
+    if (effort && effort !== 'default' && effort !== currentConfig('thinking')) {
+      await setConfig('thinking', effort, 'thinking');
+    }
+    if (permissionMode === 'plan' && currentConfig('mode') !== 'plan') {
+      await setConfig('mode', 'plan', 'plan mode');
+    } else if (permissionMode !== 'plan' && currentConfig('mode') === 'plan') {
+      // Un-stick: a resumed session left in plan mode must return to default.
+      await setConfig('mode', 'default', 'default mode');
+    }
+
+    let stopReason = 'completed';
+    if (command && command.trim()) {
+      const prompt = await buildAcpPromptBlocks(command, options.images, workingDir);
+      try {
+        const promptResult = await connection.client.request(
+          'session/prompt',
+          { sessionId: resolvedId, prompt },
+          { timeoutMs: PROMPT_REQUEST_TIMEOUT_MS },
+        );
+        stopReason = readStopReason(promptResult as AnyRecord) || 'completed';
+        // omp returns no usage in the prompt result — read the last assistant
+        // entry's usage from the session jsonl (usage lives per assistant message,
+        // not in usage_update deltas) and surface it as a token_budget status.
+        const tokenBudget = await readOmpTokenUsage(resolvedId);
+        if (tokenBudget) {
+          writer.send(createNormalizedMessage({
+            kind: 'status',
+            text: 'token_budget',
+            tokenBudget,
+            sessionId: resolvedId,
+            provider: PROVIDER,
+          }));
+        }
+      } catch (promptError) {
+        // A prompt failure that is NOT a user abort (e.g. the 30-min ceiling)
+        // should stop the turn so omp doesn't keep burning tokens on it.
+        if (!entry.aborted) {
+          try {
+            connection.client.notify('session/cancel', { sessionId: resolvedId });
+          } catch { /* connection already gone */ }
+        }
+        throw promptError;
+      }
+    }
+
+    const wasAborted = Boolean(entry.aborted);
+    if (!completeSent && !wasAborted) {
+      completeSent = true;
+      writer.send(createCompleteMessage({ provider: PROVIDER, sessionId: resolvedId, exitCode: 0 }));
+    }
+    activeOmpSessions.delete(resolvedId);
+    notifyTerminalState({ stopReason: wasAborted ? 'aborted' : stopReason });
+  } catch (error) {
+    const finalSessionId = capturedSessionId || providerSessionId || null;
+    const aborted = Boolean(entry?.aborted);
+    if (entry) {
+      activeOmpSessions.delete(entry.sessionId);
+    }
+    // A prompt failure (incl. the 30-min ceiling) leaves any pending approval
+    // registered → stale replay. Cancel omp's own pending approvals so awaiting
+    // handlers resolve. (abortOmpSession already did this for the abort case.)
+    for (const approval of getPendingApprovalsForSession(finalSessionId ?? '')) {
+      if (approval.provider === PROVIDER) {
+        resolveToolApproval(approval.requestId, { cancelled: true });
+      }
+    }
+
+    // A cancelled session/prompt rejects here; handleChatAbort already sent the
+    // aborted terminal `complete`, so don't surface the cancellation as an error.
+    if (aborted) {
+      return;
+    }
+
+    const installed = await context.isProviderInstalled();
+    const errorContent = !installed
+      ? 'omp is not installed. Install omp (https://omp.sh) and ensure it is on PATH.'
+      : error instanceof Error ? error.message : String(error);
+
+    writer.send(createNormalizedMessage({
+      kind: 'error',
+      content: errorContent,
+      sessionId: finalSessionId,
+      provider: PROVIDER,
+    }));
+    if (!completeSent) {
+      completeSent = true;
+      writer.send(createCompleteMessage({ provider: PROVIDER, sessionId: finalSessionId, exitCode: 1 }));
+    }
+    notifyTerminalState({ error });
+    // No rethrow: match sibling providers (opencode/codex). The WS gateway logs
+    // + safety-nets a duplicate complete; the REST path continues to PR steps.
+  } finally {
+    // This child now holds the session as of the jsonl it just wrote — record that
+    // so only a foreign writer (the terminal) counts as drift on the next turn.
+    // An ABORTED turn samples a little early (session/cancel is a notify, so omp may
+    // still flush the partial turn afterwards); the cost is one needless respawn on
+    // the next turn, never a stale one.
+    if (runConnection) {
+      if (capturedSessionId) {
+        loadedSessionsOf(runConnection).set(capturedSessionId, await sessionFileFingerprint(capturedSessionId));
+      }
+      releaseConnection(runConnection);
+    }
+    reapRetiredConnections();
+  }
+}
+
+export async function abortOmpSession(sessionId: string) {
+  // Clients abort with the app id, while the map is keyed by omp's own id, so a
+  // direct miss falls back to the run that owns this app session.
+  const entry = activeOmpSessions.get(sessionId)
+    ?? [...activeOmpSessions.values()].find((run) => run.appSessionId === sessionId);
+  if (!entry) {
+    return false;
+  }
+
+  entry.aborted = true;
+
+  // Cancel omp's pending approval prompts for this session so the awaiting inbound
+  // request handler resolves (otherwise the ACP request hangs forever). Filter by
+  // provider — a session id could collide with another provider's approval.
+  for (const approval of getPendingApprovalsForSession(entry.appSessionId ?? entry.sessionId)) {
+    if (approval.provider === PROVIDER) {
+      resolveToolApproval(approval.requestId, { cancelled: true });
+    }
+  }
+
+  // Graceful per-turn cancel on the shared per-cwd connection. We do NOT SIGTERM
+  // the process — it hosts other sessions for this cwd; `session/cancel` stops
+  // the current turn and the pending session/prompt rejects into spawnOmp's
+  // catch, which skips its own complete (handleChatAbort sends the aborted one).
+  try {
+    entry.connection.client.notify('session/cancel', { sessionId: entry.sessionId });
+  } catch {
+    // Connection already gone — caller still sees the run as aborted.
+  }
+  activeOmpSessions.delete(entry.sessionId);
+  return true;
+}
+
+/**
+ * IProviderRuntime implementation consumed by the provider registry, which
+ * dispatches run/abort and routes tool-approval decisions for every provider.
+ */
+export const ompRuntime = {
+  run: spawnOmp,
+  abort: abortOmpSession,
+  permissions: {
+    resolve: resolveToolApproval,
+    listPending: getPendingApprovalsForSession,
+  },
+};

--- a/server/modules/providers/list/omp/omp-session-files.ts
+++ b/server/modules/providers/list/omp/omp-session-files.ts
@@ -1,0 +1,53 @@
+import { promises as fsp } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+// id → path, because a scan readdirs EVERY project slug and both callers need the
+// path repeatedly: a turn resolves it twice (token usage, then the staleness
+// fingerprint) and history resolves it per read. The filename embeds the id and
+// omp never moves the file, so the mapping is permanent; one stat re-validates it
+// in case the file was deleted.
+const sessionFileByIdCache = new Map<string, string>();
+
+/**
+ * Locates a session's jsonl transcript by its exact native omp session id.
+ *
+ * Files are named `<ISO-ts>_<id>.jsonl`, so the id is the last `_`-delimited
+ * segment of the basename — matched exactly, because `endsWith` would also match
+ * a longer id that happens to end with this one.
+ *
+ * Consumed by the omp runtime provider (token usage and the staleness
+ * fingerprint) and the omp sessions provider (history reads); it lives here so
+ * those two cannot drift apart.
+ */
+export async function locateOmpSessionFile(sessionId: string): Promise<string | null> {
+  const cached = sessionFileByIdCache.get(sessionId);
+  if (cached) {
+    try {
+      await fsp.stat(cached);
+      return cached;
+    } catch {
+      sessionFileByIdCache.delete(sessionId);
+    }
+  }
+
+  const root = path.join(os.homedir(), '.omp', 'agent', 'sessions');
+  let slugs: string[];
+  try {
+    slugs = await fsp.readdir(root);
+  } catch {
+    return null;
+  }
+
+  for (const slug of slugs) {
+    const files = await fsp.readdir(path.join(root, slug)).catch(() => []);
+    const match = files.find((file) => file.endsWith('.jsonl') && file.slice(0, -6).split('_').pop() === sessionId);
+    if (match) {
+      const found = path.join(root, slug, match);
+      sessionFileByIdCache.set(sessionId, found);
+      return found;
+    }
+  }
+
+  return null;
+}

--- a/server/modules/providers/list/omp/omp-session-synchronizer.provider.ts
+++ b/server/modules/providers/list/omp/omp-session-synchronizer.provider.ts
@@ -1,0 +1,152 @@
+import os from 'node:os';
+import path from 'node:path';
+import fs from 'node:fs';
+import readline from 'node:readline';
+
+import { sessionsDb } from '@/modules/database/index.js';
+import {
+  findFilesRecursivelyCreatedAfter,
+  normalizeSessionName,
+  readFileTimestamps,
+  readObjectRecord,
+  readOptionalString,
+} from '@/shared/utils.js';
+import type { IProviderSessionSynchronizer } from '@/shared/interfaces.js';
+
+type ParsedSession = {
+  sessionId: string;
+  projectPath: string;
+  sessionName?: string;
+};
+
+const UNTITLED = 'Untitled omp Session';
+
+/**
+ * Session indexer for omp ACP transcripts.
+ *
+ * omp persists each session as `~/.omp/agent/sessions/<cwd-slug>/<ts>_<id>.jsonl`.
+ * agent.db has NO sessions table, so the jsonl store is the source of truth
+ * (Claude-style scan, not the Hermes SQLite one). The `type:'session'` header
+ * carries `{id, cwd, timestamp}` and a `type:'title'` entry carries the display
+ * title — neither is guaranteed to be line 1 (position varies by omp version),
+ * so we scan until both are found.
+ */
+export class OmpSessionSynchronizer implements IProviderSessionSynchronizer {
+  private readonly provider = 'omp' as const;
+  private readonly sessionsRoot = path.join(os.homedir(), '.omp', 'agent', 'sessions');
+
+  async synchronize(since?: Date): Promise<number> {
+    if (!fs.existsSync(this.sessionsRoot)) {
+      return 0;
+    }
+    const files = await findFilesRecursivelyCreatedAfter(this.sessionsRoot, '.jsonl', since ?? null);
+
+    let processed = 0;
+    for (const filePath of files) {
+      if (await this.synchronizeFile(filePath)) {
+        processed += 1;
+      }
+    }
+    return processed;
+  }
+
+  async synchronizeFile(filePath: string): Promise<string | null> {
+    // Skip omp sub-agent sidecar files (e.g. `__advisor.jsonl`). They live inside
+    // a session's dir and carry their OWN session header, so indexing them would
+    // surface confusing internal sub-sessions (the main agent's output appears as
+    // `user` messages, the sub-agent's as `assistant`). They are skipped here so a
+    // session's sidecars never appear as sessions of their own.
+    if (!filePath.endsWith('.jsonl') || path.basename(filePath).startsWith('__')) {
+      return null;
+    }
+
+    const parsed = await this.parseSessionHeader(filePath);
+    if (!parsed) {
+      return null;
+    }
+
+    // Preserve a user-set custom name (mirrors kiro/codex synchronizers): the DB
+    // upsert COALESCEs, so re-pass the existing name unless it's still the
+    // placeholder, otherwise adopt the jsonl title.
+    // App-created rows key session_id=app-id, provider_session_id=native-id, so
+    // look up by provider id first (else the rename gets clobbered by the auto
+    // title on every watcher tick) — matches codex/opencode/claude.
+    const existing = sessionsDb.getSessionByProviderSessionId(parsed.sessionId)
+      ?? sessionsDb.getSessionById(parsed.sessionId);
+    let nameToPersist = parsed.sessionName;
+    if (existing?.custom_name && existing.custom_name !== UNTITLED) {
+      nameToPersist = existing.custom_name;
+    }
+
+    const timestamps = await readFileTimestamps(filePath);
+    return sessionsDb.createSession(
+      parsed.sessionId,
+      this.provider,
+      parsed.projectPath,
+      nameToPersist,
+      timestamps.createdAt,
+      timestamps.updatedAt,
+      filePath,
+    );
+  }
+
+  /**
+   * Scans the jsonl for the `session` header (id + cwd) and the `title` entry.
+   * Short-circuits once both are found — they sit near the top in practice.
+   */
+  private async parseSessionHeader(filePath: string): Promise<ParsedSession | null> {
+    // <ts>_<id>.jsonl → the id is the last '_'-delimited segment (the ISO ts
+    // uses '-', so it never contains '_'). Used only as a fallback for id.
+    const idFromName = path.basename(filePath, '.jsonl').split('_').pop() || '';
+
+    let sessionId: string | undefined;
+    let projectPath: string | undefined;
+    let title: string | undefined;
+
+    // Keep a handle on the stream: `rl.close()` does NOT destroy its input, so the
+    // early `break` below would leak the fd until GC — once per watcher tick, per
+    // session file.
+    const stream = fs.createReadStream(filePath);
+    const rl = readline.createInterface({ input: stream, crlfDelay: Infinity });
+    try {
+      for await (const line of rl) {
+        const trimmed = line.trim();
+        if (!trimmed) {
+          continue;
+        }
+        let entry: Record<string, unknown> | null;
+        try {
+          entry = readObjectRecord(JSON.parse(trimmed));
+        } catch {
+          continue; // partial/malformed trailing line
+        }
+        if (!entry) {
+          continue;
+        }
+        if (entry.type === 'session') {
+          sessionId = readOptionalString(entry.id) ?? sessionId;
+          projectPath = readOptionalString(entry.cwd) ?? projectPath;
+          title = title ?? readOptionalString(entry.title); // some versions inline it
+        } else if (entry.type === 'title' || entry.type === 'title_change') {
+          title = readOptionalString(entry.title) ?? title;
+        }
+        if (sessionId && projectPath && title) {
+          break;
+        }
+      }
+    } finally {
+      rl.close();
+      stream.destroy();
+    }
+
+    const resolvedId = sessionId ?? (idFromName || undefined);
+    if (!resolvedId || !projectPath) {
+      return null; // without a cwd we can't attribute the session to a project
+    }
+    return {
+      sessionId: resolvedId,
+      projectPath,
+      sessionName: normalizeSessionName(title, UNTITLED),
+    };
+  }
+}

--- a/server/modules/providers/list/omp/omp-sessions.provider.ts
+++ b/server/modules/providers/list/omp/omp-sessions.provider.ts
@@ -1,0 +1,405 @@
+import fs from 'node:fs';
+import readline from 'node:readline';
+
+import { sessionsDb } from '@/modules/database/index.js';
+import { locateOmpSessionFile } from '@/modules/providers/list/omp/omp-session-files.js';
+import type { IProviderSessions } from '@/shared/interfaces.js';
+import type { AnyRecord, FetchHistoryOptions, FetchHistoryResult, NormalizedMessage } from '@/shared/types.js';
+import { createNormalizedMessage, generateMessageId, readObjectRecord, readOptionalString, sliceTailPage } from '@/shared/utils.js';
+
+const PROVIDER = 'omp' as const;
+
+/**
+ * omp persists ACP sessions as JSONL under
+ * `~/.omp/agent/sessions/<cwd-slug>/<ts>_<sessionId>.jsonl`.
+ *
+ * This provider covers both directions of one session: `normalizeMessage` maps
+ * live ACP `session/update` notifications forwarded by the runtime, and
+ * `fetchHistory` reads the same session back off disk.
+ */
+
+/**
+ * Recursively reads text out of an ACP content value: a bare string, a content
+ * block (`{type,text}`), an array of blocks, or a nested `{content:{...}}`
+ * (ToolCallContent) wrapper. Returns null when no text is found so callers can
+ * chain fallbacks with `??`.
+ */
+function readTextContent(value: unknown): string | null {
+  // Return the RAW string — never trimmed. Streaming chunks arrive split
+  // ("Hello" + " world"), so trimming here would drop the inter-chunk spaces
+  // and produce "Helloworld". Empty strings collapse to null.
+  if (typeof value === 'string') {
+    return value.length > 0 ? value : null;
+  }
+  if (Array.isArray(value)) {
+    const parts = value
+      .map((entry) => readTextContent(entry))
+      .filter((entry): entry is string => entry !== null);
+    return parts.length > 0 ? parts.join('') : null;
+  }
+  const record = readObjectRecord(value);
+  if (!record) {
+    return null;
+  }
+  const raw = (v: unknown): string | null => (typeof v === 'string' && v.length > 0 ? v : null);
+  const nested = record.content === value ? null : readTextContent(record.content);
+  return raw(record.text)
+    ?? raw(record.content)
+    ?? nested
+    ?? raw(record.delta)
+    ?? null;
+}
+
+/**
+ * Maps one ACP `session/update` notification to NormalizedMessage chunks.
+ * One update yields at most one message.
+ */
+function normalizeAcpUpdate(params: AnyRecord, sessionId: string | null): NormalizedMessage[] {
+  const update = readObjectRecord(params.update);
+  if (!update) {
+    return [];
+  }
+
+  const kind = typeof update.sessionUpdate === 'string' ? update.sessionUpdate : '';
+  const base = { sessionId, timestamp: new Date().toISOString(), provider: PROVIDER } as const;
+
+  if (kind === 'agent_message_chunk') {
+    const text = readTextContent(update.content) ?? '';
+    return text ? [createNormalizedMessage({ ...base, kind: 'stream_delta', content: text })] : [];
+  }
+
+  if (kind === 'agent_thought_chunk') {
+    const text = readTextContent(update.content) ?? '';
+    return text ? [createNormalizedMessage({ ...base, kind: 'thinking', content: text })] : [];
+  }
+
+  if (kind === 'tool_call') {
+    // A missing toolCallId gets a unique generated id so id-less tool calls
+    // don't all collapse onto '' and cross-correlate in the transcript.
+    //
+    // Defensive only: parsing every local transcript (350 files, 16,126
+    // toolCall parts) found none without an id. If omp ever emits one, the live
+    // row duplicates its history twin, because the client correlates the two by
+    // tool id and history's own fallback is `${baseId}_u${i}`, not this one. Fix
+    // that at the source — carry one id for both — rather than by guessing at a
+    // match from position or content.
+    const toolId = readOptionalString(update.toolCallId) || generateMessageId('omp_tool');
+    const toolName = typeof update.title === 'string'
+      ? update.title
+      : (typeof update.kind === 'string' ? update.kind : 'tool');
+    return [createNormalizedMessage({
+      ...base,
+      kind: 'tool_use',
+      toolName,
+      toolId,
+      toolInput: update.rawInput,
+    })];
+  }
+
+  if (kind === 'tool_call_update') {
+    const status = typeof update.status === 'string' ? update.status : 'completed';
+    // Intermediate (e.g. 'in_progress') updates are dropped so the live stream
+    // matches the terminal tool_result the history reader will produce.
+    if (status !== 'completed' && status !== 'failed') {
+      return [];
+    }
+    const toolId = readOptionalString(update.toolCallId) || generateMessageId('omp_tool');
+    // ACP carries the result under `content` (ToolCallContent[]); rawOutput/
+    // output/result are alternate fields. Reading only `output` renders an empty
+    // tool_result against real omp output.
+    const content = readTextContent(update.content)
+      ?? readTextContent(update.rawOutput)
+      ?? readTextContent(update.raw_output)
+      ?? readTextContent(update.output)
+      ?? readTextContent(update.result)
+      ?? '';
+    return [createNormalizedMessage({
+      ...base,
+      kind: 'tool_result',
+      toolId,
+      content,
+      isError: status === 'failed',
+    })];
+  }
+
+  if (kind === 'plan') {
+    return [createNormalizedMessage({ ...base, kind: 'status', text: 'plan' })];
+  }
+
+  // Live model/thinking/mode changes → status, so the UI can reflect them
+  // (parity with how other providers surface mid-session model changes). Pass
+  // configId through so the UI labels it correctly (Model vs Thinking vs Mode) —
+  // current_mode_update is always the mode.
+  if (kind === 'config_option_update' || kind === 'current_mode_update') {
+    const value = readOptionalString(update.currentValue)
+      ?? readOptionalString(update.value)
+      ?? readOptionalString(update.currentModeId)
+      ?? readOptionalString(update.mode);
+    const configId = kind === 'current_mode_update'
+      ? 'mode'
+      : (readOptionalString(update.configId) ?? readOptionalString(update.id));
+    return [createNormalizedMessage({ ...base, kind: 'status', text: kind, status: value, configId })];
+  }
+
+  // available_commands_update / session_info_update carry no user-facing state.
+  return [];
+}
+
+/**
+ * Maps one persisted jsonl entry to NormalizedMessages. A single entry can carry
+ * several content parts, so it can expand into several messages.
+ */
+function normalizeJsonlMessage(entry: AnyRecord, sessionId: string | null): NormalizedMessage[] {
+  if (entry.type !== 'message') {
+    return [];
+  }
+  const message = readObjectRecord(entry.message);
+  if (!message) {
+    return [];
+  }
+  const baseId = readOptionalString(entry.id) ?? generateMessageId(PROVIDER);
+  const ts = readOptionalString(entry.timestamp) ?? new Date().toISOString();
+  const base = { sessionId, timestamp: ts, provider: PROVIDER } as const;
+
+  // Tool result: its own message, linked to the tool_use by toolCallId.
+  if (message.role === 'toolResult') {
+    const toolId = readOptionalString(message.toolCallId) ?? baseId;
+    return [createNormalizedMessage({
+      ...base, id: `${baseId}_res`, kind: 'tool_result',
+      toolId,
+      content: readTextContent(message.content) ?? '',
+      isError: message.isError === true,
+    })];
+  }
+
+  // omp injects `role:'developer'` messages (<system-reminder> continuity nudges,
+  // incomplete-todo reminders) as model-directed instructions — internal plumbing,
+  // not conversation. Without this they render as assistant text with raw tags.
+  if (message.role === 'developer') {
+    return [];
+  }
+
+  const content = Array.isArray(message.content) ? message.content : [];
+  if (content.length === 0) {
+    return [];
+  }
+  const role = message.role === 'user' ? 'user' : 'assistant';
+  const out: NormalizedMessage[] = [];
+
+  content.forEach((rawPart: unknown, i: number) => {
+    const part = readObjectRecord(rawPart);
+    if (!part) {
+      return;
+    }
+    if (part.type === 'text') {
+      const text = readOptionalString(part.text);
+      if (text) {
+        out.push(createNormalizedMessage({ ...base, id: `${baseId}_t${i}`, kind: 'text', role, content: text }));
+      }
+    } else if (part.type === 'thinking') {
+      const text = readOptionalString(part.thinking) ?? readOptionalString(part.text);
+      if (text) {
+        out.push(createNormalizedMessage({ ...base, id: `${baseId}_k${i}`, kind: 'thinking', content: text }));
+      }
+    } else if (part.type === 'toolCall') {
+      const toolId = readOptionalString(part.id) || `${baseId}_u${i}`;
+      out.push(createNormalizedMessage({
+        ...base,
+        id: toolId,
+        kind: 'tool_use',
+        toolName: readOptionalString(part.name) ?? 'tool',
+        toolId,
+        toolInput: part.arguments,
+      }));
+    }
+  });
+
+  return out;
+}
+
+async function readOmpJsonl(filePath: string): Promise<AnyRecord[]> {
+  const entries: AnyRecord[] = [];
+  const rl = readline.createInterface({ input: fs.createReadStream(filePath), crlfDelay: Infinity });
+  for await (const line of rl) {
+    const trimmed = line.trim();
+    if (!trimmed) {
+      continue;
+    }
+    try {
+      const parsed = readObjectRecord(JSON.parse(trimmed));
+      if (parsed) {
+        entries.push(parsed);
+      }
+    } catch {
+      // A truncated final line is normal while omp is mid-write — skip it.
+    }
+  }
+  return entries;
+}
+
+/**
+ * Keeps only the entries on the session's ACTIVE branch.
+ *
+ * An omp jsonl is a tree, not a list: every entry carries `parentId`, and the
+ * terminal can walk back up and continue from an earlier point — which appends a
+ * second child under that parent instead of rewriting the file. Two omp processes
+ * on one session do the same thing. Read in file order, the result reads as two
+ * interleaved conversations.
+ *
+ * The newest CONVERSATION entry is on the branch that is live now, so its ancestor
+ * chain is what the omp TUI shows. Everything off that chain is an abandoned branch
+ * and is dropped. Entries with no parent (the `session`/`title` headers) always stay.
+ *
+ * This no-ops on the normal single-branch transcript — the walk only runs when the
+ * file actually forks. Every ambiguous case fails soft back to file order: showing
+ * an interleaved transcript is recoverable, hiding half of one is not.
+ */
+// The entry types this reader turns into visible messages. Everything else omp
+// writes — `custom` tool-lifecycle markers, `thinking_level_change`, `title_change`
+// — carries a parentId too, and that matters: an EXITING omp process writes
+// `custom/session_exit` under the head IT held, which in the two-writer case is the
+// ABANDONED branch. Taking the last parented entry as the head therefore selects the
+// dead branch (measured on a real forked transcript: 269 entries from the exit
+// marker's chain against 525 from the last message's).
+const RENDERED_ENTRY_TYPES = new Set(['message', 'custom_message']);
+
+// A tree parent, or null for the file headers (`session`, `title`) which carry no
+// `parentId` at all and always stay. An explicit `parentId: null` is a real ROOT
+// entry, so it gets a key of its own — two roots are a fork like any other.
+const ROOT_PARENT = '\u0000root';
+
+function branchParentOf(entry: AnyRecord): string | null {
+  if (entry.parentId === undefined) {
+    return null;
+  }
+  return typeof entry.parentId === 'string' ? entry.parentId : ROOT_PARENT;
+}
+
+function selectActiveBranch(entries: AnyRecord[]): AnyRecord[] {
+  const childCount = new Map<string, number>();
+  let forked = false;
+  for (const entry of entries) {
+    const parent = branchParentOf(entry);
+    if (parent === null) {
+      continue;
+    }
+    const next = (childCount.get(parent) ?? 0) + 1;
+    childCount.set(parent, next);
+    if (next > 1) {
+      forked = true;
+    }
+  }
+  if (!forked) {
+    return entries;
+  }
+
+  const byId = new Map<string, AnyRecord>();
+  for (const entry of entries) {
+    if (typeof entry.id === 'string') {
+      byId.set(entry.id, entry);
+    }
+  }
+  // Walk up from the newest entry the reader actually renders — see the note above.
+  let head: AnyRecord | null = null;
+  for (let i = entries.length - 1; i >= 0; i -= 1) {
+    const entry = entries[i];
+    if (branchParentOf(entry) !== null
+      && typeof entry.id === 'string'
+      && typeof entry.type === 'string'
+      && RENDERED_ENTRY_TYPES.has(entry.type)) {
+      head = entry;
+      break;
+    }
+  }
+
+  const onBranch = new Set<string>();
+  let cursor: AnyRecord | null = head;
+  while (cursor && typeof cursor.id === 'string' && !onBranch.has(cursor.id)) {
+    onBranch.add(cursor.id);
+    if (typeof cursor.parentId !== 'string') {
+      break; // reached the root
+    }
+    const parent = byId.get(cursor.parentId);
+    if (!parent) {
+      return entries; // a dropped malformed line broke the chain — fail soft
+    }
+    cursor = parent;
+  }
+  if (onBranch.size === 0) {
+    return entries; // no renderable head — fail soft
+  }
+
+  return entries.filter((entry) => (
+    branchParentOf(entry) === null // headers
+    || typeof entry.id !== 'string' // cannot be placed in the tree — keep it
+    || onBranch.has(entry.id)
+  ));
+}
+
+const EMPTY_PAGE: FetchHistoryResult = { messages: [], total: 0, hasMore: false, offset: 0, limit: null };
+
+// The IProviderSessions half of the omp provider, consumed by `omp.provider.ts`
+// and by the providers module's history/session services through it.
+export class OmpSessionsProvider implements IProviderSessions {
+  /**
+   * Normalizes a live ACP `session/update` notification (the `{sessionId, update}`
+   * envelope forwarded by the omp runtime) into NormalizedMessages.
+   */
+  normalizeMessage(rawMessage: unknown, sessionId: string | null): NormalizedMessage[] {
+    const raw = readObjectRecord(rawMessage);
+    if (!raw) {
+      return [];
+    }
+    if (raw.update && typeof raw.update === 'object') {
+      return normalizeAcpUpdate(raw, sessionId);
+    }
+    return normalizeJsonlMessage(raw, sessionId);
+  }
+
+  async fetchHistory(sessionId: string, options: FetchHistoryOptions = {}): Promise<FetchHistoryResult> {
+    const { limit = null, offset = 0 } = options;
+    // The jsonl is named by the native id; app-created sessions pass the app id
+    // as sessionId + the native id as providerSessionId (matches claude-sessions).
+    const providerSessionId = options.providerSessionId ?? sessionId;
+    let entries: AnyRecord[];
+    try {
+      const filePath = sessionsDb.getSessionByProviderSessionId(providerSessionId)?.jsonl_path
+        ?? sessionsDb.getSessionById(sessionId)?.jsonl_path
+        ?? await locateOmpSessionFile(providerSessionId);
+      if (!filePath) {
+        return EMPTY_PAGE;
+      }
+      entries = await readOmpJsonl(filePath);
+    } catch (error) {
+      console.warn(`[OmpProvider] Failed to load session ${sessionId}:`, error instanceof Error ? error.message : error);
+      return EMPTY_PAGE;
+    }
+
+    const normalized: NormalizedMessage[] = [];
+    for (const entry of selectActiveBranch(entries)) {
+      normalized.push(...normalizeJsonlMessage(entry, sessionId));
+    }
+
+    // Backfill tool_result onto its tool_use so the UI renders one card (same
+    // pass as the other providers' history readers).
+    const resultById = new Map<string, NormalizedMessage>();
+    for (const msg of normalized) {
+      if (msg.kind === 'tool_result' && msg.toolId) {
+        resultById.set(msg.toolId, msg);
+      }
+    }
+    for (const msg of normalized) {
+      if (msg.kind === 'tool_use' && msg.toolId) {
+        const result = resultById.get(msg.toolId);
+        if (result) {
+          msg.toolResult = { content: result.content, isError: result.isError };
+        }
+      }
+    }
+
+    const total = normalized.filter((m) => m.kind !== 'tool_result').length;
+    const { page, hasMore } = sliceTailPage(normalized, limit, offset);
+
+    return { messages: page, total, hasMore, offset: Math.max(0, offset), limit };
+  }
+}

--- a/server/modules/providers/list/omp/omp-skills.provider.ts
+++ b/server/modules/providers/list/omp/omp-skills.provider.ts
@@ -1,0 +1,192 @@
+import { readFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+import { listClaudePluginSkills } from '@/modules/providers/shared/skills/claude-plugin-skills.js';
+import { SkillsProvider } from '@/modules/providers/shared/skills/skills.provider.js';
+import type {
+  ProviderSkill,
+  ProviderSkillListOptions,
+  ProviderSkillSource,
+} from '@/shared/types.js';
+import {
+  addUniqueProviderSkillSource,
+  findTopmostGitRoot,
+  getProjectSkillSearchRoots,
+} from '@/shared/utils.js';
+
+// omp reads several agents' skill libraries and resolves name collisions by
+// provider priority, first match wins. These groups are ordered accordingly:
+// native `.omp` (100) > Claude `.claude` (80) > Claude marketplace plugins,
+// `.agent`/`.agents` and `.codex` (70) > OpenCode (55) > `.github` (30) >
+// auto-learn managed skills (5). omp's own plugins (90) register their skills
+// programmatically rather than from a skills directory, so no root exists to
+// scan for them.
+const OMP_NATIVE_PROJECT_SKILL_DIRS = [['.omp', 'skills']];
+const OMP_CLAUDE_PROJECT_SKILL_DIRS = [['.claude', 'skills']];
+
+const OMP_NATIVE_USER_SKILL_DIRS = [['.omp', 'agent', 'skills']];
+const OMP_CLAUDE_USER_SKILL_DIRS = [['.claude', 'skills']];
+
+// One entry per omp discovery provider below the plugin tier, highest priority
+// first. Within a tier omp reads the project roots before the user one, so the
+// pair has to stay together: flattening every project root ahead of every user
+// root inverted the ranking, letting `<repo>/.github/skills` (30) shadow a name
+// in `~/.codex/skills` (70).
+const OMP_COMPATIBILITY_SKILL_TIERS: { project: string[][]; user: string[][] }[] = [
+  { project: [['.agent', 'skills'], ['.agents', 'skills']], user: [['.agent', 'skills'], ['.agents', 'skills']] },
+  { project: [['.codex', 'skills']], user: [['.codex', 'skills']] },
+  { project: [['.opencode', 'skills']], user: [['.config', 'opencode', 'skills']] },
+  { project: [['.github', 'skills']], user: [] },
+  { project: [], user: [['.omp', 'agent', 'managed-skills']] },
+];
+
+/**
+ * Reads the skill names omp suppresses, from `skills.ignoredSkills` in its config.
+ *
+ * omp hides skills by name across every source it reads, so a listing that
+ * ignored this would advertise commands the agent itself refuses to load. The
+ * config is YAML and this is the only key the adapter needs, so the one block
+ * is read directly instead of taking on a YAML parser.
+ */
+const readIgnoredSkillNames = async (ompAgentHome: string): Promise<Set<string>> => {
+  const ignoredSkillNames = new Set<string>();
+
+  let content: string;
+  try {
+    content = await readFile(path.join(ompAgentHome, 'config.yml'), 'utf8');
+  } catch {
+    return ignoredSkillNames;
+  }
+
+  let inSkills = false;
+  let inIgnoredSkills = false;
+  for (const line of content.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) {
+      continue;
+    }
+
+    // A key at column zero ends the `skills:` mapping and any list inside it.
+    if (!line.startsWith(' ') && !line.startsWith('\t')) {
+      inSkills = trimmed.startsWith('skills:');
+      inIgnoredSkills = false;
+      continue;
+    }
+
+    if (!inSkills) {
+      continue;
+    }
+
+    if (!trimmed.startsWith('- ')) {
+      inIgnoredSkills = trimmed.startsWith('ignoredSkills:');
+      continue;
+    }
+
+    if (inIgnoredSkills) {
+      ignoredSkillNames.add(trimmed.slice(2).trim().replace(/^["']|["']$/g, ''));
+    }
+  }
+
+  return ignoredSkillNames;
+};
+
+export class OmpSkillsProvider extends SkillsProvider {
+  constructor() {
+    super('omp');
+  }
+
+  async listSkills(options?: ProviderSkillListOptions): Promise<ProviderSkill[]> {
+    const workspacePath = path.resolve(options?.workspacePath ?? process.cwd());
+    const repoRoot = await findTopmostGitRoot(workspacePath);
+    const { rankedAbovePlugins, rankedBelowPlugins } = this.buildSkillSourceGroups(
+      workspacePath,
+      repoRoot,
+    );
+
+    const [skillsAbovePlugins, pluginSkills, skillsBelowPlugins, ignoredSkillNames] =
+      await Promise.all([
+        this.scanSkillSources(rankedAbovePlugins),
+        listClaudePluginSkills(this.provider, path.join(os.homedir(), '.claude')),
+        this.scanSkillSources(rankedBelowPlugins),
+        readIgnoredSkillNames(path.join(os.homedir(), '.omp', 'agent')),
+      ]);
+
+    // First match wins, exactly like omp's own shadowing: the same skill name
+    // reached through two roots (`~/.agents/skills` is commonly a symlink to
+    // `~/.claude/skills`) must appear once, owned by the higher tier.
+    const skills: ProviderSkill[] = [];
+    const claimedSkillNames = new Set<string>();
+    for (const skill of [...skillsAbovePlugins, ...pluginSkills, ...skillsBelowPlugins]) {
+      if (ignoredSkillNames.has(skill.name) || claimedSkillNames.has(skill.name)) {
+        continue;
+      }
+
+      claimedSkillNames.add(skill.name);
+      skills.push(skill);
+    }
+
+    return skills;
+  }
+
+  protected async getSkillSources(workspacePath: string): Promise<ProviderSkillSource[]> {
+    const repoRoot = await findTopmostGitRoot(workspacePath);
+    const groups = this.buildSkillSourceGroups(workspacePath, repoRoot);
+
+    return [...groups.rankedAbovePlugins, ...groups.rankedBelowPlugins];
+  }
+
+  protected async getGlobalSkillSource(): Promise<ProviderSkillSource> {
+    return {
+      scope: 'user',
+      rootDir: path.join(os.homedir(), ...OMP_NATIVE_USER_SKILL_DIRS[0]),
+      commandPrefix: '/',
+    };
+  }
+
+  /**
+   * Builds omp's skill roots, split where Claude plugin skills rank.
+   *
+   * Plugin skills come from a registry rather than a root, so they cannot ride
+   * along in one source list; the caller scans each group and concatenates them
+   * with the plugin skills in between.
+   */
+  private buildSkillSourceGroups(
+    workspacePath: string,
+    repoRoot: string | null,
+  ): { rankedAbovePlugins: ProviderSkillSource[]; rankedBelowPlugins: ProviderSkillSource[] } {
+    const projectRoots = getProjectSkillSearchRoots(workspacePath, repoRoot);
+    const seenRootDirs = new Set<string>();
+
+    const addSources = (
+      target: ProviderSkillSource[],
+      scope: 'project' | 'user',
+      baseDirs: string[],
+      skillDirs: string[][],
+    ): void => {
+      for (const baseDir of baseDirs) {
+        for (const skillDir of skillDirs) {
+          addUniqueProviderSkillSource(target, seenRootDirs, {
+            scope,
+            rootDir: path.join(baseDir, ...skillDir),
+            commandPrefix: '/',
+          });
+        }
+      }
+    };
+
+    const rankedAbovePlugins: ProviderSkillSource[] = [];
+    addSources(rankedAbovePlugins, 'project', projectRoots, OMP_NATIVE_PROJECT_SKILL_DIRS);
+    addSources(rankedAbovePlugins, 'user', [os.homedir()], OMP_NATIVE_USER_SKILL_DIRS);
+    addSources(rankedAbovePlugins, 'project', projectRoots, OMP_CLAUDE_PROJECT_SKILL_DIRS);
+    addSources(rankedAbovePlugins, 'user', [os.homedir()], OMP_CLAUDE_USER_SKILL_DIRS);
+
+    const rankedBelowPlugins: ProviderSkillSource[] = [];
+    for (const tier of OMP_COMPATIBILITY_SKILL_TIERS) {
+      addSources(rankedBelowPlugins, 'project', projectRoots, tier.project);
+      addSources(rankedBelowPlugins, 'user', [os.homedir()], tier.user);
+    }
+
+    return { rankedAbovePlugins, rankedBelowPlugins };
+  }
+}

--- a/server/modules/providers/list/omp/omp.provider.ts
+++ b/server/modules/providers/list/omp/omp.provider.ts
@@ -1,0 +1,30 @@
+import { AbstractProvider } from '@/modules/providers/shared/base/abstract.provider.js';
+import { OmpProviderAuth } from '@/modules/providers/list/omp/omp-auth.provider.js';
+import { OmpProviderModels } from '@/modules/providers/list/omp/omp-models.provider.js';
+import { OmpMcpProvider } from '@/modules/providers/list/omp/omp-mcp.provider.js';
+import { OmpSessionSynchronizer } from '@/modules/providers/list/omp/omp-session-synchronizer.provider.js';
+import { OmpSessionsProvider } from '@/modules/providers/list/omp/omp-sessions.provider.js';
+import { OmpSkillsProvider } from '@/modules/providers/list/omp/omp-skills.provider.js';
+import { ompRuntime } from '@/modules/providers/list/omp/omp-runtime.provider.js';
+import type {
+  IProviderAuth,
+  IProviderModels,
+  IProviderRuntime,
+  IProviderSessionSynchronizer,
+  IProviderSessions,
+  IProviderSkills,
+} from '@/shared/interfaces.js';
+
+export class OmpProvider extends AbstractProvider {
+  readonly runtime: IProviderRuntime = ompRuntime;
+  readonly models: IProviderModels = new OmpProviderModels();
+  readonly mcp = new OmpMcpProvider();
+  readonly auth: IProviderAuth = new OmpProviderAuth();
+  readonly skills: IProviderSkills = new OmpSkillsProvider();
+  readonly sessions: IProviderSessions = new OmpSessionsProvider();
+  readonly sessionSynchronizer: IProviderSessionSynchronizer = new OmpSessionSynchronizer();
+
+  constructor() {
+    super('omp');
+  }
+}

--- a/server/modules/providers/list/omp/stdio-jsonrpc-client.ts
+++ b/server/modules/providers/list/omp/stdio-jsonrpc-client.ts
@@ -1,0 +1,330 @@
+import type { ChildProcessWithoutNullStreams } from 'node:child_process';
+
+import type { AnyRecord } from '@/shared/types.js';
+
+/**
+ * Minimal JSON-RPC 2.0 client over a child process's stdio.
+ *
+ * Designed for omp's ACP (Agent Client Protocol) endpoint, but agnostic of the
+ * method names used. Handles:
+ *   - line-buffered stdout (one JSON-RPC frame per line)
+ *   - request/response correlation by `id` (responses carry `id` and no `method`)
+ *   - notification dispatch by method name (with prefix-matching support so a
+ *     protocol extension namespace can register a wildcard handler)
+ *   - inbound server->client requests (frame with BOTH `id` and `method`, e.g.
+ *     `session/request_permission`): dispatched to a `registerRequestHandler`
+ *     callback whose resolved value is written back as a JSON-RPC response,
+ *     echoing the request id (string or number)
+ *   - graceful close that rejects all in-flight requests with the close reason
+ */
+
+type Handler = (params: AnyRecord) => void;
+type RequestId = number | string;
+type RequestHandler = (params: AnyRecord) => unknown | Promise<unknown>;
+/**
+ * JSON-RPC allows positional (array) params, but every method here takes named
+ * params — so anything that is not a plain object reaches handlers as an empty
+ * record instead of being mislabelled as one.
+ */
+function asParamRecord(params: unknown): AnyRecord {
+  return params !== null && typeof params === 'object' && !Array.isArray(params)
+    ? (params as AnyRecord)
+    : {};
+}
+
+type PendingRequest = {
+  resolve: (value: unknown) => void;
+  reject: (reason: unknown) => void;
+  method: string;
+};
+
+type StdioJsonRpcClientOptions = {
+  /** Maximum time to wait for a response, in ms. Default 120_000 (2 minutes). */
+  requestTimeoutMs?: number;
+  /** Optional callback for stderr lines from the child. */
+  onStderr?: (line: string) => void;
+  /** Optional callback for parse failures. */
+  onParseError?: (rawLine: string, error: unknown) => void;
+};
+
+/**
+ * Wraps a spawned child process and exposes JSON-RPC request/notify/onNotification.
+ *
+ * Caller owns the child process lifecycle (spawning and killing). This client
+ * only attaches stdout/stderr listeners and writes to stdin.
+ *
+ * Consumed by the omp runtime provider, which speaks ACP to an `omp` child
+ * process over this transport.
+ */
+export class StdioJsonRpcClient {
+  private nextId = 1;
+  private readonly pending = new Map<number, PendingRequest>();
+  private readonly handlers = new Map<string, Handler>();
+  private readonly prefixHandlers = new Map<string, Handler>();
+  private readonly requestHandlers = new Map<string, RequestHandler>();
+  private readonly options: Required<Pick<StdioJsonRpcClientOptions, 'requestTimeoutMs'>> &
+    Pick<StdioJsonRpcClientOptions, 'onStderr' | 'onParseError'>;
+  private stdoutBuffer = '';
+  private closed = false;
+
+  constructor(
+    private readonly child: ChildProcessWithoutNullStreams,
+    options: StdioJsonRpcClientOptions = {},
+  ) {
+    this.options = {
+      requestTimeoutMs: options.requestTimeoutMs ?? 120_000,
+      onStderr: options.onStderr,
+      onParseError: options.onParseError,
+    };
+
+    // A write to a dead child's stdin emits 'error' (EPIPE); without a listener
+    // Node throws it process-wide. Swallow it — request()'s write callback and
+    // the child 'close'/'error' handlers already reject the affected requests.
+    this.child.stdin.on('error', () => {});
+
+    this.child.stdout.setEncoding('utf8');
+    this.child.stdout.on('data', this.handleStdoutChunk);
+    if (this.child.stderr) {
+      this.child.stderr.setEncoding('utf8');
+      this.child.stderr.on('data', this.handleStderrChunk);
+    }
+    this.child.on('close', this.handleClose);
+    this.child.on('error', (error) => this.handleClose(null, null, error));
+  }
+
+  /**
+   * Sends a JSON-RPC request and resolves with the typed result.
+   *
+   * `options.timeoutMs` overrides the client-wide default for this one request;
+   * pass `0` to disable the timeout entirely. This exists because ACP
+   * `session/prompt` resolves only at end-of-turn (routinely minutes), which
+   * would spuriously reject under the 2-minute client default.
+   */
+  request<TResult = unknown>(
+    method: string,
+    params?: unknown,
+    options: { timeoutMs?: number } = {},
+  ): Promise<TResult> {
+    if (this.closed) {
+      return Promise.reject(new Error(`JSON-RPC client is closed (request: ${method})`));
+    }
+
+    const id = this.nextId;
+    this.nextId += 1;
+    const frame = JSON.stringify({ jsonrpc: '2.0', id, method, params });
+    const timeoutMs = options.timeoutMs ?? this.options.requestTimeoutMs;
+
+    return new Promise<TResult>((resolve, reject) => {
+      const timer = timeoutMs > 0
+        ? setTimeout(() => {
+            this.pending.delete(id);
+            reject(new Error(`JSON-RPC request '${method}' timed out after ${timeoutMs}ms`));
+          }, timeoutMs)
+        : null;
+
+      this.pending.set(id, {
+        resolve: (value) => {
+          if (timer) clearTimeout(timer);
+          resolve(value as TResult);
+        },
+        reject: (reason) => {
+          if (timer) clearTimeout(timer);
+          reject(reason);
+        },
+        method,
+      });
+
+      this.child.stdin.write(`${frame}\n`, (error) => {
+        if (error) {
+          if (timer) clearTimeout(timer);
+          this.pending.delete(id);
+          reject(error);
+        }
+      });
+    });
+  }
+
+  /**
+   * Sends a JSON-RPC notification (no response expected).
+   */
+  notify(method: string, params?: unknown): void {
+    if (this.closed) {
+      return;
+    }
+    const frame = JSON.stringify({ jsonrpc: '2.0', method, params });
+    this.child.stdin.write(`${frame}\n`);
+  }
+
+  /**
+   * Registers a notification handler for a specific method name.
+   *
+   * Returns a disposer that removes the handler.
+   */
+  onNotification(method: string, handler: Handler): () => void {
+    this.handlers.set(method, handler);
+    return () => this.handlers.delete(method);
+  }
+
+  /**
+   * Registers a notification handler for any method whose name starts with the
+   * given prefix (e.g. `_ext/`). Useful for protocol extension namespaces.
+   */
+  onNotificationPrefix(prefix: string, handler: Handler): () => void {
+    this.prefixHandlers.set(prefix, handler);
+    return () => this.prefixHandlers.delete(prefix);
+  }
+
+  /**
+   * Registers a handler for INBOUND server->client requests of the given method
+   * (e.g. `session/request_permission`). The handler's resolved value is written
+   * back as the JSON-RPC `result`; a thrown/rejected error becomes an `error`
+   * response. Returns a disposer.
+   */
+  registerRequestHandler(method: string, handler: RequestHandler): () => void {
+    this.requestHandlers.set(method, handler);
+    return () => this.requestHandlers.delete(method);
+  }
+
+  /**
+   * True after the child process has exited or errored.
+   */
+  isClosed(): boolean {
+    return this.closed;
+  }
+
+  private writeResponse(id: RequestId, result: unknown, error?: { code: number; message: string }): void {
+    if (this.closed) {
+      return;
+    }
+    const frame = error
+      ? { jsonrpc: '2.0', id, error }
+      : { jsonrpc: '2.0', id, result };
+    this.child.stdin.write(`${JSON.stringify(frame)}\n`);
+  }
+
+  private async handleInboundRequest(id: RequestId, method: string, params: unknown): Promise<void> {
+    const handler = this.requestHandlers.get(method);
+    if (!handler) {
+      this.writeResponse(id, undefined, { code: -32601, message: `No handler for request '${method}'` });
+      return;
+    }
+    try {
+      const result = await handler(asParamRecord(params));
+      this.writeResponse(id, result);
+    } catch (handlerError) {
+      const message = handlerError instanceof Error ? handlerError.message : String(handlerError);
+      this.writeResponse(id, undefined, { code: -32603, message });
+    }
+  }
+
+  private handleStdoutChunk = (chunk: string): void => {
+    this.stdoutBuffer += chunk;
+
+    let newlineIndex: number;
+    while ((newlineIndex = this.stdoutBuffer.indexOf('\n')) >= 0) {
+      const rawLine = this.stdoutBuffer.slice(0, newlineIndex).trim();
+      this.stdoutBuffer = this.stdoutBuffer.slice(newlineIndex + 1);
+      if (!rawLine) {
+        continue;
+      }
+
+      let frame: Record<string, unknown>;
+      try {
+        const parsed = JSON.parse(rawLine);
+        if (!parsed || typeof parsed !== 'object') {
+          continue;
+        }
+        frame = parsed as Record<string, unknown>;
+      } catch (error) {
+        this.options.onParseError?.(rawLine, error);
+        continue;
+      }
+
+      this.dispatchFrame(frame);
+    }
+  };
+
+  private handleStderrChunk = (chunk: string): void => {
+    if (!this.options.onStderr) {
+      return;
+    }
+    for (const line of chunk.split(/\r?\n/)) {
+      const trimmed = line.trim();
+      if (trimmed) {
+        this.options.onStderr(trimmed);
+      }
+    }
+  };
+
+  private handleClose = (code?: number | null, _signal?: NodeJS.Signals | null, error?: Error): void => {
+    if (this.closed) {
+      return;
+    }
+    this.closed = true;
+    const reason = error
+      ? error
+      : new Error(code === 0 ? 'JSON-RPC stream closed' : `JSON-RPC stream closed with code ${code ?? 'unknown'}`);
+    for (const pending of this.pending.values()) {
+      pending.reject(reason);
+    }
+    this.pending.clear();
+  };
+
+  private dispatchFrame(frame: Record<string, unknown>): void {
+    const id: RequestId | null = (typeof frame.id === 'number' || typeof frame.id === 'string')
+      ? frame.id
+      : null;
+    const method = typeof frame.method === 'string' ? frame.method : null;
+
+    // Inbound server->client REQUEST: carries BOTH an id and a method. Must be
+    // disambiguated from a response (which never carries `method`) even if its
+    // id happens to collide with one of our pending client-request ids.
+    if (id !== null && method) {
+      void this.handleInboundRequest(id, method, frame.params);
+      return;
+    }
+
+    // Response to one of our requests: an id and no method. Pending is keyed by
+    // the numeric ids we generate; a foreign string id simply won't match.
+    if (id !== null && method === null) {
+      const pending = typeof id === 'number' ? this.pending.get(id) : undefined;
+      if (!pending) {
+        return;
+      }
+      this.pending.delete(id as number);
+      if (frame.error && typeof frame.error === 'object') {
+        const err = frame.error as Record<string, unknown>;
+        const message = typeof err.message === 'string' ? err.message : 'JSON-RPC error';
+        const rpcError = new Error(`${message} (method: ${pending.method})`);
+        (rpcError as Error & { data?: unknown }).data = err.data;
+        pending.reject(rpcError);
+        return;
+      }
+      pending.resolve(frame.result);
+      return;
+    }
+
+    if (method) {
+      const params = frame.params;
+      const exact = this.handlers.get(method);
+      if (exact) {
+        try {
+          exact(asParamRecord(params));
+        } catch (handlerError) {
+          // Handler errors must not break the JSON-RPC stream — but they ARE
+          // logged so silent regressions don't slip past the stderr console.
+          console.error(`[StdioJsonRpcClient] notification handler for "${method}" threw:`, handlerError);
+        }
+      }
+      for (const [prefix, handler] of this.prefixHandlers) {
+        if (method.startsWith(prefix)) {
+          try {
+            handler(asParamRecord(params));
+          } catch (handlerError) {
+            console.error(`[StdioJsonRpcClient] prefix-"${prefix}" handler threw on "${method}":`, handlerError);
+          }
+        }
+      }
+    }
+  }
+}

--- a/server/modules/providers/list/opencode/opencode-skills.provider.ts
+++ b/server/modules/providers/list/opencode/opencode-skills.provider.ts
@@ -6,6 +6,7 @@ import type { ProviderSkillSource } from '@/shared/types.js';
 import {
   addUniqueProviderSkillSource,
   findTopmostGitRoot,
+  getProjectSkillSearchRoots,
 } from '@/shared/utils.js';
 
 const OPENCODE_PROJECT_SKILL_DIRS = [
@@ -30,7 +31,7 @@ export class OpenCodeSkillsProvider extends SkillsProvider {
     const seenRootDirs = new Set<string>();
     const repoRoot = await findTopmostGitRoot(workspacePath);
 
-    for (const projectRoot of this.getProjectSearchRoots(workspacePath, repoRoot)) {
+    for (const projectRoot of getProjectSkillSearchRoots(workspacePath, repoRoot)) {
       for (const skillDir of OPENCODE_PROJECT_SKILL_DIRS) {
         // OpenCode intentionally reads Claude and Agents skill folders so users
         // can reuse the same skill libraries across compatible coding agents.
@@ -51,28 +52,5 @@ export class OpenCodeSkillsProvider extends SkillsProvider {
     }
 
     return sources;
-  }
-
-  private getProjectSearchRoots(workspacePath: string, repoRoot: string | null): string[] {
-    const roots: string[] = [];
-    const normalizedWorkspacePath = path.resolve(workspacePath);
-    const normalizedRepoRoot = repoRoot ? path.resolve(repoRoot) : null;
-    let currentPath = normalizedWorkspacePath;
-
-    while (true) {
-      roots.push(currentPath);
-      if (!normalizedRepoRoot || currentPath === normalizedRepoRoot) {
-        break;
-      }
-
-      const parentPath = path.dirname(currentPath);
-      if (parentPath === currentPath) {
-        break;
-      }
-
-      currentPath = parentPath;
-    }
-
-    return roots;
   }
 }

--- a/server/modules/providers/provider.registry.ts
+++ b/server/modules/providers/provider.registry.ts
@@ -1,6 +1,7 @@
 import { ClaudeProvider } from '@/modules/providers/list/claude/claude.provider.js';
 import { CodexProvider } from '@/modules/providers/list/codex/codex.provider.js';
 import { CursorProvider } from '@/modules/providers/list/cursor/cursor.provider.js';
+import { OmpProvider } from '@/modules/providers/list/omp/omp.provider.js';
 import { OpenCodeProvider } from '@/modules/providers/list/opencode/opencode.provider.js';
 import type { IProvider } from '@/shared/interfaces.js';
 import type { LLMProvider } from '@/shared/types.js';
@@ -11,6 +12,7 @@ const providers: Record<LLMProvider, IProvider> = {
   codex: new CodexProvider(),
   cursor: new CursorProvider(),
   opencode: new OpenCodeProvider(),
+  omp: new OmpProvider(),
 };
 
 /**

--- a/server/modules/providers/provider.routes.ts
+++ b/server/modules/providers/provider.routes.ts
@@ -287,6 +287,7 @@ const parseProvider = (value: unknown): LLMProvider => {
     || normalized === 'codex'
     || normalized === 'cursor'
     || normalized === 'opencode'
+    || normalized === 'omp'
   ) {
     return normalized;
   }

--- a/server/modules/providers/services/mcp.service.ts
+++ b/server/modules/providers/services/mcp.service.ts
@@ -66,6 +66,11 @@ export const providerMcpService = {
     const results: Array<{ provider: LLMProvider; created: boolean; error?: string }> = [];
     const providers = providerRegistry.listProviders();
     for (const provider of providers) {
+      // Skip providers that can't write MCP (e.g. omp stub) — they are not
+      // failures, so a global add still succeeds for the providers that support it.
+      if (provider.mcp.supportedScopes.length === 0) {
+        continue;
+      }
       try {
         await provider.mcp.upsertServer({ ...input, scope });
         results.push({ provider: provider.id, created: true });
@@ -92,6 +97,9 @@ export const providerMcpService = {
     const results: Array<{ provider: LLMProvider; removed: boolean; error?: string }> = [];
     const providers = providerRegistry.listProviders();
     for (const provider of providers) {
+      if (provider.mcp.supportedScopes.length === 0) {
+        continue;
+      }
       try {
         const result = await provider.mcp.removeServer(input);
         results.push({ provider: provider.id, removed: result.removed });

--- a/server/modules/providers/services/provider-capabilities.service.ts
+++ b/server/modules/providers/services/provider-capabilities.service.ts
@@ -1,3 +1,7 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
 import type { LLMProvider } from '@/shared/types.js';
 
 /**
@@ -81,17 +85,71 @@ const PROVIDER_CAPABILITIES: Record<LLMProvider, ProviderCapabilities> = {
     supportsTokenUsage: true,
     supportsEffort: true,
   },
+  omp: {
+    provider: 'omp',
+    // omp (ACP) supports interactive per-tool approvals (`session/request_permission`),
+    // a `plan` mode and `bypassPermissions` (auto-allow), thinking levels mapped
+    // onto reasoning effort, images in the prompt, abort via `session/cancel`, and
+    // post-turn token usage read from the session jsonl.
+    permissionModes: ['default', 'plan', 'bypassPermissions'],
+    defaultPermissionMode: 'default',
+    supportsImages: true,
+    // buildAcpPromptBlocks skips non-image attachments, so general files would
+    // silently vanish from the prompt — don't advertise what we drop.
+    supportsFiles: false,
+    supportsAbort: true,
+    supportsPermissionRequests: true,
+    supportsTokenUsage: true,
+    supportsEffort: true,
+  },
 };
+
+/**
+ * omp's configured approval mode → the web composer's default permission mode.
+ * omp `config.yml` has `tools.approvalMode: yolo|write|always-ask`; `yolo` means
+ * "never ask" ⇒ our `bypassPermissions` (which auto-allows the ACP gate), while
+ * `write`/`always-ask` map to interactive `default`. Read from the file directly
+ * (approvalMode is unique in the config) to avoid a YAML dependency. This is only
+ * a first-time default — a mode the user picks in the UI is persisted and wins.
+ * Memoized per-process (approvalMode changes rarely; a restart re-reads) so this
+ * stays off the disk on the capabilities request path.
+ */
+let cachedOmpDefaultMode: string | null = null;
+function readOmpDefaultPermissionMode(): string {
+  if (cachedOmpDefaultMode !== null) {
+    return cachedOmpDefaultMode;
+  }
+  let mode = 'default';
+  try {
+    const cfg = fs.readFileSync(path.join(os.homedir(), '.omp', 'agent', 'config.yml'), 'utf8');
+    const match = cfg.match(/^\s*approvalMode:\s*(\S+)/m);
+    // Strip surrounding quotes so `approvalMode: "yolo"` still maps correctly.
+    if (match?.[1]?.replace(/['"]/g, '') === 'yolo') {
+      mode = 'bypassPermissions';
+    }
+  } catch {
+    // no config → default
+  }
+  cachedOmpDefaultMode = mode;
+  return mode;
+}
+
+function withDynamicDefaults(caps: ProviderCapabilities): ProviderCapabilities {
+  if (caps?.provider === 'omp') {
+    return { ...caps, defaultPermissionMode: readOmpDefaultPermissionMode() };
+  }
+  return caps;
+}
 
 /**
  * Application service exposing the provider capability matrix.
  */
 export const providerCapabilitiesService = {
   getProviderCapabilities(provider: LLMProvider): ProviderCapabilities {
-    return PROVIDER_CAPABILITIES[provider];
+    return withDynamicDefaults(PROVIDER_CAPABILITIES[provider]);
   },
 
   listAllProviderCapabilities(): ProviderCapabilities[] {
-    return Object.values(PROVIDER_CAPABILITIES);
+    return Object.values(PROVIDER_CAPABILITIES).map(withDynamicDefaults);
   },
 };

--- a/server/modules/providers/services/provider-token-usage.service.ts
+++ b/server/modules/providers/services/provider-token-usage.service.ts
@@ -6,6 +6,8 @@ import path from 'node:path';
 import Database from 'better-sqlite3';
 
 import { sessionsDb } from '@/modules/database/index.js';
+import { OMP_FALLBACK_CONTEXT_WINDOW, readOmpContextWindow } from '@/modules/providers/list/omp/omp-models.provider.js';
+import { readOmpSessionUsage } from '@/modules/providers/list/omp/omp-runtime.provider.js';
 import type { AnyRecord } from '@/shared/types.js';
 import { AppError, getOpenCodeDatabasePath } from '@/shared/utils.js';
 
@@ -19,6 +21,10 @@ type ProviderTokenUsageServiceDependencies = {
   readDirectory: (directoryPath: string) => Promise<Dirent[]>;
   readTextFile: (filePath: string) => Promise<string>;
   getClaudeContextWindow: () => string | undefined;
+  // Injected because the real reader spawns the `omp` binary through a
+  // module-level cache: a test that reached it paid the models timeout and
+  // then leaked the resolved catalog into every later test in the process.
+  getOmpContextWindow: (provider: string | null, model: string | null) => Promise<number | null>;
 };
 
 type TokenUsageResult = {
@@ -26,6 +32,12 @@ type TokenUsageResult = {
   total?: number;
   inputTokens: number;
   outputTokens: number;
+  /**
+   * Identifier of the model the latest turn ran on, when the transcript
+   * records it. Providers whose session-level model is a "use my own config"
+   * sentinel (omp) can only answer per turn, so this is optional everywhere.
+   */
+  model?: string;
   cacheReadTokens?: number;
   cacheCreationTokens?: number;
   cacheTokens?: number;
@@ -53,6 +65,7 @@ const defaultDependencies: ProviderTokenUsageServiceDependencies = {
   readDirectory: (directoryPath) => fsp.readdir(directoryPath, { withFileTypes: true }),
   readTextFile: (filePath) => fsp.readFile(filePath, 'utf8'),
   getClaudeContextWindow: () => process.env.CONTEXT_WINDOW,
+  getOmpContextWindow: readOmpContextWindow,
 };
 
 function readUsageNumber(value: unknown): number {
@@ -288,6 +301,32 @@ export function createProviderTokenUsageService(
         }
 
         return readOpenCodeTokenUsage(databasePath, providerSessionId);
+      }
+
+      if (session.provider === 'omp') {
+        // omp's jsonl entries are `type:'message'` with `.message.usage` (camelCase),
+        // so the Claude reader below (which scans `type:'assistant'` + snake_case)
+        // would report zeros. Read it the way the omp adapter does.
+        const record = await readOmpSessionUsage(providerSessionId, session.jsonl_path);
+        if (!record) {
+          return { used: 0, total: 0, inputTokens: 0, outputTokens: 0, breakdown: { input: 0, output: 0 } };
+        }
+        const { usage } = record;
+        const inputTokens = Number(usage.input || 0) + Number(usage.cacheRead || 0);
+        const outputTokens = Number(usage.output || 0);
+        return {
+          used: Number(usage.totalTokens || inputTokens + outputTokens),
+          // The window belongs to the model the turn actually ran on, which the
+          // transcript records per message — the session's configured model is
+          // usually the "use omp default" sentinel and says nothing. Reporting a
+          // flat 200k understated Opus 5 by 5x.
+          total: await dependencies.getOmpContextWindow(record.provider, record.model)
+            ?? OMP_FALLBACK_CONTEXT_WINDOW,
+          model: record.model ?? undefined,
+          inputTokens,
+          outputTokens,
+          breakdown: { input: inputTokens, output: outputTokens },
+        };
       }
 
       if (session.provider === 'codex') {

--- a/server/modules/providers/services/session-synchronizer.service.ts
+++ b/server/modules/providers/services/session-synchronizer.service.ts
@@ -22,6 +22,7 @@ export const sessionSynchronizerService = {
       codex: 0,
       cursor: 0,
       opencode: 0,
+      omp: 0,
     };
     const failures: string[] = [];
 

--- a/server/modules/providers/services/sessions-watcher.service.ts
+++ b/server/modules/providers/services/sessions-watcher.service.ts
@@ -29,6 +29,10 @@ const PROVIDER_WATCH_PATHS: Array<{ provider: LLMProvider; rootPath: string }> =
     provider: 'opencode',
     rootPath: path.join(os.homedir(), '.local', 'share', 'opencode'),
   },
+  {
+    provider: 'omp',
+    rootPath: path.join(os.homedir(), '.omp', 'agent', 'sessions'),
+  },
 ];
 
 const WATCHER_IGNORED_PATTERNS = [

--- a/server/modules/providers/shared/mcp/mcp.provider.ts
+++ b/server/modules/providers/shared/mcp/mcp.provider.ts
@@ -24,7 +24,7 @@ const normalizeServerName = (name: string): string => {
  */
 export abstract class McpProvider implements IProviderMcp {
   protected readonly provider: LLMProvider;
-  protected readonly supportedScopes: McpScope[];
+  readonly supportedScopes: McpScope[];
   protected readonly supportedTransports: McpTransport[];
 
   protected constructor(

--- a/server/modules/providers/shared/skills/claude-plugin-skills.ts
+++ b/server/modules/providers/shared/skills/claude-plugin-skills.ts
@@ -1,0 +1,236 @@
+import { readFile, readdir, stat } from 'node:fs/promises';
+import path from 'node:path';
+
+import { parseFrontMatter } from '@/shared/frontmatter.js';
+import type { LLMProvider, ProviderSkill } from '@/shared/types.js';
+import {
+  findProviderSkillMarkdownFiles,
+  readJsonConfig,
+  readObjectRecord,
+  readOptionalString,
+  readProviderSkillMarkdownDefinition,
+} from '@/shared/utils.js';
+
+/**
+ * Claude Code marketplace plugins ship skills outside any `skills` root, so they
+ * are discovered through the plugin registry instead of a directory scan. Shared
+ * because omp reads the same installed plugins as one of its own skill tiers.
+ */
+
+const getClaudePluginName = (pluginId: string): string | null => {
+  const normalizedPluginId = pluginId.trim();
+  if (!normalizedPluginId || normalizedPluginId === '@') {
+    return null;
+  }
+
+  const [pluginName] = normalizedPluginId.split('@');
+  return readOptionalString(pluginName) ?? null;
+};
+
+const pathExistsAsDirectory = async (directoryPath: string): Promise<boolean> => {
+  try {
+    const directoryStats = await stat(directoryPath);
+    return directoryStats.isDirectory();
+  } catch {
+    return false;
+  }
+};
+
+const listChildDirectories = async (directoryPath: string): Promise<string[]> => {
+  try {
+    const entries = await readdir(directoryPath, { withFileTypes: true });
+    return entries
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => path.join(directoryPath, entry.name))
+      .sort((left, right) => left.localeCompare(right));
+  } catch {
+    return [];
+  }
+};
+
+const readClaudePluginName = async (
+  installPath: string,
+  pluginId: string,
+): Promise<string | null> => {
+  try {
+    const pluginConfig = await readJsonConfig(
+      path.join(installPath, '.claude-plugin', 'plugin.json'),
+    );
+
+    // Older or partial plugin installs may not have plugin.json yet. Falling
+    // back keeps discovery useful without inventing a separate namespace.
+    return readOptionalString(pluginConfig.name) ?? getClaudePluginName(pluginId);
+  } catch {
+    return getClaudePluginName(pluginId);
+  }
+};
+
+const readPluginCommandDefinition = async (
+  commandPath: string,
+): Promise<{ name: string; description: string }> => {
+  const content = await readFile(commandPath, 'utf8');
+  const parsed = parseFrontMatter(content);
+  const data = readObjectRecord(parsed.data) ?? {};
+
+  return {
+    name: path.basename(commandPath).replace(/\.md$/i, ''),
+    description: readOptionalString(data.description) ?? '',
+  };
+};
+
+const listPluginCommandSkills = async (
+  provider: LLMProvider,
+  commandsPath: string,
+  pluginId: string,
+  pluginName: string,
+): Promise<ProviderSkill[]> => {
+  const skills: ProviderSkill[] = [];
+
+  try {
+    const entries = await readdir(commandsPath, { withFileTypes: true });
+    const commandFiles = entries
+      .filter((entry) => entry.isFile() && entry.name.toLowerCase().endsWith('.md'))
+      .sort((left, right) => left.name.localeCompare(right.name));
+
+    for (const commandFile of commandFiles) {
+      const sourcePath = path.join(commandsPath, commandFile.name);
+      try {
+        const definition = await readPluginCommandDefinition(sourcePath);
+        skills.push({
+          provider,
+          name: definition.name,
+          description: definition.description,
+          command: `/${pluginName}:${definition.name}`,
+          scope: 'plugin',
+          sourcePath,
+          pluginName,
+          pluginId,
+        });
+      } catch {
+        // Malformed command markdown should not block sibling plugin commands.
+      }
+    }
+  } catch {
+    // Missing or unreadable command folders are treated as empty plugin command sets.
+  }
+
+  return skills;
+};
+
+const listPluginSkillMarkdowns = async (
+  provider: LLMProvider,
+  installPath: string,
+  pluginId: string,
+  pluginName: string,
+): Promise<ProviderSkill[]> => {
+  const skillFiles = await findProviderSkillMarkdownFiles(path.join(installPath, 'skills'), {
+    recursive: true,
+  });
+  const skills: ProviderSkill[] = [];
+
+  for (const skillPath of skillFiles) {
+    try {
+      const definition = await readProviderSkillMarkdownDefinition(skillPath);
+      skills.push({
+        provider,
+        name: definition.name,
+        description: definition.description,
+        command: `/${pluginName}:${definition.name}`,
+        scope: 'plugin',
+        sourcePath: skillPath,
+        pluginName,
+        pluginId,
+      });
+    } catch {
+      // A bad plugin skill file should not block other installed plugin skills.
+    }
+  }
+
+  return skills;
+};
+
+/**
+ * Lists the skills of every enabled Claude Code plugin, attributed to `provider`.
+ */
+export async function listClaudePluginSkills(
+  provider: LLMProvider,
+  claudeHomePath: string,
+): Promise<ProviderSkill[]> {
+  const settings = await readJsonConfig(path.join(claudeHomePath, 'settings.json'));
+  const enabledPlugins = readObjectRecord(settings.enabledPlugins);
+  if (!enabledPlugins) {
+    return [];
+  }
+
+  const installedConfig = await readJsonConfig(
+    path.join(claudeHomePath, 'plugins', 'installed_plugins.json'),
+  );
+  const installedPlugins = readObjectRecord(installedConfig.plugins);
+  if (!installedPlugins) {
+    return [];
+  }
+
+  const skills: ProviderSkill[] = [];
+  const visitedPluginFolders = new Set<string>();
+  const pluginEntries = Object.entries(enabledPlugins)
+    .sort(([left], [right]) => left.localeCompare(right));
+  for (const [pluginId, enabled] of pluginEntries) {
+    if (enabled !== true) {
+      continue;
+    }
+
+    const installs = installedPlugins[pluginId];
+    if (!Array.isArray(installs)) {
+      continue;
+    }
+
+    for (const install of installs) {
+      const installRecord = readObjectRecord(install);
+      const installPath = readOptionalString(installRecord?.installPath);
+      if (!installPath) {
+        continue;
+      }
+
+      // Claude's installed path points at one version folder; the usable
+      // plugin payloads live in the direct child folders beside it.
+      const pluginFolders = await listChildDirectories(path.dirname(installPath));
+      for (const pluginFolder of pluginFolders) {
+        const pluginFolderKey = `${pluginId}:${path.resolve(pluginFolder)}`;
+        if (visitedPluginFolders.has(pluginFolderKey)) {
+          continue;
+        }
+        visitedPluginFolders.add(pluginFolderKey);
+
+        const pluginName = await readClaudePluginName(pluginFolder, pluginId);
+        if (!pluginName) {
+          continue;
+        }
+
+        const commandsPath = path.join(pluginFolder, 'commands');
+        const commandSkills = (await pathExistsAsDirectory(commandsPath))
+          ? await listPluginCommandSkills(provider, commandsPath, pluginId, pluginName)
+          : [];
+
+        // A plugin that ships commands wraps its own skills in them, so the
+        // commands are the user-facing surface and the skill files are noise.
+        // A commands folder holding nothing this agent can read is not: several
+        // plugins keep `.toml` command files there for other harnesses and put
+        // the real payload in `skills/`.
+        if (commandSkills.length > 0) {
+          skills.push(...commandSkills);
+          continue;
+        }
+
+        if (!(await pathExistsAsDirectory(path.join(pluginFolder, 'skills')))) {
+          continue;
+        }
+
+        skills.push(
+          ...(await listPluginSkillMarkdowns(provider, pluginFolder, pluginId, pluginName)),
+        );
+      }
+    }
+  }
+
+  return skills;
+}

--- a/server/modules/providers/shared/skills/skills.provider.ts
+++ b/server/modules/providers/shared/skills/skills.provider.ts
@@ -94,9 +94,18 @@ export abstract class SkillsProvider implements IProviderSkills {
 
   async listSkills(options?: ProviderSkillListOptions): Promise<ProviderSkill[]> {
     const workspacePath = resolveWorkspacePath(options?.workspacePath);
-    const sources = await this.getSkillSources(workspacePath);
-    const skills: ProviderSkill[] = [];
+    return this.scanSkillSources(await this.getSkillSources(workspacePath));
+  }
 
+  /**
+   * Reads every skill markdown under `sources`, keeping the order they arrive in.
+   *
+   * Split out of `listSkills` so a provider whose ranking interleaves scanned
+   * roots with skills that do not come from a root (omp ranks Claude plugin
+   * skills between two of its own root tiers) can compose the groups itself.
+   */
+  protected async scanSkillSources(sources: ProviderSkillSource[]): Promise<ProviderSkill[]> {
+    const skills: ProviderSkill[] = [];
     for (const source of sources) {
       const skillFiles = await findProviderSkillMarkdownFiles(source.rootDir, {
         recursive: source.recursive,

--- a/server/modules/providers/tests/mcp.test.ts
+++ b/server/modules/providers/tests/mcp.test.ts
@@ -313,8 +313,13 @@ test('providerMcpService global adder writes to all providers and rejects unsupp
       workspacePath,
     });
 
+    // omp declares no supported scopes (MCP stubbed), so it is SKIPPED — the
+    // global add succeeds for the 4 file-backed providers and omp never appears
+    // as a failure (regression fix: one unsupported provider must not fail the
+    // whole global add for everyone else).
     assert.equal(globalResult.length, 4);
     assert.ok(globalResult.every((entry) => entry.created === true));
+    assert.ok(!globalResult.some((entry) => entry.provider === 'omp'));
 
     const claudeProject = await readJson(path.join(workspacePath, '.mcp.json'));
     assert.ok((claudeProject.mcpServers as Record<string, unknown>)['global-http']);

--- a/server/modules/providers/tests/omp-auth.test.ts
+++ b/server/modules/providers/tests/omp-auth.test.ts
@@ -1,0 +1,32 @@
+/**
+ * Unit test for OmpProviderAuth (P7). The off-PATH case is deterministic; the
+ * real-binary case just asserts a well-formed, non-throwing status (portable
+ * across machines that may or may not have omp / an agent.db).
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { OmpProviderAuth } from '@/modules/providers/list/omp/omp-auth.provider.js';
+
+describe('OmpProviderAuth', () => {
+  it('reports installed:false when omp is off PATH (async spawn, fail-closed)', async () => {
+    const prev = process.env.OMP_PATH;
+    process.env.OMP_PATH = '/nonexistent/omp-xyz';
+    try {
+      const status = await new OmpProviderAuth().getStatus();
+      assert.equal(status.installed, false);
+      assert.equal(status.authenticated, false);
+      assert.equal(status.provider, 'omp');
+      assert.ok(status.error, 'not-installed carries an error');
+    } finally {
+      if (prev === undefined) delete process.env.OMP_PATH; else process.env.OMP_PATH = prev;
+    }
+  });
+
+  it('returns a well-formed status against the real binary without throwing', async () => {
+    const status = await new OmpProviderAuth().getStatus();
+    assert.equal(status.provider, 'omp');
+    assert.equal(typeof status.installed, 'boolean');
+    assert.equal(typeof status.authenticated, 'boolean');
+  });
+});

--- a/server/modules/providers/tests/omp-history.test.ts
+++ b/server/modules/providers/tests/omp-history.test.ts
@@ -1,0 +1,268 @@
+/**
+ * Integration test for the omp jsonl synchronizer + history reader.
+ *
+ * Isolated SQLite DB + tmp `~/.omp/agent/sessions` tree: drops a fixture jsonl
+ * (header + title + a toolCall/toolResult pair + usage), runs synchronizeFile,
+ * then fetchHistory — asserting the DB row and the normalized/paged messages.
+ */
+import assert from 'node:assert/strict';
+import { mkdtemp, rm, mkdir, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { describe, it, before, after } from 'node:test';
+
+const ORIGINAL_HOME = process.env.HOME;
+const ORIGINAL_USERPROFILE = process.env.USERPROFILE;
+const ORIGINAL_DB = process.env.DATABASE_PATH;
+
+const SESSION_ID = 'testsession01';
+const CWD = '/work/omp-proj';
+let tempHome: string;
+let tempDbDir: string;
+let jsonlPath: string;
+
+const FIXTURE_LINES = [
+  { type: 'session', version: 3, id: SESSION_ID, timestamp: '2026-07-21T00:00:00.000Z', cwd: CWD },
+  { type: 'title', v: 1, title: 'My omp Session', source: 'auto' },
+  { type: 'message', id: 'm1', message: { role: 'user', content: [{ type: 'text', text: 'run ls' }] } },
+  {
+    type: 'message',
+    id: 'm2',
+    message: {
+      role: 'assistant',
+      content: [
+        { type: 'thinking', thinking: 'let me list files' },
+        { type: 'text', text: 'Listing now' },
+        // omp's real on-disk shape: camelCase `toolCall` with `arguments` (not
+        // the Anthropic `tool_use`/`input`).
+        { type: 'toolCall', id: 'tool1', name: 'Bash', arguments: { command: 'ls' } },
+      ],
+      usage: { input: 100, output: 20, cacheRead: 5, cacheWrite: 0, totalTokens: 120 },
+    },
+  },
+  // omp records the result as its own message with role `toolResult`, linked by
+  // `toolCallId`, content as text blocks.
+  { type: 'message', id: 'm3', message: { role: 'toolResult', toolCallId: 'tool1', toolName: 'Bash', content: [{ type: 'text', text: 'file.txt' }] } },
+];
+
+before(async () => {
+  tempHome = await mkdtemp(path.join(tmpdir(), 'omp-sync-home-'));
+  tempDbDir = await mkdtemp(path.join(tmpdir(), 'omp-sync-db-'));
+  process.env.HOME = tempHome;
+  process.env.USERPROFILE = tempHome;
+  process.env.DATABASE_PATH = path.join(tempDbDir, 'auth.db');
+
+  const slugDir = path.join(tempHome, '.omp', 'agent', 'sessions', '-work-omp-proj');
+  await mkdir(slugDir, { recursive: true });
+  jsonlPath = path.join(slugDir, `2026-07-21T00-00-00-000Z_${SESSION_ID}.jsonl`);
+  await writeFile(jsonlPath, FIXTURE_LINES.map((l) => JSON.stringify(l)).join('\n') + '\n');
+});
+
+after(async () => {
+  if (ORIGINAL_HOME !== undefined) process.env.HOME = ORIGINAL_HOME; else delete process.env.HOME;
+  if (ORIGINAL_USERPROFILE !== undefined) process.env.USERPROFILE = ORIGINAL_USERPROFILE; else delete process.env.USERPROFILE;
+  if (ORIGINAL_DB !== undefined) process.env.DATABASE_PATH = ORIGINAL_DB; else delete process.env.DATABASE_PATH;
+  if (tempHome) await rm(tempHome, { recursive: true, force: true });
+  if (tempDbDir) await rm(tempDbDir, { recursive: true, force: true });
+});
+
+describe('omp synchronizer + fetchHistory', () => {
+  it('indexes a jsonl into a sessions row and reads paged history back', async () => {
+    const { closeConnection, initializeDatabase, sessionsDb } = await import('@/modules/database/index.js');
+    const { OmpSessionSynchronizer } = await import('@/modules/providers/list/omp/omp-session-synchronizer.provider.js');
+    const { OmpSessionsProvider } = await import('@/modules/providers/list/omp/omp-sessions.provider.js');
+
+    closeConnection();
+    await initializeDatabase();
+
+    // --- synchronizer ---
+    const synchronizer = new OmpSessionSynchronizer();
+    const upsertedId = await synchronizer.synchronizeFile(jsonlPath);
+    assert.equal(upsertedId, SESSION_ID);
+
+    const row = sessionsDb.getSessionById(SESSION_ID);
+    assert.ok(row, 'session row should exist');
+    assert.equal(row.provider, 'omp');
+    assert.equal(row.project_path, CWD);
+    assert.equal(row.custom_name, 'My omp Session');
+    assert.equal(row.jsonl_path, jsonlPath);
+
+    // --- fetchHistory (full) ---
+    const provider = new OmpSessionsProvider();
+    const all = await provider.fetchHistory(SESSION_ID, {});
+    const kinds = all.messages.map((m) => m.kind);
+    assert.deepEqual(kinds, ['text', 'thinking', 'text', 'tool_use', 'tool_result']);
+    assert.equal(all.total, 4, 'total excludes the standalone tool_result');
+
+    const toolUse = all.messages.find((m) => m.kind === 'tool_use')!;
+    assert.equal(toolUse.toolName, 'Bash');
+    assert.equal(toolUse.toolId, 'tool1');
+    assert.deepEqual(toolUse.toolInput, { command: 'ls' });
+    assert.deepEqual(toolUse.toolResult, { content: 'file.txt', isError: false });
+
+    const userText = all.messages.find((m) => m.kind === 'text' && m.role === 'user')!;
+    assert.equal(userText.content, 'run ls');
+
+    // --- paging (tail) ---
+    const tail = await provider.fetchHistory(SESSION_ID, { limit: 2, offset: 0 });
+    assert.equal(tail.messages.length, 2);
+    assert.equal(tail.hasMore, true);
+    assert.equal(tail.messages.at(-1)!.kind, 'tool_result', 'newest entry is last');
+
+    closeConnection();
+  });
+
+  it('renders only the active branch of a forked transcript', async () => {
+    // An omp jsonl is a tree: continuing from an earlier point (terminal history
+    // navigation, or a second omp process resuming a stale copy) appends a SECOND
+    // child under that parent. Read in file order the two branches interleave.
+    const { closeConnection, initializeDatabase } = await import('@/modules/database/index.js');
+    const { OmpSessionsProvider } = await import('@/modules/providers/list/omp/omp-sessions.provider.js');
+
+    closeConnection();
+    await initializeDatabase();
+
+    const NATIVE = 'forkedsession03';
+    const cwd3 = '/work/omp-proj3';
+    const slugDir = path.join(tempHome, '.omp', 'agent', 'sessions', '-work-omp-proj3');
+    await mkdir(slugDir, { recursive: true });
+    const jsonl3 = path.join(slugDir, `2026-07-21T02-00-00-000Z_${NATIVE}.jsonl`);
+    const msg = (id: string, parentId: string | null, role: string, text: string) => JSON.stringify({
+      type: 'message', id, parentId, message: { role, content: [{ type: 'text', text }] },
+    });
+    await writeFile(jsonl3, [
+      JSON.stringify({ type: 'session', version: 3, id: NATIVE, timestamp: '2026-07-21T02:00:00.000Z', cwd: cwd3 }),
+      msg('m1', null, 'user', 'first question'),
+      msg('m2', 'm1', 'assistant', 'first answer'),
+      // abandoned branch, interleaved with the live one exactly as two writers leave it
+      msg('b1', 'm2', 'user', 'abandoned question'),
+      msg('c1', 'm2', 'user', 'live question'),
+      msg('b2', 'b1', 'assistant', 'abandoned answer'),
+      msg('c2', 'c1', 'assistant', 'live answer'),
+      // The LAST line of a real forked file is usually the exit marker of whichever
+      // omp process died first, parented to the head IT held — here the abandoned
+      // branch. Taking it as the head would render the dead branch and hide the
+      // live one, which is the very symptom this filter exists to remove.
+      JSON.stringify({
+        type: 'custom', customType: 'session_exit', id: 'x1', parentId: 'b2',
+        data: { reason: 'sigint' },
+      }),
+    ].join('\n') + '\n');
+
+    const provider = new OmpSessionsProvider();
+    const history = await provider.fetchHistory(NATIVE, {});
+    assert.deepEqual(
+      history.messages.map((m) => m.content),
+      ['first question', 'first answer', 'live question', 'live answer'],
+      'the newest RENDERED entry picks the branch, not a trailing lifecycle marker',
+    );
+
+    closeConnection();
+  });
+
+  it('falls back to file order when a fork cannot be resolved', async () => {
+    // Every ambiguous case must degrade to the old interleaved view: showing both
+    // branches is recoverable, hiding the live one is not.
+    const { closeConnection, initializeDatabase } = await import('@/modules/database/index.js');
+    const { OmpSessionsProvider } = await import('@/modules/providers/list/omp/omp-sessions.provider.js');
+
+    closeConnection();
+    await initializeDatabase();
+
+    const NATIVE = 'brokensession04';
+    const slugDir = path.join(tempHome, '.omp', 'agent', 'sessions', '-work-omp-proj4');
+    await mkdir(slugDir, { recursive: true });
+    const jsonl4 = path.join(slugDir, `2026-07-21T03-00-00-000Z_${NATIVE}.jsonl`);
+    const msg = (id: string, parentId: string | null, role: string, text: string) => JSON.stringify({
+      type: 'message', id, parentId, message: { role, content: [{ type: 'text', text }] },
+    });
+    await writeFile(jsonl4, [
+      JSON.stringify({ type: 'session', version: 3, id: NATIVE, timestamp: '2026-07-21T03:00:00.000Z', cwd: '/work/omp-proj4' }),
+      msg('m1', null, 'user', 'first question'),
+      msg('b1', 'm1', 'user', 'abandoned question'),
+      // `gone` is missing from the file — a malformed line the reader dropped. The
+      // chain from the newest entry breaks, so nothing above it can be placed.
+      msg('c1', 'gone', 'user', 'live question'),
+    ].join('\n') + '\n');
+
+    const provider = new OmpSessionsProvider();
+    const history = await provider.fetchHistory(NATIVE, {});
+    assert.deepEqual(
+      history.messages.map((m) => m.content),
+      ['first question', 'abandoned question', 'live question'],
+      'a broken chain keeps every message instead of dropping the transcript above it',
+    );
+
+    closeConnection();
+  });
+
+  it('preserves a user rename on an APP-created row across re-sync (bug #1)', async () => {
+    const { closeConnection, initializeDatabase, sessionsDb } = await import('@/modules/database/index.js');
+    const { OmpSessionSynchronizer } = await import('@/modules/providers/list/omp/omp-session-synchronizer.provider.js');
+
+    closeConnection();
+    await initializeDatabase();
+
+    const NATIVE = 'renamesession02';
+    const cwd2 = '/work/omp-proj2';
+    const slugDir = path.join(tempHome, '.omp', 'agent', 'sessions', '-work-omp-proj2');
+    await mkdir(slugDir, { recursive: true });
+    const jsonl2 = path.join(slugDir, `2026-07-21T01-00-00-000Z_${NATIVE}.jsonl`);
+    await writeFile(jsonl2, [
+      JSON.stringify({ type: 'session', version: 3, id: NATIVE, timestamp: '2026-07-21T01:00:00.000Z', cwd: cwd2 }),
+      JSON.stringify({ type: 'title', v: 1, title: 'Auto Generated Title', source: 'auto' }),
+      JSON.stringify({ type: 'message', id: 'x1', message: { role: 'user', content: [{ type: 'text', text: 'hi' }] } }),
+    ].join('\n') + '\n');
+
+    // App-created row: session_id = app id, provider_session_id = native id.
+    const appId = sessionsDb.createAppSession('app-id-xyz', 'omp', cwd2);
+    sessionsDb.assignProviderSessionId(appId, NATIVE);
+    sessionsDb.updateSessionCustomName(appId, 'User Renamed');
+
+    await new OmpSessionSynchronizer().synchronizeFile(jsonl2);
+
+    const row = sessionsDb.getSessionByProviderSessionId(NATIVE);
+    assert.equal(row?.custom_name, 'User Renamed', 'user rename must survive re-sync (not clobbered by the jsonl auto-title)');
+
+    closeConnection();
+  });
+  it('hides omp\'s internal developer-role system reminders', async () => {
+    const { closeConnection, initializeDatabase } = await import('@/modules/database/index.js');
+    const { OmpSessionSynchronizer } = await import('@/modules/providers/list/omp/omp-session-synchronizer.provider.js');
+    const { OmpSessionsProvider } = await import('@/modules/providers/list/omp/omp-sessions.provider.js');
+
+    closeConnection();
+    await initializeDatabase();
+
+    const NATIVE = 'devremindersess05';
+    const cwd5 = '/work/omp-dev';
+    const slugDir = path.join(tempHome, '.omp', 'agent', 'sessions', '-work-omp-dev');
+    await mkdir(slugDir, { recursive: true });
+    const jsonl5 = path.join(slugDir, `2026-07-21T03-00-00-000Z_${NATIVE}.jsonl`);
+    await writeFile(jsonl5, [
+      JSON.stringify({ type: 'session', version: 3, id: NATIVE, timestamp: '2026-07-21T03:00:00.000Z', cwd: cwd5 }),
+      JSON.stringify({ type: 'title', v: 1, title: 'Dev', source: 'auto' }),
+      JSON.stringify({ type: 'message', id: 't1', message: { role: 'assistant', content: [
+        { type: 'toolCall', id: 'td1', name: 'todo', arguments: { i: 'Plan', op: 'init' } },
+      ] } }),
+      JSON.stringify({ type: 'message', id: 't2', message: { role: 'toolResult', toolCallId: 'td1', toolName: 'todo',
+        content: [{ type: 'text', text: 'Overall: 0/1' }] } }),
+      // omp's internal continuity nudge — must NOT appear in the transcript
+      JSON.stringify({ type: 'message', id: 'd1', message: { role: 'developer', attribution: 'agent',
+        content: [{ type: 'text', text: '<system-reminder>\nYou stopped with 1 incomplete todo item(s):\n- Setup\n</system-reminder>' }] } }),
+    ].join('\n') + '\n');
+
+    await new OmpSessionSynchronizer().synchronizeFile(jsonl5);
+    const all = await new OmpSessionsProvider().fetchHistory(NATIVE, {});
+
+    assert.ok(
+      all.messages.every((m) => !(m.content ?? '').includes('system-reminder')),
+      'developer-role <system-reminder> messages are hidden',
+    );
+
+    const toolResult = all.messages.find((m) => m.kind === 'tool_result')!;
+    assert.equal(toolResult.content, 'Overall: 0/1', 'a tool result carries its text content');
+
+    closeConnection();
+  });
+});

--- a/server/modules/providers/tests/omp-models.test.ts
+++ b/server/modules/providers/tests/omp-models.test.ts
@@ -1,0 +1,40 @@
+/**
+ * Unit test for the omp `omp models --json` catalog parse (P6). Pure — no exec.
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { parseOmpModels, OMP_CONFIGURED_MODEL_SENTINEL } from '@/modules/providers/list/omp/omp-models.provider.js';
+
+describe('parseOmpModels', () => {
+  it('maps selector/name, marks thinking models with effort, sentinel first, dedupes', () => {
+    // Real omp shape: `thinking` is this model's own level array, OR null.
+    const json = JSON.stringify({
+      models: [
+        { provider: 'openai', id: 'gpt-5.2', selector: 'openai/gpt-5.2', name: 'GPT-5.2', thinking: ['minimal', 'low', 'medium', 'high'], contextWindow: 400000 },
+        { provider: 'anthropic', id: 'opus', selector: 'anthropic/opus', name: 'Claude Opus', thinking: null },
+        { provider: 'openai', id: 'gpt-5.2', selector: 'openai/gpt-5.2', name: 'dup' }, // duplicate selector
+      ],
+    });
+    const def = parseOmpModels(json);
+
+    assert.equal(def.OPTIONS[0].value, OMP_CONFIGURED_MODEL_SENTINEL, 'sentinel first');
+    assert.equal(def.DEFAULT, OMP_CONFIGURED_MODEL_SENTINEL);
+
+    const gpt = def.OPTIONS.find((o) => o.value === 'openai/gpt-5.2')!;
+    assert.equal(gpt.label, 'GPT-5.2');
+    assert.equal(gpt.description, 'openai/gpt-5.2');
+    assert.ok(gpt.effort, 'thinking model gets effort');
+    // effort levels are exactly the model's own list (not a hardcoded 7).
+    assert.deepEqual(gpt.effort!.values.map((v) => v.value), ['minimal', 'low', 'medium', 'high']);
+
+    const opus = def.OPTIONS.find((o) => o.value === 'anthropic/opus')!;
+    assert.equal(opus.effort, undefined, 'non-thinking model has no effort');
+
+    assert.equal(def.OPTIONS.filter((o) => o.value === 'openai/gpt-5.2').length, 1, 'deduped');
+  });
+
+  it('falls back to sentinel-only on empty catalog', () => {
+    assert.deepEqual(parseOmpModels('{"models":[]}').OPTIONS.map((o) => o.value), [OMP_CONFIGURED_MODEL_SENTINEL]);
+  });
+});

--- a/server/modules/providers/tests/omp-runtime.fakeproc.test.ts
+++ b/server/modules/providers/tests/omp-runtime.fakeproc.test.ts
@@ -1,0 +1,261 @@
+// P9: end-to-end adapter test through the REAL spawnOmp path against a FAKE
+// `omp` process (a node script speaking ACP JSON-RPC 2.0 over stdio, put on
+// OMP_PATH). No paid omp calls. Run with tsx:
+//   ./node_modules/.bin/tsx --tsconfig server/tsconfig.json --test server/modules/providers/list/omp/omp-runtime.fakeproc.test.js
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, writeFileSync, readFileSync, existsSync, mkdirSync, appendFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import type { AnyRecord, ProviderRuntimeContext } from '@/shared/types.js';
+
+// A minimal ACP agent: answers initialize/session/new/set_config_option, streams
+// an assistant chunk + a tool_call/tool_call_update, then sends ONE inbound
+// session/request_permission and only answers session/prompt once the client
+// responds to it. Records its argv so the test can assert the spawn args.
+const FAKE_OMP = `#!/usr/bin/env node
+const fs = require('node:fs');
+fs.writeFileSync(process.env.OMP_FAKE_ARGV_FILE, process.argv.slice(2).join(' '));
+// One line per child, so a test can count how many times omp was spawned.
+if (process.env.OMP_FAKE_SPAWN_FILE) fs.appendFileSync(process.env.OMP_FAKE_SPAWN_FILE, process.pid + '\\n');
+// Real omp writes a session_exit entry when it exits gracefully; record the polite
+// signal instead so a test can prove we never send one to a retired child.
+if (process.env.OMP_FAKE_SIGTERM_FILE) {
+  process.on('SIGTERM', () => fs.appendFileSync(process.env.OMP_FAKE_SIGTERM_FILE, process.pid + '\\n'));
+}
+const SID = 'fake-sess-1';
+const PERM_ID = 'perm-1';
+const OPTIONS = [
+  { optionId: 'ao', kind: 'allow_once', name: 'Allow once' },
+  { optionId: 'aa', kind: 'allow_always', name: 'Always allow' },
+  { optionId: 'ro', kind: 'reject_once', name: 'Reject' },
+  { optionId: 'ra', kind: 'reject_always', name: 'Always reject' },
+];
+let promptId = null;
+let buf = '';
+const send = (o) => process.stdout.write(JSON.stringify(o) + '\\n');
+process.stdin.setEncoding('utf8');
+process.stdin.on('data', (chunk) => {
+  buf += chunk;
+  let nl;
+  while ((nl = buf.indexOf('\\n')) >= 0) {
+    const line = buf.slice(0, nl).trim();
+    buf = buf.slice(nl + 1);
+    if (!line) continue;
+    let f; try { f = JSON.parse(line); } catch { continue; }
+    // Response to our permission request. VALIDATE it the way real omp does
+    // (@112180739): look up the returned optionId → its kind must be an allow
+    // kind. Only THEN does the tool run (completed); a wrong shape / non-allow
+    // optionId → the tool is denied (failed). This asserts the agent ACTS on our
+    // response, catching response-shape regressions the old blind test missed.
+    if (f.id === PERM_ID && f.method === undefined) {
+      const opt = OPTIONS.find((o) => o.optionId === f?.result?.outcome?.optionId);
+      const allowed = f?.result?.outcome?.outcome === 'selected' && opt && opt.kind.startsWith('allow');
+      send({ jsonrpc: '2.0', method: 'session/update', params: { sessionId: SID, update: {
+        sessionUpdate: 'tool_call_update', toolCallId: 't1',
+        status: allowed ? 'completed' : 'failed',
+        content: allowed ? 'ran' : 'Tool call denied by user: bash',
+      } } });
+      if (promptId !== null) send({ jsonrpc: '2.0', id: promptId, result: { stopReason: 'end_turn' } });
+      continue;
+    }
+    if (f.method === 'initialize') {
+      send({ jsonrpc: '2.0', id: f.id, result: { agentCapabilities: { loadSession: true, promptCapabilities: { image: true } } } });
+    } else if (f.method === 'session/new') {
+      send({ jsonrpc: '2.0', id: f.id, result: { sessionId: SID, configOptions: [] } });
+    } else if (f.method === 'session/prompt') {
+      promptId = f.id;
+      send({ jsonrpc: '2.0', method: 'session/update', params: { sessionId: SID, update: { sessionUpdate: 'agent_message_chunk', content: { type: 'text', text: 'hi' } } } });
+      send({ jsonrpc: '2.0', method: 'session/update', params: { sessionId: SID, update: { sessionUpdate: 'tool_call', toolCallId: 't1', title: 'Bash', rawInput: { command: 'ls' } } } });
+      // Tool does NOT run until the permission response validates as an allow.
+      send({ jsonrpc: '2.0', id: PERM_ID, method: 'session/request_permission', params: { sessionId: SID, toolName: 'Bash', input: { command: 'ls' }, options: OPTIONS } });
+    } else if (f.id !== undefined && f.method !== undefined) {
+      send({ jsonrpc: '2.0', id: f.id, result: {} });
+    }
+  }
+});
+`;
+
+const waitFor = async (predicate: () => boolean, ms = 8000) => {
+  const start = Date.now();
+  while (Date.now() - start < ms) {
+    if (predicate()) return true;
+    await new Promise((r) => setTimeout(r, 15));
+  }
+  return false;
+};
+
+// Runs one turn through the real spawnOmp against the fake omp. In 'default'
+// mode it waits for the emitted permission_request and resolves it with `allow`;
+// in 'plan' mode the adapter auto-denies synchronously (no UI prompt), so there
+// is nothing to wait on. Returns captured messages + the recorded argv.
+async function runFakeTurn({ allow = true, permissionMode = 'default' } = {}) {
+  const dir = mkdtempSync(join(tmpdir(), 'omp-fake-'));
+  const fakePath = join(dir, 'omp');
+  const argvFile = join(dir, 'argv.txt');
+  writeFileSync(fakePath, FAKE_OMP, { mode: 0o755 });
+
+  const prev = { OMP_PATH: process.env.OMP_PATH, HOME: process.env.HOME, OMP_FAKE_ARGV_FILE: process.env.OMP_FAKE_ARGV_FILE };
+  process.env.OMP_PATH = fakePath;
+  process.env.OMP_FAKE_ARGV_FILE = argvFile;
+  process.env.HOME = dir; // isolate the post-turn token-usage jsonl glob
+
+  const { spawnOmp, __closeConnectionsForTest } = await import('@/modules/providers/list/omp/omp-runtime.provider.js');
+  const { resolveToolApproval } = await import('@/shared/tool-approval-registry.js');
+  const { OmpSessionsProvider } = await import('@/modules/providers/list/omp/omp-sessions.provider.js');
+
+  // Stands in for the IProviderRuntime context the provider registry passes in.
+  const ompSessions = new OmpSessionsProvider();
+  const context: ProviderRuntimeContext = {
+    normalizeMessage: (raw, sid) => ompSessions.normalizeMessage(raw, sid),
+    resolveProviderSessionId: (sid) => sid ?? null,
+    resolveResumeModel: async () => undefined,
+    getProviderModels: async () => ({ OPTIONS: [], DEFAULT: '' }),
+    isProviderInstalled: async () => true,
+  };
+
+  const captured: AnyRecord[] = [];
+  let sessionIdSet = null;
+  const writer = { userId: null, setSessionId: (id: string) => { sessionIdSet = id; }, send: (m: AnyRecord) => captured.push(m) };
+
+  try {
+    const runPromise = spawnOmp('do it', { cwd: dir, projectPath: dir, permissionMode }, writer, context);
+    if (permissionMode === 'default') {
+      const gotPrompt = await waitFor(() => captured.some((m) => m.kind === 'permission_request'));
+      assert.ok(gotPrompt, 'a permission_request should be emitted');
+      resolveToolApproval(captured.find((m) => m.kind === 'permission_request')!.requestId, { allow });
+    }
+    // plan mode: routePermissionRequest auto-denies synchronously — no prompt to answer.
+    await runPromise;
+    return { captured, sessionIdSet, argvFile };
+  } finally {
+    __closeConnectionsForTest();
+    for (const [k, v] of Object.entries(prev)) { if (v === undefined) delete process.env[k]; else process.env[k] = v; }
+  }
+}
+
+const orderOf = (captured: AnyRecord[]) => captured.map((m: AnyRecord) => m.kind).filter((k: string) =>
+  ['session_created', 'stream_delta', 'tool_use', 'permission_request', 'tool_result', 'complete'].includes(k));
+
+test('ALLOW: streamed turn + approval round-trip runs the tool', async () => {
+  const { captured, sessionIdSet, argvFile } = await runFakeTurn({ allow: true });
+
+  // argv: `acp --config <overlay>` — and the overlay actually contains the fix.
+  const argv = readFileSync(argvFile, 'utf8');
+  assert.match(argv, /^acp\b/, 'spawned with the acp subcommand');
+  const configPath = argv.match(/--config\s+(\S+)/)?.[1];
+  assert.ok(configPath && existsSync(configPath), 'overlay path passed via --config');
+  const overlay = readFileSync(configPath, 'utf8');
+  assert.match(overlay, /approvalMode:\s*always-ask/, 'overlay forces always-ask');
+  for (const tool of ['bash', 'edit', 'delete', 'move']) {
+    assert.match(overlay, new RegExp(`${tool}:\\s*allow`), `overlay pre-allows ${tool}'s inner gate`);
+  }
+
+  assert.equal(sessionIdSet, 'fake-sess-1');
+  assert.equal(captured.find((m) => m.kind === 'session_created')?.newSessionId, 'fake-sess-1');
+  // Tool RUNS only after approval → tool_result after permission_request.
+  assert.deepEqual(orderOf(captured), ['session_created', 'stream_delta', 'tool_use', 'permission_request', 'tool_result', 'complete']);
+  const toolResult = captured.find((m) => m.kind === 'tool_result');
+  assert.equal(toolResult?.isError, false, 'approved tool ran, not denied');
+  assert.equal(toolResult?.content, 'ran');
+  assert.equal(captured.find((m) => m.kind === 'stream_delta')?.content, 'hi');
+  assert.equal(captured.filter((m) => m.kind === 'complete').length, 1, 'exactly one complete');
+  assert.equal(captured.find((m) => m.kind === 'complete')?.exitCode, 0);
+});
+
+test('DENY: rejected approval blocks the tool but still completes', async () => {
+  const { captured } = await runFakeTurn({ allow: false });
+  // createPermissionDecision(deny) → reject_once optionId → fake marks the tool failed.
+  const toolResult = captured.find((m) => m.kind === 'tool_result');
+  assert.equal(toolResult?.isError, true, 'denied tool must NOT run');
+  assert.match(toolResult?.content ?? '', /denied/i);
+  assert.equal(captured.filter((m) => m.kind === 'complete').length, 1, 'a terminal complete still arrives');
+});
+
+// A warm child ignores session/load for a session it already holds, so a session
+// the user's terminal has appended to since must be resumed on a NEW child —
+// otherwise the turn continues from a frozen snapshot and forks the transcript.
+test('a session changed on disk by another omp process resumes on a fresh child', async () => {
+  const dir = mkdtempSync(join(tmpdir(), 'omp-fake-stale-'));
+  const fakePath = join(dir, 'omp');
+  const spawnFile = join(dir, 'spawns.txt');
+  const sigtermFile = join(dir, 'sigterms.txt');
+  writeFileSync(fakePath, FAKE_OMP, { mode: 0o755 });
+  writeFileSync(spawnFile, '');
+  writeFileSync(sigtermFile, '');
+
+  const prev = {
+    OMP_PATH: process.env.OMP_PATH,
+    HOME: process.env.HOME,
+    OMP_FAKE_ARGV_FILE: process.env.OMP_FAKE_ARGV_FILE,
+    OMP_FAKE_SPAWN_FILE: process.env.OMP_FAKE_SPAWN_FILE,
+    OMP_FAKE_SIGTERM_FILE: process.env.OMP_FAKE_SIGTERM_FILE,
+  };
+  process.env.OMP_PATH = fakePath;
+  process.env.OMP_FAKE_ARGV_FILE = join(dir, 'argv.txt');
+  process.env.OMP_FAKE_SPAWN_FILE = spawnFile;
+  process.env.OMP_FAKE_SIGTERM_FILE = sigtermFile;
+  process.env.HOME = dir; // the session-file lookup is rooted at $HOME
+
+  const SID = 'fake-sess-1';
+  const sessionDir = join(dir, '.omp', 'agent', 'sessions', 'proj');
+  mkdirSync(sessionDir, { recursive: true });
+  const jsonlPath = join(sessionDir, `2026-08-09T00-00-00-000Z_${SID}.jsonl`);
+  writeFileSync(jsonlPath, `${JSON.stringify({ type: 'session', id: SID, cwd: dir })}\n`);
+
+  const { spawnOmp, __closeConnectionsForTest } = await import('@/modules/providers/list/omp/omp-runtime.provider.js');
+  const { OmpSessionsProvider } = await import('@/modules/providers/list/omp/omp-sessions.provider.js');
+  const ompSessions = new OmpSessionsProvider();
+  const context: ProviderRuntimeContext = {
+    normalizeMessage: (raw, sid) => ompSessions.normalizeMessage(raw, sid),
+    resolveProviderSessionId: (sid) => sid ?? null,
+    resolveResumeModel: async () => undefined,
+    getProviderModels: async () => ({ OPTIONS: [], DEFAULT: '' }),
+    isProviderInstalled: async () => true,
+  };
+  // bypassPermissions auto-allows the fake's permission request, so a turn needs
+  // no UI round-trip and the harness can run several back to back.
+  const runTurn = () => spawnOmp(
+    'go',
+    { cwd: dir, projectPath: dir, sessionId: SID, permissionMode: 'bypassPermissions' },
+    { userId: null, setSessionId: () => {}, send: () => {} },
+    context,
+  );
+  const spawnCount = () => readFileSync(spawnFile, 'utf8').trim().split('\n').filter(Boolean).length;
+
+  try {
+    await runTurn();
+    assert.equal(spawnCount(), 1, 'first turn spawns the child');
+
+    await runTurn();
+    assert.equal(spawnCount(), 1, 'an unchanged session reuses the warm child');
+
+    // Stand in for the user's terminal appending to the same session.
+    appendFileSync(jsonlPath, `${JSON.stringify({ type: 'message', id: 'x1', parentId: null })}\n`);
+    await runTurn();
+    assert.equal(spawnCount(), 2, 'a foreign write retires the stale child and respawns');
+
+    await runTurn();
+    assert.equal(spawnCount(), 2, 'the fresh child is then reused again');
+
+    // The retired child must be killed HARD. A graceful exit makes omp append a
+    // session_exit entry under the head that child held — the abandoned branch —
+    // and the next session/load resumes from the file's last entry, which would put
+    // the replacement child straight back on the stale branch.
+    await new Promise((resolve) => setTimeout(resolve, 1000)); // let a signal land
+    assert.equal(readFileSync(sigtermFile, 'utf8'), '', 'a retired child is never asked to exit politely');
+  } finally {
+    __closeConnectionsForTest();
+    for (const [k, v] of Object.entries(prev)) { if (v === undefined) delete process.env[k]; else process.env[k] = v; }
+  }
+});
+
+test('PLAN mode: sensitive tool auto-denied client-side with NO UI prompt', async () => {
+  const { captured } = await runFakeTurn({ permissionMode: 'plan' });
+  // The plan-mode early-return in routePermissionRequest denies WITHOUT prompting.
+  assert.equal(captured.filter((m) => m.kind === 'permission_request').length, 0, 'plan mode emits no UI prompt');
+  const toolResult = captured.find((m) => m.kind === 'tool_result');
+  assert.equal(toolResult?.isError, true, 'plan mode auto-denies the sensitive tool (not run)');
+  assert.equal(captured.filter((m) => m.kind === 'complete').length, 1, 'a terminal complete still arrives');
+});

--- a/server/modules/providers/tests/omp-runtime.test.ts
+++ b/server/modules/providers/tests/omp-runtime.test.ts
@@ -1,0 +1,472 @@
+// Covers the omp runtime adapter end to end against a fake ACP child: session
+// multiplexing (two runs sharing one per-cwd `omp acp` connection must not
+// cross-talk), the approval round-trip in every permission mode, the delegated
+// filesystem guard, abort, and resume.
+import assert from 'node:assert/strict';
+import { mkdtempSync, writeFileSync, readFileSync, symlinkSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import test from 'node:test';
+
+import { spawnOmp, abortOmpSession, __setConnectionFactoryForTest, writeFileNoFollow, approvalProfileFor, APPROVAL_PROFILES } from '@/modules/providers/list/omp/omp-runtime.provider.js';
+import type { OmpConnection } from '@/modules/providers/list/omp/omp-runtime.provider.js';
+import { OmpSessionsProvider } from '@/modules/providers/list/omp/omp-sessions.provider.js';
+import { resolveToolApproval } from '@/shared/tool-approval-registry.js';
+import type { AnyRecord, ProviderRuntimeContext } from '@/shared/types.js';
+
+// The provider registry supplies this IProviderRuntime context in production;
+// normalizeMessage delegates to the real omp normalizer, as the registry does.
+const ompSessions = new OmpSessionsProvider();
+const TEST_CONTEXT: ProviderRuntimeContext = {
+  normalizeMessage: (raw, sid) => ompSessions.normalizeMessage(raw, sid),
+  resolveProviderSessionId: (sid) => sid ?? null,
+  resolveResumeModel: async () => undefined,
+  getProviderModels: async () => ({ OPTIONS: [], DEFAULT: '' }),
+  isProviderInstalled: async () => true,
+};
+
+const flush = async (n = 6) => {
+  for (let i = 0; i < n; i += 1) {
+    await new Promise((r) => setImmediate(r));
+  }
+};
+
+function makeWriter() {
+  const sent: AnyRecord[] = [];
+  return {
+    sent,
+    userId: null,
+    setSessionId() {},
+    send(msg: AnyRecord) { sent.push(msg); },
+  };
+}
+
+// One fake connection shared by every run in the same cwd. Hands out distinct
+// session ids from session/new, holds session/prompt open until released, and
+// captures the connection-level session/update handler installed by the adapter.
+// Waits until the run under test has actually queued the request we are about to
+// answer, so a slower setup path cannot race the release. Wall-clock, not ticks:
+// the run may be waiting on fs work that no number of microtask turns advances.
+const waitForPending = async (queue: unknown[], what: string) => {
+  const deadline = Date.now() + 10_000;
+  while (queue.length === 0 && Date.now() < deadline) {
+    await new Promise((r) => setTimeout(r, 5));
+  }
+  // Fail loudly: releasing an empty queue leaves the run awaiting forever, and the
+  // suite runs with no per-test timeout, so the whole thing would hang instead.
+  assert.ok(queue.length > 0, `timed out waiting for a pending ${what}`);
+};
+
+function makeFakeConnection() {
+  let sessionCounter = 0;
+  const releasePrompt: Array<(value: AnyRecord) => void> = [];
+  const releaseLoad: Array<() => void> = [];
+
+  let updateHandlerFn: ((params: AnyRecord) => void) | null = null;
+  const requestHandlers = new Map();
+
+  const connection = {
+    initializeResult: { agentCapabilities: { loadSession: true } },
+    client: {
+      request(method: string) {
+        if (method === 'session/new') {
+          sessionCounter += 1;
+          return Promise.resolve({ sessionId: `S${sessionCounter}` });
+        }
+        if (method === 'session/load') {
+          // Held so tests can abort DURING the setup window (before load resolves).
+          return new Promise((resolve) => releaseLoad.push(() => resolve({})));
+        }
+        if (method === 'session/prompt') {
+          return new Promise((resolve) => releasePrompt.push(resolve));
+        }
+        return Promise.resolve({});
+      },
+      notify() {},
+      onNotification(method: string, handler: (params: AnyRecord) => void) {
+        if (method === 'session/update') {
+          updateHandlerFn = handler;
+        }
+        return () => {};
+      },
+      registerRequestHandler(method: string, handler: (params: AnyRecord) => unknown) {
+        requestHandlers.set(method, handler);
+        return () => {};
+      },
+      isClosed() { return false; },
+    },
+  } as unknown as OmpConnection;
+  connection.ready = Promise.resolve(connection);
+
+  return {
+    connection,
+    fireUpdate: (params: AnyRecord) => updateHandlerFn?.(params),
+    firePermission: (params: AnyRecord) => requestHandlers.get('session/request_permission')?.(params),
+    fireRequest: (method: string, params: AnyRecord) => requestHandlers.get(method)!(params),
+    // Condition-based, not tick-counted: the runtime may await fs work (the
+    // on-disk staleness check) before it issues session/load, so releasing on a
+    // fixed number of ticks would fire before the request exists and hang the run.
+    releaseLoads: async () => {
+      await waitForPending(releaseLoad, 'session/load');
+      releaseLoad.splice(0).forEach((fn) => fn());
+    },
+    releaseAllPrompts: async () => {
+      await waitForPending(releasePrompt, 'session/prompt');
+      releasePrompt.splice(0).forEach((resolve) => resolve({ stopReason: 'end_turn' }));
+    },
+  };
+}
+
+const ALLOW_OPTIONS = [
+  { kind: 'allow_once', optionId: 'ao' },
+  { kind: 'allow_always', optionId: 'aa' },
+  { kind: 'reject_once', optionId: 'ro' },
+];
+
+test('session/update routes to the owning run only — no cross-talk', async () => {
+  const fake = makeFakeConnection();
+  __setConnectionFactoryForTest(() => fake.connection);
+  try {
+    const writerA = makeWriter();
+    const writerB = makeWriter();
+
+    // Same cwd → both runs share the one connection.
+    const runA = spawnOmp('hi', { cwd: '/multiplex-test', projectPath: '/multiplex-test' }, writerA, TEST_CONTEXT);
+    await flush();
+    const runB = spawnOmp('hi', { cwd: '/multiplex-test', projectPath: '/multiplex-test' }, writerB, TEST_CONTEXT);
+    await flush();
+
+    // Each run announces its OWN native id — B never adopts A's.
+    const scA = writerA.sent.find((m) => m.kind === 'session_created');
+    const scB = writerB.sent.find((m) => m.kind === 'session_created');
+    assert.equal(scA?.newSessionId, 'S1', 'run A session_created should carry S1');
+    assert.equal(scB?.newSessionId, 'S2', 'run B session_created should carry its own S2, not S1');
+
+    // An update for S1 reaches ONLY A's writer.
+    fake.fireUpdate({
+      sessionId: 'S1',
+      update: { sessionUpdate: 'agent_message_chunk', content: { type: 'text', text: 'forA' } },
+    });
+
+    const deltasA = writerA.sent.filter((m) => m.kind === 'stream_delta');
+    const deltasB = writerB.sent.filter((m) => m.kind === 'stream_delta');
+    assert.equal(deltasA.length, 1, 'A should receive exactly the one update addressed to S1');
+    assert.equal(deltasA[0].content, 'forA');
+    assert.equal(deltasB.length, 0, 'B must receive no update addressed to S1');
+
+    // Let both turns finish so the module state is clean.
+    await fake.releaseAllPrompts();
+    await Promise.allSettled([runA, runB]);
+
+    assert.equal(writerA.sent.filter((m) => m.kind === 'complete').length, 1);
+    assert.equal(writerB.sent.filter((m) => m.kind === 'complete').length, 1);
+  } finally {
+    __setConnectionFactoryForTest(null);
+  }
+});
+
+test('default mode: inbound permission request → UI prompt → resolveToolApproval → allow decision', async () => {
+  const fake = makeFakeConnection();
+  __setConnectionFactoryForTest(() => fake.connection);
+  try {
+    const writer = makeWriter();
+    const run = spawnOmp('do a thing', { cwd: '/appr-default', projectPath: '/appr-default', permissionMode: 'default' }, writer, TEST_CONTEXT);
+    await flush();
+
+    // omp asks to run a tool for this run's session (S1).
+    const decisionP = fake.firePermission({ sessionId: 'S1', toolName: 'Write', input: { path: 'x' }, options: ALLOW_OPTIONS });
+    await flush();
+
+    const pr = writer.sent.find((m) => m.kind === 'permission_request');
+    assert.ok(pr, 'a permission_request should be emitted to the UI');
+    assert.equal(pr.toolName, 'Write');
+    assert.ok(pr.requestId, 'permission_request carries a requestId');
+
+    // User approves through the shared registry (same path as chat.permission-response).
+    resolveToolApproval(pr.requestId, { allow: true });
+    const decision = await decisionP;
+    assert.deepEqual(decision, { outcome: { outcome: 'selected', optionId: 'ao' } });
+
+    await fake.releaseAllPrompts();
+    await Promise.allSettled([run]);
+  } finally {
+    __setConnectionFactoryForTest(null);
+  }
+});
+
+test('bypassPermissions: inbound permission request auto-allows with NO UI prompt', async () => {
+  const fake = makeFakeConnection();
+  __setConnectionFactoryForTest(() => fake.connection);
+  try {
+    const writer = makeWriter();
+    const run = spawnOmp('do a thing', { cwd: '/appr-bypass', projectPath: '/appr-bypass', permissionMode: 'bypassPermissions' }, writer, TEST_CONTEXT);
+    await flush();
+
+    const decision = await fake.firePermission({ sessionId: 'S1', toolName: 'Write', options: ALLOW_OPTIONS });
+    assert.deepEqual(decision, { outcome: { outcome: 'selected', optionId: 'ao' } });
+    assert.equal(writer.sent.filter((m) => m.kind === 'permission_request').length, 0, 'bypass must not emit a prompt');
+
+    await fake.releaseAllPrompts();
+    await Promise.allSettled([run]);
+  } finally {
+    __setConnectionFactoryForTest(null);
+  }
+});
+
+// Starts a run bound to a REAL cwd so the fs delegation handlers register.
+async function startRunForFs(fake: ReturnType<typeof makeFakeConnection>, cwd: string, permissionMode = 'default') {
+  const writer = makeWriter();
+  const run = spawnOmp('go', { cwd, projectPath: cwd, permissionMode }, writer, TEST_CONTEXT);
+  await flush();
+  return { writer, run };
+}
+
+test('fs guard rejects symlink/traversal/absolute escapes (read + write)', async () => {
+  const outside = mkdtempSync(join(tmpdir(), 'omp-fs-outside-'));
+  writeFileSync(join(outside, 'secret.txt'), 'SECRET');
+  const cwd = mkdtempSync(join(tmpdir(), 'omp-fs-cwd-'));
+  writeFileSync(join(cwd, 'real.txt'), 'hello');
+  symlinkSync(join(outside, 'secret.txt'), join(cwd, 'linkfile')); // file symlink escaping cwd
+  symlinkSync(outside, join(cwd, 'linkdir')); // parent-dir symlink escaping cwd
+
+  const fake = makeFakeConnection();
+  __setConnectionFactoryForTest(() => fake.connection);
+  try {
+    const { run } = await startRunForFs(fake, cwd);
+
+    // Positive controls: a real in-cwd file reads back, and a legit in-cwd write
+    // succeeds and lands the content (guards against a reject-everything regression).
+    assert.deepEqual(await fake.fireRequest('fs/read_text_file', { path: join(cwd, 'real.txt') }), { content: 'hello' });
+    assert.equal(await fake.fireRequest('fs/write_text_file', { path: join(cwd, 'created.txt'), content: 'written', sessionId: 'S1' }), null);
+    assert.equal(readFileSync(join(cwd, 'created.txt'), 'utf8'), 'written');
+
+    // READ escapes → rejected.
+    await assert.rejects(fake.fireRequest('fs/read_text_file', { path: join(cwd, 'linkfile') }), /escape/i, 'symlink read escape');
+    await assert.rejects(fake.fireRequest('fs/read_text_file', { path: join(outside, 'secret.txt') }), /escape/i, 'absolute outside read');
+    await assert.rejects(fake.fireRequest('fs/read_text_file', { path: join(cwd, '..', '..', 'etc', 'hosts') }), /escape/i, '.. traversal read');
+
+    // WRITE escapes → rejected (file never modified).
+    await assert.rejects(fake.fireRequest('fs/write_text_file', { path: join(cwd, 'linkfile'), content: 'x' }), /symlink/i, 'write through file symlink');
+    await assert.rejects(fake.fireRequest('fs/write_text_file', { path: join(cwd, 'linkdir', 'pwned.txt'), content: 'x' }), /escape/i, 'write via parent-dir symlink');
+    await assert.rejects(fake.fireRequest('fs/write_text_file', { path: join(outside, 'clobber.txt'), content: 'x' }), /escape/i, 'absolute outside write');
+
+    // F1 fail-closed: a valid in-cwd write with an unknown session is rejected.
+    await assert.rejects(fake.fireRequest('fs/write_text_file', { path: join(cwd, 'orphan.txt'), content: 'x', sessionId: 'nope' }), /no live session/i, 'unknown session write');
+
+    await fake.releaseAllPrompts();
+    await Promise.allSettled([run]);
+  } finally {
+    __setConnectionFactoryForTest(null);
+  }
+});
+
+test('fs write rejects non-string content and plan-mode writes', async () => {
+  const cwd = mkdtempSync(join(tmpdir(), 'omp-fs-plan-'));
+  const fake = makeFakeConnection();
+  __setConnectionFactoryForTest(() => fake.connection);
+  try {
+    const { run } = await startRunForFs(fake, cwd, 'plan');
+
+    // non-string content must throw, not truncate to ''.
+    await assert.rejects(fake.fireRequest('fs/write_text_file', { path: join(cwd, 'a.txt'), content: 123, sessionId: 'S1' }), /string/i);
+    // plan mode is read-only.
+    await assert.rejects(fake.fireRequest('fs/write_text_file', { path: join(cwd, 'a.txt'), content: 'ok', sessionId: 'S1' }), /read-only/i);
+
+    await fake.releaseAllPrompts();
+    await Promise.allSettled([run]);
+  } finally {
+    __setConnectionFactoryForTest(null);
+  }
+});
+
+test('abort during setup runs no turn, and a later resume of the same id completes exactly once', async () => {
+  const fake = makeFakeConnection();
+  __setConnectionFactoryForTest(() => fake.connection);
+  try {
+    // Turn 1: resume 'S1', abort while session/load is still pending (setup window).
+    const w1 = makeWriter();
+    const run1 = spawnOmp('hi', { cwd: '/abort-resume', projectPath: '/abort-resume', sessionId: 'S1', permissionMode: 'default' }, w1, TEST_CONTEXT);
+    await flush();
+    assert.equal(await abortOmpSession('S1'), true, 'abort finds the pre-registered resume entry');
+    await fake.releaseLoads(); // load resolves → SF-1 early-return, no prompt
+    await run1;
+    assert.equal(w1.sent.filter((m) => m.kind === 'complete').length, 0, 'aborted setup emits no complete (handleChatAbort owns it)');
+
+    // Turn 2: resume the SAME id. Pre-fix, the leaked abortedSessionIds entry made
+    // wasAborted true here and SUPPRESSED this complete — now it completes once.
+    const w2 = makeWriter();
+    const run2 = spawnOmp('hi', { cwd: '/abort-resume', projectPath: '/abort-resume', sessionId: 'S1', permissionMode: 'default' }, w2, TEST_CONTEXT);
+    await flush();
+    await fake.releaseLoads();
+    await flush();
+    await fake.releaseAllPrompts();
+    await run2;
+    assert.equal(w2.sent.filter((m) => m.kind === 'complete').length, 1, 'resumed turn completes exactly once');
+    assert.equal(w2.sent.find((m) => m.kind === 'complete')?.exitCode, 0);
+  } finally {
+    __setConnectionFactoryForTest(null);
+  }
+});
+
+test('resume via session/load streams and completes normally', async () => {
+  const fake = makeFakeConnection();
+  __setConnectionFactoryForTest(() => fake.connection);
+  try {
+    const w = makeWriter();
+    const run = spawnOmp('hi', { cwd: '/resume', projectPath: '/resume', sessionId: 'S9', permissionMode: 'default' }, w, TEST_CONTEXT);
+    await flush();
+    await fake.releaseLoads();
+    await flush(); // acceptingUpdates now true; prompt pending
+    fake.fireUpdate({ sessionId: 'S9', update: { sessionUpdate: 'agent_message_chunk', content: { type: 'text', text: 'resumed' } } });
+    await fake.releaseAllPrompts();
+    await run;
+
+    assert.ok(w.sent.some((m) => m.kind === 'stream_delta' && m.content === 'resumed'), 'resumed session streams');
+    assert.equal(w.sent.filter((m) => m.kind === 'complete').length, 1, 'resume completes once');
+    assert.equal(w.sent.filter((m) => m.kind === 'session_created').length, 0, 'resume does not re-announce session_created');
+  } finally {
+    __setConnectionFactoryForTest(null);
+  }
+});
+
+// The delegated-write guard must never follow a symlink out of the workspace. The
+// `noFollow = 0` cases emulate Windows, where O_NOFOLLOW does not exist and the
+// descriptor has to be verified against the path instead.
+test('writeFileNoFollow refuses symlinks and survives a mid-write swap', async () => {
+  const { mkdtempSync, writeFileSync, readFileSync, symlinkSync, unlinkSync } = await import('node:fs');
+  const dir = mkdtempSync(join(tmpdir(), 'omp-nofollow-'));
+
+  // Plain regular file: writes normally, both with and without the flag.
+  const plain = join(dir, 'plain.txt');
+  writeFileSync(plain, 'old-and-longer');
+  await writeFileNoFollow(plain, 'new');
+  assert.equal(readFileSync(plain, 'utf8'), 'new', 'truncates then writes');
+  await writeFileNoFollow(plain, 'flagless', 0);
+  assert.equal(readFileSync(plain, 'utf8'), 'flagless', 'same result on the flagless path');
+
+  // A symlinked target is refused, and its victim is left untouched.
+  for (const noFollow of [undefined, 0]) {
+    const victim = join(dir, `victim-${String(noFollow)}.txt`);
+    const link = join(dir, `link-${String(noFollow)}.txt`);
+    writeFileSync(victim, 'SECRET');
+    symlinkSync(victim, link);
+    await assert.rejects(
+      () => (noFollow === undefined ? writeFileNoFollow(link, 'PWNED') : writeFileNoFollow(link, 'PWNED', 0)),
+      /symlink/,
+      `symlink refused (noFollow=${String(noFollow)})`,
+    );
+    assert.equal(readFileSync(victim, 'utf8'), 'SECRET', 'victim untouched');
+  }
+
+  // NOTE: the case the identity comparison exists for — the path being a symlink
+  // at open() and swapped for an innocent regular file before the check — cannot be
+  // driven deterministically from here (whether the swap lands before or after
+  // open() is a real race), so it is deliberately not timing-tested. The flagless
+  // symlink case above covers the same comparison: a symlink's lstat inode never
+  // matches the inode of the file the descriptor actually opened.
+});
+
+// omp gates some tools internally, where only a TTY can answer; headless that gate
+// fails as "Tool call denied by user: <tool>". Which tools are pre-allowed there
+// therefore depends on the run's permission mode, and getting it wrong silently
+// breaks a tool (this is exactly how `eval` broke) or silently widens plan mode.
+test('approval profile follows the permission mode', () => {
+  // bypassPermissions deliberately shares the gated (always-ask) profile rather
+  // than omp's `yolo`: yolo auto-approves even omp's "override" tools (rm -rf /,
+  // dd of=/dev/, curl|bash), and bypass can be a user's DEFAULT mode because it is
+  // derived from their `approvalMode: yolo` config. routePermissionRequest
+  // auto-allows the bypass run instead, with no prompt and the backstop intact.
+  assert.equal(approvalProfileFor('bypassPermissions'), 'gated');
+  assert.equal(approvalProfileFor('default'), 'gated');
+  assert.equal(approvalProfileFor('plan'), 'plan');
+  assert.equal(approvalProfileFor('something-unknown'), 'gated', 'unknown modes stay gated');
+
+  // No profile may hand omp `yolo` — that is what drops the backstop.
+  for (const [name, yml] of Object.entries(APPROVAL_PROFILES)) {
+    assert.match(yml, /approvalMode: always-ask/, `${name} must gate through omp`);
+    assert.ok(!yml.includes('yolo'), `${name} must not use omp yolo`);
+  }
+
+  // default: every tool omp gates internally must be pre-allowed. omp emits no ACP
+  // request for these, so without an entry each fails headlessly as "Tool call
+  // denied by user: <tool>" — how the eval and write bugs both reached a user.
+  for (const tool of ['write', 'eval', 'ast_edit', 'memory_edit', 'manage_skill', 'browser', 'task']) {
+    assert.match(APPROVAL_PROFILES.gated, new RegExp(`\\n    ${tool}: allow\\n`), `${tool} must be pre-allowed`);
+    // …and withheld from plan: omp never asks about them, so an entry would let
+    // them run unprompted and plan would stop being read-only.
+    assert.ok(!APPROVAL_PROFILES.plan.includes(`${tool}: allow`), `plan must not pre-allow ${tool}`);
+  }
+
+  // The ACP-gated four stay in BOTH: `allow` only satisfies omp's inner gate, and
+  // our own routePermissionRequest still decides (auto-deny in plan).
+  for (const tool of ['bash', 'edit', 'delete', 'move']) {
+    assert.match(APPROVAL_PROFILES.plan, new RegExp(`\\n    ${tool}: allow\\n`), `${tool} must stay gated-but-allowed in plan`);
+    assert.match(APPROVAL_PROFILES.gated, new RegExp(`\\n    ${tool}: allow\\n`));
+  }
+});
+
+// Callers hand the runtime the stable app session id, never omp's own. These two
+// cover the translation in both directions: without it a resumed chat silently
+// starts a blank session (load/fork reject an id omp never issued) and an abort
+// keyed by the app id never finds the run it is meant to stop.
+function recordingFake() {
+  const fake = makeFakeConnection();
+  const calls: Array<{ method: string; params: AnyRecord }> = [];
+  const inner = fake.connection.client.request.bind(fake.connection.client);
+  fake.connection.client.request = ((method: string, params: AnyRecord) => {
+    calls.push({ method, params });
+    return inner(method, params);
+  }) as typeof fake.connection.client.request;
+  return { ...fake, calls };
+}
+
+test('a session with no native id yet starts new instead of loading the app id', async () => {
+  const fake = recordingFake();
+  __setConnectionFactoryForTest(() => fake.connection);
+  try {
+    const w = makeWriter();
+    // A row created by POST /api/providers/sessions: provider_session_id is NULL.
+    const context: ProviderRuntimeContext = { ...TEST_CONTEXT, resolveProviderSessionId: () => null };
+    const run = spawnOmp('hi', { cwd: '/fresh', projectPath: '/fresh', sessionId: 'APP-1' }, w, context);
+    await flush();
+    await fake.releaseAllPrompts();
+    await run;
+
+    assert.equal(fake.calls.filter((c) => c.method === 'session/load').length, 0,
+      'an app id omp never issued must not be sent to session/load');
+    assert.equal(fake.calls.filter((c) => c.method === 'session/fork').length, 0);
+    assert.equal(fake.calls.filter((c) => c.method === 'session/new').length, 1);
+    assert.equal(w.sent.find((m) => m.kind === 'session_created')?.newSessionId, 'S1',
+      'the client learns omp\u2019s native id from session_created');
+  } finally {
+    __setConnectionFactoryForTest(null);
+  }
+});
+
+test('a mapped session resumes with omp\u2019s native id, and abort accepts the app id', async () => {
+  const fake = recordingFake();
+  __setConnectionFactoryForTest(() => fake.connection);
+  try {
+    const w = makeWriter();
+    // The row maps app id APP-2 to the native id omp announced on the first turn.
+    const context: ProviderRuntimeContext = {
+      ...TEST_CONTEXT,
+      resolveProviderSessionId: (sid) => (sid === 'APP-2' ? 'S9' : null),
+    };
+    const run = spawnOmp('hi', { cwd: '/mapped', projectPath: '/mapped', sessionId: 'APP-2' }, w, context);
+    await flush();
+    await fake.releaseLoads();
+    await flush();
+
+    const load = fake.calls.find((c) => c.method === 'session/load');
+    assert.equal(load?.params?.sessionId, 'S9', 'resume must use the native id, not the app id');
+
+    assert.equal(await abortOmpSession('APP-2'), true,
+      'the client aborts with the app id, so it must reach the run keyed by the native id');
+
+    await fake.releaseAllPrompts();
+    await run;
+  } finally {
+    __setConnectionFactoryForTest(null);
+  }
+});

--- a/server/modules/providers/tests/omp-stdio-jsonrpc-client.test.ts
+++ b/server/modules/providers/tests/omp-stdio-jsonrpc-client.test.ts
@@ -1,0 +1,375 @@
+/**
+ * Real unit tests for StdioJsonRpcClient.
+ *
+ * Backs the JSON-RPC 2.0 wire protocol against an in-process child substitute:
+ * a Node Duplex acting as the child's stdio pair so we can drive byte streams
+ * exactly like the real ChildProcessWithoutNullStreams. No mocks, no spies —
+ * the assertions exercise the real transport state machine.
+ *
+ * Run with `node --test --import tsx`.
+ */
+import assert from 'node:assert/strict';
+import type { ChildProcessWithoutNullStreams } from 'node:child_process';
+import { EventEmitter } from 'node:events';
+import { PassThrough } from 'node:stream';
+import { describe, it } from 'node:test';
+
+import { StdioJsonRpcClient } from '@/modules/providers/list/omp/stdio-jsonrpc-client.js';
+
+// Build a minimal stand-in matching the surface area StdioJsonRpcClient uses:
+// stdin (writable), stdout (readable), stderr (readable), and the EE for
+// 'close' / 'error'. The class never touches any other ChildProcess fields.
+function makeFakeChild(): {
+  child: ChildProcessWithoutNullStreams;
+  emitStdout: (chunk: string) => void;
+  emitStderr: (chunk: string) => void;
+  emitClose: (code: number | null) => void;
+  emitError: (err: Error) => void;
+  stdinWrites: string[];
+} {
+  const stdout = new PassThrough();
+  const stderr = new PassThrough();
+  const stdinWrites: string[] = [];
+  const stdin = {
+    write(chunk: string, callback?: (err?: Error | null) => void): boolean {
+      stdinWrites.push(chunk);
+      callback?.(null);
+      return true;
+    },
+    end(): void {},
+    on(): void {}, // real child stdin is a stream; the client attaches an 'error' listener
+  };
+
+  const ee = new EventEmitter();
+  const fake = Object.assign(ee, {
+    stdin,
+    stdout,
+    stderr,
+    killed: false,
+  });
+
+  return {
+    child: fake as unknown as ChildProcessWithoutNullStreams,
+    emitStdout: (chunk: string) => stdout.write(chunk),
+    emitStderr: (chunk: string) => stderr.write(chunk),
+    emitClose: (code: number | null) => ee.emit('close', code),
+    emitError: (err: Error) => ee.emit('error', err),
+    stdinWrites,
+  };
+}
+
+describe('StdioJsonRpcClient', () => {
+  it('correlates request id to response result', async () => {
+    const fake = makeFakeChild();
+    const client = new StdioJsonRpcClient(fake.child);
+
+    const promise = client.request<{ value: number }>('test/method', { foo: 1 });
+
+    // Verify the wire format we produced
+    assert.equal(fake.stdinWrites.length, 1);
+    const sent = JSON.parse(fake.stdinWrites[0].trim());
+    assert.equal(sent.jsonrpc, '2.0');
+    assert.equal(sent.method, 'test/method');
+    assert.deepEqual(sent.params, { foo: 1 });
+    assert.equal(typeof sent.id, 'number');
+
+    // Send back a matching response
+    fake.emitStdout(`${JSON.stringify({ jsonrpc: '2.0', id: sent.id, result: { value: 42 } })}\n`);
+
+    const result = await promise;
+    assert.deepEqual(result, { value: 42 });
+  });
+
+  it('rejects on JSON-RPC error frame with the error message', async () => {
+    const fake = makeFakeChild();
+    const client = new StdioJsonRpcClient(fake.child);
+
+    const promise = client.request('failing/method');
+    const sent = JSON.parse(fake.stdinWrites[0].trim());
+
+    fake.emitStdout(
+      `${JSON.stringify({
+        jsonrpc: '2.0',
+        id: sent.id,
+        error: { code: -32603, message: 'Internal error', data: { detail: 'backend broke' } },
+      })}\n`,
+    );
+
+    await assert.rejects(promise, (err: Error) => {
+      assert.match(err.message, /Internal error/);
+      assert.match(err.message, /failing\/method/);
+      return true;
+    });
+  });
+
+  it('handles a frame split across multiple stdout chunks', async () => {
+    const fake = makeFakeChild();
+    const client = new StdioJsonRpcClient(fake.child);
+
+    const promise = client.request('split/test');
+    const sent = JSON.parse(fake.stdinWrites[0].trim());
+    const fullFrame = JSON.stringify({ jsonrpc: '2.0', id: sent.id, result: 'ok' }) + '\n';
+
+    // Split mid-string across 4 chunks
+    fake.emitStdout(fullFrame.slice(0, 5));
+    fake.emitStdout(fullFrame.slice(5, 20));
+    fake.emitStdout(fullFrame.slice(20, 35));
+    fake.emitStdout(fullFrame.slice(35));
+
+    assert.equal(await promise, 'ok');
+  });
+
+  it('handles multiple frames in one chunk', async () => {
+    const fake = makeFakeChild();
+    const client = new StdioJsonRpcClient(fake.child);
+
+    const p1 = client.request('a');
+    const p2 = client.request('b');
+    const id1 = JSON.parse(fake.stdinWrites[0]).id;
+    const id2 = JSON.parse(fake.stdinWrites[1]).id;
+
+    const combined =
+      JSON.stringify({ jsonrpc: '2.0', id: id1, result: 'first' }) + '\n' +
+      JSON.stringify({ jsonrpc: '2.0', id: id2, result: 'second' }) + '\n';
+    fake.emitStdout(combined);
+
+    assert.equal(await p1, 'first');
+    assert.equal(await p2, 'second');
+  });
+
+  it('skips empty lines and CRLF without crashing', async () => {
+    const fake = makeFakeChild();
+    const client = new StdioJsonRpcClient(fake.child);
+
+    const p = client.request('crlf/test');
+    const sent = JSON.parse(fake.stdinWrites[0]);
+
+    fake.emitStdout('\n\r\n   \n');
+    fake.emitStdout(`${JSON.stringify({ jsonrpc: '2.0', id: sent.id, result: 'ok' })}\r\n`);
+
+    assert.equal(await p, 'ok');
+  });
+
+  it('routes notifications to exact-method handlers', async () => {
+    const fake = makeFakeChild();
+    const client = new StdioJsonRpcClient(fake.child);
+
+    let received: unknown = null;
+    client.onNotification('session/update', (params) => {
+      received = params;
+    });
+
+    fake.emitStdout(`${JSON.stringify({
+      jsonrpc: '2.0',
+      method: 'session/update',
+      params: { sessionId: 'abc', update: { sessionUpdate: 'agent_message_chunk' } },
+    })}\n`);
+
+    // Allow microtask queue to flush
+    await new Promise((r) => setImmediate(r));
+
+    assert.deepEqual(received, { sessionId: 'abc', update: { sessionUpdate: 'agent_message_chunk' } });
+  });
+
+  it('routes prefixed notifications to wildcard handlers', async () => {
+    const fake = makeFakeChild();
+    const client = new StdioJsonRpcClient(fake.child);
+
+    const seen: Array<{ method: string; params: unknown }> = [];
+    client.onNotificationPrefix('_ext/', (params) => {
+      seen.push({ method: 'prefix-match', params });
+    });
+
+    fake.emitStdout(`${JSON.stringify({ jsonrpc: '2.0', method: '_ext/metadata', params: { x: 1 } })}\n`);
+    fake.emitStdout(`${JSON.stringify({ jsonrpc: '2.0', method: '_ext/mcp/server_initialized', params: { y: 2 } })}\n`);
+    fake.emitStdout(`${JSON.stringify({ jsonrpc: '2.0', method: 'session/update', params: { z: 3 } })}\n`);
+
+    await new Promise((r) => setImmediate(r));
+
+    // Only the two _ext/* notifications hit the prefix handler
+    assert.equal(seen.length, 2);
+    assert.deepEqual(seen.map((s) => s.params), [{ x: 1 }, { y: 2 }]);
+  });
+
+  it('rejects all pending requests on child close', async () => {
+    const fake = makeFakeChild();
+    const client = new StdioJsonRpcClient(fake.child);
+
+    const p1 = client.request('a').catch((e: Error) => e);
+    const p2 = client.request('b').catch((e: Error) => e);
+
+    fake.emitClose(1);
+
+    const [e1, e2] = await Promise.all([p1, p2]);
+    assert.match((e1 as Error).message, /closed/);
+    assert.match((e2 as Error).message, /closed/);
+  });
+
+  it('rejects new requests after close synchronously', async () => {
+    const fake = makeFakeChild();
+    const client = new StdioJsonRpcClient(fake.child);
+    fake.emitClose(0);
+
+    await assert.rejects(client.request('after-close'), (err: Error) => {
+      assert.match(err.message, /closed/);
+      return true;
+    });
+  });
+
+  it('survives non-JSON stdout lines without crashing', async () => {
+    const fake = makeFakeChild();
+    let parseErrors = 0;
+    const client = new StdioJsonRpcClient(fake.child, {
+      onParseError: () => { parseErrors += 1; },
+    });
+
+    const p = client.request('survive/test');
+    const sent = JSON.parse(fake.stdinWrites[0]);
+
+    // First a stderr leak that landed on stdout (not JSON), then a valid frame
+    fake.emitStdout('warning: something is up on stderr but emitted on stdout\n');
+    fake.emitStdout(`${JSON.stringify({ jsonrpc: '2.0', id: sent.id, result: 'still works' })}\n`);
+
+    assert.equal(await p, 'still works');
+    assert.equal(parseErrors, 1);
+  });
+
+  it('forwards stderr lines to onStderr callback', async () => {
+    const fake = makeFakeChild();
+    const stderrLines: string[] = [];
+    new StdioJsonRpcClient(fake.child, { onStderr: (l) => stderrLines.push(l) });
+
+    fake.emitStderr('first error\nsecond error\n');
+    await new Promise((r) => setImmediate(r));
+
+    assert.deepEqual(stderrLines, ['first error', 'second error']);
+  });
+
+  it('rejects request that times out', async () => {
+    const fake = makeFakeChild();
+    const client = new StdioJsonRpcClient(fake.child, { requestTimeoutMs: 50 });
+
+    await assert.rejects(client.request('slow/method'), (err: Error) => {
+      assert.match(err.message, /timed out/);
+      assert.match(err.message, /slow\/method/);
+      return true;
+    });
+  });
+
+  it('per-request timeoutMs:0 disables the timeout even when the client default is tiny', async () => {
+    const fake = makeFakeChild();
+    // Client default would reject after 30ms; the prompt-style request opts out.
+    const client = new StdioJsonRpcClient(fake.child, { requestTimeoutMs: 30 });
+
+    const promise = client.request('session/prompt', {}, { timeoutMs: 0 });
+    const sent = JSON.parse(fake.stdinWrites[0].trim());
+
+    // Wait well past the client default; a disabled timeout must NOT reject.
+    await new Promise((r) => setTimeout(r, 60));
+    fake.emitStdout(`${JSON.stringify({ jsonrpc: '2.0', id: sent.id, result: 'end_turn' })}\n`);
+
+    assert.equal(await promise, 'end_turn');
+  });
+
+  it('answers an inbound server->client request via a registered handler, echoing the id', async () => {
+    const fake = makeFakeChild();
+    const client = new StdioJsonRpcClient(fake.child);
+
+    let receivedParams: unknown = null;
+    client.registerRequestHandler('session/request_permission', (params) => {
+      receivedParams = params;
+      return { outcome: { outcome: 'selected', optionId: 'allow_once' } };
+    });
+
+    // ACP uses string ids for inbound requests.
+    fake.emitStdout(`${JSON.stringify({
+      jsonrpc: '2.0',
+      id: 'req-1',
+      method: 'session/request_permission',
+      params: { sessionId: 'abc', toolName: 'Write' },
+    })}\n`);
+
+    // Handler runs async; the response is written once it resolves.
+    await new Promise((r) => setImmediate(r));
+    await new Promise((r) => setImmediate(r));
+
+    assert.deepEqual(receivedParams, { sessionId: 'abc', toolName: 'Write' });
+    const resp = fake.stdinWrites.map((w) => JSON.parse(w.trim())).find((f) => f.id === 'req-1');
+    assert.ok(resp, 'a response frame with the request id should be written to stdin');
+    assert.equal(resp.id, 'req-1');
+    assert.deepEqual(resp.result, { outcome: { outcome: 'selected', optionId: 'allow_once' } });
+    assert.equal(resp.error, undefined);
+  });
+
+  it('treats an inbound request as a request even when its id collides with a pending call (SF-3)', async () => {
+    const fake = makeFakeChild();
+    const client = new StdioJsonRpcClient(fake.child);
+    let handlerCalled = false;
+    client.registerRequestHandler('server/ask', () => { handlerCalled = true; return 'handled'; });
+
+    const pending = client.request('client/call');
+    const sentId = JSON.parse(fake.stdinWrites[0]).id; // numeric id we generated
+
+    // Inbound request reusing the SAME id + a method must NOT resolve `pending`.
+    fake.emitStdout(`${JSON.stringify({ jsonrpc: '2.0', id: sentId, method: 'server/ask', params: {} })}\n`);
+    await new Promise((r) => setImmediate(r));
+    assert.equal(handlerCalled, true, 'inbound request with method should hit the request handler');
+
+    // The client call is still pending; its real response (no method) resolves it.
+    fake.emitStdout(`${JSON.stringify({ jsonrpc: '2.0', id: sentId, result: 'real' })}\n`);
+    assert.equal(await pending, 'real');
+  });
+
+  it('notify() does not expect a response and never resolves a promise', () => {
+    const fake = makeFakeChild();
+    const client = new StdioJsonRpcClient(fake.child);
+
+    client.notify('session/cancel', { sessionId: 'abc' });
+
+    assert.equal(fake.stdinWrites.length, 1);
+    const sent = JSON.parse(fake.stdinWrites[0].trim());
+    assert.equal(sent.jsonrpc, '2.0');
+    assert.equal(sent.method, 'session/cancel');
+    assert.equal('id' in sent, false, 'notification frames must have no id');
+  });
+
+  it('continues processing frames when a notification handler throws', async () => {
+    const fake = makeFakeChild();
+    const client = new StdioJsonRpcClient(fake.child);
+
+    let goodCalls = 0;
+    client.onNotification('throws', () => {
+      throw new Error('handler boom');
+    });
+    client.onNotification('survives', () => {
+      goodCalls += 1;
+    });
+
+    // Suppress the expected console.error so it doesn't pollute test output;
+    // we still want to assert the stream itself kept flowing.
+    const originalConsoleError = console.error;
+    const errorCalls: unknown[][] = [];
+    console.error = (...args) => {
+      errorCalls.push(args);
+    };
+
+    try {
+      // Three frames: throwing handler, recoverable handler, then a request
+      // response that proves the dispatch loop wasn't broken.
+      const promise = client.request('after-throw');
+      const sent = JSON.parse(fake.stdinWrites[0].trim());
+
+      fake.emitStdout(`${JSON.stringify({ jsonrpc: '2.0', method: 'throws', params: {} })}\n`);
+      fake.emitStdout(`${JSON.stringify({ jsonrpc: '2.0', method: 'survives', params: {} })}\n`);
+      fake.emitStdout(`${JSON.stringify({ jsonrpc: '2.0', id: sent.id, result: 'still works' })}\n`);
+
+      assert.equal(await promise, 'still works');
+      // Allow the synchronous notification handlers to finish
+      await new Promise((r) => setImmediate(r));
+      assert.equal(goodCalls, 1);
+      assert.ok(errorCalls.length >= 1, 'handler errors should be logged');
+    } finally {
+      console.error = originalConsoleError;
+    }
+  });
+});

--- a/server/modules/providers/tests/provider-runtime.service.test.ts
+++ b/server/modules/providers/tests/provider-runtime.service.test.ts
@@ -76,6 +76,7 @@ test('providerRegistry owns one runtime for every registered provider', () => {
     'codex',
     'cursor',
     'opencode',
+    'omp',
   ]);
   assert.equal(providers.every((provider) => typeof provider.runtime.run === 'function'), true);
   assert.equal(providers.every((provider) => typeof provider.runtime.abort === 'function'), true);

--- a/server/modules/providers/tests/provider-token-usage.service.test.ts
+++ b/server/modules/providers/tests/provider-token-usage.service.test.ts
@@ -113,6 +113,57 @@ test('Codex token usage uses the latest token_count snapshot', async () => {
   }
 });
 
+test('omp token usage reports the model the last turn ran on', async () => {
+  const tempDirectory = await mkdtemp(path.join(tmpdir(), 'provider-token-usage-omp-'));
+  const sessionFilePath = path.join(tempDirectory, 'provider-session.jsonl');
+
+  try {
+    // Two assistant turns: the LAST one wins, so a mid-session model switch is
+    // reported rather than the model the session opened on. The provider/model
+    // pair is absent from every catalog and the context-window read is stubbed
+    // below, which pins `total` to the fallback.
+    await writeFile(sessionFilePath, [
+      JSON.stringify({
+        type: 'message',
+        message: {
+          role: 'assistant',
+          provider: 'acme',
+          model: 'first-model',
+          usage: { input: 1, output: 1, cacheRead: 0, totalTokens: 2 },
+        },
+      }),
+      JSON.stringify({
+        type: 'message',
+        message: {
+          role: 'assistant',
+          provider: 'acme',
+          model: 'no-such-model',
+          usage: { input: 100, output: 30, cacheRead: 20, totalTokens: 150 },
+        },
+      }),
+    ].join('\n'));
+
+    const service = createProviderTokenUsageService({
+      getSessionById: () => createSessionRow({ provider: 'omp', jsonl_path: sessionFilePath }),
+      // The real reader spawns `omp` behind a module-level cache, so leaving it
+      // in place made this test pay the models timeout and leak its resolved
+      // catalog into every later test in the process.
+      getOmpContextWindow: async () => null,
+    });
+
+    assert.deepEqual(await service.getSessionTokenUsage('app-session'), {
+      used: 150,
+      total: 200_000,
+      model: 'no-such-model',
+      inputTokens: 120,
+      outputTokens: 30,
+      breakdown: { input: 120, output: 30 },
+    });
+  } finally {
+    await rm(tempDirectory, { recursive: true, force: true });
+  }
+});
+
 test('OpenCode token usage resolves its provider-native id from the session row', async () => {
   const tempDirectory = await mkdtemp(path.join(tmpdir(), 'provider-token-usage-opencode-'));
   const databasePath = path.join(tempDirectory, 'opencode.db');

--- a/server/modules/providers/tests/skills.test.ts
+++ b/server/modules/providers/tests/skills.test.ts
@@ -690,3 +690,127 @@ test('providerSkillsService rejects managed skill creation for opencode', { conc
     /does not support managed global skills/i,
   );
 });
+
+/**
+ * This test covers omp skill ranking: its own `.omp` roots outrank the Claude and
+ * compatibility roots it also reads, one name reached through two roots is listed
+ * once, and `skills.ignoredSkills` in omp's config hides a skill everywhere.
+ */
+test('providerSkillsService ranks and de-duplicates omp skill sources', { concurrency: false }, async () => {
+  const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'llm-skills-omp-'));
+  const repoRoot = path.join(tempRoot, 'repo');
+  const workspacePath = path.join(repoRoot, 'packages', 'app');
+  await fs.mkdir(path.join(repoRoot, '.git'), { recursive: true });
+  await fs.mkdir(workspacePath, { recursive: true });
+
+  const restoreHomeDir = patchHomeDir(tempRoot);
+  try {
+    await fs.mkdir(path.join(tempRoot, '.omp', 'agent'), { recursive: true });
+    await fs.writeFile(
+      path.join(tempRoot, '.omp', 'agent', 'config.yml'),
+      'skills: \n  ignoredSkills: \n    - omp-hidden\nmemories: \n  enabled: true\n',
+      'utf8',
+    );
+
+    await writeSkill(
+      path.join(workspacePath, '.omp', 'skills'),
+      'omp-native-dir',
+      'omp-native',
+      'omp native project skill',
+    );
+    await writeSkill(
+      path.join(tempRoot, '.omp', 'agent', 'skills'),
+      'omp-user-dir',
+      'omp-user',
+      'omp native user skill',
+    );
+    await writeSkill(
+      path.join(tempRoot, '.omp', 'agent', 'managed-skills'),
+      'omp-managed-dir',
+      'omp-managed',
+      'omp managed skill',
+    );
+    await writeSkill(
+      path.join(repoRoot, '.github', 'skills'),
+      'omp-github-dir',
+      'omp-github',
+      'omp github skill',
+    );
+    await writeSkill(
+      path.join(tempRoot, '.claude', 'skills'),
+      'omp-shared-dir',
+      'omp-shared',
+      'Claude copy outranks the compatibility copy',
+    );
+    await writeSkill(
+      path.join(tempRoot, '.agents', 'skills'),
+      'omp-shared-dir',
+      'omp-shared',
+      'Agents copy is shadowed',
+    );
+    await writeSkill(
+      path.join(tempRoot, '.claude', 'skills'),
+      'omp-hidden-dir',
+      'omp-hidden',
+      'Suppressed by omp config',
+    );
+
+    const skills = await providerSkillsService.listProviderSkills('omp', { workspacePath });
+    const byName = new Map(skills.map((skill) => [skill.name, skill]));
+
+    assert.equal(byName.get('omp-native')?.scope, 'project');
+    assert.equal(byName.get('omp-native')?.command, '/omp-native');
+    assert.equal(byName.get('omp-user')?.scope, 'user');
+    assert.equal(byName.get('omp-managed')?.scope, 'user');
+    assert.equal(byName.get('omp-github')?.scope, 'project');
+    assert.equal(byName.has('omp-hidden'), false);
+
+    assert.equal(skills.filter((skill) => skill.name === 'omp-shared').length, 1);
+    assert.equal(
+      byName.get('omp-shared')?.sourcePath,
+      path.join(tempRoot, '.claude', 'skills', 'omp-shared-dir', 'SKILL.md'),
+    );
+  } finally {
+    restoreHomeDir();
+    await fs.rm(tempRoot, { recursive: true, force: true });
+  }
+});
+
+/**
+ * This test covers omp global skill writes, which land in omp's own user root so
+ * they outrank every borrowed source and stay out of the auto-learn directory.
+ */
+test('providerSkillsService writes omp global skills into omp native user root', { concurrency: false }, async () => {
+  const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'llm-skills-omp-write-'));
+  const workspacePath = path.join(tempRoot, 'workspace');
+  await fs.mkdir(workspacePath, { recursive: true });
+
+  const restoreHomeDir = patchHomeDir(tempRoot);
+  try {
+    const [created] = await providerSkillsService.addProviderSkills('omp', {
+      entries: [{
+        content: '---\nname: omp-written\ndescription: Written through the adapter\n---\n\nBody.',
+      }],
+    });
+
+    assert.equal(created.scope, 'user');
+    assert.equal(
+      created.sourcePath,
+      path.join(tempRoot, '.omp', 'agent', 'skills', 'omp-written', 'SKILL.md'),
+    );
+
+    const listed = await providerSkillsService.listProviderSkills('omp', { workspacePath });
+    assert.equal(listed.some((skill) => skill.name === 'omp-written'), true);
+
+    const removal = await providerSkillsService.removeProviderSkill('omp', {
+      directoryName: 'omp-written',
+    });
+    assert.equal(removal.removed, true);
+
+    const remaining = await providerSkillsService.listProviderSkills('omp', { workspacePath });
+    assert.equal(remaining.some((skill) => skill.name === 'omp-written'), false);
+  } finally {
+    restoreHomeDir();
+    await fs.rm(tempRoot, { recursive: true, force: true });
+  }
+});

--- a/server/modules/websocket/services/shell-websocket.service.ts
+++ b/server/modules/websocket/services/shell-websocket.service.ts
@@ -216,6 +216,13 @@ function buildShellCommand(
     return initialCommand || 'opencode';
   }
 
+  if (provider === 'omp') {
+    if (resumeSessionId) {
+      return `omp -r "${resumeSessionId}"`;
+    }
+    return initialCommand || 'omp';
+  }
+
   const command = initialCommand || 'claude';
   if (resumeSessionId) {
     if (os.platform() === 'win32') {
@@ -536,6 +543,8 @@ export function handleShellConnection(
                 ? 'Codex'
                 : provider === 'opencode'
                     ? 'OpenCode'
+                : provider === 'omp'
+                    ? 'omp'
                   : 'Claude';
           welcomeMsg = hasSession && resumeSessionId
             ? `\x1b[36mResuming ${providerName} session ${resumeSessionId} in: ${projectPath}\x1b[0m\r\n`

--- a/server/shared/image-attachments.ts
+++ b/server/shared/image-attachments.ts
@@ -433,3 +433,57 @@ export function buildCodexInputItems(prompt: string, images: unknown, cwd?: stri
   }
   return items;
 }
+
+type AcpPromptBlock =
+  | { type: 'text'; text: string }
+  | { type: 'image'; mimeType: string; data: string };
+
+/**
+ * Builds the ACP `session/prompt` content list (used by omp): the prompt text
+ * followed by one base64 `image` block per attachment.
+ *
+ * ACP reuses MCP's `ContentBlock`, so an image block is
+ * `{type:'image', mimeType, data}` with base64 `data`
+ * (https://agentclientprotocol.com/protocol/v1/content). Image blocks are only
+ * appended when the prompt actually carries attachments, and only after the same
+ * allowed-root and symlink checks the other providers' builders apply.
+ *
+ * Consumed by the omp runtime provider when it sends a prompt, and by the
+ * providers module's capability service to report image support.
+ */
+export async function buildAcpPromptBlocks(
+  prompt: string,
+  images: unknown,
+  cwd?: string,
+): Promise<AcpPromptBlock[]> {
+  const blocks: AcpPromptBlock[] = [{ type: 'text', text: prompt }];
+
+  for (const descriptor of normalizeImageDescriptors(images)) {
+    const mediaType = resolveImageMediaType(descriptor);
+    if (!mediaType || !mediaType.startsWith('image/')) {
+      console.warn(`[Images] Skipping non-image attachment for omp: ${descriptor.path}`);
+      continue;
+    }
+
+    const resolvedPath = resolveImageAbsolutePath(cwd, descriptor.path);
+    if (!isAllowedImageSourcePath(resolvedPath, cwd)) {
+      console.warn(`[Images] Refusing to read image outside allowed roots: ${descriptor.path}`);
+      continue;
+    }
+
+    try {
+      const canonicalPath = await fs.realpath(resolvedPath);
+      if (!isAllowedImageSourcePath(canonicalPath, cwd)) {
+        console.warn(`[Images] Refusing to read symlinked image outside allowed roots: ${descriptor.path}`);
+        continue;
+      }
+      const bytes = await fs.readFile(canonicalPath);
+      blocks.push({ type: 'image', mimeType: mediaType, data: bytes.toString('base64') });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      console.warn(`[Images] Failed to read image ${descriptor.path}: ${message}`);
+    }
+  }
+
+  return blocks;
+}

--- a/server/shared/interfaces.ts
+++ b/server/shared/interfaces.ts
@@ -135,6 +135,11 @@ export interface IProviderSkills {
  * `ProviderMcpServer` records used by routes and frontend state.
  */
 export interface IProviderMcp {
+  /**
+   * MCP scopes this provider can write. Empty = MCP management unsupported
+   * (the global add/remove-to-all-providers helpers skip such providers).
+   */
+  readonly supportedScopes: McpScope[];
   listServers(options?: { workspacePath?: string }): Promise<Record<McpScope, ProviderMcpServer[]>>;
   listServersForScope(scope: McpScope, options?: { workspacePath?: string }): Promise<ProviderMcpServer[]>;
   upsertServer(input: UpsertProviderMcpServerInput): Promise<ProviderMcpServer>;

--- a/server/shared/tests/tool-approval-registry.test.ts
+++ b/server/shared/tests/tool-approval-registry.test.ts
@@ -1,0 +1,302 @@
+import assert from 'node:assert/strict';
+import test, { mock } from 'node:test';
+
+import type { ProviderPermissionDecision } from '@/shared/types.js';
+import {
+  getPendingApprovalsForSession,
+  registerApproval,
+  resolveToolApproval,
+  unregisterApproval,
+} from '@/shared/tool-approval-registry.js';
+
+const APPROVAL_MAX_AGE_MS = 30 * 60 * 1000;
+const SWEEP_INTERVAL_MS = 60 * 1000;
+// Expiry is age-based (`now - receivedAt`), so a realistic epoch keeps the
+// arithmetic honest and matches what a real run registers.
+const CLOCK_START_MS = Date.UTC(2026, 0, 1);
+
+// The registry is a process-wide singleton, so every test uses its own request
+// ids and leaves the map empty — a leaked entry would also leave the sweep
+// interval armed for the next test.
+type Outcome = ProviderPermissionDecision | { cancelled: true };
+
+function collector(): { outcomes: Outcome[]; resolver: (outcome: Outcome) => void } {
+  const outcomes: Outcome[] = [];
+  return { outcomes, resolver: (outcome) => outcomes.push(outcome) };
+}
+
+test('registerApproval exposes the approval to its own session only', () => {
+  const receivedAt = new Date('2026-01-01T00:00:00.000Z');
+  const { resolver } = collector();
+
+  registerApproval('req-list', {
+    resolver,
+    sessionId: 'session-a',
+    provider: 'claude',
+    meta: { toolName: 'Write', input: { file: 'a.txt' }, context: { cwd: '/tmp' }, receivedAt },
+  });
+
+  try {
+    assert.deepEqual(getPendingApprovalsForSession('session-a'), [
+      {
+        requestId: 'req-list',
+        toolName: 'Write',
+        input: { file: 'a.txt' },
+        context: { cwd: '/tmp' },
+        sessionId: 'session-a',
+        provider: 'claude',
+        receivedAt,
+      },
+    ]);
+    assert.deepEqual(getPendingApprovalsForSession('session-b'), []);
+  } finally {
+    unregisterApproval('req-list');
+  }
+});
+
+test('registerApproval reads the legacy underscore metadata the Claude runtime attaches', () => {
+  const receivedAt = new Date('2026-01-01T00:00:00.000Z');
+  const { resolver } = collector();
+
+  registerApproval('req-legacy', {
+    resolver,
+    sessionId: 'session-legacy',
+    provider: 'claude',
+    meta: { _toolName: 'Bash', _input: { command: 'ls' }, _context: null, _receivedAt: receivedAt },
+  });
+
+  try {
+    const [pending] = getPendingApprovalsForSession('session-legacy');
+    assert.equal(pending?.toolName, 'Bash');
+    assert.deepEqual(pending?.input, { command: 'ls' });
+    assert.equal(pending?.receivedAt, receivedAt);
+  } finally {
+    unregisterApproval('req-legacy');
+  }
+});
+
+test('registerApproval ignores a missing request id or a non-function resolver', () => {
+  const { resolver } = collector();
+
+  registerApproval('', { resolver, sessionId: 'session-invalid' });
+  registerApproval('req-invalid', {
+    resolver: undefined as unknown as (outcome: Outcome) => void,
+    sessionId: 'session-invalid',
+  });
+
+  assert.deepEqual(getPendingApprovalsForSession('session-invalid'), []);
+  assert.equal(resolveToolApproval('req-invalid', { allow: true }), false);
+});
+
+test('an unnamed approval falls back to UnknownTool', () => {
+  const { resolver } = collector();
+
+  registerApproval('req-unnamed', { resolver, sessionId: 'session-unnamed' });
+
+  try {
+    const [pending] = getPendingApprovalsForSession('session-unnamed');
+    assert.equal(pending?.toolName, 'UnknownTool');
+    assert.equal(pending?.provider, null);
+  } finally {
+    unregisterApproval('req-unnamed');
+  }
+});
+
+test('resolveToolApproval delivers an allow decision to the waiting resolver', () => {
+  const { outcomes, resolver } = collector();
+  const decision: ProviderPermissionDecision = { allow: true, updatedInput: { file: 'b.txt' } };
+
+  registerApproval('req-allow', { resolver, sessionId: 'session-allow', provider: 'claude' });
+
+  try {
+    assert.equal(resolveToolApproval('req-allow', decision), true);
+    assert.deepEqual(outcomes, [decision]);
+  } finally {
+    unregisterApproval('req-allow');
+  }
+});
+
+test('resolveToolApproval delivers a deny decision to the waiting resolver', () => {
+  const { outcomes, resolver } = collector();
+  const decision: ProviderPermissionDecision = { allow: false, message: 'denied by user' };
+
+  registerApproval('req-deny', { resolver, sessionId: 'session-deny', provider: 'claude' });
+
+  try {
+    assert.equal(resolveToolApproval('req-deny', decision), true);
+    assert.deepEqual(outcomes, [decision]);
+  } finally {
+    unregisterApproval('req-deny');
+  }
+});
+
+test('resolveToolApproval reports an unknown request id instead of throwing', () => {
+  assert.equal(resolveToolApproval('req-never-registered', { allow: true }), false);
+});
+
+test('unregisterApproval drops the approval without settling its resolver', () => {
+  const { outcomes, resolver } = collector();
+
+  registerApproval('req-unregister', { resolver, sessionId: 'session-unregister' });
+  unregisterApproval('req-unregister');
+
+  assert.deepEqual(getPendingApprovalsForSession('session-unregister'), []);
+  assert.deepEqual(outcomes, []);
+  // The runtime's own cleanup path must stay idempotent.
+  unregisterApproval('req-unregister');
+  assert.equal(resolveToolApproval('req-unregister', { allow: true }), false);
+});
+
+test('a stalled approval expires on its own timer and cancels the waiter it left hanging', (t) => {
+  t.mock.timers.enable({ apis: ['setInterval', 'Date'], now: CLOCK_START_MS });
+  t.after(() => {
+    unregisterApproval('req-stalled');
+    mock.timers.reset();
+  });
+
+  const { outcomes, resolver } = collector();
+
+  // No later registerApproval call — the registration-time sweep cannot be what
+  // clears this entry, so only the interval can.
+  registerApproval('req-stalled', {
+    resolver,
+    sessionId: 'session-stalled',
+    provider: 'claude',
+    meta: { toolName: 'Write' },
+  });
+
+  t.mock.timers.tick(APPROVAL_MAX_AGE_MS);
+  assert.deepEqual(outcomes, [], 'an approval inside its window must stay pending');
+  assert.equal(getPendingApprovalsForSession('session-stalled').length, 1);
+
+  t.mock.timers.tick(SWEEP_INTERVAL_MS);
+
+  assert.deepEqual(outcomes, [{ cancelled: true }], 'the stalled waiter must be cancelled');
+  assert.deepEqual(
+    getPendingApprovalsForSession('session-stalled'),
+    [],
+    'the expired approval must be dropped after its waiter is settled',
+  );
+  // Cancelling happens strictly before deletion, so a late decision finds nothing.
+  assert.equal(resolveToolApproval('req-stalled', { allow: true }), false);
+});
+
+test('an approval resolved inside its window is never cancelled by the sweep', (t) => {
+  t.mock.timers.enable({ apis: ['setInterval', 'Date'], now: CLOCK_START_MS });
+  t.after(() => {
+    unregisterApproval('req-in-window');
+    mock.timers.reset();
+  });
+
+  const { outcomes, resolver } = collector();
+  registerApproval('req-in-window', { resolver, sessionId: 'session-in-window' });
+
+  assert.equal(resolveToolApproval('req-in-window', { allow: true }), true);
+  unregisterApproval('req-in-window');
+  t.mock.timers.tick(APPROVAL_MAX_AGE_MS + SWEEP_INTERVAL_MS * 2);
+
+  assert.deepEqual(outcomes, [{ allow: true }]);
+});
+
+test('the sweep timer never keeps the event loop alive', () => {
+  const refdTimeoutsBefore = process
+    .getActiveResourcesInfo()
+    .filter((resource) => resource === 'Timeout').length;
+  const { resolver } = collector();
+
+  registerApproval('req-unref', { resolver, sessionId: 'session-unref' });
+
+  try {
+    assert.equal(
+      process.getActiveResourcesInfo().filter((resource) => resource === 'Timeout').length,
+      refdTimeoutsBefore,
+      'the sweep interval must be unref\u2019d, otherwise the server (and this test run) can never exit',
+    );
+  } finally {
+    unregisterApproval('req-unref');
+  }
+});
+
+test('a non-Date receivedAt is pinned to a real timestamp and still expires', (t) => {
+  t.mock.timers.enable({ apis: ['setInterval', 'Date'], now: CLOCK_START_MS });
+  t.after(() => {
+    unregisterApproval('req-bad-date');
+    mock.timers.reset();
+  });
+
+  const { outcomes, resolver } = collector();
+
+  // The Claude runtime is JavaScript, so the declared `Date` does not hold at
+  // runtime. Before coercion this entry read as "unknown age" and was immortal.
+  registerApproval('req-bad-date', {
+    resolver,
+    sessionId: 'session-bad-date',
+    meta: { toolName: 'Write', receivedAt: '2026-01-01T00:00:00.000Z' as unknown as Date },
+  });
+
+  const [pending] = getPendingApprovalsForSession('session-bad-date');
+  assert.ok(pending?.receivedAt instanceof Date, 'the replayed view must carry a real Date');
+  assert.equal(pending?.receivedAt.getTime(), CLOCK_START_MS);
+
+  t.mock.timers.tick(APPROVAL_MAX_AGE_MS + SWEEP_INTERVAL_MS);
+
+  assert.deepEqual(outcomes, [{ cancelled: true }]);
+  assert.deepEqual(getPendingApprovalsForSession('session-bad-date'), []);
+});
+
+test('an approval received at the Unix epoch expires like any other', (t) => {
+  t.mock.timers.enable({ apis: ['setInterval', 'Date'], now: CLOCK_START_MS });
+  t.after(() => {
+    unregisterApproval('req-epoch');
+    mock.timers.reset();
+  });
+
+  const { outcomes, resolver } = collector();
+
+  // A timestamp of 0 is a valid age, not a missing one.
+  registerApproval('req-epoch', {
+    resolver,
+    sessionId: 'session-epoch',
+    meta: { receivedAt: new Date(0) },
+  });
+
+  t.mock.timers.tick(SWEEP_INTERVAL_MS);
+
+  assert.deepEqual(outcomes, [{ cancelled: true }], 'an epoch-old approval is long expired');
+  assert.deepEqual(getPendingApprovalsForSession('session-epoch'), []);
+});
+
+test('resolveToolApproval settles a request exactly once', () => {
+  const { outcomes, resolver } = collector();
+
+  registerApproval('req-once', { resolver, sessionId: 'session-once', provider: 'claude' });
+
+  try {
+    assert.equal(resolveToolApproval('req-once', { allow: true }), true);
+    // A duplicate or late `chat.permission-response`, or an abort racing the
+    // user's click, must not deliver a second decision.
+    assert.equal(resolveToolApproval('req-once', { allow: false }), false);
+    assert.deepEqual(outcomes, [{ allow: true }]);
+    assert.deepEqual(
+      getPendingApprovalsForSession('session-once'),
+      [],
+      'a settled approval must stop being replayed to a resubscribing client',
+    );
+  } finally {
+    unregisterApproval('req-once');
+  }
+});
+
+test('a resolver that throws still consumes its approval', () => {
+  registerApproval('req-throws', {
+    resolver: () => { throw new Error('resolver already settled'); },
+    sessionId: 'session-throws',
+  });
+
+  try {
+    assert.equal(resolveToolApproval('req-throws', { allow: true }), true);
+    assert.deepEqual(getPendingApprovalsForSession('session-throws'), []);
+  } finally {
+    unregisterApproval('req-throws');
+  }
+});

--- a/server/shared/tool-approval-registry.ts
+++ b/server/shared/tool-approval-registry.ts
@@ -1,0 +1,204 @@
+import type { LLMProvider, ProviderPermissionDecision } from '@/shared/types.js';
+
+/**
+ * A resolver settles the turn waiting on one approval: either with the user's
+ * decision, or with `{cancelled:true}` when the approval is swept away.
+ */
+type ApprovalResolver = (outcome: ProviderPermissionDecision | { cancelled: true }) => void;
+
+type ApprovalMeta = {
+  toolName?: string;
+  _toolName?: string;
+  input?: unknown;
+  _input?: unknown;
+  context?: unknown;
+  _context?: unknown;
+  receivedAt?: Date;
+  _receivedAt?: Date;
+};
+
+type PendingApproval = {
+  resolver: ApprovalResolver;
+  sessionId: string | null;
+  provider: LLMProvider | null;
+  meta: ApprovalMeta;
+  receivedAt: Date;
+};
+
+/** One pending approval as reported to a client resubscribing to its session. */
+type PendingApprovalView = {
+  requestId: string;
+  toolName: string;
+  input: unknown;
+  context: unknown;
+  sessionId: string;
+  provider: LLMProvider | null;
+  receivedAt: Date;
+};
+
+const pendingApprovals = new Map<string, PendingApproval>();
+const APPROVAL_MAX_AGE_MS = 30 * 60 * 1000;
+
+// `meta` crosses a JS boundary - the Claude runtime is still JavaScript, so its
+// declared `Date` buys nothing at runtime and a string (or an unparseable Date)
+// reaches us. Pin a real timestamp at registration: an entry whose age cannot be
+// read would be immortal in the sweep below, and would break the `receivedAt`
+// contract of the pending-approval replay that clients resubscribe with.
+function coerceReceivedAt(value: unknown): Date {
+  const time = value instanceof Date ? value.getTime() : Number.NaN;
+  return Number.isFinite(time) ? (value as Date) : new Date();
+}
+
+// Drop approvals whose run died without resolving them (WS disconnect, process
+// crash) so their captured payloads/closures don't accumulate unbounded.
+function sweepExpiredApprovals(now = Date.now()): void {
+  for (const [requestId, entry] of pendingApprovals) {
+    const receivedAt = entry.receivedAt instanceof Date ? entry.receivedAt.getTime() : Number.NaN;
+    // Unknown age expires rather than persists: the fail-safe direction is to
+    // unblock a waiter we can no longer reason about, not to hang it forever.
+    if (!Number.isFinite(receivedAt) || now - receivedAt > APPROVAL_MAX_AGE_MS) {
+      // Resolve as cancelled BEFORE dropping, so the awaiting turn (e.g. an omp
+      // ACP request handler, or a Claude wait-forever tool) unblocks instead of
+      // hanging forever.
+      try {
+        entry.resolver({ cancelled: true });
+      } catch (error) {
+        // The entry is dropped either way, so a throw here loses the cancellation:
+        // that turn stays parked and nothing will sweep it again. Name it.
+        console.warn(
+          `[Approvals] cancelling ${requestId} threw; its turn may stay parked:`,
+          error instanceof Error ? error.message : error,
+        );
+      }
+      pendingApprovals.delete(requestId);
+    }
+  }
+}
+
+// Registration-time sweeping alone leaves the LAST stalled approval pending
+// forever: nothing else calls the sweep, and unlike the Claude runtime (which
+// applies its own per-request timeout) the omp ACP handler awaits its resolver
+// indefinitely. An unref'd interval bounds that wait without holding the process
+// open, and only runs while approvals are actually outstanding.
+const SWEEP_INTERVAL_MS = 60 * 1000;
+let sweepTimer: ReturnType<typeof setInterval> | null = null;
+
+function stopSweepTimer(): void {
+  if (sweepTimer) {
+    clearInterval(sweepTimer);
+    sweepTimer = null;
+  }
+}
+
+function ensureSweepTimer(): void {
+  if (sweepTimer || pendingApprovals.size === 0) {
+    return;
+  }
+  sweepTimer = setInterval(() => {
+    sweepExpiredApprovals();
+    if (pendingApprovals.size === 0) {
+      stopSweepTimer();
+    }
+  }, SWEEP_INTERVAL_MS);
+  // Never keep the event loop (or a test run) alive just to sweep.
+  sweepTimer.unref?.();
+}
+
+// Consumed by each provider runtime in `@/modules/providers` (currently the
+// Claude runtime) to park a turn until the user answers its permission prompt.
+export function registerApproval(
+  requestId: string,
+  {
+    resolver,
+    sessionId = null,
+    provider = null,
+    meta = {},
+  }: {
+    resolver: ApprovalResolver;
+    sessionId?: string | null;
+    provider?: LLMProvider | null;
+    meta?: ApprovalMeta;
+  },
+): void {
+  if (!requestId || typeof resolver !== 'function') {
+    return;
+  }
+
+  sweepExpiredApprovals();
+
+  pendingApprovals.set(requestId, {
+    resolver,
+    sessionId,
+    provider,
+    meta,
+    receivedAt: coerceReceivedAt(meta.receivedAt || meta._receivedAt),
+  });
+  ensureSweepTimer();
+}
+
+// Consumed by the provider runtimes' own cleanup paths: a turn that settled,
+// timed out, or aborted drops its approval without settling the resolver twice.
+export function unregisterApproval(requestId: string): void {
+  pendingApprovals.delete(requestId);
+  if (pendingApprovals.size === 0) {
+    stopSweepTimer();
+  }
+}
+
+// Consumed by the provider runtimes, which re-expose it as
+// `runtime.permissions.resolve` so the websocket module's
+// `chat.permission-response` handler can settle the waiting turn. Callers also
+// settle an approval as cancelled (abort / stale replay), which is not a user
+// decision — hence the same union the resolver accepts.
+export function resolveToolApproval(
+  requestId: string,
+  decision: ProviderPermissionDecision | { cancelled: true },
+): boolean {
+  const entry = pendingApprovals.get(requestId);
+  if (!entry) {
+    return false;
+  }
+
+  // Consume BEFORE settling. A duplicate or late `chat.permission-response`, or
+  // an abort racing the user's click, must not hand a second decision to a
+  // resolver that already settled - and a provider that forgets its own cleanup
+  // must not leak the entry.
+  unregisterApproval(requestId);
+  try {
+    entry.resolver(decision);
+  } catch (error) {
+    // Consuming first means a throw here is the provider's resolver failing, not
+    // a double-settle, and the entry is already gone so the sweep cannot retry it.
+    // Report rather than lose the turn silently; the boolean still answers only
+    // "did this request exist", which is all the websocket handler decides on.
+    console.warn(
+      `[Approvals] the resolver for ${requestId} threw; its turn may stay parked:`,
+      error instanceof Error ? error.message : error,
+    );
+  }
+  return true;
+}
+
+// Consumed by the provider runtimes as `runtime.permissions.listPending`, so
+// `@/modules/websocket` can replay outstanding prompts to a client that
+// resubscribes to a session mid-approval.
+export function getPendingApprovalsForSession(sessionId: string): PendingApprovalView[] {
+  const pending: PendingApprovalView[] = [];
+  for (const [requestId, entry] of pendingApprovals.entries()) {
+    if (entry.sessionId !== sessionId) {
+      continue;
+    }
+
+    pending.push({
+      requestId,
+      toolName: entry.meta.toolName || entry.meta._toolName || 'UnknownTool',
+      input: entry.meta.input ?? entry.meta._input,
+      context: entry.meta.context ?? entry.meta._context,
+      sessionId,
+      provider: entry.provider,
+      receivedAt: entry.receivedAt,
+    });
+  }
+
+  return pending;
+}

--- a/server/shared/types.ts
+++ b/server/shared/types.ts
@@ -66,7 +66,7 @@ export type AuthenticatedWebSocketRequest = IncomingMessage & {
  * Use this as the source of truth whenever a function or payload needs to identify
  * a specific LLM integration.
  */
-export type LLMProvider = 'claude' | 'codex' | 'cursor' | 'opencode';
+export type LLMProvider = 'claude' | 'codex' | 'cursor' | 'opencode' | 'omp';
 
 /**
  * One selectable model row in a provider model catalog.

--- a/server/shared/utils.ts
+++ b/server/shared/utils.ts
@@ -665,6 +665,38 @@ export function addUniqueProviderSkillSource(
   sources.push({ ...source, rootDir: normalizedRootDir });
 }
 
+/**
+ * Lists the project directories a skill lookup walks, nearest first.
+ *
+ * Providers that support per-project skills read them from the working
+ * directory and from every parent up to the repository root, so a skill placed
+ * at the top of a monorepo stays visible inside its packages.
+ */
+export function getProjectSkillSearchRoots(
+  workspacePath: string,
+  repoRoot: string | null,
+): string[] {
+  const roots: string[] = [];
+  const normalizedRepoRoot = repoRoot ? path.resolve(repoRoot) : null;
+  let currentPath = path.resolve(workspacePath);
+
+  while (true) {
+    roots.push(currentPath);
+    if (!normalizedRepoRoot || currentPath === normalizedRepoRoot) {
+      break;
+    }
+
+    const parentPath = path.dirname(currentPath);
+    if (parentPath === currentPath) {
+      break;
+    }
+
+    currentPath = parentPath;
+  }
+
+  return roots;
+}
+
 // ---------------------------
 //----------------- PROVIDER SKILL MARKDOWN UTILITIES ------------
 /**

--- a/src/components/chat/hooks/useChatComposerState.ts
+++ b/src/components/chat/hooks/useChatComposerState.ts
@@ -630,6 +630,8 @@ export function useChatComposerState({
               ? 'codex-settings'
               : provider === 'opencode'
                   ? 'opencode-settings'
+                : provider === 'omp'
+                  ? 'omp-settings'
                 : 'claude-settings';
         const savedSettings = safeLocalStorage.getItem(settingsKey);
         if (savedSettings) {

--- a/src/components/chat/hooks/useChatProviderState.ts
+++ b/src/components/chat/hooks/useChatProviderState.ts
@@ -22,9 +22,10 @@ const FALLBACK_DEFAULT_MODEL: Record<LLMProvider, string> = {
   cursor: 'gpt-5.3-codex',
   codex: 'gpt-5.4',
   opencode: 'anthropic/claude-sonnet-4-5',
+  omp: '__omp_configured_model__',
 };
 
-const PROVIDERS: LLMProvider[] = ['claude', 'cursor', 'codex', 'opencode'];
+const PROVIDERS: LLMProvider[] = ['claude', 'cursor', 'codex', 'opencode', 'omp'];
 
 const readStoredProvider = (): LLMProvider => {
   const storedProvider = localStorage.getItem('selected-provider');
@@ -44,6 +45,7 @@ const FALLBACK_PERMISSION_MODES: Record<LLMProvider, PermissionMode[]> = {
   cursor: ['default', 'acceptEdits', 'bypassPermissions', 'plan'],
   codex: ['default', 'acceptEdits', 'bypassPermissions'],
   opencode: ['default', 'acceptEdits', 'bypassPermissions', 'plan'],
+  omp: ['default', 'plan', 'bypassPermissions'],
 };
 
 type ProviderCapabilities = {
@@ -137,6 +139,9 @@ export function useChatProviderState({ selectedSession, selectedProject: _select
   const [opencodeModel, setOpenCodeModel] = useState<string>(() => {
     return localStorage.getItem('opencode-model') || FALLBACK_DEFAULT_MODEL.opencode;
   });
+  const [ompModel, setOmpModel] = useState<string>(() => {
+    return localStorage.getItem('omp-model') || FALLBACK_DEFAULT_MODEL.omp;
+  });
 
   /**
    * Backend-owned capability matrix keyed by provider. Drives the permission
@@ -175,6 +180,12 @@ export function useChatProviderState({ selectedSession, selectedProject: _select
     if (targetProvider === 'codex') {
       setCodexModel(model);
       localStorage.setItem('codex-model', model);
+      return;
+    }
+
+    if (targetProvider === 'omp') {
+      setOmpModel(model);
+      localStorage.setItem('omp-model', model);
       return;
     }
 
@@ -366,7 +377,8 @@ export function useChatProviderState({ selectedSession, selectedProject: _select
     cursor: cursorModel,
     codex: codexModel,
     opencode: opencodeModel,
-  }), [claudeModel, cursorModel, codexModel, opencodeModel]);
+    omp: ompModel,
+  }), [claudeModel, cursorModel, codexModel, opencodeModel, ompModel]);
 
   useEffect(() => {
     const claude = providerModelCatalog.claude;
@@ -419,6 +431,19 @@ export function useChatProviderState({ selectedSession, selectedProject: _select
       }
     }
   }, [providerModelCatalog.opencode, opencodeModel]);
+
+  useEffect(() => {
+    const omp = providerModelCatalog.omp;
+    if (omp) {
+      const next = pickStoredOrCurrent('omp-model', ompModel, omp);
+      if (next !== ompModel) {
+        setOmpModel(next);
+      }
+      if (localStorage.getItem('omp-model') !== next) {
+        localStorage.setItem('omp-model', next);
+      }
+    }
+  }, [providerModelCatalog.omp, ompModel]);
 
   useEffect(() => {
     const nextEfforts: Partial<Record<LLMProvider, string>> = {};
@@ -867,6 +892,8 @@ export function useChatProviderState({ selectedSession, selectedProject: _select
     currentProviderModelOptions,
     opencodeModel,
     setOpenCodeModel,
+    ompModel,
+    setOmpModel,
     permissionMode,
     setPermissionMode,
     pendingPermissionRequests,

--- a/src/components/chat/hooks/useChatRealtimeHandlers.ts
+++ b/src/components/chat/hooks/useChatRealtimeHandlers.ts
@@ -312,8 +312,24 @@ export function useChatRealtimeHandlers({
           if (msg.text === 'token_budget' && msg.tokenBudget) {
             setTokenBudget(msg.tokenBudget as Record<string, unknown>);
           } else if (msg.text && sid) {
+            // Friendly-label the internal status tokens (omp emits these for live
+            // model/thinking/mode changes; 'plan' from plan-mode) so the activity
+            // pill shows readable text, not the raw token.
+            const rawText = msg.text as string;
+            const value = typeof msg.status === 'string' ? msg.status : undefined;
+            // configId disambiguates a config_option_update (model vs thinking vs mode)
+            // so a thinking change doesn't render as "Model: high".
+            const configId = typeof (msg as { configId?: unknown }).configId === 'string'
+              ? (msg as { configId: string }).configId
+              : undefined;
+            const configLabel = configId === 'thinking' ? 'Thinking' : configId === 'mode' ? 'Mode' : 'Model';
+            const statusText =
+              rawText === 'plan' ? 'Planning'
+              : rawText === 'config_option_update' ? (value ? `${configLabel}: ${value}` : `${configLabel} updated`)
+              : rawText === 'current_mode_update' ? (value ? `Mode: ${value}` : 'Mode changed')
+              : rawText;
             onSessionProcessing?.(sid, {
-              statusText: msg.text as string,
+              statusText,
               canInterrupt: msg.canInterrupt !== false,
             });
           }

--- a/src/components/chat/view/ChatInterface.tsx
+++ b/src/components/chat/view/ChatInterface.tsx
@@ -74,6 +74,8 @@ function ChatInterface({
     currentProviderModelOptions,
     opencodeModel,
     setOpenCodeModel,
+    ompModel,
+    setOmpModel,
     permissionMode,
     pendingPermissionRequests,
     setPendingPermissionRequests,
@@ -315,6 +317,8 @@ function ChatInterface({
         ? t('messageTypes.codex')
         : provider === 'opencode'
             ? t('messageTypes.opencode', { defaultValue: 'OpenCode' })
+          : provider === 'omp'
+            ? t('messageTypes.omp', { defaultValue: 'omp' })
           : t('messageTypes.claude');
 
   if (!selectedProject) {
@@ -356,6 +360,8 @@ function ChatInterface({
           setCodexModel={setCodexModel}
           opencodeModel={opencodeModel}
           setOpenCodeModel={setOpenCodeModel}
+          ompModel={ompModel}
+          setOmpModel={setOmpModel}
           providerModelCatalog={providerModelCatalog}
           providerModelActions={providerModelActions}
           providerModelsLoading={providerModelsLoading}

--- a/src/components/chat/view/subcomponents/ChatMessagesPane.tsx
+++ b/src/components/chat/view/subcomponents/ChatMessagesPane.tsx
@@ -42,6 +42,8 @@ interface ChatMessagesPaneProps {
   setCodexModel: (model: string) => void;
   opencodeModel: string;
   setOpenCodeModel: (model: string) => void;
+  ompModel: string;
+  setOmpModel: (model: string) => void;
   providerModelCatalog: Partial<Record<LLMProvider, ProviderModelsDefinition>>;
   providerModelActions: ProviderModelActions;
   providerModelsLoading: boolean;
@@ -91,6 +93,8 @@ function ChatMessagesPane({
   setCodexModel,
   opencodeModel,
   setOpenCodeModel,
+  ompModel,
+  setOmpModel,
   providerModelCatalog,
   providerModelActions,
   providerModelsLoading,
@@ -198,6 +202,8 @@ function ChatMessagesPane({
           setCodexModel={setCodexModel}
           opencodeModel={opencodeModel}
           setOpenCodeModel={setOpenCodeModel}
+          ompModel={ompModel}
+          setOmpModel={setOmpModel}
           providerModelCatalog={providerModelCatalog}
           providerModelActions={providerModelActions}
           providerModelsLoading={providerModelsLoading}

--- a/src/components/chat/view/subcomponents/CommandResultModal.tsx
+++ b/src/components/chat/view/subcomponents/CommandResultModal.tsx
@@ -63,6 +63,7 @@ const PROVIDER_LABELS: Record<string, string> = {
   cursor: 'Cursor',
   codex: 'Codex',
   opencode: 'OpenCode',
+  omp: 'omp',
 };
 
 const FALLBACK_COMMANDS: CommandEntry[] = [

--- a/src/components/chat/view/subcomponents/MessageComponent.tsx
+++ b/src/components/chat/view/subcomponents/MessageComponent.tsx
@@ -165,6 +165,8 @@ const MessageComponent = memo(({ message, prevMessage, createDiff, onFileOpen, s
                           ? t('messageTypes.codex')
                           : provider === 'opencode'
                               ? t('messageTypes.opencode', { defaultValue: 'OpenCode' })
+                          : provider === 'omp'
+                              ? t('messageTypes.omp', { defaultValue: 'omp' })
                               : t('messageTypes.claude'))}
               </div>
             </div>

--- a/src/components/chat/view/subcomponents/ProviderSelectionEmptyState.tsx
+++ b/src/components/chat/view/subcomponents/ProviderSelectionEmptyState.tsx
@@ -34,6 +34,7 @@ const PROVIDER_META: { id: LLMProvider; name: string }[] = [
   { id: "codex", name: "OpenAI" },
   { id: "cursor", name: "Cursor" },
   { id: "opencode", name: "OpenCode" },
+  { id: "omp", name: "omp" },
 ];
 
 const MOD_KEY =
@@ -64,6 +65,8 @@ type ProviderSelectionEmptyStateProps = {
   setCodexModel: (model: string) => void;
   opencodeModel: string;
   setOpenCodeModel: (model: string) => void;
+  ompModel: string;
+  setOmpModel: (model: string) => void;
   providerModelCatalog: Partial<Record<LLMProvider, ProviderModelsDefinition>>;
   providerModelActions: ProviderModelActions;
   providerModelsLoading: boolean;
@@ -93,10 +96,12 @@ function getCurrentModel(
   cu: string,
   co: string,
   o: string,
+  omp: string,
 ) {
   if (p === "claude") return c;
   if (p === "codex") return co;
   if (p === "opencode") return o;
+  if (p === "omp") return omp;
   return cu;
 }
 
@@ -105,6 +110,7 @@ function getProviderDisplayName(p: LLMProvider) {
   if (p === "cursor") return "Cursor";
   if (p === "codex") return "Codex";
   if (p === "opencode") return "OpenCode";
+  if (p === "omp") return "omp";
   return "Claude";
 }
 
@@ -122,6 +128,8 @@ export default function ProviderSelectionEmptyState({
   setCodexModel,
   opencodeModel,
   setOpenCodeModel,
+  ompModel,
+  setOmpModel,
   providerModelCatalog,
   providerModelActions,
   providerModelsLoading,
@@ -152,6 +160,7 @@ export default function ProviderSelectionEmptyState({
     cursorModel,
     codexModel,
     opencodeModel,
+    ompModel,
   );
 
   const currentModelLabel = useMemo(() => {
@@ -173,12 +182,15 @@ export default function ProviderSelectionEmptyState({
       } else if (providerId === "opencode") {
         setOpenCodeModel(modelValue);
         localStorage.setItem("opencode-model", modelValue);
+      } else if (providerId === "omp") {
+        setOmpModel(modelValue);
+        localStorage.setItem("omp-model", modelValue);
       } else {
         setCursorModel(modelValue);
         localStorage.setItem("cursor-model", modelValue);
       }
     },
-    [setClaudeModel, setCursorModel, setCodexModel, setOpenCodeModel],
+    [setClaudeModel, setCursorModel, setCodexModel, setOpenCodeModel, setOmpModel],
   );
 
   const handleModelSelect = useCallback(
@@ -381,6 +393,12 @@ export default function ProviderSelectionEmptyState({
                 opencode: t("providerSelection.readyPrompt.opencode", {
                   model: opencodeModel,
                   defaultValue: "Ready with OpenCode {{model}}",
+                }),
+                omp: t("providerSelection.readyPrompt.omp", {
+                  // currentModelLabel maps the sentinel → "Use omp default" so the
+                  // tagline never shows the raw __omp_configured_model__ token.
+                  model: currentModelLabel,
+                  defaultValue: "Ready with omp {{model}}",
                 }),
               }[provider]
             }

--- a/src/components/llm-logo-provider/OmpLogo.tsx
+++ b/src/components/llm-logo-provider/OmpLogo.tsx
@@ -1,0 +1,26 @@
+type OmpLogoProps = {
+  className?: string;
+};
+
+// omp (Oh My Pi) — no fetchable official asset (omp.sh 403s), so a plain "π" mark.
+const OmpLogo = ({ className = 'w-5 h-5' }: OmpLogoProps) => (
+  <svg
+    viewBox="0 0 24 24"
+    role="img"
+    aria-label="omp"
+    className={className}
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <rect x="2.5" y="2.5" width="19" height="19" rx="4" className="fill-foreground" />
+    <path
+      d="M6.5 8.7h11M9.3 8.7v8.1M14.7 8.7v6.1c0 1.2.7 2 2 1.9"
+      className="stroke-background"
+      strokeWidth="1.9"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </svg>
+);
+
+export default OmpLogo;

--- a/src/components/llm-logo-provider/SessionProviderLogo.tsx
+++ b/src/components/llm-logo-provider/SessionProviderLogo.tsx
@@ -3,6 +3,7 @@ import ClaudeLogo from './ClaudeLogo';
 import CodexLogo from './CodexLogo';
 import CursorLogo from './CursorLogo';
 import OpenCodeLogo from './OpenCodeLogo';
+import OmpLogo from './OmpLogo';
 
 type SessionProviderLogoProps = {
   provider?: LLMProvider | string | null;
@@ -23,6 +24,10 @@ export default function SessionProviderLogo({
 
   if (provider === 'opencode') {
     return <OpenCodeLogo className={className} />;
+  }
+
+  if (provider === 'omp') {
+    return <OmpLogo className={className} />;
   }
 
   return <ClaudeLogo className={className} />;

--- a/src/components/mcp/constants.ts
+++ b/src/components/mcp/constants.ts
@@ -5,13 +5,17 @@ export const MCP_PROVIDER_NAMES: Record<McpProvider, string> = {
   cursor: 'Cursor',
   codex: 'Codex',
   opencode: 'OpenCode',
+  omp: 'omp',
 };
 
+// omp MCP management is stubbed (backend upsert throws 501), so no scopes/transports
+// are offered in the UI.
 export const MCP_SUPPORTED_SCOPES: Record<McpProvider, McpScope[]> = {
   claude: ['user', 'project', 'local'],
   cursor: ['user', 'project'],
   codex: ['user', 'project'],
   opencode: ['user', 'project'],
+  omp: [],
 };
 
 export const MCP_SUPPORTED_TRANSPORTS: Record<McpProvider, McpTransport[]> = {
@@ -19,6 +23,7 @@ export const MCP_SUPPORTED_TRANSPORTS: Record<McpProvider, McpTransport[]> = {
   cursor: ['stdio', 'http'],
   codex: ['stdio', 'http'],
   opencode: ['stdio', 'http'],
+  omp: [],
 };
 
 export const MCP_GLOBAL_SUPPORTED_SCOPES: McpScope[] = ['user', 'project'];
@@ -30,6 +35,7 @@ export const MCP_PROVIDER_BUTTON_CLASSES: Record<McpProvider, string> = {
   cursor: 'bg-primary text-primary-foreground hover:bg-primary/90',
   codex: 'bg-primary text-primary-foreground hover:bg-primary/90',
   opencode: 'bg-primary text-primary-foreground hover:bg-primary/90',
+  omp: 'bg-primary text-primary-foreground hover:bg-primary/90',
 };
 
 export const MCP_SUPPORTS_WORKING_DIRECTORY: Record<McpProvider, boolean> = {
@@ -37,6 +43,7 @@ export const MCP_SUPPORTS_WORKING_DIRECTORY: Record<McpProvider, boolean> = {
   cursor: false,
   codex: true,
   opencode: false,
+  omp: false,
 };
 
 export const DEFAULT_MCP_FORM: McpFormState = {

--- a/src/components/mcp/view/McpServers.tsx
+++ b/src/components/mcp/view/McpServers.tsx
@@ -9,6 +9,7 @@ import {
   MCP_GLOBAL_SUPPORTED_TRANSPORTS,
   MCP_PROVIDER_BUTTON_CLASSES,
   MCP_PROVIDER_NAMES,
+  MCP_SUPPORTED_SCOPES,
 } from '../constants';
 import { useMcpServers } from '../hooks/useMcpServers';
 import { maskSecret } from '../utils/mcpFormatting';
@@ -142,6 +143,10 @@ export default function McpServers({ selectedProvider, currentProjects }: McpSer
             <p className="text-sm text-muted-foreground">{description}</p>
           </div>
         </div>
+        {/* A provider with no writable scopes (e.g. omp — MCP stubbed) can't take a
+            provider-specific server, so that entry is hidden instead of opening a
+            form that 501s. The global add stays: the service skips unwritable
+            providers and still applies the config to the ones that support it. */}
         <ActionMenu
           label="Add MCP Server"
           icon={Plus}
@@ -155,13 +160,15 @@ export default function McpServers({ selectedProvider, currentProjects }: McpSer
               icon: Globe,
               onSelect: openGlobalForm,
             },
-            {
-              key: 'provider',
-              label: providerButtonLabel,
-              description: providerAddDescription,
-              icon: Server,
-              onSelect: () => openForm(),
-            },
+            ...(MCP_SUPPORTED_SCOPES[selectedProvider].length > 0
+              ? [{
+                key: 'provider',
+                label: providerButtonLabel,
+                description: providerAddDescription,
+                icon: Server,
+                onSelect: () => openForm(),
+              }]
+              : []),
           ]}
         />
 

--- a/src/components/provider-auth/types.ts
+++ b/src/components/provider-auth/types.ts
@@ -10,13 +10,14 @@ export type ProviderAuthStatus = {
 
 export type ProviderAuthStatusMap = Record<LLMProvider, ProviderAuthStatus>;
 
-export const CLI_PROVIDERS: LLMProvider[] = ['claude', 'cursor', 'codex', 'opencode'];
+export const CLI_PROVIDERS: LLMProvider[] = ['claude', 'cursor', 'codex', 'opencode', 'omp'];
 
 export const PROVIDER_AUTH_STATUS_ENDPOINTS: Record<LLMProvider, string> = {
   claude: '/api/providers/claude/auth/status',
   cursor: '/api/providers/cursor/auth/status',
   codex: '/api/providers/codex/auth/status',
   opencode: '/api/providers/opencode/auth/status',
+  omp: '/api/providers/omp/auth/status',
 };
 
 export const createInitialProviderAuthStatusMap = (loading = true): ProviderAuthStatusMap => ({
@@ -24,4 +25,5 @@ export const createInitialProviderAuthStatusMap = (loading = true): ProviderAuth
   cursor: { authenticated: false, email: null, method: null, error: null, loading },
   codex: { authenticated: false, email: null, method: null, error: null, loading },
   opencode: { authenticated: false, email: null, method: null, error: null, loading },
+  omp: { authenticated: false, email: null, method: null, error: null, loading },
 });

--- a/src/components/provider-auth/view/ProviderLoginModal.tsx
+++ b/src/components/provider-auth/view/ProviderLoginModal.tsx
@@ -41,6 +41,11 @@ const getProviderCommand = ({
     return 'opencode auth login';
   }
 
+  // omp has no `login` subcommand — launch the interactive TUI to set up creds.
+  if (provider === 'omp') {
+    return 'omp';
+  }
+
   return 'claude --dangerously-skip-permissions /login';
 };
 
@@ -49,6 +54,7 @@ const getProviderTitle = (provider: LLMProvider) => {
   if (provider === 'cursor') return 'Cursor CLI Login';
   if (provider === 'codex') return 'Codex CLI Login';
   if (provider === 'opencode') return 'OpenCode CLI Login';
+  if (provider === 'omp') return 'omp Setup';
   return 'Claude CLI Login';
 };
 

--- a/src/components/settings/constants/constants.ts
+++ b/src/components/settings/constants/constants.ts
@@ -39,7 +39,7 @@ export const SETTINGS_MAIN_TABS: SettingsMainTabMeta[] = [
   { id: 'about', label: 'About', keywords: 'about version info', icon: Info },
 ];
 
-export const AGENT_PROVIDERS: AgentProvider[] = ['claude', 'cursor', 'codex', 'opencode'];
+export const AGENT_PROVIDERS: AgentProvider[] = ['claude', 'cursor', 'codex', 'opencode', 'omp'];
 export const AGENT_CATEGORIES: AgentCategory[] = ['account', 'permissions', 'mcp'];
 
 export const DEFAULT_PROJECT_SORT_ORDER: ProjectSortOrder = 'name';

--- a/src/components/settings/view/tabs/agents-settings/AgentListItem.tsx
+++ b/src/components/settings/view/tabs/agents-settings/AgentListItem.tsx
@@ -12,7 +12,7 @@ type AgentListItemProps = {
 
 type AgentConfig = {
   name: string;
-  color: 'blue' | 'purple' | 'gray' | 'zinc';
+  color: 'blue' | 'purple' | 'gray' | 'zinc' | 'emerald';
 };
 
 const agentConfig: Record<AgentProvider, AgentConfig> = {
@@ -32,6 +32,10 @@ const agentConfig: Record<AgentProvider, AgentConfig> = {
     name: 'OpenCode',
     color: 'zinc',
   },
+  omp: {
+    name: 'omp',
+    color: 'emerald',
+  },
 };
 
 const colorClasses = {
@@ -46,6 +50,9 @@ const colorClasses = {
   },
   zinc: {
     dot: 'bg-zinc-500',
+  },
+  emerald: {
+    dot: 'bg-emerald-500',
   },
 } as const;
 

--- a/src/components/settings/view/tabs/agents-settings/AgentsSettingsTab.tsx
+++ b/src/components/settings/view/tabs/agents-settings/AgentsSettingsTab.tsx
@@ -20,14 +20,21 @@ export default function AgentsSettingsTab({
 }: AgentsSettingsTabProps) {
   const [selectedAgent, setSelectedAgent] = useState<AgentProvider>('claude');
   const [selectedCategory, setSelectedCategory] = useState<AgentCategory>('account');
-  const visibleCategories = useMemo<AgentCategory[]>(() => (
-    selectedAgent === 'opencode'
-      ? ['account', 'permissions', 'mcp']
-      : ['account', 'permissions', 'mcp', 'skills']
-  ), [selectedAgent]);
+  const visibleCategories = useMemo<AgentCategory[]>(() => {
+    // omp permission modes are chosen per-chat in the composer, not persisted in
+    // settings, so there's no Permissions content to show — hide the tab.
+    if (selectedAgent === 'omp') {
+      return ['account', 'mcp', 'skills'];
+    }
+    // opencode: skills stubbed; its Permissions tab is empty upstream (left as-is).
+    if (selectedAgent === 'opencode') {
+      return ['account', 'permissions', 'mcp'];
+    }
+    return ['account', 'permissions', 'mcp', 'skills'];
+  }, [selectedAgent]);
 
   const visibleAgents = useMemo<AgentProvider[]>(() => {
-    return ['claude', 'cursor', 'codex', 'opencode'];
+    return ['claude', 'cursor', 'codex', 'opencode', 'omp'];
   }, []);
 
   const agentContextById = useMemo<Record<AgentProvider, AgentContext>>(() => ({
@@ -47,12 +54,17 @@ export default function AgentsSettingsTab({
       authStatus: providerAuthStatus.opencode,
       onLogin: () => onProviderLogin('opencode'),
     },
+    omp: {
+      authStatus: providerAuthStatus.omp,
+      onLogin: () => onProviderLogin('omp'),
+    },
   }), [
     onProviderLogin,
     providerAuthStatus.claude,
     providerAuthStatus.codex,
     providerAuthStatus.cursor,
     providerAuthStatus.opencode,
+    providerAuthStatus.omp,
   ]);
 
   useEffect(() => {

--- a/src/components/settings/view/tabs/agents-settings/sections/AgentSelectorSection.tsx
+++ b/src/components/settings/view/tabs/agents-settings/sections/AgentSelectorSection.tsx
@@ -8,6 +8,7 @@ const AGENT_NAMES: Record<AgentProvider, string> = {
   cursor: 'Cursor',
   codex: 'Codex',
   opencode: 'OpenCode',
+  omp: 'omp',
 };
 
 export default function AgentSelectorSection({
@@ -20,10 +21,12 @@ export default function AgentSelectorSection({
     <div className="flex-shrink-0 border-b border-border px-3 py-2 md:px-4 md:py-3">
       <PillBar className="w-full md:w-auto">
         {agents.map((agent) => {
+          // Keep these in step with agentConfig in AgentListItem.tsx.
           const dotColor =
             agent === 'claude' ? 'bg-blue-500' :
             agent === 'cursor' ? 'bg-purple-500' :
-            agent === 'opencode' ? 'bg-zinc-500' : 'bg-foreground/60';
+            agent === 'opencode' ? 'bg-zinc-500' :
+            agent === 'omp' ? 'bg-emerald-500' : 'bg-foreground/60';
 
           return (
             <Pill

--- a/src/components/settings/view/tabs/agents-settings/sections/content/AccountContent.tsx
+++ b/src/components/settings/view/tabs/agents-settings/sections/content/AccountContent.tsx
@@ -54,6 +54,15 @@ const agentConfig: Record<AgentProvider, AgentVisualConfig> = {
     subtextClass: 'text-zinc-700 dark:text-zinc-300',
     buttonClass: 'bg-zinc-900 hover:bg-zinc-800 active:bg-zinc-950 dark:bg-zinc-700 dark:hover:bg-zinc-600',
   },
+  omp: {
+    name: 'omp',
+    description: 'omp (Oh My Pi) CLI assistant',
+    bgClass: 'bg-emerald-50 dark:bg-emerald-900/20',
+    borderClass: 'border-emerald-200 dark:border-emerald-800',
+    textClass: 'text-emerald-900 dark:text-emerald-100',
+    subtextClass: 'text-emerald-700 dark:text-emerald-300',
+    buttonClass: 'bg-emerald-600 hover:bg-emerald-700 active:bg-emerald-800',
+  },
 };
 
 export default function AccountContent({ agent, authStatus, onLogin }: AccountContentProps) {

--- a/src/components/sidebar/view/subcomponents/SidebarSessionItem.tsx
+++ b/src/components/sidebar/view/subcomponents/SidebarSessionItem.tsx
@@ -40,6 +40,7 @@ const PROVIDER_LABELS: Record<LLMProvider, string> = {
   codex: 'Codex',
   cursor: 'Cursor',
   opencode: 'OpenCode',
+  omp: 'omp',
 };
 
 type CopyState = 'loading' | 'idle' | 'copying' | 'copied' | 'error';

--- a/src/components/skills/view/ProviderSkills.tsx
+++ b/src/components/skills/view/ProviderSkills.tsx
@@ -60,9 +60,11 @@ const PROVIDER_NAMES: Record<SkillsProvider, string> = {
   codex: 'Codex',
   cursor: 'Cursor',
   opencode: 'OpenCode',
+  omp: 'omp',
 };
 
-const PROVIDER_SKILL_PATHS: Record<Exclude<SkillsProvider, 'opencode'>, string> = {
+// opencode + omp don't support managed skill creation (omp's skills are stubbed).
+const PROVIDER_SKILL_PATHS: Record<Exclude<SkillsProvider, 'opencode' | 'omp'>, string> = {
   claude: '~/.claude/skills/<skill-name>/SKILL.md',
   codex: '~/.agents/skills/<skill-name>/SKILL.md',
   cursor: '~/.cursor/skills/<skill-name>/SKILL.md',
@@ -220,7 +222,9 @@ export default function ProviderSkills({ selectedProvider, currentProjects }: Pr
   const folderInputRef = useRef<HTMLInputElement | null>(null);
 
   const providerName = PROVIDER_NAMES[selectedProvider];
-  const providerPath = selectedProvider === 'opencode' ? null : PROVIDER_SKILL_PATHS[selectedProvider];
+  const providerPath = (selectedProvider === 'opencode' || selectedProvider === 'omp')
+    ? null
+    : PROVIDER_SKILL_PATHS[selectedProvider];
 
   useEffect(() => {
     setQueuedFiles([]);

--- a/src/i18n/locales/en/chat.json
+++ b/src/i18n/locales/en/chat.json
@@ -18,7 +18,8 @@
     "claude": "Claude",
     "cursor": "Cursor",
     "codex": "Codex",
-    "opencode": "OpenCode"
+    "opencode": "OpenCode",
+    "omp": "omp"
   },
   "tools": {
     "settings": "Tool Settings",
@@ -161,6 +162,7 @@
       "cursor": "Ready to use Cursor with {{model}}. Start typing your message below.",
       "codex": "Ready to use Codex with {{model}}. Start typing your message below.",
       "opencode": "Ready to use OpenCode with {{model}}. Start typing your message below.",
+      "omp": "Ready to use omp with {{model}}. Start typing your message below.",
       "default": "Select a provider above to begin"
     },
     "pressToSearch": "Press <kbd>{{shortcut}}</kbd> to search sessions, files, and commits"

--- a/src/types/app.ts
+++ b/src/types/app.ts
@@ -1,4 +1,4 @@
-export type LLMProvider = 'claude' | 'cursor' | 'codex' | 'opencode';
+export type LLMProvider = 'claude' | 'cursor' | 'codex' | 'opencode' | 'omp';
 
 export type ProviderModelOption = {
   value: string;


### PR DESCRIPTION
Closes #1039.

Adds [Oh My Pi (`omp`)](https://omp.sh/) as a first-class agent provider, following the existing provider architecture.

> **Rewritten 2026-08-11.** The original branch had grown to 61 commits and 91 files, mixing the provider with a pile of generic chat fixes. It has been rebuilt from scratch on current `main` as a **5-commit stack that contains the omp provider and nothing else**. Every generic change has been moved off this branch — see [Explicitly out of scope](#explicitly-out-of-scope). This is a force-push over the old tip; the old state is preserved on my fork.

## Review order

This PR's diff is **A + B**, because it sits on top of a prerequisite refactor that is also submitted on its own:

| | Branch | PR | Contents |
|---|---|---|---|
| **A** | `feat/shared-tool-approval-registry` | #1141 | provider-agnostic tool-approval registry (prerequisite) |
| **B** | `feat/omp-provider` | **this PR** | the omp provider |
| **C** | `feat/omp-rich-history` | not opened yet | rich omp transcript UX (follow-up) |

- **Review B alone:** [`feat/shared-tool-approval-registry...feat/omp-provider`](https://github.com/materemias/claudecodeui/compare/feat/shared-tool-approval-registry...feat/omp-provider) — 68 files, +5,077/−281.
- Preview C if useful: [`feat/omp-provider...feat/omp-rich-history`](https://github.com/materemias/claudecodeui/compare/feat/omp-provider...feat/omp-rich-history) — 15 files, +1,291/−93. It stays branch-only until this lands.

When #1141 merges I will rebase A out of this branch with `--force-with-lease`, and this PR's diff becomes B-only. If you would rather review one PR, close #1141 and I will keep A as the first commit here.

## The commits

Each commit compiles and passes its own narrow tests; no commit repairs a knowingly broken earlier one.

**1. `refactor(approvals): extract a shared tool-approval registry`** — 4 files (this is #1141)
Moves the pending-approval map out of the Claude SDK adapter into `server/shared/tool-approval-registry.ts`, so both runtimes share one `chat.permission-response` → `resolveToolApproval` gateway. Claude's behavior is unchanged; the expiry sweep now cancels a stalled waiter instead of dropping it.

**2. `feat(omp): add ACP stdio JSON-RPC transport`** — 2 files
`stdio-jsonrpc-client.ts` plus a 375-line test: newline-framed request/response correlation, notifications, **inbound** requests (the agent asks *us*), process-exit and error handling, malformed frames, unregistered methods.

**3. `feat(omp): add the omp provider backend`** — 27 files, the bulk of the PR
`omp.provider.ts` and its parts: `omp-runtime.provider.ts` (process/session lifecycle, model + thinking configuration, approvals, abort, prompt input, realpath-guarded fs delegation, fork/resume, active-branch selection, hard child retirement), `omp-sessions.provider.ts` (jsonl history → normalized messages, paging), `omp-session-synchronizer.provider.ts`, `omp-auth.provider.ts`, `omp-models.provider.ts`, `omp-mcp.provider.ts`, `omp-skills.provider.ts`, and one shared `omp-session-files.ts` locator so the runtime and the reader cannot drift. Registry entry, capability matrix, and `omp`'s member in the `LLMProvider` union land here too, because TypeScript's exhaustive `Record<LLMProvider, …>` maps make that atomic. Tests live in `server/modules/providers/tests/`.

**4. `feat(omp): wire omp into the server surfaces`** — 16 files
Agent dispatch (`agent.routes.ts`), WebSocket shell/resume, sessions watcher, token-usage service, MCP service, skills, command-model lookup, and `public/api-docs.html`.

**5. `feat(omp): add minimal web UI integration`** — 23 files
Provider union in the frontend types, selector, logo, login/auth pane, agent settings, account/settings state, sidebar label, i18n string. Deliberately minimal: no new transcript widgets, no changes to generic chat behavior.

## Transport: ACP, not `rpc-ui`

The issue suggested `omp --mode rpc-ui`. I prototyped both and went with **`omp acp`** (ACP over JSON-RPC/stdio):

- **Structured approvals.** ACP `session/request_permission` carries the real option set (`allow_once` / `allow_always` / `reject_once` / `reject_always`), which maps onto the existing permission UI. `rpc-ui`'s `extension_ui_request` only offers a coarse Approve/Deny.
- **Real session resume.** ACP `session/fork` rehydrates an on-disk session — full history, plus a `parentSession` link the omp TUI itself can navigate.
- **Reusable surface.** ACP is a standard, so this adapter is a step toward a generic ACP provider (relevant to #574) rather than an omp-only dialect.

Happy to revisit if you'd prefer `rpc-ui`.

## Acceptance criteria from #1039

1. **Select omp, open a project, start a chat** — registered end to end: selector, settings, logo, enabled-provider controls, binary detection.
2. **Structured streaming, no ANSI parsing** — assistant/thinking chunks, tool calls, tool results and errors arrive as ACP `session/update` notifications and are normalized into the existing chat message kinds.
3. **Approve/reject + abort** — approvals gated per session by permission mode (`bypassPermissions` auto-allows, `default` prompts, `plan` auto-denies sensitive tools); abort via `session/cancel`.
4. **Reload and resume with history intact** — resume walks `session/load` (in-process) → **`session/fork`** (on-disk, full history) → `session/new` as a last resort. Verified across a real server restart.
5. **Model selection** — catalog from `omp models --json`; omp resolves the effective model itself, so a "use omp's configured model" sentinel is the default rather than forcing a choice. Post-turn telemetry reports the model that actually ran, not the sentinel.

## Notable design points

- **One `omp acp` child per cwd, multiplexing many sessions.** `session/update` and inbound `session/request_permission` are routed to the owning run by session id; each run emits exactly one terminal `complete`.
- **History comes from omp's own store** (`~/.omp/agent/sessions/**.jsonl`) — no second session store. omp's on-disk shape is *not* Anthropic-shaped: tool calls are `{type:'toolCall', name, arguments}` inside the assistant message, results are separate `role:'toolResult'` entries linked by `toolCallId`. An omp jsonl is also a **tree**, not a list — the reader walks the newest conversation's branch so a session continued from the TUI doesn't read as two interleaved dialogues.
- **fs delegation is realpath-guarded** and confined to the working directory; image attachments come from omp's content-addressed blob store with a mime allowlist and a size cap.

## Two defects found while rebuilding

Both were present in the old branch and are fixed here, with regression tests:

1. **Resume was silently broken.** Every other runtime maps the app session id to the provider-native id via `context.resolveProviderSessionId()`; the omp runtime passed the app id straight to `session/load` and `session/fork`, so both failed and the run started blank ("history lost") while looking successful. Tests now cover the mapping in both directions.
2. **Abort reported success while the child kept running.** The run was keyed by native id but `activeOmpSessions` by app id, so `session/cancel` never reached the live child.

## Explicitly out of scope

Removed from this branch on purpose, so the diff stays reviewable:

- **Rich omp transcript UX** (todo widget, advisor-note weaving, per-tool views, image rendering in history, collaborator turns) → branch C above, after this lands.
- **Generic chat fixes** that were tangled into the old branch and are *not* omp-specific: LaTeX/`\text` escape handling, large-JSON/`TextContent` folding, a fallback row for tools with no config, reasoning/background stream buffers, scroll pinning, queued-message auto-send, chat back/top navigation, generic resume recovery, a generic command-model service, and pre-turn composer model display. These stay on a local branch and are not submitted here. Say the word and I'll open them separately.
- **Onboarding.** omp is absent from the "Connect Agents" onboarding step (`AgentConnectionsStep.tsx`), which keeps its own hard-coded list. The old branch didn't touch it either; I left it alone rather than widening this PR.
- **`write` cannot be gated by this UI.** omp routes only `bash`/`edit`/`delete`/`move` through ACP `session/request_permission`; `write` it resolves itself. A denied `bash` can therefore be followed by an ungated `write` — documented rather than worked around, since the fix belongs in omp.

## Verification

At `f038dfe`:

- `npm run typecheck` — clean
- `npm run lint` — 0 errors (including the `boundaries/*` rules, which is what checks the barrel and shared-file discipline)
- `npm run build` — passes
- server tests — **323/323 pass**, run serialized:
  `npx tsx --tsconfig server/tsconfig.json --test --test-concurrency=1 "server/**/*.test.ts" "server/**/*.test.js"`

New coverage runs the ACP adapter against a fake `omp` process (no paid calls): transport framing, approval allow/deny/plan-mode/bypass, cross-session isolation, fs-guard escapes, abort during startup, resume via `session/load`, the app↔native id mapping, the jsonl normalizer, the SQLite synchronizer, and history paging.

**Caveat, pre-existing on `main`:** with the default parallel test workers, `server/modules/agent/tests/agent.routes.test.ts` dies with Node's `Unable to deserialize cloned data due to invalid or unsupported version`. It reproduces identically on a pristine `main` checkout (262/263 there), which is why the numbers above come from a serialized run.

**Live smoke path** against a running server on an isolated port and database, with omp 17.2.13 and a cheap model: install/auth detection, model catalog + sentinel, streaming turn, gated file write with allow / deny / bypass / plan mode, abort of an active turn, **server restart → reopen → resume with prior context intact**, history paging, skills listing, actual-turn model, context window and token telemetry — then the same path in the browser: select omp, authenticate, run a tool-using turn, baseline tool rendering, reopen the session.

## Trying it

Requires `omp` on `PATH` (developed against 17.0.6 – 17.2.13). Pick **omp** in the provider selector, open a project, and chat. To exercise resume, start a session in the `omp` TUI, then open it from the web UI and send a prompt — it continues that conversation as a new branch of the original, which stays intact and navigable from the TUI's session tree.

Screenshots: my day-to-day omp transcripts are real work, so the smoke run above used a throwaway project. Happy to add screenshots or a recording from it if that's a merge requirement.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)


