### PR TITLE
fix: resolve @/ path aliases so the server test suite can load

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "build:server": "tsc -p server/tsconfig.json && tsc-alias -p server/tsconfig.json",
     "preview": "vite preview",
     "typecheck": "tsc --noEmit -p tsconfig.json && tsc --noEmit -p server/tsconfig.json",
-    "test": "node --import tsx --test \"server/**/*.test.ts\" \"server/**/*.test.js\"",
+    "test": "tsx --tsconfig server/tsconfig.json --test \"server/**/*.test.ts\" \"server/**/*.test.js\"",
     "lint": "eslint src/ server/",
     "lint:fix": "eslint src/ server/ --fix",
     "start": "npm run build && npm run server",


### PR DESCRIPTION
## Problem

The `test` script added in #1037 has never worked on a clean checkout:

```
"test": "node --import tsx --test \"server/**/*.test.ts\" \"server/**/*.test.js\""
```

`node --import tsx --test` resolves `@/` module specifiers against the **root** `tsconfig.json`, which maps `@/*` → `src/*` (the frontend). The server's own alias lives in `server/tsconfig.json`, mapping `@/*` → `server/*`. Every server test file that imports anything via `@/...` dies at module load with:

```
ERR_MODULE_NOT_FOUND: Cannot find package '@/shared'
```

This has been silent because no CI workflow runs `npm test` — the workflows under `.github/workflows/` cover desktop builds, Docker, release, and a Discord notifier, and the only quality gate any of them runs is `npm run typecheck` (which passes, since `tsc -p server/tsconfig.json` already reads the correct config). #248 is the open standing request for real CI/test infrastructure — this doesn't add CI, but it makes the existing script usable once someone does.

## Fix

Point `tsx` at the server's own tsconfig so its path-alias resolution matches what `tsc` already uses:

```diff
-    "test": "node --import tsx --test \"server/**/*.test.ts\" \"server/**/*.test.js\"",
+    "test": "tsx --tsconfig server/tsconfig.json --test \"server/**/*.test.ts\" \"server/**/*.test.js\"",
```

## Verification

Measured on `origin/main` at the commit this branches from (`59472c07`):

| | Discovered | Pass | Fail |
|---|---|---|---|
| Before | 76 | 27 | 49 |
| After | 253 | 253 | 0 |

`npm run typecheck` and `npm run build` are both unchanged (they already used the correct tsconfig).

## Reproduction

```
git clone https://github.com/siteboon/claudecodeui.git
cd claudecodeui
npm ci
npm test   # 49 failures at module load, ERR_MODULE_NOT_FOUND
```

Apply the diff above and re-run — all discovered tests load and pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the test command to run reliably while preserving the existing test file selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->