### PR TITLE
fix: tolerate client clock skew before treating an auth token as expired

### DIFF
--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -42,9 +42,15 @@ const readTokenClaims = (token) => {
   }
 };
 
+// Tolerance for client/server clock skew. The server's own jwt.verify is the
+// real authority; this check only decides whether the client should discard a
+// token locally. Without an allowance, a browser clock running slightly ahead
+// reads a still-server-valid token as expired and drops the session.
+export const TOKEN_EXPIRY_SKEW_MS = 60_000;
+
 export const isAuthTokenExpired = (token) => {
   const claims = readTokenClaims(token);
-  return claims ? Date.now() >= claims.expiresAt : false;
+  return claims ? Date.now() >= claims.expiresAt + TOKEN_EXPIRY_SKEW_MS : false;
 };
 
 export const getAuthTokenRefreshDelay = (token) => {

--- a/src/utils/api.test.js
+++ b/src/utils/api.test.js
@@ -1,0 +1,47 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { isAuthTokenExpired, TOKEN_EXPIRY_SKEW_MS } from './api.js';
+
+// Builds a JWT-shaped string (header.payload.signature, base64url segments) without
+// needing a real signing library — isAuthTokenExpired() never verifies the signature,
+// it only decodes the payload, so the header/signature segments are placeholders.
+const makeToken = (payload) => {
+  const encode = (value) =>
+    Buffer.from(JSON.stringify(value)).toString('base64url');
+  return `${encode({ alg: 'HS256', typ: 'JWT' })}.${encode(payload)}.signature`;
+};
+
+test('isAuthTokenExpired: a token well before its exp is not expired', () => {
+  const now = Math.floor(Date.now() / 1000);
+  const token = makeToken({ iat: now - 60, exp: now + 600 }); // 10 min from now
+  assert.equal(isAuthTokenExpired(token), false);
+});
+
+test('isAuthTokenExpired: a token expired within the clock-skew tolerance is not treated as expired', () => {
+  const now = Math.floor(Date.now() / 1000);
+  const skewSeconds = TOKEN_EXPIRY_SKEW_MS / 1000;
+  const token = makeToken({ iat: now - 600, exp: now - Math.floor(skewSeconds / 2) });
+  assert.equal(isAuthTokenExpired(token), false);
+});
+
+test('isAuthTokenExpired: a token expired just past the clock-skew tolerance is expired', () => {
+  const now = Math.floor(Date.now() / 1000);
+  const skewSeconds = TOKEN_EXPIRY_SKEW_MS / 1000;
+  const token = makeToken({ iat: now - 600, exp: now - skewSeconds - 5 });
+  assert.equal(isAuthTokenExpired(token), true);
+});
+
+test('isAuthTokenExpired: a token expired well past the skew tolerance is expired', () => {
+  const now = Math.floor(Date.now() / 1000);
+  const token = makeToken({ iat: now - 600, exp: now - 600 }); // 10 min ago
+  assert.equal(isAuthTokenExpired(token), true);
+});
+
+test('isAuthTokenExpired: a malformed/unreadable token is unaffected by the skew change', () => {
+  // readTokenClaims() returns null for these, so isAuthTokenExpired() short-circuits
+  // to false regardless of TOKEN_EXPIRY_SKEW_MS — behaviour unchanged by this fix.
+  assert.equal(isAuthTokenExpired('not-a-jwt'), false);
+  assert.equal(isAuthTokenExpired('only.two-segments'), false);
+  assert.equal(isAuthTokenExpired(null), false);
+});


### PR DESCRIPTION
## Problem

`isAuthTokenExpired` compares the token's `exp` claim against the client's own clock with zero tolerance:

```js
export const isAuthTokenExpired = (token) => {
  const claims = readTokenClaims(token);
  return claims ? Date.now() >= claims.expiresAt : false;
};
```

This sits inside `getStoredAuthToken()`, which every `authenticatedFetch` call goes through — so it runs on **every authenticated read**, not just a websocket reconnect. If a browser's clock runs even a few seconds ahead of the server, a still-valid token gets read as expired and the client silently drops the session, even though the server's own `jwt.verify` (the real authority) would still accept it.

We hit this in our own deployment and originally fixed it in #980, which added a 60s skew allowance. #980 was closed unmerged and folded into #1037 — most of that PR's behavior (exp/iat-based refresh scheduling, focus/visibility refresh triggers) survived the merge, but the clock-skew tolerance itself didn't carry over.

## Fix

Restore a non-zero tolerance, applied only in `isAuthTokenExpired`:

```js
export const TOKEN_EXPIRY_SKEW_MS = 60_000;

export const isAuthTokenExpired = (token) => {
  const claims = readTokenClaims(token);
  return claims ? Date.now() >= claims.expiresAt + TOKEN_EXPIRY_SKEW_MS : false;
};
```

`getAuthTokenRefreshDelay`'s midpoint-based refresh scheduling is untouched — it's correct as-is and unrelated to this check. 60s is a starting point, not a load-bearing number; if a different value is preferred that's a reasonable discussion, the important part is that it's non-zero.

## Verification

Added `src/utils/api.test.js` covering the boundary: not-expired well before `exp`, not-expired within the skew window, expired just past the skew window, expired well past it, and unchanged behavior for a malformed/unreadable token (still not-expired, since `readTokenClaims` returns `null` and short-circuits regardless of skew). Confirmed the within-skew case is the one that actually discriminates: it flips to failing if `TOKEN_EXPIRY_SKEW_MS` is set back to `0`, so the test isn't just trivially passing.

One caveat worth flagging: like the repo's existing `src/components/git-panel/utils/commitGraph.test.ts`-style frontend tests, this isn't wired into `npm test` (that glob is `server/**` only) — consistent with existing convention rather than a new gap. It also can't be run standalone via a plain `node --test`/`tsx --test` invocation, because `api.js` transitively imports `IS_PLATFORM` from `src/constants/config.ts`, which reads `import.meta.env.VITE_IS_PLATFORM` — a Vite-only macro that isn't available outside a Vite/bundler context. That's a pre-existing property of this file, not something this change introduces. I verified the test's assertions and its discrimination against `TOKEN_EXPIRY_SKEW_MS = 0` against an isolated copy of the same logic before committing. Real frontend test execution is part of what #248 (CI/test infrastructure) would need to address.

## Manual repro

Set your system clock ~30s ahead, load the app with a token close to expiry, and watch the client drop the session on the next authenticated request — even though the server would still accept the token.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authentication reliability by allowing a 60-second tolerance for minor differences between client and server clocks when validating session tokens.
  * Prevented tokens from being treated as expired prematurely.

* **Tests**
  * Added coverage for valid, near-expiration, expired, and malformed authentication tokens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->