### PR TITLE
fix(search): match Claude transcripts by provider_session_id

### DIFF
--- a/server/modules/providers/services/session-conversations-search.service.ts
+++ b/server/modules/providers/services/session-conversations-search.service.ts
@@ -787,11 +787,18 @@ async function parseClaudeSessionMatches(
       ? matchedSessionsForFile
       : [session];
 
-    const targetSessionIds = new Set(targetSessions.map((candidate) => candidate.session_id));
+    // Transcript lines are tagged with the provider session id (e.g. Claude's own
+    // conversation UUID), which is not necessarily the app-facing `session_id`.
+    // Match and attribute by the provider id, but map results back to the
+    // internal `session_id` the rest of the app uses to identify sessions.
+    const providerToInternalId = new Map<string, string>();
     const customNameBySessionId = new Map<string, string | null>();
     for (const candidate of targetSessions) {
-      customNameBySessionId.set(candidate.session_id, candidate.custom_name ?? null);
+      const providerId = candidate.provider_session_id || candidate.session_id;
+      providerToInternalId.set(providerId, candidate.session_id);
+      customNameBySessionId.set(providerId, candidate.custom_name ?? null);
     }
+    const targetSessionIds = new Set(providerToInternalId.keys());
 
     type ClaudeSessionSearchState = {
       matches: SessionConversationMatch[];
@@ -912,8 +919,9 @@ async function parseClaudeSessionMatches(
         continue;
       }
 
-      fileResults.set(sessionId, {
-        sessionId,
+      const internalSessionId = providerToInternalId.get(sessionId) ?? sessionId;
+      fileResults.set(internalSessionId, {
+        sessionId: internalSessionId,
         provider: 'claude',
         sessionSummary: toSummaryText(
           customNameBySessionId.get(sessionId) ?? null,


### PR DESCRIPTION
I got this project running today, I had a vibe-coded in house app that was doing the same sort of thing for me, but this is way better. Nice work!
One issue I had was the the search feature wasn't working. Claude pinned down the issue and fixed. I can't claim any understanding of the code or the fix, but I tested and it does fix the conversation search issue. If this is not the correct fix, feel free to close and fix correctly. Here's what claude said:

Full-text conversation search (`/api/providers/search/sessions`) returns zero
results whenever a session's app-facing `session_id` differs from its
`provider_session_id` (Claude's own conversation UUID) — e.g. sessions created through the app/platform flow, resumed sessions, or migrated ones.

`parseClaudeSessionMatches` reads the transcript JSONL, whose every line is
tagged with `sessionId` = the **provider** UUID. But it built its
`targetSessionIds` gate (and the custom-name map) from the **internal**
`session_id`, so every transcript line failed the `targetSessionIds.has(entrySessionId)`
check and no messages were ever examined. Separately, the per-file results map
was keyed by the provider UUID (the state key) while the final lookup used
`session.session_id`, so even matches that were collected could not be returned.

ripgrep still reported the files as matching, so the search "ran" and returned
`done` with no results — silently empty.

### Fix
Match and attribute by `provider_session_id` (falling back to `session_id` for
rows where they coincide), and map the per-session result back to the internal
`session_id` so the returned `sessionId` is still what the rest of the app uses
to navigate. Two small edits in `parseClaudeSessionMatches`, no API changes.

### Verifying
On an install where `session_id != provider_session_id`, searching a common word
returned 0 results before and real matches after (results reference the internal
session id, so clicking a hit navigates correctly).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Claude transcript matching by correctly associating logs with provider session IDs.
  * Preserved custom conversation names and summaries when searching across sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->