### PR TITLE
feat: add control-plane Server and Worker chat routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,71 @@ Open `http://localhost:3001` — all your existing sessions are discovered autom
 
 Visit the **[documentation →](https://cloudcli.ai/docs)** for full configuration options, PM2, remote server setup and more.
 
+#### Multi-machine control plane (experimental on this branch)
+
+Branch `feat/cloud-control-plane-workers` splits **Server** (web UI / control plane) from **Worker** (per-machine agent runner):
+
+- Run Server on a cloud host (put HTTPS/WSS reverse proxy in front)
+- Run Worker on each developer machine; workers dial out to Server
+- **No public npm publish required** — install from Git
+
+Today this is still one repo with two commands (not separate packages yet):
+
+| Role | Command |
+|------|---------|
+| Server | `cloudcli start` (default) |
+| Worker | `cloudcli worker start --server <url> --token <mw_...>` |
+
+**Install from Git (recommended)**
+
+```bash
+git clone -b feat/cloud-control-plane-workers https://github.com/Aaronlll/claudecodeui.git
+cd claudecodeui
+npm install
+npm run build
+```
+
+Or install the branch with npm (still run `npm run build` in the checkout if needed):
+
+```bash
+npm install -g git+https://github.com/Aaronlll/claudecodeui.git#feat/cloud-control-plane-workers
+```
+
+**Start Server (cloud)**
+
+```bash
+npm run server
+# or
+node dist-server/server/modules/cli/cli.js start --port 3001
+```
+
+Open `http://SERVER_IP:3001` (use HTTPS reverse proxy in production; keep `:3001` private).
+
+**Register a Worker**
+
+1. Web UI → Settings → **Machines**
+2. Create a machine and **copy the `mw_` token immediately** (shown once)
+3. On each developer machine:
+
+```bash
+# Local debug without a prior build
+npx tsx --tsconfig server/tsconfig.json server/modules/cli/cli.ts worker start \
+  --server ws://127.0.0.1:3001 \
+  --token mw_YOUR_TOKEN
+
+# Remote Server (use wss)
+node dist-server/server/modules/cli/cli.js worker start \
+  --server wss://agents.example.com \
+  --token mw_YOUR_TOKEN \
+  --name my-laptop
+```
+
+Env vars also work: `WORKER_SERVER_URL`, `WORKER_TOKEN`, `WORKER_NAME`.
+
+The Machines list should show **online**; use **Ping** to verify connectivity.
+
+> **Phase 1 reality (do not mis-test):** Worker only does online / heartbeat / Ping. Web chat is still `Browser → Server /ws → Server-local CLI`. If Server and Worker share one host, a working web chat only proves the old monolith — **not** Worker routing. Phase 3 will route chat through Worker and **require** native CLI transcript sync so `resume` works on that Worker.
+
 #### Docker Sandboxes (Experimental)
 
 Run agents in isolated sandboxes with hypervisor-level isolation. Starts Claude Code by default. Requires the [`sbx` CLI](https://docs.docker.com/ai/sandboxes/get-started/).

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -91,6 +91,79 @@ cloudcli
 
 更多配置选项、PM2、远程服务器设置等，请参阅 **[文档 →](https://cloudcli.ai/docs)**。
 
+#### 多机控制面（本分支实验功能）
+
+本分支 `feat/cloud-control-plane-workers` 支持把 **Server（网页/控制面）** 和 **Worker（各机执行端）** 分开跑：
+
+- Server 部署在云机器上（建议前面挂 HTTPS / WSS 反代）
+- 每台开发机只跑 Worker，主动连出到 Server
+- **不必发布到 npm 公共仓库**；直接从 Git 安装即可
+
+当前仍是同一仓库、两个命令（尚未拆成两个 npm 包）：
+
+| 角色 | 命令 |
+|------|------|
+| Server | `cloudcli start`（默认） |
+| Worker | `cloudcli worker start --server <url> --token <mw_...>` |
+
+**从 Git 安装（推荐）**
+
+```bash
+git clone -b feat/cloud-control-plane-workers https://github.com/Aaronlll/claudecodeui.git
+cd claudecodeui
+npm install
+npm run build
+```
+
+也可用 npm 直接装 Git 分支（装完后仍建议在仓库目录执行一次 `npm run build`）：
+
+```bash
+npm install -g git+https://github.com/Aaronlll/claudecodeui.git#feat/cloud-control-plane-workers
+```
+
+**云上启动 Server**
+
+```bash
+# 在仓库目录
+npm run server
+# 或
+node dist-server/server/modules/cli/cli.js start --port 3001
+```
+
+浏览器打开 `http://服务器IP:3001`（生产请用 HTTPS 反代，例如 Caddy/Nginx，并把 `:3001` 仅绑定本机）。
+
+**注册 Worker 机器**
+
+1. 打开网页 → 设置 → **机器**
+2. 新建机器，**立即复制** 显示的 `mw_` 令牌（只显示一次）
+3. 在各台开发机启动 Worker：
+
+```bash
+# 开发调试（未 build 也可用）
+npx tsx --tsconfig server/tsconfig.json server/modules/cli/cli.ts worker start \
+  --server ws://127.0.0.1:3001 \
+  --token mw_你的令牌
+
+# 生产 / 远端 Server（务必用 wss）
+node dist-server/server/modules/cli/cli.js worker start \
+  --server wss://agents.example.com \
+  --token mw_你的令牌 \
+  --name my-laptop
+```
+
+也可用环境变量：
+
+```bash
+export WORKER_SERVER_URL=wss://agents.example.com
+export WORKER_TOKEN=mw_你的令牌
+export WORKER_NAME=my-laptop
+node dist-server/server/modules/cli/cli.js worker start
+```
+
+网页机器列表应显示 **online**；可点 **Ping** 做连通性检查。
+
+> **Phase 1 现状（勿测错）：** Worker 只做上线 / 心跳 / Ping。网页对话仍是 `Browser → Server /ws → Server 本机 CLI`。若 Server 与 Worker 同机，网页能聊只是本地一体机在答，**不代表**已走 Worker。后续 Phase 3 会改成经 Worker 执行，并**强制**与原生 CLI 会话文件同步，以便在该 Worker 上 `resume`。
+
 #### Docker Sandboxes（实验性）
 
 在隔离的沙箱中运行代理，具有虚拟机管理程序级别的隔离。默认启动 Claude Code。需要 [`sbx` CLI](https://docs.docker.com/ai/sandboxes/get-started/)。

--- a/plan.md
+++ b/plan.md
@@ -1,0 +1,264 @@
+# Cloud Control Plane + Multi-Machine Workers
+
+> Branch: `feat/cloud-control-plane-workers`  
+> Status: Phase 2/3 routed chat + control-plane decoupling in progress  
+> Last updated: 2026-08-02
+
+## Goal
+
+Deploy a **cloud Server** (web UI / control plane) that manages and chats with **independent Agents on multiple machines**. Each machine runs a **Worker** that executes local CLIs (Claude / Cursor / Codex / OpenCode).
+
+**Hard requirement:** web chat and native CLI on the Worker machine must stay in sync. After chatting on the web, the user must be able to go to that Worker machine and `resume` the same session with native `cursor` / `codex` / Claude CLI. Cloud history alone is not enough.
+
+Not in scope for v1: remote file tree, remote Git, remote Shell/PTY.
+
+## Current reality (important — do not mis-test)
+
+Set `CONTROL_PLANE=1` on the Server (alias: `DISABLE_SESSION_WATCHERS=1`).
+
+```text
+控制面模式 (CONTROL_PLANE=1):
+  Browser → Server /ws → Worker WS chat.run → Worker 本机 providerRuntime
+  Server: 不跑 CLI、不扫 ~/.cursor|~/.codex、历史只读 session_messages
+  新建会话必须带 machineId
+
+未开控制面（旧单体兼容）:
+  仍可 Server 本机 runtime + 本机 transcript watcher
+```
+
+Same-box Server+Worker is OK for smoke tests **if** Worker logs show `chat.run`. Cross-host E2E remains the gold standard for Phase 4.
+
+## Product decisions (locked)
+
+| Decision | Choice |
+|---|---|
+| Workspace model | **A — Independent per machine**. No shared task queue across machines. |
+| Session truth | **Dual-write**: Server stores canonical web history; Worker keeps **native provider files** so local CLI can resume. |
+| Local delete | Cloud history remains for web reopen/continue. |
+| Native CLI resume after web chat | **Required in v1** (same Worker machine). Must sync / keep provider artifacts usable for resume. |
+| Restore native files after local wipe | **In scope with chat routing** (Server → Worker rewrite or replay into provider-native store). |
+| IDE-like panels (files / Git / shell) | **Out of v1** on the cloud UI path. |
+| TLS | Production uses **HTTPS + WSS** via reverse proxy; Node listens on localhost. |
+
+## Target architecture
+
+```text
+Browser
+  │  https://  +  wss://
+  ▼
+Reverse proxy (Caddy / Nginx / cloud LB)  ← TLS terminates here
+  │  http://127.0.0.1:3001
+  ▼
+Server (control plane)
+  - static web UI
+  - auth / API
+  - machine registry
+  - session + message DB (cloud copy / web source of truth)
+  - chat WS hub (browser ↔ route to worker)   ← NOT in-process providerRuntime
+  ▲
+  │  wss:// (workers dial out; NAT-friendly)
+  │
+  ├── Worker@machine-1  → local Claude/Cursor/Codex + native transcript files
+  ├── Worker@machine-2
+  └── Worker@machine-N
+```
+
+### Responsibility split
+
+| Concern | Server | Worker |
+|---|---|---|
+| Web UI | Yes | No |
+| User auth | Yes | No |
+| Machine register / heartbeat / online | Yes | Connect + heartbeat |
+| Session list / open history (web) | Persist + serve | Report / stream events |
+| Message persistence (cloud) | Persist | Stream events up |
+| Native provider transcripts (CLI resume) | May push restore payloads | Own `~/.claude` / `~/.cursor` / `~/.codex` … |
+| Run / abort agent | Dispatch by `machine_id` | Execute local provider runtime |
+| Provider credentials / local CLI install | No | Yes (on that machine) |
+| File tree / Git / PTY | Deferred | Local only for now |
+
+## Install shape (post-MVP packaging)
+
+Prefer Git install first (no public npm required). One repo, two commands for now; split packages later if needed.
+
+```bash
+# Cloud server
+npm run build && npm run server
+
+# Each agent machine
+node dist-server/server/modules/cli/cli.js worker start \
+  --server wss://agents.example.com \
+  --token <machine-token>
+```
+
+Notes:
+
+- Server process should **not** require Claude/Cursor CLI on the cloud host once chat is Worker-routed.
+- Worker should **not** need the web UI bundle.
+- Do **not** expose Node `:3001` publicly; only the reverse proxy.
+
+## HTTPS / WSS requirements
+
+1. Browser → Server: `https` + `wss` (mandatory in production).
+2. Worker → Server: `wss` with machine token (mandatory in production).
+3. Proxy must support WebSocket upgrade and long-lived connections (chat can run a long time).
+4. Frontend already selects `wss` when the page is `https`; keep that invariant.
+5. Dev may stay on `http`/`ws`; production config forces TLS URLs.
+
+## Data model (minimal)
+
+### `machines`
+
+- `id`, `name`, `token_hash`, `status` (`online`/`offline`), `last_seen_at`, `created_at`
+- Optional: hostname, labels, supported providers
+
+### `sessions` (extend existing concept)
+
+- Keep app session id as the ID the UI knows
+- Add `machine_id` (required for routed chat)
+- Keep `provider`, project path (machine-local path), titles, timestamps
+- Provider-native session id remains a mapping field when available
+
+### `messages` (or equivalent event log)
+
+- Store normalized chat messages / envelopes needed to render history on the web
+- Enough to reopen a session after local deletion
+- Streaming live path still uses WS; persistence is durable cloud copy
+
+### Native sync artifacts
+
+- Worker reports provider-native session ids + paths after runs
+- Server can request Worker to ensure local resume files exist (write-back / replay) when web continues a session whose local files are missing
+- Success means: on that Worker, native CLI `resume` sees the same conversation
+
+## Protocol sketch (Worker ↔ Server)
+
+Transport: Worker outbound WebSocket (production: `wss`).
+
+**Worker → Server**
+
+- `worker.hello` — auth with machine token, advertise capabilities
+- `worker.heartbeat`
+- `worker.session_upsert` — local session metadata / native id mapping
+- `worker.event` — normalized chat events for an app session (`seq`, payload)
+- `worker.run_complete` / errors
+
+**Server → Worker**
+
+- `worker.welcome` — assigned machine id / server features
+- `chat.run` — start or continue a run (`sessionId`, provider, prompt, options)
+- `chat.abort`
+- `chat.permission_response`
+- `session.ensure_native` — ensure local provider files exist for resume (sync/write-back)
+
+Browser continues to speak the existing app chat WS protocol to Server; Server routes runs to the correct Worker by `session.machine_id` / explicit machine selection on new chats.
+
+## Phased plan
+
+### Phase 0 — Branch & planning
+
+- [x] Branch: `feat/cloud-control-plane-workers`
+- [x] This plan (`plan.md`)
+- [ ] Keep `main` aligned with upstream/fork sync; merge `main` into this branch regularly
+
+### Phase 1 — Machine registry + Worker tunnel (no real agent yet) ✅
+
+- [x] Server module `machines` (register, list, revoke token, online state)
+- [x] Worker process entry (`cloudcli worker start`)
+- [x] Outbound WS connect + token auth + heartbeat
+- [x] Echo / ping path
+- [x] Minimal UI: machine list + online indicator
+
+**Exit criteria met:** browser sees online machines; Worker reconnects; Ping works.  
+**Explicitly NOT done:** chat still uses Server-local providerRuntime.
+
+### Phase 2 — Cloud session store + machine binding
+
+- [x] Persist sessions with `machine_id`
+- [x] Persist message/event history on Server
+- [x] UI: per-machine session list, open history from cloud (machine picker + `selected-machine-id`)
+- [x] Stop treating “same box Server+Worker” as proof of routed chat
+
+**Exit criteria:** web can list/open sessions by machine from Server DB.
+
+### Phase 3 — Routed chat **and** native sync (together — required)
+
+Do these as one milestone; do not ship web-only history without native resume on the Worker.
+
+- [x] New chat: pick machine + provider
+- [x] Server `/ws` `chat.send` dispatches `chat.run` to that Worker (no in-process runtime on Server)
+- [x] Worker runs local provider runtime; streams events up; Server fans out + persists
+- [x] Abort + permission approval round-trip via Server
+- [x] **Native sync:** Worker leaves provider-native artifacts such that `cursor` / `codex` / Claude CLI on that machine can resume the same session (run-local + path report)
+- [x] **Write-back:** if local native files are missing but cloud history exists, Server asks Worker to restore/replay enough for native resume before continuing (Claude/Codex jsonl rewrite; Cursor drops native id and starts fresh)
+- [ ] Verification matrix: web chat on Worker A → native resume on Worker A works; Worker B does not see A’s native files (independent machines)
+
+**Exit criteria:**
+
+1. Chat packets clearly go Worker WS (not Server-local runtime).
+2. Same session resume works with native CLI **on that Worker**.
+3. Cloud UI still shows history if local files were deleted, and can restore native resume after write-back.
+
+### Phase 4 — Hardening
+
+- [ ] Reliable reconnect + event replay / catch-up
+- [ ] Worker offline UX
+- [ ] Token rotation, basic audit logs
+- [ ] systemd/pm2 examples; Caddy/Nginx sample for HTTPS+WSS
+- [ ] Packaging: `server` / `worker` commands
+- [ ] Test rule: Server host ≠ Worker host for chat E2E
+
+### Phase 5 — Optional later
+
+- [ ] Remote file tree / Git / Shell via Worker RPC
+- [ ] Bulk import of pre-existing local provider histories
+- [ ] Split npm packages `@scope/cloudcli-server` / `@scope/cloudcli-worker`
+
+## Mapping onto this repo
+
+Existing strengths to reuse:
+
+- Provider interfaces (`IProviderRuntime`, sessions, normalized messages)
+- Chat WS envelope / `seq` / subscribe model
+- Auth patterns for browser users
+- Module layout under `server/modules/*`
+
+Likely new / changed areas:
+
+- `server/modules/machines/` — registry + tokens + presence ✅
+- `server/modules/worker-gateway/` — Worker WS protocol ✅ (ping only so far)
+- Session/message persistence with `machine_id`
+- `providerRuntimeService` / chat handler — dispatch to Worker instead of in-process run
+- Native sync/write-back helpers per provider on Worker
+- CLI entry — `worker start` ✅; keep Server start as today
+- Frontend — machine picker + filter sessions by machine
+
+## Sync / merge workflow
+
+```bash
+git checkout main
+git pull origin main
+
+git checkout feat/cloud-control-plane-workers
+git merge main
+```
+
+## Install from Git (no npm publish)
+
+See `README.zh-CN.md` / `README.md` section **多机控制面 / Multi-machine control plane**.
+
+## Non-goals / exclusions (v1)
+
+- Turning the cloud UI into a full remote IDE
+- Requiring inbound ports to worker machines
+- Storing raw provider credentials on the Server
+- Cross-machine native resume (session created on Worker A, resume files expected on Worker B) — out of scope under model A
+
+## Success definition (v1)
+
+1. Server deployed behind HTTPS.
+2. N workers on different machines connect with tokens over WSS.
+3. Web UI lists machines and their sessions independently.
+4. User chats via web → Server routes to chosen Worker (proven, not same-box illusion).
+5. Cloud keeps message history if local files disappear.
+6. **On that Worker, native Claude/Cursor/Codex CLI can resume the web-created session** after sync/write-back.

--- a/server/index.ts
+++ b/server/index.ts
@@ -9,7 +9,7 @@ import http from 'http';
 import express, { type NextFunction, type Request, type Response } from 'express';
 import cors from 'cors';
 
-import { AppError, findApplicationRoot, getModuleDirectory, terminalTextStyles } from '@/shared/utils.js';
+import { AppError, findApplicationRoot, getModuleDirectory, isControlPlaneMode, terminalTextStyles } from '@/shared/utils.js';
 import {
     closeSessionsWatcher,
     initializeSessionsWatcher,
@@ -50,6 +50,7 @@ import browserUseMcpRoutes from './modules/browser-use/browser-use-mcp.routes.js
 import { browserUseService } from './modules/browser-use/browser-use.service.js';
 import { initializeDatabase, sessionsDb } from './modules/database/index.js';
 import { configureWebPush } from './modules/notifications/index.js';
+import { machinesRoutes, machinesService, workerConnectionRegistry } from './modules/machines/index.js';
 import { IS_PLATFORM } from './constants/config.js';
 
 const __dirname = getModuleDirectory(import.meta.url);
@@ -99,6 +100,7 @@ const wss = createWebSocketServer(server, {
     verifyClient: {
         isPlatform: IS_PLATFORM,
         authenticateWebSocket,
+        authenticateWorkerWebSocket: (token) => machinesService.authenticateWorkerToken(token),
     },
     chat: {
         runtime: providerRuntimeService,
@@ -114,6 +116,9 @@ const wss = createWebSocketServer(server, {
         },
     },
     getPluginPort,
+    handleWorkerConnection: (ws, request) => {
+        workerConnectionRegistry.handleConnection(ws, request);
+    },
 });
 
 // Make WebSocket server available to routes
@@ -172,6 +177,9 @@ app.use('/api/commands', authenticateToken, commandsRoutes);
 
 // Settings API Routes (protected)
 app.use('/api/settings', authenticateToken, settingsRoutes);
+
+// Control-plane machines (protected)
+app.use('/api/machines', authenticateToken, machinesRoutes);
 
 app.use('/api/system', authenticateToken, systemRoutes);
 
@@ -361,8 +369,14 @@ async function startServer() {
             console.log(`${terminalTextStyles.tip('[TIP]')}  Run "cloudcli status" for full configuration details`);
             console.log('');
 
-            // Start watching the projects folder for changes
-            await initializeSessionsWatcher();
+            // Control-plane Servers must not index local provider homes — that
+            // couples the cloud host to whatever CLI history happens to live
+            // on the same box (and was the OOM source during same-box tests).
+            if (isControlPlaneMode()) {
+                console.log(`${terminalTextStyles.info('[INFO]')} Control-plane mode: session watchers disabled`);
+            } else {
+                await initializeSessionsWatcher();
+            }
 
             // Start server-side plugin processes for enabled plugins
             startEnabledPluginServers().catch(err => {

--- a/server/modules/cli/cli.module.ts
+++ b/server/modules/cli/cli.module.ts
@@ -92,5 +92,13 @@ export function createCliApplication(): CliApplication {
       const { startBrowserUseMcp } = await import('../browser-use/index.js');
       await startBrowserUseMcp();
     },
+    startWorker: async (options) => {
+      const { createWorkerAgentService } = await import('../worker-agent/index.js');
+      const workerAgent = createWorkerAgentService({
+        environment: process.env,
+        output,
+      });
+      return workerAgent.start(options);
+    },
   });
 }

--- a/server/modules/cli/cli.service.ts
+++ b/server/modules/cli/cli.service.ts
@@ -23,6 +23,11 @@ type CliServiceDependencies = {
   updateGlobalPackage(): void;
   startServer(): Promise<void>;
   startBrowserUseMcp(): Promise<void>;
+  startWorker(options: {
+    serverUrl?: string;
+    token?: string;
+    name?: string;
+  }): Promise<number>;
 };
 
 type ParsedCliArguments = {
@@ -30,6 +35,9 @@ type ParsedCliArguments = {
   options: {
     serverPort?: string;
     databasePath?: string;
+    serverUrl?: string;
+    token?: string;
+    name?: string;
   };
   remainingArguments: string[];
 };
@@ -41,6 +49,8 @@ function parseCliArguments(argumentsList: string[]): ParsedCliArguments {
     remainingArguments: [],
   };
 
+  let commandLocked = false;
+
   for (let argumentIndex = 0; argumentIndex < argumentsList.length; argumentIndex += 1) {
     const argument = argumentsList[argumentIndex];
     if (argument === '--port' || argument === '-p') {
@@ -51,15 +61,46 @@ function parseCliArguments(argumentsList: string[]): ParsedCliArguments {
       parsedArguments.options.databasePath = argumentsList[++argumentIndex];
     } else if (argument.startsWith('--database-path=')) {
       parsedArguments.options.databasePath = argument.slice('--database-path='.length);
+    } else if (argument === '--server') {
+      parsedArguments.options.serverUrl = argumentsList[++argumentIndex];
+    } else if (argument.startsWith('--server=')) {
+      parsedArguments.options.serverUrl = argument.slice('--server='.length);
+    } else if (argument === '--token') {
+      parsedArguments.options.token = argumentsList[++argumentIndex];
+    } else if (argument.startsWith('--token=')) {
+      parsedArguments.options.token = argument.slice('--token='.length);
+    } else if (argument === '--name') {
+      parsedArguments.options.name = argumentsList[++argumentIndex];
+    } else if (argument.startsWith('--name=')) {
+      parsedArguments.options.name = argument.slice('--name='.length);
     } else if (argument === '--help' || argument === '-h') {
       parsedArguments.command = 'help';
+      commandLocked = true;
     } else if (argument === '--version' || argument === '-v') {
       parsedArguments.command = 'version';
+      commandLocked = true;
     } else if (!argument.startsWith('-')) {
-      parsedArguments.command = argument;
       if (argument === 'sandbox') {
+        parsedArguments.command = 'sandbox';
         parsedArguments.remainingArguments = argumentsList.slice(argumentIndex + 1);
         break;
+      }
+
+      if (argument === 'worker') {
+        const subcommand = argumentsList[argumentIndex + 1];
+        if (subcommand && !subcommand.startsWith('-')) {
+          parsedArguments.command = `worker:${subcommand}`;
+          argumentIndex += 1;
+        } else {
+          parsedArguments.command = 'worker:help';
+        }
+        commandLocked = true;
+        continue;
+      }
+
+      if (!commandLocked) {
+        parsedArguments.command = argument;
+        commandLocked = true;
       }
     }
   }
@@ -156,6 +197,7 @@ Usage:
 
 Commands:
   start            Start the CloudCLI server (default)
+  worker start     Connect this machine as a control-plane worker
   sandbox          Manage Docker sandbox environments
   browser-use-mcp  Run Browser MCP stdio server
   status           Show configuration and data locations
@@ -166,12 +208,16 @@ Commands:
 Options:
   -p, --port <port>           Set server port (default: 3001)
   --database-path <path>      Set custom database location
+  --server <url>              Worker control-plane URL (https:// or wss://)
+  --token <token>             Worker machine token (mw_...)
+  --name <name>               Optional worker display name
   -h, --help                  Show this help information
   -v, --version               Show version information
 
 Examples:
   $ cloudcli                        # Start with defaults
   $ cloudcli --port 8080            # Start on port 8080
+  $ cloudcli worker start --server wss://agents.example.com --token mw_xxx
   $ cloudcli sandbox ~/my-project   # Run in a Docker sandbox
   $ cloudcli status                 # Show configuration
 
@@ -252,6 +298,24 @@ export function createCliService(dependencies: CliServiceDependencies): CliAppli
         case 'start':
           void checkForUpdates(true);
           await dependencies.startServer();
+          return 0;
+        case 'worker:start':
+          return dependencies.startWorker({
+            serverUrl: parsedArguments.options.serverUrl,
+            token: parsedArguments.options.token,
+            name: parsedArguments.options.name,
+          });
+        case 'worker:help':
+        case 'worker':
+          dependencies.output.log(`
+Usage:
+  cloudcli worker start --server <url> --token <mw_...> [--name <name>]
+
+Environment:
+  WORKER_SERVER_URL / CLOUDCLI_SERVER_URL
+  WORKER_TOKEN / CLOUDCLI_WORKER_TOKEN
+  WORKER_NAME
+`);
           return 0;
         case 'sandbox':
           return dependencies.sandboxService.execute(parsedArguments.remainingArguments);

--- a/server/modules/cli/tests/cli.service.test.ts
+++ b/server/modules/cli/tests/cli.service.test.ts
@@ -45,6 +45,7 @@ function createHarness() {
       serverStarts += 1;
     },
     startBrowserUseMcp: async () => undefined,
+    startWorker: async () => 0,
   });
 
   return {
@@ -88,4 +89,60 @@ test('returns a failure code for an unknown command without exiting the process'
 
   assert.equal(exitCode, 1);
   assert.match(harness.errorMessages[0], /Unknown command: unknown/);
+});
+
+test('routes worker start to the injected worker starter with server and token options', async () => {
+  const harness = createHarness();
+  let workerOptions: { serverUrl?: string; token?: string; name?: string } | null = null;
+  const service = createCliService({
+    applicationRoot: '/application',
+    defaultDatabasePath: '/home/user/.cloudcli/auth.db',
+    homeDirectory: '/home/user',
+    packageMetadata: {
+      version: '1.2.3',
+      homepage: 'https://cloudcli.example',
+      bugsUrl: 'https://cloudcli.example/issues',
+    },
+    environment: harness.environment,
+    fileSystem: {
+      readTextFile: () => {
+        throw new Error('missing');
+      },
+      pathExists: () => false,
+      getFileStats: () => ({ size: 0, modifiedAt: new Date(0) }),
+    },
+    output: {
+      log: (message = '') => harness.logMessages.push(message),
+      error: (message = '') => harness.errorMessages.push(message),
+    },
+    sandboxService: {
+      execute: async () => 0,
+    },
+    getLatestPackageVersion: async () => '1.2.3',
+    updateGlobalPackage: () => undefined,
+    startServer: async () => undefined,
+    startBrowserUseMcp: async () => undefined,
+    startWorker: async (options) => {
+      workerOptions = options;
+      return 0;
+    },
+  });
+
+  const exitCode = await service.run([
+    'worker',
+    'start',
+    '--server',
+    'wss://agents.example.com',
+    '--token',
+    'mw_abc',
+    '--name',
+    'dev-box',
+  ]);
+
+  assert.equal(exitCode, 0);
+  assert.deepEqual(workerOptions, {
+    serverUrl: 'wss://agents.example.com',
+    token: 'mw_abc',
+    name: 'dev-box',
+  });
 });

--- a/server/modules/database/index.ts
+++ b/server/modules/database/index.ts
@@ -4,12 +4,20 @@ export { apiKeysDb } from '@/modules/database/repositories/api-keys.js';
 export { appConfigDb } from '@/modules/database/repositories/app-config.js';
 export { credentialsDb } from '@/modules/database/repositories/credentials.js';
 export { githubTokensDb } from '@/modules/database/repositories/github-tokens.js';
+// machinesDb: used by Machines and Worker Gateway modules for control-plane machine records.
+export { machinesDb } from '@/modules/database/repositories/machines.db.js';
+export type {
+  MachineStatus,
+  PublicMachineRecord,
+} from '@/modules/database/repositories/machines.db.js';
 export { notificationChannelEndpointsDb } from '@/modules/database/repositories/notification-channel-endpoints.js';
 export { notificationPreferencesDb } from '@/modules/database/repositories/notification-preferences.js';
 // projectsDb: used by Projects, Worktrees, Git, WebSocket, and notification modules to persist and resolve project records.
 export { projectsDb } from '@/modules/database/repositories/projects.db.js';
 export { pushSubscriptionsDb } from '@/modules/database/repositories/push-subscriptions.js';
 export { scanStateDb } from '@/modules/database/repositories/scan-state.db.js';
+// sessionMessagesDb: used by control-plane chat routing to persist cloud copies of live events.
+export { sessionMessagesDb } from '@/modules/database/repositories/session-messages.db.js';
 export { sessionsDb } from '@/modules/database/repositories/sessions.db.js';
 export { userDb } from '@/modules/database/repositories/users.js';
 export { vapidKeysDb } from '@/modules/database/repositories/vapid-keys.js';

--- a/server/modules/database/migrations.ts
+++ b/server/modules/database/migrations.ts
@@ -3,9 +3,11 @@ import { Database } from 'better-sqlite3';
 import {
   APP_CONFIG_TABLE_SCHEMA_SQL,
   LAST_SCANNED_AT_SQL,
+  MACHINES_TABLE_SCHEMA_SQL,
   NOTIFICATION_CHANNEL_ENDPOINTS_TABLE_SCHEMA_SQL,
   PROJECTS_TABLE_SCHEMA_SQL,
   PUSH_SUBSCRIPTIONS_TABLE_SCHEMA_SQL,
+  SESSION_MESSAGES_TABLE_SCHEMA_SQL,
   SESSIONS_TABLE_SCHEMA_SQL,
   USER_NOTIFICATION_PREFERENCES_TABLE_SCHEMA_SQL,
   VAPID_KEYS_TABLE_SCHEMA_SQL,
@@ -487,6 +489,24 @@ export const runMigrations = (db: Database) => {
     }
 
     db.exec(LAST_SCANNED_AT_SQL);
+
+    db.exec(MACHINES_TABLE_SCHEMA_SQL);
+    db.exec('CREATE INDEX IF NOT EXISTS idx_machines_token_hash ON machines(token_hash)');
+    db.exec('CREATE INDEX IF NOT EXISTS idx_machines_status ON machines(status)');
+
+    addColumnToTableIfNotExists(
+      db,
+      'sessions',
+      getTableInfo(db, 'sessions').map((column) => column.name),
+      'machine_id',
+      'TEXT'
+    );
+    db.exec('CREATE INDEX IF NOT EXISTS idx_sessions_machine_id ON sessions(machine_id)');
+
+    db.exec(SESSION_MESSAGES_TABLE_SCHEMA_SQL);
+    db.exec('CREATE INDEX IF NOT EXISTS idx_session_messages_session_id ON session_messages(session_id)');
+    db.exec('CREATE INDEX IF NOT EXISTS idx_session_messages_session_seq ON session_messages(session_id, seq)');
+
     console.log('Database migrations completed successfully');
   } catch (error: any) {
     console.error('Error running migrations:', error.message);

--- a/server/modules/database/repositories/machines.db.ts
+++ b/server/modules/database/repositories/machines.db.ts
@@ -1,0 +1,193 @@
+/**
+ * Machines repository.
+ *
+ * Persists control-plane machine records used by the multi-worker gateway.
+ * Tokens are stored as SHA-256 hashes; the plaintext token is only returned at
+ * creation time by the machines service.
+ */
+
+import crypto from 'node:crypto';
+
+import { getConnection } from '@/modules/database/connection.js';
+
+export type MachineStatus = 'online' | 'offline';
+
+export type MachineRow = {
+  id: string;
+  name: string;
+  token_hash: string;
+  token_prefix: string;
+  status: MachineStatus;
+  last_seen_at: string | null;
+  hostname: string | null;
+  created_at: string;
+  revoked_at: string | null;
+};
+
+export type PublicMachineRecord = {
+  id: string;
+  name: string;
+  tokenPrefix: string;
+  status: MachineStatus;
+  lastSeenAt: string | null;
+  hostname: string | null;
+  createdAt: string;
+  revokedAt: string | null;
+};
+
+function mapMachineRow(row: MachineRow): PublicMachineRecord {
+  return {
+    id: row.id,
+    name: row.name,
+    tokenPrefix: row.token_prefix,
+    status: row.status,
+    lastSeenAt: row.last_seen_at,
+    hostname: row.hostname,
+    createdAt: row.created_at,
+    revokedAt: row.revoked_at,
+  };
+}
+
+/** Hashes a machine token for durable storage and lookup. */
+export function hashMachineToken(token: string): string {
+  return crypto.createHash('sha256').update(token).digest('hex');
+}
+
+/** Generates a cryptographically random machine worker token with the `mw_` prefix. */
+export function generateMachineToken(): string {
+  return `mw_${crypto.randomBytes(32).toString('hex')}`;
+}
+
+export const machinesDb = {
+  hashMachineToken,
+  generateMachineToken,
+
+  /** Inserts a machine row. Callers must pass an already-hashed token. */
+  createMachine(input: {
+    id: string;
+    name: string;
+    tokenHash: string;
+    tokenPrefix: string;
+  }): PublicMachineRecord {
+    const db = getConnection();
+    db.prepare(
+      `INSERT INTO machines (id, name, token_hash, token_prefix, status)
+       VALUES (?, ?, ?, ?, 'offline')`,
+    ).run(input.id, input.name, input.tokenHash, input.tokenPrefix);
+
+    const row = db
+      .prepare('SELECT * FROM machines WHERE id = ?')
+      .get(input.id) as MachineRow;
+    return mapMachineRow(row);
+  },
+
+  /** Lists non-revoked machines, newest first. */
+  listMachines(): PublicMachineRecord[] {
+    const db = getConnection();
+    const rows = db
+      .prepare(
+        `SELECT * FROM machines
+         WHERE revoked_at IS NULL
+         ORDER BY created_at DESC`,
+      )
+      .all() as MachineRow[];
+    return rows.map(mapMachineRow);
+  },
+
+  /** Returns one machine by id, including revoked rows. */
+  getMachineById(machineId: string): PublicMachineRecord | null {
+    const db = getConnection();
+    const row = db
+      .prepare('SELECT * FROM machines WHERE id = ?')
+      .get(machineId) as MachineRow | undefined;
+    return row ? mapMachineRow(row) : null;
+  },
+
+  /**
+   * Resolves an active machine from a plaintext token.
+   * Returns null when the token is unknown or the machine was revoked.
+   */
+  findActiveMachineByToken(token: string): PublicMachineRecord | null {
+    const db = getConnection();
+    const row = db
+      .prepare(
+        `SELECT * FROM machines
+         WHERE token_hash = ? AND revoked_at IS NULL`,
+      )
+      .get(hashMachineToken(token)) as MachineRow | undefined;
+    return row ? mapMachineRow(row) : null;
+  },
+
+  /** Renames a non-revoked machine. Returns null when missing/revoked. */
+  renameMachine(machineId: string, name: string): PublicMachineRecord | null {
+    const db = getConnection();
+    const result = db
+      .prepare(
+        `UPDATE machines
+         SET name = ?
+         WHERE id = ? AND revoked_at IS NULL`,
+      )
+      .run(name, machineId);
+    if (result.changes === 0) {
+      return null;
+    }
+    return machinesDb.getMachineById(machineId);
+  },
+
+  /** Soft-revokes a machine so its token can no longer authenticate. */
+  revokeMachine(machineId: string): boolean {
+    const db = getConnection();
+    const result = db
+      .prepare(
+        `UPDATE machines
+         SET revoked_at = CURRENT_TIMESTAMP, status = 'offline'
+         WHERE id = ? AND revoked_at IS NULL`,
+      )
+      .run(machineId);
+    return result.changes > 0;
+  },
+
+  /** Marks a machine online and refreshes last-seen metadata. */
+  markOnline(machineId: string, hostname?: string | null): PublicMachineRecord | null {
+    const db = getConnection();
+    const result = db
+      .prepare(
+        `UPDATE machines
+         SET status = 'online',
+             last_seen_at = CURRENT_TIMESTAMP,
+             hostname = COALESCE(?, hostname)
+         WHERE id = ? AND revoked_at IS NULL`,
+      )
+      .run(hostname ?? null, machineId);
+    if (result.changes === 0) {
+      return null;
+    }
+    return machinesDb.getMachineById(machineId);
+  },
+
+  /** Marks a machine offline. */
+  markOffline(machineId: string): PublicMachineRecord | null {
+    const db = getConnection();
+    const result = db
+      .prepare(
+        `UPDATE machines
+         SET status = 'offline', last_seen_at = CURRENT_TIMESTAMP
+         WHERE id = ? AND revoked_at IS NULL`,
+      )
+      .run(machineId);
+    if (result.changes === 0) {
+      return null;
+    }
+    return machinesDb.getMachineById(machineId);
+  },
+
+  /** Touches last_seen_at for an online machine heartbeat. */
+  touchHeartbeat(machineId: string): void {
+    const db = getConnection();
+    db.prepare(
+      `UPDATE machines
+       SET last_seen_at = CURRENT_TIMESTAMP
+       WHERE id = ? AND revoked_at IS NULL`,
+    ).run(machineId);
+  },
+};

--- a/server/modules/database/repositories/session-messages.db.ts
+++ b/server/modules/database/repositories/session-messages.db.ts
@@ -1,0 +1,75 @@
+/**
+ * Cloud-side session message log used by the control plane.
+ *
+ * Stores normalized chat envelopes so the web UI can reload history even when
+ * Worker-local provider transcripts are missing. Native CLI resume still depends
+ * on Worker-local artifacts; this table is the Server copy.
+ */
+
+import { getConnection } from '@/modules/database/connection.js';
+
+export type SessionMessageRow = {
+  id: number;
+  session_id: string;
+  seq: number | null;
+  kind: string;
+  payload_json: string;
+  created_at: string;
+};
+
+export const sessionMessagesDb = {
+  /** Appends one normalized outbound chat event for a session. */
+  appendMessage(input: {
+    sessionId: string;
+    seq?: number | null;
+    kind: string;
+    payload: unknown;
+  }): void {
+    const db = getConnection();
+    db.prepare(
+      `INSERT INTO session_messages (session_id, seq, kind, payload_json)
+       VALUES (?, ?, ?, ?)`,
+    ).run(
+      input.sessionId,
+      input.seq ?? null,
+      input.kind,
+      JSON.stringify(input.payload),
+    );
+  },
+
+  /** Returns stored messages for a session in insertion order. */
+  listMessages(sessionId: string, options: { limit?: number; offset?: number } = {}): SessionMessageRow[] {
+    const db = getConnection();
+    const limit = options.limit;
+    const offset = options.offset ?? 0;
+
+    if (typeof limit === 'number') {
+      return db
+        .prepare(
+          `SELECT id, session_id, seq, kind, payload_json, created_at
+           FROM session_messages
+           WHERE session_id = ?
+           ORDER BY id ASC
+           LIMIT ? OFFSET ?`,
+        )
+        .all(sessionId, limit, offset) as SessionMessageRow[];
+    }
+
+    return db
+      .prepare(
+        `SELECT id, session_id, seq, kind, payload_json, created_at
+         FROM session_messages
+         WHERE session_id = ?
+         ORDER BY id ASC`,
+      )
+      .all(sessionId) as SessionMessageRow[];
+  },
+
+  countMessages(sessionId: string): number {
+    const db = getConnection();
+    const row = db
+      .prepare('SELECT COUNT(*) AS count FROM session_messages WHERE session_id = ?')
+      .get(sessionId) as { count: number };
+    return row.count;
+  },
+};

--- a/server/modules/database/repositories/sessions.db.ts
+++ b/server/modules/database/repositories/sessions.db.ts
@@ -9,6 +9,8 @@ type SessionRow = {
   project_path: string | null;
   jsonl_path: string | null;
   custom_name: string | null;
+  /** Control-plane worker id; null means Server-local execution. */
+  machine_id: string | null;
   /** Model this session runs with; NULL until the app records one for it. */
   model: string | null;
   isArchived: number;
@@ -17,7 +19,7 @@ type SessionRow = {
 };
 
 const SESSION_ROW_COLUMNS =
-  'session_id, provider, provider_session_id, project_path, jsonl_path, custom_name, model, isArchived, created_at, updated_at';
+  'session_id, provider, provider_session_id, project_path, jsonl_path, custom_name, machine_id, model, isArchived, created_at, updated_at';
 
 const SQLITE_UTC_TIMESTAMP_REGEX = /^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/;
 
@@ -153,18 +155,38 @@ export const sessionsDb = {
    * stays NULL until the provider runtime announces its own id and
    * `assignProviderSessionId` records the mapping.
    */
-  createAppSession(sessionId: string, provider: string, projectPath: string): string {
+  createAppSession(
+    sessionId: string,
+    provider: string,
+    projectPath: string,
+    machineId: string | null = null,
+  ): string {
     const db = getConnection();
     const normalizedProjectPath = normalizeProjectPathForProvider(provider, projectPath);
 
     projectsDb.createProjectPath(normalizedProjectPath);
 
     db.prepare(
-      `INSERT INTO sessions (session_id, provider, provider_session_id, custom_name, project_path, jsonl_path, isArchived, created_at, updated_at)
-       VALUES (?, ?, NULL, NULL, ?, NULL, 0, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)`
-    ).run(sessionId, provider, normalizedProjectPath);
+      `INSERT INTO sessions (session_id, provider, provider_session_id, custom_name, project_path, jsonl_path, machine_id, isArchived, created_at, updated_at)
+       VALUES (?, ?, NULL, NULL, ?, NULL, ?, 0, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)`
+    ).run(sessionId, provider, normalizedProjectPath, machineId);
 
     return sessionId;
+  },
+
+  /**
+   * Clears the provider-native session id when Worker-local artifacts cannot be
+   * restored (e.g. Cursor store.db). The next run starts a fresh native session.
+   */
+  clearProviderSessionId(sessionId: string): void {
+    const db = getConnection();
+    db.prepare(
+      `UPDATE sessions SET
+         provider_session_id = NULL,
+         jsonl_path = NULL,
+         updated_at = CURRENT_TIMESTAMP
+       WHERE session_id = ?`,
+    ).run(sessionId);
   },
 
   /**
@@ -227,6 +249,26 @@ export const sessionsDb = {
        SET model = ?
        WHERE session_id = ?`
     ).run(model, sessionId);
+  },
+
+  /** Binds a session to a control-plane worker machine. */
+  setSessionMachineId(sessionId: string, machineId: string | null): void {
+    const db = getConnection();
+    db.prepare(
+      `UPDATE sessions
+       SET machine_id = ?, updated_at = CURRENT_TIMESTAMP
+       WHERE session_id = ?`
+    ).run(machineId, sessionId);
+  },
+
+  /** Updates the on-disk transcript path reported by a Worker after a run. */
+  setSessionJsonlPath(sessionId: string, jsonlPath: string | null): void {
+    const db = getConnection();
+    db.prepare(
+      `UPDATE sessions
+       SET jsonl_path = ?, updated_at = CURRENT_TIMESTAMP
+       WHERE session_id = ?`
+    ).run(jsonlPath, sessionId);
   },
 
   updateSessionCustomName(sessionId: string, customName: string): void {

--- a/server/modules/database/schema.ts
+++ b/server/modules/database/schema.ts
@@ -109,6 +109,9 @@ CREATE TABLE IF NOT EXISTS sessions (
     custom_name TEXT,
     project_path TEXT,
     jsonl_path TEXT,
+    -- Control-plane worker that owns native execution for this session.
+    -- NULL means legacy/local in-process execution on the Server host.
+    machine_id TEXT,
     -- Model this session runs with. Written when the user picks a model for the
     -- session and on every send, so reopening a session restores the model it
     -- was last used with instead of falling back to the catalog default.
@@ -135,6 +138,32 @@ CREATE TABLE IF NOT EXISTS app_config (
     key TEXT PRIMARY KEY,
     value TEXT NOT NULL,
     created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+);
+`;
+
+export const MACHINES_TABLE_SCHEMA_SQL = `
+CREATE TABLE IF NOT EXISTS machines (
+    id TEXT PRIMARY KEY NOT NULL,
+    name TEXT NOT NULL,
+    token_hash TEXT UNIQUE NOT NULL,
+    token_prefix TEXT NOT NULL,
+    status TEXT NOT NULL DEFAULT 'offline',
+    last_seen_at DATETIME,
+    hostname TEXT,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    revoked_at DATETIME
+);
+`;
+
+export const SESSION_MESSAGES_TABLE_SCHEMA_SQL = `
+CREATE TABLE IF NOT EXISTS session_messages (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    session_id TEXT NOT NULL,
+    seq INTEGER,
+    kind TEXT NOT NULL,
+    payload_json TEXT NOT NULL,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (session_id) REFERENCES sessions(session_id) ON DELETE CASCADE
 );
 `;
 
@@ -181,4 +210,12 @@ CREATE INDEX IF NOT EXISTS idx_session_ids_lookup ON sessions(session_id);
 ${LAST_SCANNED_AT_SQL}
 
 ${APP_CONFIG_TABLE_SCHEMA_SQL}
+
+${MACHINES_TABLE_SCHEMA_SQL}
+CREATE INDEX IF NOT EXISTS idx_machines_token_hash ON machines(token_hash);
+CREATE INDEX IF NOT EXISTS idx_machines_status ON machines(status);
+
+${SESSION_MESSAGES_TABLE_SCHEMA_SQL}
+CREATE INDEX IF NOT EXISTS idx_session_messages_session_id ON session_messages(session_id);
+CREATE INDEX IF NOT EXISTS idx_session_messages_session_seq ON session_messages(session_id, seq);
 `;

--- a/server/modules/machines/index.ts
+++ b/server/modules/machines/index.ts
@@ -1,0 +1,9 @@
+// machinesRoutes / machinesService / workerConnectionRegistry: composed here so
+// the server entrypoint and websocket gateway share one process-local instance.
+export {
+  machinesRoutes,
+  machinesService,
+  workerConnectionRegistry,
+  createMachinesService,
+} from './machines.module.js';
+export type { MachinesService } from './machines.module.js';

--- a/server/modules/machines/machines.module.ts
+++ b/server/modules/machines/machines.module.ts
@@ -1,0 +1,29 @@
+import { createWorkerConnectionRegistry } from '@/modules/worker-gateway/index.js';
+
+import { createMachinesRouter } from './machines.routes.js';
+import { createMachinesService } from './machines.service.js';
+
+/**
+ * Process-local machines service used by HTTP routes and worker authentication.
+ */
+export const machinesService = createMachinesService();
+
+/**
+ * Process-local worker socket registry. Lives beside machines because presence
+ * and ping both need the same machinesService instance.
+ */
+export const workerConnectionRegistry = createWorkerConnectionRegistry({
+  machinesService,
+});
+
+/**
+ * Authenticated machines HTTP router mounted by the server entrypoint under
+ * `/api/machines`.
+ */
+export const machinesRoutes = createMachinesRouter({
+  machinesService,
+  pingMachine: (machineId) => workerConnectionRegistry.pingMachine(machineId),
+});
+
+export { createMachinesService } from './machines.service.js';
+export type { MachinesService } from './machines.service.js';

--- a/server/modules/machines/machines.routes.ts
+++ b/server/modules/machines/machines.routes.ts
@@ -1,0 +1,91 @@
+import express from 'express';
+
+import {
+  AppError,
+  asyncHandler,
+  createApiSuccessResponse,
+} from '@/shared/utils.js';
+
+import type { MachinesService } from './machines.service.js';
+
+type MachinesRouterDependencies = {
+  machinesService: MachinesService;
+  pingMachine: (machineId: string) => Promise<{
+    ok: boolean;
+    latencyMs: number;
+    payload: string;
+  }>;
+};
+
+/**
+ * Creates thin HTTP handlers for control-plane machine management.
+ *
+ * Consumed by the machines module composition root and mounted under
+ * `/api/machines` by the server entrypoint.
+ */
+export function createMachinesRouter(
+  dependencies: MachinesRouterDependencies,
+): express.Router {
+  const router = express.Router();
+
+  router.get(
+    '/',
+    asyncHandler(async (_req, res) => {
+      res.json(createApiSuccessResponse({
+        machines: dependencies.machinesService.listMachines(),
+      }));
+    }),
+  );
+
+  router.post(
+    '/',
+    asyncHandler(async (req, res) => {
+      const result = dependencies.machinesService.createMachine(req.body?.name);
+      res.status(201).json(createApiSuccessResponse({
+        machine: result.machine,
+        token: result.token,
+      }));
+    }),
+  );
+
+  router.patch(
+    '/:machineId',
+    asyncHandler(async (req, res) => {
+      const machine = dependencies.machinesService.renameMachine(
+        String(req.params.machineId),
+        req.body?.name,
+      );
+      res.json(createApiSuccessResponse({ machine }));
+    }),
+  );
+
+  router.delete(
+    '/:machineId',
+    asyncHandler(async (req, res) => {
+      dependencies.machinesService.revokeMachine(String(req.params.machineId));
+      res.json(createApiSuccessResponse({ revoked: true }));
+    }),
+  );
+
+  router.post(
+    '/:machineId/ping',
+    asyncHandler(async (req, res) => {
+      const machineId = String(req.params.machineId);
+      const machine = dependencies.machinesService.getMachine(machineId);
+      if (!machine) {
+        throw new AppError('Machine not found', {
+          code: 'MACHINE_NOT_FOUND',
+          statusCode: 404,
+        });
+      }
+
+      const result = await dependencies.pingMachine(machineId);
+      res.json(createApiSuccessResponse({
+        machineId,
+        ...result,
+      }));
+    }),
+  );
+
+  return router;
+}

--- a/server/modules/machines/machines.service.ts
+++ b/server/modules/machines/machines.service.ts
@@ -1,0 +1,167 @@
+import crypto from 'node:crypto';
+
+import {
+  machinesDb,
+  type PublicMachineRecord,
+} from '@/modules/database/index.js';
+import { AppError } from '@/shared/utils.js';
+import type {
+  AuthenticatedWorkerMachine,
+  ControlPlaneMachine,
+} from '@/shared/types.js';
+
+type MachinesServiceDependencies = {
+  createId(): string;
+  generateToken(): string;
+  hashToken(token: string): string;
+  createMachine(input: {
+    id: string;
+    name: string;
+    tokenHash: string;
+    tokenPrefix: string;
+  }): PublicMachineRecord;
+  listMachines(): PublicMachineRecord[];
+  getMachineById(machineId: string): PublicMachineRecord | null;
+  findActiveMachineByToken(token: string): PublicMachineRecord | null;
+  renameMachine(machineId: string, name: string): PublicMachineRecord | null;
+  revokeMachine(machineId: string): boolean;
+  markOnline(machineId: string, hostname?: string | null): PublicMachineRecord | null;
+  markOffline(machineId: string): PublicMachineRecord | null;
+  touchHeartbeat(machineId: string): void;
+};
+
+const defaultDependencies: MachinesServiceDependencies = {
+  createId: () => crypto.randomUUID(),
+  generateToken: () => machinesDb.generateMachineToken(),
+  hashToken: (token) => machinesDb.hashMachineToken(token),
+  createMachine: (input) => machinesDb.createMachine(input),
+  listMachines: () => machinesDb.listMachines(),
+  getMachineById: (machineId) => machinesDb.getMachineById(machineId),
+  findActiveMachineByToken: (token) => machinesDb.findActiveMachineByToken(token),
+  renameMachine: (machineId, name) => machinesDb.renameMachine(machineId, name),
+  revokeMachine: (machineId) => machinesDb.revokeMachine(machineId),
+  markOnline: (machineId, hostname) => machinesDb.markOnline(machineId, hostname),
+  markOffline: (machineId) => machinesDb.markOffline(machineId),
+  touchHeartbeat: (machineId) => machinesDb.touchHeartbeat(machineId),
+};
+
+function toControlPlaneMachine(record: PublicMachineRecord): ControlPlaneMachine {
+  return {
+    id: record.id,
+    name: record.name,
+    tokenPrefix: record.tokenPrefix,
+    status: record.status,
+    lastSeenAt: record.lastSeenAt,
+    hostname: record.hostname,
+    createdAt: record.createdAt,
+    revokedAt: record.revokedAt,
+  };
+}
+
+/**
+ * Creates the machines application service used by HTTP routes and the worker
+ * gateway for registration, token auth, and presence updates.
+ */
+export function createMachinesService(
+  dependencyOverrides: Partial<MachinesServiceDependencies> = {},
+) {
+  const dependencies = { ...defaultDependencies, ...dependencyOverrides };
+
+  return {
+    listMachines(): ControlPlaneMachine[] {
+      return dependencies.listMachines().map(toControlPlaneMachine);
+    },
+
+    createMachine(rawName: unknown): {
+      machine: ControlPlaneMachine;
+      token: string;
+    } {
+      const name = typeof rawName === 'string' ? rawName.trim() : '';
+      if (!name) {
+        throw new AppError('Machine name is required', {
+          code: 'MACHINE_NAME_REQUIRED',
+          statusCode: 400,
+        });
+      }
+
+      const token = dependencies.generateToken();
+      const machine = toControlPlaneMachine(
+        dependencies.createMachine({
+          id: dependencies.createId(),
+          name,
+          tokenHash: dependencies.hashToken(token),
+          tokenPrefix: token.slice(0, 11),
+        }),
+      );
+
+      return { machine, token };
+    },
+
+    renameMachine(machineId: string, rawName: unknown): ControlPlaneMachine {
+      const name = typeof rawName === 'string' ? rawName.trim() : '';
+      if (!name) {
+        throw new AppError('Machine name is required', {
+          code: 'MACHINE_NAME_REQUIRED',
+          statusCode: 400,
+        });
+      }
+
+      const machine = dependencies.renameMachine(machineId, name);
+      if (!machine) {
+        throw new AppError('Machine not found', {
+          code: 'MACHINE_NOT_FOUND',
+          statusCode: 404,
+        });
+      }
+      return toControlPlaneMachine(machine);
+    },
+
+    revokeMachine(machineId: string): void {
+      const revoked = dependencies.revokeMachine(machineId);
+      if (!revoked) {
+        throw new AppError('Machine not found', {
+          code: 'MACHINE_NOT_FOUND',
+          statusCode: 404,
+        });
+      }
+    },
+
+    /**
+     * Validates a worker websocket token. Used by websocket verifyClient for
+     * `/worker` upgrades.
+     */
+    authenticateWorkerToken(token: string | null): AuthenticatedWorkerMachine | null {
+      if (!token || !token.startsWith('mw_')) {
+        return null;
+      }
+
+      const machine = dependencies.findActiveMachineByToken(token);
+      if (!machine) {
+        return null;
+      }
+
+      return { id: machine.id, name: machine.name };
+    },
+
+    markOnline(machineId: string, hostname?: string | null): ControlPlaneMachine | null {
+      const machine = dependencies.markOnline(machineId, hostname);
+      return machine ? toControlPlaneMachine(machine) : null;
+    },
+
+    markOffline(machineId: string): ControlPlaneMachine | null {
+      const machine = dependencies.markOffline(machineId);
+      return machine ? toControlPlaneMachine(machine) : null;
+    },
+
+    touchHeartbeat(machineId: string): void {
+      dependencies.touchHeartbeat(machineId);
+    },
+
+    getMachine(machineId: string): ControlPlaneMachine | null {
+      const machine = dependencies.getMachineById(machineId);
+      return machine && !machine.revokedAt ? toControlPlaneMachine(machine) : null;
+    },
+  };
+}
+
+export type MachinesService = ReturnType<typeof createMachinesService>;

--- a/server/modules/machines/tests/machines.service.test.ts
+++ b/server/modules/machines/tests/machines.service.test.ts
@@ -1,0 +1,114 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { createMachinesService } from '../machines.service.js';
+
+function createHarness() {
+  const machines = new Map<string, {
+    id: string;
+    name: string;
+    tokenHash: string;
+    tokenPrefix: string;
+    status: 'online' | 'offline';
+    lastSeenAt: string | null;
+    hostname: string | null;
+    createdAt: string;
+    revokedAt: string | null;
+  }>();
+  const tokens = new Map<string, string>();
+
+  const service = createMachinesService({
+    createId: () => 'machine-1',
+    generateToken: () => 'mw_test_token_value_0001',
+    hashToken: (token) => `hash:${token}`,
+    createMachine: (input) => {
+      const record = {
+        id: input.id,
+        name: input.name,
+        tokenHash: input.tokenHash,
+        tokenPrefix: input.tokenPrefix,
+        status: 'offline' as const,
+        lastSeenAt: null,
+        hostname: null,
+        createdAt: '2026-01-01T00:00:00.000Z',
+        revokedAt: null,
+      };
+      machines.set(record.id, record);
+      tokens.set(input.tokenHash, record.id);
+      return { ...record, tokenPrefix: record.tokenPrefix };
+    },
+    listMachines: () => [...machines.values()]
+      .filter((row) => !row.revokedAt)
+      .map((row) => ({ ...row })),
+    getMachineById: (machineId) => {
+      const row = machines.get(machineId);
+      return row ? { ...row } : null;
+    },
+    findActiveMachineByToken: (token) => {
+      const machineId = tokens.get(`hash:${token}`);
+      if (!machineId) return null;
+      const row = machines.get(machineId);
+      return row && !row.revokedAt ? { ...row } : null;
+    },
+    renameMachine: (machineId, name) => {
+      const row = machines.get(machineId);
+      if (!row || row.revokedAt) return null;
+      row.name = name;
+      return { ...row };
+    },
+    revokeMachine: (machineId) => {
+      const row = machines.get(machineId);
+      if (!row || row.revokedAt) return false;
+      row.revokedAt = '2026-01-02T00:00:00.000Z';
+      row.status = 'offline';
+      return true;
+    },
+    markOnline: (machineId, hostname) => {
+      const row = machines.get(machineId);
+      if (!row || row.revokedAt) return null;
+      row.status = 'online';
+      row.lastSeenAt = '2026-01-01T01:00:00.000Z';
+      if (hostname) row.hostname = hostname;
+      return { ...row };
+    },
+    markOffline: (machineId) => {
+      const row = machines.get(machineId);
+      if (!row || row.revokedAt) return null;
+      row.status = 'offline';
+      return { ...row };
+    },
+    touchHeartbeat: (machineId) => {
+      const row = machines.get(machineId);
+      if (row) row.lastSeenAt = '2026-01-01T02:00:00.000Z';
+    },
+  });
+
+  return { service, machines };
+}
+
+test('createMachine returns plaintext token once and lists the machine', () => {
+  const { service } = createHarness();
+  const created = service.createMachine('laptop-a');
+  assert.equal(created.token, 'mw_test_token_value_0001');
+  assert.equal(created.machine.name, 'laptop-a');
+  assert.equal(created.machine.status, 'offline');
+  assert.equal(service.listMachines().length, 1);
+});
+
+test('authenticateWorkerToken accepts active tokens and rejects revoked ones', () => {
+  const { service } = createHarness();
+  const created = service.createMachine('laptop-a');
+  const authed = service.authenticateWorkerToken(created.token);
+  assert.deepEqual(authed, { id: 'machine-1', name: 'laptop-a' });
+
+  service.revokeMachine('machine-1');
+  assert.equal(service.authenticateWorkerToken(created.token), null);
+});
+
+test('markOnline updates presence used by the control-plane UI', () => {
+  const { service } = createHarness();
+  service.createMachine('laptop-a');
+  const online = service.markOnline('machine-1', 'host-a');
+  assert.equal(online?.status, 'online');
+  assert.equal(online?.hostname, 'host-a');
+});

--- a/server/modules/projects/services/projects-with-sessions-fetch.service.ts
+++ b/server/modules/projects/services/projects-with-sessions-fetch.service.ts
@@ -5,7 +5,7 @@ import { projectsDb, sessionsDb } from '@/modules/database/index.js';
 import { sessionSynchronizerService } from '@/modules/providers/index.js';
 import { WS_OPEN_STATE, connectedClients } from '@/modules/websocket/index.js';
 import type { RealtimeClientConnection } from '@/shared/types.js';
-import { AppError } from '@/shared/utils.js';
+import { AppError, isControlPlaneMode } from '@/shared/utils.js';
 
 type SessionSummary = {
   id: string;
@@ -75,6 +75,17 @@ export type ProjectSessionsPageApiView = {
 
 const DEFAULT_PROJECT_SESSIONS_PAGE_SIZE = 20;
 const MAX_PROJECT_SESSIONS_PAGE_SIZE = 200;
+
+/**
+ * Local-disk session sync is a monolith leftover. Control-plane Servers keep
+ * session truth in SQLite (fed by Worker reports / web creates) instead.
+ */
+function shouldSynchronizeFromLocalDisk(skipSynchronization?: boolean): boolean {
+  if (skipSynchronization || isControlPlaneMode()) {
+    return false;
+  }
+  return true;
+}
 
 /**
  * Generate better display name from path.
@@ -180,7 +191,7 @@ function broadcastProgress(progress: ProgressUpdate) {
 export async function getProjectsWithSessions(
   options: GetProjectsWithSessionsOptions = {}
 ): Promise<ProjectListItem[]> {
-  if (!options.skipSynchronization) {
+  if (shouldSynchronizeFromLocalDisk(options.skipSynchronization)) {
     await sessionSynchronizerService.synchronizeSessions();
   }
 
@@ -248,7 +259,7 @@ export async function getProjectsWithSessions(
 export async function getArchivedProjectsWithSessions(
   options: Pick<GetProjectsWithSessionsOptions, 'skipSynchronization'> = {},
 ): Promise<ArchivedProjectListItem[]> {
-  if (!options.skipSynchronization) {
+  if (shouldSynchronizeFromLocalDisk(options.skipSynchronization)) {
     await sessionSynchronizerService.synchronizeSessions();
   }
 

--- a/server/modules/providers/index.ts
+++ b/server/modules/providers/index.ts
@@ -2,6 +2,8 @@ export { sessionSynchronizerService } from './services/session-synchronizer.serv
 export { providerSkillsService } from './services/skills.service.js';
 export { providerMcpService } from './services/mcp.service.js';
 export { providerRuntimeService } from './services/provider-runtime.service.js';
+// providerRegistry: used by Worker chat runner to resolve local provider adapters.
+export { providerRegistry } from './provider.registry.js';
 
 // providerModelsService: used by Commands to list models and resolve the active session model.
 export { providerModelsService } from './services/provider-models.service.js';

--- a/server/modules/providers/provider.routes.ts
+++ b/server/modules/providers/provider.routes.ts
@@ -552,7 +552,8 @@ router.post(
     const body = (req.body ?? {}) as Record<string, unknown>;
     const provider = parseProvider(body.provider);
     const projectPath = typeof body.projectPath === 'string' ? body.projectPath : '';
-    const result = sessionsService.createAppSession(provider, projectPath);
+    const machineId = typeof body.machineId === 'string' ? body.machineId : null;
+    const result = sessionsService.createAppSession(provider, projectPath, machineId);
     res.status(201).json(createApiSuccessResponse(result));
   }),
 );

--- a/server/modules/providers/services/sessions.service.ts
+++ b/server/modules/providers/services/sessions.service.ts
@@ -2,7 +2,7 @@ import { randomUUID } from 'node:crypto';
 import fsp from 'node:fs/promises';
 import path from 'node:path';
 
-import { projectsDb, sessionsDb } from '@/modules/database/index.js';
+import { machinesDb, projectsDb, sessionMessagesDb, sessionsDb } from '@/modules/database/index.js';
 import { chatRunRegistry } from '@/modules/websocket/index.js';
 import { providerRegistry } from '@/modules/providers/provider.registry.js';
 import type {
@@ -11,12 +11,13 @@ import type {
   LLMProvider,
   NormalizedMessage,
 } from '@/shared/types.js';
-import { AppError } from '@/shared/utils.js';
+import { AppError, isControlPlaneMode } from '@/shared/utils.js';
 
 type CreateAppSessionResult = {
   sessionId: string;
   provider: LLMProvider;
   projectPath: string;
+  machineId: string | null;
 };
 
 type ArchivedSessionListItem = {
@@ -156,7 +157,11 @@ export const sessionsService = {
    * for the lifetime of the conversation. The provider-native id is mapped to
    * this row later, when the provider runtime announces it mid-run.
    */
-  createAppSession(provider: LLMProvider, projectPath: string): CreateAppSessionResult {
+  createAppSession(
+    provider: LLMProvider,
+    projectPath: string,
+    machineId: string | null = null,
+  ): CreateAppSessionResult {
     const normalizedProjectPath = projectPath.trim();
     if (!normalizedProjectPath) {
       throw new AppError('projectPath is required.', {
@@ -165,13 +170,39 @@ export const sessionsService = {
       });
     }
 
+    const normalizedMachineId =
+      typeof machineId === 'string' && machineId.trim() ? machineId.trim() : null;
+
+    if (isControlPlaneMode() && !normalizedMachineId) {
+      throw new AppError('machineId is required in control-plane mode. Select a Worker machine first.', {
+        code: 'MACHINE_REQUIRED',
+        statusCode: 400,
+      });
+    }
+
+    if (normalizedMachineId) {
+      const machine = machinesDb.getMachineById(normalizedMachineId);
+      if (!machine || machine.revokedAt) {
+        throw new AppError(`Machine "${normalizedMachineId}" was not found.`, {
+          code: 'MACHINE_NOT_FOUND',
+          statusCode: 404,
+        });
+      }
+    }
+
     const sessionId = randomUUID();
-    sessionsDb.createAppSession(sessionId, provider, normalizedProjectPath);
+    sessionsDb.createAppSession(
+      sessionId,
+      provider,
+      normalizedProjectPath,
+      normalizedMachineId,
+    );
 
     return {
       sessionId,
       provider,
       projectPath: normalizedProjectPath,
+      machineId: normalizedMachineId,
     };
   },
 
@@ -219,6 +250,42 @@ export const sessionsService = {
       });
     }
 
+    const offset = options.offset ?? 0;
+    const limit = options.limit ?? null;
+
+    // Prefer the cloud copy for Worker-bound chats and any session that already
+    // has dual-written messages. Do NOT force this path for every session in
+    // control-plane mode: legacy rows were indexed from local provider files
+    // and have no `session_messages` yet — blocking disk reads made the web UI
+    // look like all history vanished.
+    const cloudCount = sessionMessagesDb.countMessages(sessionId);
+    if (session.machine_id || cloudCount > 0) {
+      const rows = sessionMessagesDb.listMessages(sessionId, {
+        limit: typeof limit === 'number' ? limit : undefined,
+        offset,
+      });
+      const messages = rows
+        .map((row) => {
+          try {
+            return {
+              ...(JSON.parse(row.payload_json) as NormalizedMessage),
+              sessionId,
+            };
+          } catch {
+            return null;
+          }
+        })
+        .filter((message): message is NormalizedMessage => Boolean(message));
+
+      return {
+        messages,
+        total: cloudCount,
+        hasMore: typeof limit === 'number' ? offset + messages.length < cloudCount : false,
+        offset,
+        limit,
+      };
+    }
+
     // App-created sessions that never produced a provider transcript yet
     // (e.g. first message still streaming) simply have no history.
     if (!session.provider_session_id) {
@@ -226,15 +293,18 @@ export const sessionsService = {
         messages: [],
         total: 0,
         hasMore: false,
-        offset: options.offset ?? 0,
-        limit: options.limit ?? null,
+        offset,
+        limit,
       };
     }
 
+    // Legacy / unbound sessions: hydrate from provider-native files when they
+    // exist on this host. Control-plane Servers still refuse to *run* these
+    // locally; remote Worker history fetch is a later RPC.
     const provider = session.provider as LLMProvider;
     const result = await providerRegistry.resolveProvider(provider).sessions.fetchHistory(sessionId, {
-      limit: options.limit ?? null,
-      offset: options.offset ?? 0,
+      limit,
+      offset,
       projectPath: session.project_path ?? '',
       providerSessionId: session.provider_session_id,
     });

--- a/server/modules/providers/tests/provider-token-usage.service.test.ts
+++ b/server/modules/providers/tests/provider-token-usage.service.test.ts
@@ -17,6 +17,7 @@ function createSessionRow(overrides: Record<string, unknown> = {}) {
     project_path: null,
     jsonl_path: null,
     custom_name: null,
+    machine_id: null,
     model: null,
     isArchived: 0,
     created_at: '2026-01-01T00:00:00.000Z',

--- a/server/modules/websocket/services/chat-websocket.service.ts
+++ b/server/modules/websocket/services/chat-websocket.service.ts
@@ -2,7 +2,8 @@ import path from 'node:path';
 
 import type { WebSocket } from 'ws';
 
-import { sessionsDb } from '@/modules/database/index.js';
+import { sessionMessagesDb, sessionsDb } from '@/modules/database/index.js';
+import { workerConnectionRegistry } from '@/modules/machines/index.js';
 import { providerModelsService } from '@/modules/providers/index.js';
 import { chatRunRegistry } from '@/modules/websocket/services/chat-run-registry.service.js';
 import { connectedClients, WS_OPEN_STATE } from '@/modules/websocket/services/websocket-state.service.js';
@@ -16,10 +17,11 @@ import type {
   AnyRecord,
   AuthenticatedWebSocketRequest,
   LLMProvider,
+  NormalizedMessage,
   ProviderPermissionDecision,
   ProviderRuntimeWriter,
 } from '@/shared/types.js';
-import { parseIncomingJsonObject } from '@/shared/utils.js';
+import { createNormalizedMessage, isControlPlaneMode, parseIncomingJsonObject } from '@/shared/utils.js';
 
 /**
  * Trust boundary for client-supplied image attachments: chat.send options come
@@ -167,7 +169,21 @@ async function handleChatSend(
   }
 
   const provider = session.provider as LLMProvider;
-  if (!dependencies.runtime.hasRuntime(provider)) {
+
+  // Control-plane Servers never run provider CLIs locally. Legacy sessions
+  // without a machine binding must be rebound or recreated on a Worker.
+  if (isControlPlaneMode() && !session.machine_id) {
+    sendProtocolError(
+      ws,
+      'MACHINE_REQUIRED',
+      `Session "${sessionId}" has no machine binding. Create a new chat after selecting a Worker machine.`,
+      sessionId,
+    );
+    return;
+  }
+
+  // Worker-bound sessions do not need a Server-local provider install.
+  if (!session.machine_id && !dependencies.runtime.hasRuntime(provider)) {
     sendProtocolError(ws, 'UNSUPPORTED_PROVIDER', `Provider "${provider}" is not available.`, sessionId);
     return;
   }
@@ -227,6 +243,129 @@ async function handleChatSend(
     projectPath: session.project_path ?? clientOptions.projectPath,
   };
 
+  const persistLatestOutbound = () => {
+    const outbound = run.events[run.events.length - 1];
+    if (!outbound || typeof outbound.kind !== 'string') {
+      return;
+    }
+    sessionMessagesDb.appendMessage({
+      sessionId,
+      seq: typeof outbound.seq === 'number' ? outbound.seq : null,
+      kind: outbound.kind,
+      payload: outbound,
+    });
+  };
+
+  // Persist the user turn into the cloud copy before dispatch so web history
+  // and ensure_native write-back both see the prompt even if the Worker dies.
+  if (session.machine_id && command.trim()) {
+    sessionMessagesDb.appendMessage({
+      sessionId,
+      kind: 'text',
+      payload: createNormalizedMessage({
+        kind: 'text',
+        provider,
+        sessionId,
+        role: 'user',
+        content: command,
+      }),
+    });
+  }
+
+  // Control-plane sessions are bound to a Worker. Never fall back to the
+  // Server-local runtime — that would create the same-box testing illusion.
+  if (session.machine_id) {
+    let providerSessionId = session.provider_session_id;
+    try {
+      // Before resume, ask the Worker to ensure native artifacts exist (and
+      // best-effort restore Claude/Codex transcripts from the cloud copy).
+      if (providerSessionId && sessionMessagesDb.countMessages(sessionId) > 0) {
+        const cloudRows = sessionMessagesDb.listMessages(sessionId);
+        const cloudMessages = cloudRows
+          .map((row) => {
+            try {
+              return JSON.parse(row.payload_json) as NormalizedMessage;
+            } catch {
+              return null;
+            }
+          })
+          .filter((message): message is NormalizedMessage => Boolean(message?.kind));
+
+        const ensureResult = await workerConnectionRegistry.ensureNativeSession({
+          machineId: session.machine_id,
+          sessionId,
+          provider,
+          providerSessionId,
+          projectPath: session.project_path,
+          messages: cloudMessages,
+        });
+
+        if (ensureResult.jsonlPath) {
+          sessionsDb.setSessionJsonlPath(sessionId, ensureResult.jsonlPath);
+        }
+        if (ensureResult.dropProviderSessionId) {
+          sessionsDb.clearProviderSessionId(sessionId);
+          providerSessionId = null;
+        } else if (!ensureResult.success) {
+          throw new Error(ensureResult.error || 'Failed to ensure native session on Worker');
+        }
+      }
+
+      workerConnectionRegistry.dispatchChatRun({
+        machineId: session.machine_id,
+        sessionId,
+        provider,
+        providerSessionId,
+        command,
+        options: runtimeOptions,
+        onEvent: (event) => {
+          run.writer.send(event);
+          persistLatestOutbound();
+        },
+        onComplete: (result) => {
+          if (result.providerSessionId) {
+            sessionsDb.assignProviderSessionId(sessionId, result.providerSessionId);
+          }
+          if (typeof result.jsonlPath === 'string' && result.jsonlPath) {
+            sessionsDb.setSessionJsonlPath(sessionId, result.jsonlPath);
+          }
+          chatRunRegistry.completeRunIfCurrent(run, {
+            exitCode: result.exitCode ?? (result.success === false ? 1 : 0),
+            aborted: Boolean(result.aborted),
+          });
+        },
+        onError: (error) => {
+          run.writer.send(createNormalizedMessage({
+            kind: 'error',
+            provider,
+            sessionId,
+            content: error,
+          }));
+          persistLatestOutbound();
+          chatRunRegistry.completeRunIfCurrent(run, { exitCode: 1 });
+        },
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      console.error('[Chat] Worker dispatch failed', { sessionId, error: message });
+      run.writer.send(createNormalizedMessage({
+        kind: 'error',
+        provider,
+        sessionId,
+        content: message,
+      }));
+      persistLatestOutbound();
+      chatRunRegistry.completeRunIfCurrent(run, { exitCode: 1 });
+    }
+    return;
+  }
+
+  if (isControlPlaneMode()) {
+    // Defensive: MACHINE_REQUIRED is checked earlier; never reach local runtime.
+    chatRunRegistry.completeRunIfCurrent(run, { exitCode: 1 });
+    return;
+  }
+
   try {
     await dependencies.runtime.run(provider, command, runtimeOptions, run.writer);
   } catch (error) {
@@ -264,10 +403,21 @@ async function handleChatAbort(
     return;
   }
 
-  const success = await dependencies.runtime.abort(run.provider, sessionId);
+  const session = sessionsDb.getSessionById(sessionId);
+  if (session?.machine_id) {
+    try {
+      workerConnectionRegistry.abortChatRun(session.machine_id, sessionId);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      sendProtocolError(ws, 'MACHINE_OFFLINE', message, sessionId);
+      return;
+    }
+  } else {
+    await dependencies.runtime.abort(run.provider, sessionId);
+  }
 
   chatRunRegistry.completeRun(sessionId, {
-    exitCode: success ? 0 : 1,
+    exitCode: 0,
     aborted: true,
   });
 }
@@ -340,11 +490,33 @@ function handleChatSubscribe(
 
 /**
  * Handles `chat.permission-response`: forwards a tool-approval decision to the
- * pending approval resolver (Claude is the only provider with interactive
- * approvals today, but the message is intentionally provider-neutral).
+ * pending approval resolver. Worker-bound sessions route the decision to the
+ * machine that owns the live runtime; local sessions resolve in-process.
  */
 function handlePermissionResponse(data: AnyRecord, dependencies: ChatWebSocketDependencies): void {
   if (typeof data.requestId !== 'string' || data.requestId.length === 0) {
+    return;
+  }
+
+  const sessionId = typeof data.sessionId === 'string' ? data.sessionId : '';
+  const session = sessionId ? sessionsDb.getSessionById(sessionId) : null;
+  if (session?.machine_id) {
+    try {
+      workerConnectionRegistry.dispatchPermissionResponse({
+        machineId: session.machine_id,
+        requestId: data.requestId,
+        allow: Boolean(data.allow),
+        updatedInput: data.updatedInput,
+        message: typeof data.message === 'string' ? data.message : undefined,
+        rememberEntry: data.rememberEntry,
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      console.error('[Chat] Failed to route permission response to Worker', {
+        sessionId,
+        error: message,
+      });
+    }
     return;
   }
 

--- a/server/modules/websocket/services/websocket-auth.service.ts
+++ b/server/modules/websocket/services/websocket-auth.service.ts
@@ -1,6 +1,9 @@
 import type { VerifyClientCallbackSync } from 'ws';
 
-import type { AuthenticatedWebSocketRequest } from '@/shared/types.js';
+import type {
+  AuthenticatedWebSocketRequest,
+  AuthenticatedWorkerMachine,
+} from '@/shared/types.js';
 
 type WebSocketAuthDependencies = {
   isPlatform: boolean;
@@ -10,6 +13,11 @@ type WebSocketAuthDependencies = {
     username?: string;
     [key: string]: unknown;
   } | null;
+  /**
+   * Validates a worker machine token for `/worker` upgrades. When omitted,
+   * worker connections are rejected.
+   */
+  authenticateWorkerWebSocket?: (token: string | null) => AuthenticatedWorkerMachine | null;
 };
 
 /**
@@ -27,6 +35,23 @@ export function verifyWebSocketClient(
   }
 
   console.log('WebSocket connection attempt to:', `${loggedUrl.pathname}${loggedUrl.search}`);
+
+  // Worker sockets authenticate with a machine token, not a user JWT.
+  if (upgradeUrl.pathname === '/worker') {
+    const token =
+      upgradeUrl.searchParams.get('token') ??
+      request.headers.authorization?.split(' ')[1] ??
+      null;
+    const machine = dependencies.authenticateWorkerWebSocket?.(token) ?? null;
+    if (!machine) {
+      console.log('[WARN] Worker WebSocket authentication failed');
+      return false;
+    }
+
+    request.machine = machine;
+    console.log('[OK] Worker WebSocket authenticated for machine:', machine.id);
+    return true;
+  }
 
   // Platform mode: use the first DB user and skip token checks.
   if (dependencies.isPlatform) {

--- a/server/modules/websocket/services/websocket-server.service.ts
+++ b/server/modules/websocket/services/websocket-server.service.ts
@@ -14,6 +14,14 @@ type WebSocketServerDependencies = {
   chat: Parameters<typeof handleChatConnection>[2];
   shell: Parameters<typeof handleShellConnection>[1];
   getPluginPort: Parameters<typeof handlePluginWsProxy>[2];
+  /**
+   * Optional worker gateway handler for `/worker` sockets. When omitted, worker
+   * paths are closed immediately after upgrade.
+   */
+  handleWorkerConnection?: (
+    ws: WebSocket,
+    request: AuthenticatedWebSocketRequest,
+  ) => void;
 };
 
 /**
@@ -110,6 +118,17 @@ export function createWebSocketServer(
 
     if (pathname === '/desktop-notifications') {
       handleDesktopNotificationsConnection(ws, incomingRequest);
+      return;
+    }
+
+    if (pathname === '/worker') {
+      if (dependencies.handleWorkerConnection) {
+        dependencies.handleWorkerConnection(ws, incomingRequest);
+        return;
+      }
+
+      console.log('[WARN] Worker WebSocket path is not configured');
+      ws.close();
       return;
     }
 

--- a/server/modules/worker-agent/index.ts
+++ b/server/modules/worker-agent/index.ts
@@ -1,0 +1,17 @@
+import { createWorkerAgentService } from './worker-agent.service.js';
+
+/**
+ * Creates the production worker-agent service for the CLI `worker` command.
+ */
+export function createWorkerAgentApplication() {
+  return createWorkerAgentService({
+    environment: process.env,
+    output: {
+      log: (message = '') => console.log(message),
+      error: (message = '') => console.error(message),
+    },
+  });
+}
+
+export { createWorkerAgentService } from './worker-agent.service.js';
+export type { WorkerAgentService } from './worker-agent.service.js';

--- a/server/modules/worker-agent/tests/worker-native-artifacts.service.test.ts
+++ b/server/modules/worker-agent/tests/worker-native-artifacts.service.test.ts
@@ -1,0 +1,83 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+
+import { createWorkerNativeArtifactsService } from '../worker-native-artifacts.service.js';
+
+test('ensureNative restores a Claude jsonl from cloud turns', async () => {
+  const home = await mkdtemp(path.join(os.tmpdir(), 'worker-native-claude-'));
+  try {
+    const service = createWorkerNativeArtifactsService({
+      getHomeDirectory: () => home,
+    });
+
+    const projectPath = '/home/aaron/demo';
+    const providerSessionId = 'claude-sess-1';
+    const result = await service.ensureNative({
+      provider: 'claude',
+      providerSessionId,
+      projectPath,
+      messages: [
+        {
+          id: 'm1',
+          sessionId: 'app-1',
+          timestamp: '2026-08-02T01:00:00.000Z',
+          provider: 'claude',
+          kind: 'text',
+          role: 'user',
+          content: 'hello from cloud',
+        },
+        {
+          id: 'm2',
+          sessionId: 'app-1',
+          timestamp: '2026-08-02T01:00:01.000Z',
+          provider: 'claude',
+          kind: 'text',
+          role: 'assistant',
+          content: 'hi back',
+        },
+      ],
+    });
+
+    assert.equal(result.success, true);
+    assert.equal(result.restored, true);
+    assert.ok(result.jsonlPath);
+    const body = await readFile(result.jsonlPath!, 'utf8');
+    assert.match(body, /hello from cloud/);
+    assert.match(body, /hi back/);
+    assert.match(body, /claude-sess-1/);
+
+    const second = await service.ensureNative({
+      provider: 'claude',
+      providerSessionId,
+      projectPath,
+      messages: [],
+    });
+    assert.equal(second.restored, false);
+    assert.equal(second.jsonlPath, result.jsonlPath);
+  } finally {
+    await rm(home, { recursive: true, force: true });
+  }
+});
+
+test('ensureNative drops Cursor provider id when store.db is missing', async () => {
+  const home = await mkdtemp(path.join(os.tmpdir(), 'worker-native-cursor-'));
+  try {
+    const service = createWorkerNativeArtifactsService({
+      getHomeDirectory: () => home,
+    });
+    const result = await service.ensureNative({
+      provider: 'cursor',
+      providerSessionId: 'cursor-1',
+      projectPath: '/tmp/project',
+      messages: [],
+    });
+    assert.equal(result.success, true);
+    assert.equal(result.dropProviderSessionId, true);
+    assert.equal(result.jsonlPath, null);
+  } finally {
+    await rm(home, { recursive: true, force: true });
+  }
+});

--- a/server/modules/worker-agent/worker-agent.service.ts
+++ b/server/modules/worker-agent/worker-agent.service.ts
@@ -1,0 +1,285 @@
+import os from 'node:os';
+
+import { WebSocket } from 'ws';
+
+import type {
+  CliEnvironment,
+  CliOutput,
+  WorkerProtocolMessage,
+} from '@/shared/types.js';
+import { terminalTextStyles } from '@/shared/utils.js';
+
+type WorkerAgentServiceDependencies = {
+  environment: CliEnvironment;
+  output: CliOutput;
+  getHostname?: () => string;
+  createWebSocket?: (url: string) => WebSocket;
+  setIntervalFn?: typeof setInterval;
+  clearIntervalFn?: typeof clearInterval;
+  setTimeoutFn?: typeof setTimeout;
+  clearTimeoutFn?: typeof clearTimeout;
+};
+
+type WorkerStartOptions = {
+  serverUrl?: string;
+  token?: string;
+  name?: string;
+};
+
+function normalizeServerUrl(rawUrl: string): string {
+  const trimmed = rawUrl.trim().replace(/\/$/, '');
+  if (trimmed.startsWith('https://')) {
+    return `wss://${trimmed.slice('https://'.length)}`;
+  }
+  if (trimmed.startsWith('http://')) {
+    return `ws://${trimmed.slice('http://'.length)}`;
+  }
+  if (trimmed.startsWith('wss://') || trimmed.startsWith('ws://')) {
+    return trimmed;
+  }
+  throw new Error('Server URL must start with https://, http://, wss://, or ws://');
+}
+
+function buildWorkerUrl(serverUrl: string, token: string): string {
+  const base = normalizeServerUrl(serverUrl);
+  const url = new URL('/worker', `${base}/`);
+  url.searchParams.set('token', token);
+  return url.toString();
+}
+
+function parseWorkerMessage(raw: WebSocket.RawData): WorkerProtocolMessage | null {
+  try {
+    const text = typeof raw === 'string' ? raw : raw.toString('utf8');
+    const parsed = JSON.parse(text) as Partial<WorkerProtocolMessage>;
+    if (!parsed || typeof parsed.type !== 'string') {
+      return null;
+    }
+    return parsed as WorkerProtocolMessage;
+  } catch {
+    return null;
+  }
+}
+
+function sendJson(ws: WebSocket, message: WorkerProtocolMessage): void {
+  if (ws.readyState !== WebSocket.OPEN) {
+    return;
+  }
+  ws.send(JSON.stringify(message));
+}
+
+/**
+ * Creates the worker agent CLI service that dials the cloud control plane,
+ * keeps a heartbeat loop, and executes routed chat runs on this machine.
+ */
+export function createWorkerAgentService(
+  dependencies: WorkerAgentServiceDependencies,
+) {
+  const getHostname = dependencies.getHostname ?? (() => os.hostname());
+  const createWebSocket = dependencies.createWebSocket ?? ((url: string) => new WebSocket(url));
+  const setIntervalFn = dependencies.setIntervalFn ?? setInterval;
+  const clearIntervalFn = dependencies.clearIntervalFn ?? clearInterval;
+  const setTimeoutFn = dependencies.setTimeoutFn ?? setTimeout;
+  const clearTimeoutFn = dependencies.clearTimeoutFn ?? clearTimeout;
+
+  return {
+    async start(options: WorkerStartOptions): Promise<number> {
+      const serverUrl =
+        options.serverUrl ||
+        dependencies.environment.WORKER_SERVER_URL ||
+        dependencies.environment.CLOUDCLI_SERVER_URL;
+      const token =
+        options.token ||
+        dependencies.environment.WORKER_TOKEN ||
+        dependencies.environment.CLOUDCLI_WORKER_TOKEN;
+      const workerName =
+        options.name ||
+        dependencies.environment.WORKER_NAME ||
+        getHostname();
+
+      if (!serverUrl) {
+        dependencies.output.error(
+          `${terminalTextStyles.error('[ERROR]')} Missing server URL. Pass --server or set WORKER_SERVER_URL.`,
+        );
+        return 1;
+      }
+      if (!token) {
+        dependencies.output.error(
+          `${terminalTextStyles.error('[ERROR]')} Missing worker token. Pass --token or set WORKER_TOKEN.`,
+        );
+        return 1;
+      }
+
+      let reconnectAttempt = 0;
+      let stopped = false;
+      let heartbeatTimer: ReturnType<typeof setInterval> | null = null;
+      let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+      let activeSocket: WebSocket | null = null;
+
+      const { createWorkerChatRunner } = await import('./worker-chat-runner.service.js');
+      let chatRunner: ReturnType<typeof createWorkerChatRunner> | null = null;
+
+      const clearHeartbeat = () => {
+        if (heartbeatTimer) {
+          clearIntervalFn(heartbeatTimer);
+          heartbeatTimer = null;
+        }
+      };
+
+      const connect = (): Promise<void> => new Promise((resolve) => {
+        let settled = false;
+        const settle = () => {
+          if (!settled) {
+            settled = true;
+            resolve();
+          }
+        };
+
+        const url = buildWorkerUrl(serverUrl, token);
+        dependencies.output.log(
+          `${terminalTextStyles.info('[INFO]')} Connecting worker to ${normalizeServerUrl(serverUrl)}/worker`,
+        );
+
+        const ws = createWebSocket(url);
+        activeSocket = ws;
+        chatRunner = createWorkerChatRunner({
+          send: (message) => sendJson(ws, message),
+        });
+
+        ws.on('open', () => {
+          reconnectAttempt = 0;
+          sendJson(ws, {
+            type: 'worker.hello',
+            hostname: getHostname(),
+            name: workerName,
+          });
+          clearHeartbeat();
+          heartbeatTimer = setIntervalFn(() => {
+            sendJson(ws, { type: 'worker.heartbeat' });
+          }, 15_000);
+        });
+
+        ws.on('message', (raw) => {
+          const message = parseWorkerMessage(raw);
+          if (!message) {
+            return;
+          }
+
+          switch (message.type) {
+            case 'worker.welcome': {
+              dependencies.output.log(
+                `${terminalTextStyles.ok('[OK]')} Worker online as machine ${message.machineId || '(unknown)'}`,
+              );
+              settle();
+              break;
+            }
+            case 'worker.ping': {
+              sendJson(ws, {
+                type: 'worker.pong',
+                requestId: message.requestId,
+                payload: message.payload,
+              });
+              dependencies.output.log(
+                `${terminalTextStyles.dim('[PING]')} echo ${message.requestId || ''}`.trim(),
+              );
+              break;
+            }
+            case 'chat.run': {
+              dependencies.output.log(
+                `${terminalTextStyles.info('[INFO]')} chat.run session=${message.sessionId || ''} provider=${message.provider || ''}`,
+              );
+              void chatRunner?.handleChatRun(message);
+              break;
+            }
+            case 'chat.abort': {
+              dependencies.output.log(
+                `${terminalTextStyles.warn('[WARN]')} chat.abort session=${message.sessionId || ''}`,
+              );
+              void chatRunner?.handleChatAbort(message);
+              break;
+            }
+            case 'chat.permission_response': {
+              chatRunner?.handlePermissionResponse(message);
+              break;
+            }
+            case 'session.ensure_native': {
+              dependencies.output.log(
+                `${terminalTextStyles.info('[INFO]')} session.ensure_native session=${message.sessionId || ''} provider=${message.provider || ''}`,
+              );
+              void chatRunner?.handleEnsureNative(message);
+              break;
+            }
+            case 'worker.error': {
+              dependencies.output.error(
+                `${terminalTextStyles.error('[ERROR]')} ${message.error || 'Worker protocol error'}`,
+              );
+              break;
+            }
+            default:
+              break;
+          }
+        });
+
+        ws.on('close', () => {
+          clearHeartbeat();
+          activeSocket = null;
+          if (stopped) {
+            settle();
+            return;
+          }
+
+          reconnectAttempt += 1;
+          const delayMs = Math.min(30_000, 1_000 * (2 ** Math.min(reconnectAttempt, 5)));
+          dependencies.output.log(
+            `${terminalTextStyles.warn('[WARN]')} Worker disconnected. Reconnecting in ${Math.round(delayMs / 1000)}s...`,
+          );
+          reconnectTimer = setTimeoutFn(() => {
+            void connect();
+          }, delayMs);
+          settle();
+        });
+
+        ws.on('error', (error) => {
+          const message = error instanceof Error ? error.message : String(error);
+          dependencies.output.error(
+            `${terminalTextStyles.error('[ERROR]')} Worker socket error: ${message}`,
+          );
+        });
+      });
+
+      const shutdown = () => {
+        if (stopped) {
+          return;
+        }
+        stopped = true;
+        clearHeartbeat();
+        if (reconnectTimer) {
+          clearTimeoutFn(reconnectTimer);
+          reconnectTimer = null;
+        }
+        if (activeSocket && activeSocket.readyState === WebSocket.OPEN) {
+          activeSocket.close(1000, 'Worker shutting down');
+        }
+      };
+
+      process.once('SIGINT', shutdown);
+      process.once('SIGTERM', shutdown);
+
+      await connect();
+
+      await new Promise<void>((resolve) => {
+        const onStop = () => {
+          process.off('SIGINT', onStop);
+          process.off('SIGTERM', onStop);
+          shutdown();
+          resolve();
+        };
+        process.once('SIGINT', onStop);
+        process.once('SIGTERM', onStop);
+      });
+
+      return 0;
+    },
+  };
+}
+
+export type WorkerAgentService = ReturnType<typeof createWorkerAgentService>;

--- a/server/modules/worker-agent/worker-chat-runner.service.ts
+++ b/server/modules/worker-agent/worker-chat-runner.service.ts
@@ -1,0 +1,242 @@
+import { providerRegistry } from '@/modules/providers/index.js';
+import type {
+  AnyRecord,
+  LLMProvider,
+  NormalizedMessage,
+  ProviderPermissionDecision,
+  ProviderRuntimeContext,
+  ProviderRuntimeWriter,
+  WorkerProtocolMessage,
+} from '@/shared/types.js';
+
+import { createWorkerNativeArtifactsService } from './worker-native-artifacts.service.js';
+
+type WorkerChatRunnerDependencies = {
+  send(message: WorkerProtocolMessage): void;
+};
+
+type ActiveLocalRun = {
+  sessionId: string;
+  provider: LLMProvider;
+  abort: () => Promise<boolean>;
+};
+
+/**
+ * Creates the Worker-side chat executor used by `cloudcli worker`.
+ *
+ * Runs provider CLIs/SDKs on this machine so native transcript files land in
+ * the local provider directories (required for native resume), while streaming
+ * normalized events back to the Server over the worker websocket.
+ */
+export function createWorkerChatRunner(dependencies: WorkerChatRunnerDependencies) {
+  const activeRuns = new Map<string, ActiveLocalRun>();
+  const nativeArtifacts = createWorkerNativeArtifactsService();
+
+  return {
+    async handleChatRun(message: WorkerProtocolMessage): Promise<void> {
+      const sessionId = typeof message.sessionId === 'string' ? message.sessionId : '';
+      const provider = message.provider as LLMProvider | undefined;
+      const command = typeof message.command === 'string' ? message.command : '';
+      const options = (message.options ?? {}) as AnyRecord;
+      const providerSessionId =
+        typeof message.providerSessionId === 'string' ? message.providerSessionId : null;
+      const projectPath =
+        (typeof options.cwd === 'string' && options.cwd) ||
+        (typeof options.projectPath === 'string' && options.projectPath) ||
+        null;
+
+      if (!sessionId || !provider) {
+        dependencies.send({
+          type: 'worker.error',
+          sessionId,
+          error: 'chat.run requires sessionId and provider',
+        });
+        return;
+      }
+
+      if (activeRuns.has(sessionId)) {
+        dependencies.send({
+          type: 'worker.error',
+          sessionId,
+          error: `Session "${sessionId}" already has a local run`,
+        });
+        return;
+      }
+
+      let capturedProviderSessionId = providerSessionId;
+      let aborted = false;
+      const providerAdapter = providerRegistry.resolveProvider(provider);
+
+      const writer: ProviderRuntimeWriter = {
+        send(data: unknown) {
+          if (!data || typeof data !== 'object' || typeof (data as AnyRecord).kind !== 'string') {
+            return;
+          }
+          const record = data as AnyRecord;
+          if (record.kind === 'session_created') {
+            const announced =
+              (typeof record.newSessionId === 'string' && record.newSessionId) ||
+              (typeof record.sessionId === 'string' && record.sessionId) ||
+              null;
+            if (announced) {
+              capturedProviderSessionId = announced;
+            }
+          }
+          dependencies.send({
+            type: 'worker.event',
+            sessionId,
+            event: data as NormalizedMessage,
+          });
+        },
+        setSessionId(nextId: string) {
+          if (nextId) {
+            capturedProviderSessionId = nextId;
+          }
+        },
+      };
+
+      const context: ProviderRuntimeContext = {
+        resolveProviderSessionId: () => capturedProviderSessionId,
+        resolveResumeModel: async () =>
+          typeof options.model === 'string' ? options.model : undefined,
+        getProviderModels: async () => ({ OPTIONS: [], DEFAULT: '' }),
+        normalizeMessage: (raw, sid) => providerAdapter.sessions.normalizeMessage(raw, sid),
+        isProviderInstalled: async () => true,
+      };
+
+      activeRuns.set(sessionId, {
+        sessionId,
+        provider,
+        abort: async () => {
+          aborted = true;
+          return Boolean(await providerAdapter.runtime.abort(sessionId));
+        },
+      });
+
+      let exitCode = 0;
+      let jsonlPath: string | null = null;
+      try {
+        await providerAdapter.runtime.run(
+          command,
+          {
+            ...options,
+            sessionId,
+          },
+          writer,
+          context,
+        );
+      } catch (error) {
+        exitCode = 1;
+        const content = error instanceof Error ? error.message : String(error);
+        dependencies.send({
+          type: 'worker.event',
+          sessionId,
+          event: {
+            kind: 'error',
+            id: `worker-error-${Date.now()}`,
+            sessionId,
+            timestamp: new Date().toISOString(),
+            content,
+            provider,
+          },
+        });
+      } finally {
+        if (capturedProviderSessionId) {
+          try {
+            jsonlPath = await nativeArtifacts.resolveNativePath(
+              provider,
+              capturedProviderSessionId,
+              projectPath,
+            );
+          } catch {
+            // Path reporting is best-effort; the run already finished.
+          }
+        }
+
+        activeRuns.delete(sessionId);
+        dependencies.send({
+          type: 'worker.run_complete',
+          sessionId,
+          providerSessionId: capturedProviderSessionId,
+          jsonlPath,
+          success: exitCode === 0 && !aborted,
+          exitCode: aborted ? 0 : exitCode,
+          aborted,
+        });
+      }
+    },
+
+    async handleChatAbort(message: WorkerProtocolMessage): Promise<void> {
+      const sessionId = typeof message.sessionId === 'string' ? message.sessionId : '';
+      const active = sessionId ? activeRuns.get(sessionId) : undefined;
+      if (!active) {
+        return;
+      }
+      await active.abort();
+    },
+
+    handlePermissionResponse(message: WorkerProtocolMessage): void {
+      const requestId = typeof message.requestId === 'string' ? message.requestId : '';
+      if (!requestId) {
+        return;
+      }
+      const decision: ProviderPermissionDecision = {
+        allow: Boolean(message.allow),
+        updatedInput: message.updatedInput,
+        message: typeof message.message === 'string' ? message.message : undefined,
+        rememberEntry: message.rememberEntry,
+      };
+      for (const provider of providerRegistry.listProviders()) {
+        provider.runtime.permissions?.resolve(requestId, decision);
+      }
+    },
+
+    async handleEnsureNative(message: WorkerProtocolMessage): Promise<void> {
+      const requestId = typeof message.requestId === 'string' ? message.requestId : '';
+      const provider = message.provider as LLMProvider | undefined;
+      const providerSessionId =
+        typeof message.providerSessionId === 'string' ? message.providerSessionId : null;
+      const projectPath =
+        typeof message.projectPath === 'string' ? message.projectPath : null;
+
+      if (!requestId || !provider) {
+        dependencies.send({
+          type: 'session.native_ready',
+          requestId,
+          success: false,
+          error: 'session.ensure_native requires requestId and provider',
+        });
+        return;
+      }
+
+      try {
+        const result = await nativeArtifacts.ensureNative({
+          provider,
+          providerSessionId,
+          projectPath,
+          messages: Array.isArray(message.messages) ? message.messages : [],
+        });
+        dependencies.send({
+          type: 'session.native_ready',
+          requestId,
+          sessionId: message.sessionId,
+          success: result.success,
+          jsonlPath: result.jsonlPath,
+          restored: result.restored,
+          dropProviderSessionId: result.dropProviderSessionId,
+          error: result.error,
+        });
+      } catch (error) {
+        dependencies.send({
+          type: 'session.native_ready',
+          requestId,
+          sessionId: message.sessionId,
+          success: false,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    },
+  };
+}
+
+export type WorkerChatRunner = ReturnType<typeof createWorkerChatRunner>;

--- a/server/modules/worker-agent/worker-native-artifacts.service.ts
+++ b/server/modules/worker-agent/worker-native-artifacts.service.ts
@@ -1,0 +1,322 @@
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import fsp from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+import type { LLMProvider, NormalizedMessage } from '@/shared/types.js';
+
+type NativeArtifactsDependencies = {
+  getHomeDirectory: () => string;
+  fileExists: (filePath: string) => boolean;
+  readDirectory: (directoryPath: string) => Promise<string[]>;
+  mkdir: (directoryPath: string) => Promise<void>;
+  writeTextFile: (filePath: string, contents: string) => Promise<void>;
+  now: () => Date;
+};
+
+const defaultDependencies: NativeArtifactsDependencies = {
+  getHomeDirectory: () => os.homedir(),
+  fileExists: (filePath) => fs.existsSync(filePath),
+  readDirectory: async (directoryPath) => {
+    const entries = await fsp.readdir(directoryPath, { withFileTypes: true });
+    return entries.map((entry) => path.join(directoryPath, entry.name));
+  },
+  mkdir: async (directoryPath) => {
+    await fsp.mkdir(directoryPath, { recursive: true });
+  },
+  writeTextFile: (filePath, contents) => fsp.writeFile(filePath, contents, 'utf8'),
+  now: () => new Date(),
+};
+
+export type EnsureNativeResult = {
+  success: boolean;
+  jsonlPath: string | null;
+  restored: boolean;
+  dropProviderSessionId?: boolean;
+  error?: string;
+};
+
+function encodeClaudeProjectPath(projectPath: string): string {
+  return projectPath.replace(/[^a-zA-Z0-9-]/g, '-');
+}
+
+function extractTextTurns(messages: NormalizedMessage[]): Array<{
+  role: 'user' | 'assistant';
+  content: string;
+  timestamp: string;
+  id: string;
+}> {
+  const turns: Array<{
+    role: 'user' | 'assistant';
+    content: string;
+    timestamp: string;
+    id: string;
+  }> = [];
+
+  for (const message of messages) {
+    const content = typeof message.content === 'string' ? message.content.trim() : '';
+    if (!content) {
+      continue;
+    }
+    if (message.role !== 'user' && message.role !== 'assistant') {
+      continue;
+    }
+    turns.push({
+      role: message.role,
+      content,
+      timestamp: message.timestamp || new Date().toISOString(),
+      id: message.id || crypto.randomUUID(),
+    });
+  }
+
+  return turns;
+}
+
+async function findCodexSessionFile(
+  directoryPath: string,
+  providerSessionId: string,
+  dependencies: NativeArtifactsDependencies,
+): Promise<string | null> {
+  let entries: string[];
+  try {
+    entries = await dependencies.readDirectory(directoryPath);
+  } catch {
+    return null;
+  }
+
+  for (const entryPath of entries) {
+    let isDirectory = false;
+    try {
+      isDirectory = (await fsp.stat(entryPath)).isDirectory();
+    } catch {
+      continue;
+    }
+
+    if (isDirectory) {
+      const nested = await findCodexSessionFile(entryPath, providerSessionId, dependencies);
+      if (nested) {
+        return nested;
+      }
+      continue;
+    }
+
+    const baseName = path.basename(entryPath);
+    if (baseName.includes(providerSessionId) && baseName.endsWith('.jsonl')) {
+      return entryPath;
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Creates Worker-local helpers that locate and (best-effort) restore provider
+ * native session artifacts so the same-machine CLI can resume web chats.
+ *
+ * Used by the worker chat runner and `session.ensure_native` handling.
+ */
+export function createWorkerNativeArtifactsService(
+  dependencyOverrides: Partial<NativeArtifactsDependencies> = {},
+) {
+  const dependencies = { ...defaultDependencies, ...dependencyOverrides };
+
+  const resolveClaudePath = (providerSessionId: string, projectPath: string | null): string | null => {
+    if (!projectPath) {
+      return null;
+    }
+    const encoded = encodeClaudeProjectPath(projectPath);
+    return path.join(
+      dependencies.getHomeDirectory(),
+      '.claude',
+      'projects',
+      encoded,
+      `${providerSessionId}.jsonl`,
+    );
+  };
+
+  const resolveCursorStorePath = (providerSessionId: string, projectPath: string | null): string | null => {
+    const cwd = projectPath || process.cwd();
+    const cwdId = crypto.createHash('md5').update(cwd).digest('hex');
+    return path.join(
+      dependencies.getHomeDirectory(),
+      '.cursor',
+      'chats',
+      cwdId,
+      providerSessionId,
+      'store.db',
+    );
+  };
+
+  return {
+    /**
+     * Resolves an existing on-disk path for a provider-native session, or null
+     * when the artifact is missing / layout cannot be discovered yet.
+     */
+    async resolveNativePath(
+      provider: LLMProvider,
+      providerSessionId: string,
+      projectPath: string | null,
+    ): Promise<string | null> {
+      if (provider === 'claude') {
+        const candidate = resolveClaudePath(providerSessionId, projectPath);
+        if (candidate && dependencies.fileExists(candidate)) {
+          return candidate;
+        }
+        return null;
+      }
+
+      if (provider === 'codex') {
+        return findCodexSessionFile(
+          path.join(dependencies.getHomeDirectory(), '.codex', 'sessions'),
+          providerSessionId,
+          dependencies,
+        );
+      }
+
+      if (provider === 'cursor') {
+        const storePath = resolveCursorStorePath(providerSessionId, projectPath);
+        if (storePath && dependencies.fileExists(storePath)) {
+          return storePath;
+        }
+        return null;
+      }
+
+      return null;
+    },
+
+    /**
+     * Ensures local native artifacts exist for resume. When missing, writes a
+     * best-effort Claude/Codex transcript from cloud-normalized turns. Cursor
+     * store.db cannot be reconstructed; missing Cursor artifacts ask the Server
+     * to drop the native id so the next run starts fresh.
+     */
+    async ensureNative(input: {
+      provider: LLMProvider;
+      providerSessionId: string | null;
+      projectPath: string | null;
+      messages?: NormalizedMessage[];
+    }): Promise<EnsureNativeResult> {
+      const { provider, providerSessionId, projectPath } = input;
+      if (!providerSessionId) {
+        return { success: true, jsonlPath: null, restored: false };
+      }
+
+      if (provider === 'claude') {
+        const targetPath = resolveClaudePath(providerSessionId, projectPath);
+        if (!targetPath) {
+          return {
+            success: false,
+            jsonlPath: null,
+            restored: false,
+            error: 'Claude ensure_native requires projectPath',
+          };
+        }
+        if (dependencies.fileExists(targetPath)) {
+          return { success: true, jsonlPath: targetPath, restored: false };
+        }
+
+        const cwd = projectPath || process.cwd();
+        const turns = extractTextTurns(input.messages ?? []);
+        const lines = turns.map((turn) => JSON.stringify({
+          type: turn.role,
+          uuid: turn.id,
+          sessionId: providerSessionId,
+          cwd,
+          timestamp: turn.timestamp,
+          message: {
+            role: turn.role,
+            content: [{ type: 'text', text: turn.content }],
+          },
+        }));
+
+        if (lines.length === 0) {
+          lines.push(JSON.stringify({
+            type: 'user',
+            uuid: crypto.randomUUID(),
+            sessionId: providerSessionId,
+            cwd,
+            timestamp: dependencies.now().toISOString(),
+            message: {
+              role: 'user',
+              content: [{ type: 'text', text: '[cloudcli] Restored empty session shell for native resume' }],
+            },
+          }));
+        }
+
+        await dependencies.mkdir(path.dirname(targetPath));
+        await dependencies.writeTextFile(targetPath, `${lines.join('\n')}\n`);
+        return { success: true, jsonlPath: targetPath, restored: true };
+      }
+
+      if (provider === 'codex') {
+        const existing = await findCodexSessionFile(
+          path.join(dependencies.getHomeDirectory(), '.codex', 'sessions'),
+          providerSessionId,
+          dependencies,
+        );
+        if (existing) {
+          return { success: true, jsonlPath: existing, restored: false };
+        }
+
+        const now = dependencies.now();
+        const year = String(now.getUTCFullYear());
+        const month = String(now.getUTCMonth() + 1).padStart(2, '0');
+        const day = String(now.getUTCDate()).padStart(2, '0');
+        const sessionsDir = path.join(
+          dependencies.getHomeDirectory(),
+          '.codex',
+          'sessions',
+          year,
+          month,
+          day,
+        );
+        const targetPath = path.join(sessionsDir, `rollout-${providerSessionId}.jsonl`);
+        const cwd = projectPath || process.cwd();
+        const turns = extractTextTurns(input.messages ?? []);
+        const lines = [
+          JSON.stringify({
+            type: 'session_meta',
+            payload: { id: providerSessionId, cwd },
+          }),
+        ];
+        for (const turn of turns) {
+          if (turn.role === 'user') {
+            lines.push(JSON.stringify({
+              type: 'event_msg',
+              payload: { type: 'user_message', message: turn.content },
+            }));
+          } else {
+            lines.push(JSON.stringify({
+              type: 'event_msg',
+              payload: { type: 'agent_message', message: turn.content },
+            }));
+          }
+        }
+
+        await dependencies.mkdir(sessionsDir);
+        await dependencies.writeTextFile(targetPath, `${lines.join('\n')}\n`);
+        return { success: true, jsonlPath: targetPath, restored: true };
+      }
+
+      if (provider === 'cursor') {
+        const storePath = resolveCursorStorePath(providerSessionId, projectPath);
+        if (storePath && dependencies.fileExists(storePath)) {
+          return { success: true, jsonlPath: storePath, restored: false };
+        }
+        return {
+          success: true,
+          jsonlPath: null,
+          restored: false,
+          dropProviderSessionId: true,
+          error: 'Cursor store.db rewrite is not supported; next run starts a fresh native session',
+        };
+      }
+
+      // OpenCode and unknown providers: nothing filesystem-shaped to restore.
+      return { success: true, jsonlPath: null, restored: false };
+    },
+  };
+}
+
+export type WorkerNativeArtifactsService = ReturnType<typeof createWorkerNativeArtifactsService>;

--- a/server/modules/worker-gateway/index.ts
+++ b/server/modules/worker-gateway/index.ts
@@ -1,0 +1,5 @@
+// createWorkerConnectionRegistry: used by the machines module composition root.
+export {
+  createWorkerConnectionRegistry,
+} from './services/worker-connection.service.js';
+export type { WorkerConnectionRegistry } from './services/worker-connection.service.js';

--- a/server/modules/worker-gateway/services/worker-connection.service.ts
+++ b/server/modules/worker-gateway/services/worker-connection.service.ts
@@ -1,0 +1,469 @@
+import crypto from 'node:crypto';
+
+import { WebSocket } from 'ws';
+
+import type { MachinesService } from '@/modules/machines/index.js';
+import type {
+  AnyRecord,
+  AuthenticatedWebSocketRequest,
+  LLMProvider,
+  NormalizedMessage,
+  WorkerProtocolMessage,
+} from '@/shared/types.js';
+import { AppError } from '@/shared/utils.js';
+
+type PendingPing = {
+  resolve: (result: { ok: boolean; latencyMs: number; payload: string }) => void;
+  reject: (error: Error) => void;
+  startedAt: number;
+  timer: ReturnType<typeof setTimeout>;
+};
+
+type PendingEnsureNative = {
+  resolve: (result: {
+    success: boolean;
+    jsonlPath: string | null;
+    restored: boolean;
+    dropProviderSessionId?: boolean;
+    error?: string;
+  }) => void;
+  reject: (error: Error) => void;
+  timer: ReturnType<typeof setTimeout>;
+};
+
+type ActiveWorkerChatRun = {
+  machineId: string;
+  sessionId: string;
+  onEvent: (event: NormalizedMessage) => void;
+  onComplete: (result: {
+    providerSessionId?: string | null;
+    jsonlPath?: string | null;
+    success?: boolean;
+    exitCode?: number;
+    aborted?: boolean;
+  }) => void;
+  onError: (error: string) => void;
+};
+
+type WorkerConnectionRegistryDependencies = {
+  machinesService: MachinesService;
+  createRequestId?: () => string;
+  pingTimeoutMs?: number;
+  ensureNativeTimeoutMs?: number;
+};
+
+function parseWorkerMessage(raw: WebSocket.RawData): WorkerProtocolMessage | null {
+  try {
+    const text = typeof raw === 'string' ? raw : raw.toString('utf8');
+    const parsed = JSON.parse(text) as Partial<WorkerProtocolMessage>;
+    if (!parsed || typeof parsed.type !== 'string') {
+      return null;
+    }
+    return parsed as WorkerProtocolMessage;
+  } catch {
+    return null;
+  }
+}
+
+function sendJson(ws: WebSocket, message: WorkerProtocolMessage): void {
+  if (ws.readyState !== WebSocket.OPEN) {
+    return;
+  }
+  ws.send(JSON.stringify(message));
+}
+
+/**
+ * Creates the in-memory worker connection registry used for presence, ping, and
+ * routed chat execution between the Server control plane and Workers.
+ */
+export function createWorkerConnectionRegistry(
+  dependencies: WorkerConnectionRegistryDependencies,
+) {
+  const socketsByMachineId = new Map<string, WebSocket>();
+  const machineIdBySocket = new Map<WebSocket, string>();
+  const pendingPings = new Map<string, PendingPing>();
+  const pendingEnsureNatives = new Map<string, PendingEnsureNative>();
+  const activeChatRuns = new Map<string, ActiveWorkerChatRun>();
+  const pingTimeoutMs = dependencies.pingTimeoutMs ?? 5_000;
+  const ensureNativeTimeoutMs = dependencies.ensureNativeTimeoutMs ?? 30_000;
+  const createRequestId =
+    dependencies.createRequestId ?? (() => crypto.randomUUID());
+
+  const clearPendingPing = (requestId: string) => {
+    const pending = pendingPings.get(requestId);
+    if (!pending) {
+      return;
+    }
+    clearTimeout(pending.timer);
+    pendingPings.delete(requestId);
+  };
+
+  const clearPendingEnsureNative = (requestId: string) => {
+    const pending = pendingEnsureNatives.get(requestId);
+    if (!pending) {
+      return;
+    }
+    clearTimeout(pending.timer);
+    pendingEnsureNatives.delete(requestId);
+  };
+
+  const failActiveRunsForMachine = (machineId: string, error: string) => {
+    for (const [sessionId, run] of activeChatRuns.entries()) {
+      if (run.machineId !== machineId) {
+        continue;
+      }
+      activeChatRuns.delete(sessionId);
+      run.onError(error);
+    }
+  };
+
+  const detachSocket = (machineId: string, ws: WebSocket) => {
+    const current = socketsByMachineId.get(machineId);
+    if (current === ws) {
+      socketsByMachineId.delete(machineId);
+      machineIdBySocket.delete(ws);
+      dependencies.machinesService.markOffline(machineId);
+      failActiveRunsForMachine(machineId, 'Worker disconnected');
+    }
+  };
+
+  const getOpenSocket = (machineId: string): WebSocket => {
+    const socket = socketsByMachineId.get(machineId);
+    if (!socket || socket.readyState !== WebSocket.OPEN) {
+      throw new AppError('Machine is offline', {
+        code: 'MACHINE_OFFLINE',
+        statusCode: 409,
+      });
+    }
+    return socket;
+  };
+
+  return {
+    isOnline(machineId: string): boolean {
+      const socket = socketsByMachineId.get(machineId);
+      return Boolean(socket && socket.readyState === WebSocket.OPEN);
+    },
+
+    /**
+     * Sends a ping to an online worker and resolves when the matching pong
+     * arrives or the timeout elapses.
+     */
+    pingMachine(machineId: string): Promise<{
+      ok: boolean;
+      latencyMs: number;
+      payload: string;
+    }> {
+      const socket = getOpenSocket(machineId);
+      const requestId = createRequestId();
+      const payload = `echo:${requestId}`;
+      const startedAt = Date.now();
+
+      return new Promise((resolve, reject) => {
+        const timer = setTimeout(() => {
+          clearPendingPing(requestId);
+          reject(new AppError('Machine ping timed out', {
+            code: 'MACHINE_PING_TIMEOUT',
+            statusCode: 504,
+          }));
+        }, pingTimeoutMs);
+
+        pendingPings.set(requestId, {
+          resolve,
+          reject,
+          startedAt,
+          timer,
+        });
+
+        sendJson(socket, {
+          type: 'worker.ping',
+          requestId,
+          payload,
+        });
+      });
+    },
+
+    /**
+     * Dispatches a chat run to a Worker. Live normalized events are forwarded
+     * through `onEvent`; completion updates provider-native mapping via
+     * `onComplete`.
+     */
+    dispatchChatRun(input: {
+      machineId: string;
+      sessionId: string;
+      provider: LLMProvider;
+      providerSessionId: string | null;
+      command: string;
+      options: AnyRecord;
+      onEvent: ActiveWorkerChatRun['onEvent'];
+      onComplete: ActiveWorkerChatRun['onComplete'];
+      onError: ActiveWorkerChatRun['onError'];
+    }): void {
+      const socket = getOpenSocket(input.machineId);
+      if (activeChatRuns.has(input.sessionId)) {
+        throw new AppError(`Session "${input.sessionId}" already has a worker run.`, {
+          code: 'RUN_IN_PROGRESS',
+          statusCode: 409,
+        });
+      }
+
+      activeChatRuns.set(input.sessionId, {
+        machineId: input.machineId,
+        sessionId: input.sessionId,
+        onEvent: input.onEvent,
+        onComplete: input.onComplete,
+        onError: input.onError,
+      });
+
+      sendJson(socket, {
+        type: 'chat.run',
+        requestId: createRequestId(),
+        sessionId: input.sessionId,
+        provider: input.provider,
+        providerSessionId: input.providerSessionId,
+        command: input.command,
+        options: input.options,
+      });
+    },
+
+    /** Asks a Worker to abort the active run for one app session. */
+    abortChatRun(machineId: string, sessionId: string): void {
+      const socket = getOpenSocket(machineId);
+      sendJson(socket, {
+        type: 'chat.abort',
+        sessionId,
+      });
+    },
+
+    /**
+     * Forwards a browser tool-approval decision to the Worker that owns the
+     * session's Claude (or other) runtime pending map.
+     */
+    dispatchPermissionResponse(input: {
+      machineId: string;
+      requestId: string;
+      allow: boolean;
+      updatedInput?: unknown;
+      message?: string;
+      rememberEntry?: unknown;
+    }): void {
+      const socket = getOpenSocket(input.machineId);
+      sendJson(socket, {
+        type: 'chat.permission_response',
+        requestId: input.requestId,
+        allow: input.allow,
+        updatedInput: input.updatedInput,
+        message: input.message,
+        rememberEntry: input.rememberEntry,
+      });
+    },
+
+    /**
+     * Asks a Worker to verify (and best-effort restore) provider-native files
+     * so a subsequent `chat.run` can resume on that machine.
+     */
+    ensureNativeSession(input: {
+      machineId: string;
+      sessionId: string;
+      provider: LLMProvider;
+      providerSessionId: string | null;
+      projectPath: string | null;
+      messages: NormalizedMessage[];
+    }): Promise<{
+      success: boolean;
+      jsonlPath: string | null;
+      restored: boolean;
+      dropProviderSessionId?: boolean;
+      error?: string;
+    }> {
+      const socket = getOpenSocket(input.machineId);
+      const requestId = createRequestId();
+
+      return new Promise((resolve, reject) => {
+        const timer = setTimeout(() => {
+          clearPendingEnsureNative(requestId);
+          reject(new AppError('Native session ensure timed out', {
+            code: 'ENSURE_NATIVE_TIMEOUT',
+            statusCode: 504,
+          }));
+        }, ensureNativeTimeoutMs);
+
+        pendingEnsureNatives.set(requestId, {
+          resolve,
+          reject,
+          timer,
+        });
+
+        sendJson(socket, {
+          type: 'session.ensure_native',
+          requestId,
+          sessionId: input.sessionId,
+          provider: input.provider,
+          providerSessionId: input.providerSessionId,
+          projectPath: input.projectPath,
+          messages: input.messages,
+        });
+      });
+    },
+
+    /**
+     * Handles an authenticated `/worker` websocket connection.
+     *
+     * Used by the shared websocket gateway after machine-token verification.
+     */
+    handleConnection(ws: WebSocket, request: AuthenticatedWebSocketRequest): void {
+      const machine = request.machine;
+      if (!machine?.id) {
+        sendJson(ws, { type: 'worker.error', error: 'Unauthenticated worker' });
+        ws.close(4401, 'Unauthenticated worker');
+        return;
+      }
+
+      const existing = socketsByMachineId.get(machine.id);
+      if (existing && existing !== ws) {
+        try {
+          existing.close(4000, 'Replaced by newer worker connection');
+        } catch {
+          // Ignore close failures on the stale socket.
+        }
+      }
+
+      socketsByMachineId.set(machine.id, ws);
+      machineIdBySocket.set(ws, machine.id);
+      dependencies.machinesService.markOnline(machine.id);
+
+      sendJson(ws, {
+        type: 'worker.welcome',
+        machineId: machine.id,
+        name: machine.name,
+      });
+
+      ws.on('message', (raw) => {
+        const message = parseWorkerMessage(raw);
+        if (!message) {
+          sendJson(ws, { type: 'worker.error', error: 'Invalid JSON message' });
+          return;
+        }
+
+        switch (message.type) {
+          case 'worker.hello': {
+            dependencies.machinesService.markOnline(
+              machine.id,
+              typeof message.hostname === 'string' ? message.hostname : null,
+            );
+            if (typeof message.name === 'string' && message.name.trim()) {
+              try {
+                dependencies.machinesService.renameMachine(machine.id, message.name);
+              } catch {
+                // Rename is best-effort during hello; presence already succeeded.
+              }
+            }
+            sendJson(ws, {
+              type: 'worker.welcome',
+              machineId: machine.id,
+              name: machine.name,
+            });
+            break;
+          }
+          case 'worker.heartbeat': {
+            dependencies.machinesService.touchHeartbeat(machine.id);
+            break;
+          }
+          case 'worker.pong': {
+            const requestId = message.requestId;
+            if (!requestId) {
+              break;
+            }
+            const pending = pendingPings.get(requestId);
+            if (!pending) {
+              break;
+            }
+            clearPendingPing(requestId);
+            pending.resolve({
+              ok: true,
+              latencyMs: Date.now() - pending.startedAt,
+              payload: typeof message.payload === 'string' ? message.payload : '',
+            });
+            break;
+          }
+          case 'worker.ping': {
+            sendJson(ws, {
+              type: 'worker.pong',
+              requestId: message.requestId,
+              payload: message.payload,
+            });
+            break;
+          }
+          case 'worker.event': {
+            const sessionId = typeof message.sessionId === 'string' ? message.sessionId : '';
+            const run = sessionId ? activeChatRuns.get(sessionId) : undefined;
+            if (!run || !message.event || typeof message.event.kind !== 'string') {
+              break;
+            }
+            run.onEvent(message.event);
+            break;
+          }
+          case 'worker.run_complete': {
+            const sessionId = typeof message.sessionId === 'string' ? message.sessionId : '';
+            const run = sessionId ? activeChatRuns.get(sessionId) : undefined;
+            if (!run) {
+              break;
+            }
+            activeChatRuns.delete(sessionId);
+            run.onComplete({
+              providerSessionId: message.providerSessionId,
+              jsonlPath: message.jsonlPath,
+              success: message.success,
+              exitCode: message.exitCode,
+              aborted: message.aborted,
+            });
+            break;
+          }
+          case 'worker.error': {
+            const sessionId = typeof message.sessionId === 'string' ? message.sessionId : '';
+            const run = sessionId ? activeChatRuns.get(sessionId) : undefined;
+            if (run) {
+              activeChatRuns.delete(sessionId);
+              run.onError(message.error || 'Worker error');
+            }
+            break;
+          }
+          case 'session.native_ready': {
+            const requestId = message.requestId;
+            if (!requestId) {
+              break;
+            }
+            const pending = pendingEnsureNatives.get(requestId);
+            if (!pending) {
+              break;
+            }
+            clearPendingEnsureNative(requestId);
+            pending.resolve({
+              success: message.success !== false,
+              jsonlPath: typeof message.jsonlPath === 'string' ? message.jsonlPath : null,
+              restored: Boolean(message.restored),
+              dropProviderSessionId: Boolean(message.dropProviderSessionId),
+              error: typeof message.error === 'string' ? message.error : undefined,
+            });
+            break;
+          }
+          default: {
+            sendJson(ws, {
+              type: 'worker.error',
+              error: `Unsupported message type: ${message.type}`,
+            });
+          }
+        }
+      });
+
+      ws.on('close', () => {
+        detachSocket(machine.id, ws);
+      });
+
+      ws.on('error', () => {
+        detachSocket(machine.id, ws);
+      });
+    },
+  };
+}
+
+export type WorkerConnectionRegistry = ReturnType<typeof createWorkerConnectionRegistry>;

--- a/server/modules/worker-gateway/tests/worker-connection.service.test.ts
+++ b/server/modules/worker-gateway/tests/worker-connection.service.test.ts
@@ -1,0 +1,120 @@
+import assert from 'node:assert/strict';
+import { EventEmitter } from 'node:events';
+import test from 'node:test';
+
+import { WebSocket } from 'ws';
+
+import { createMachinesService } from '@/modules/machines/index.js';
+
+import { createWorkerConnectionRegistry } from '../services/worker-connection.service.js';
+
+class FakeSocket extends EventEmitter {
+  readyState: typeof WebSocket.OPEN = WebSocket.OPEN;
+  sent: string[] = [];
+
+  send(data: string) {
+    this.sent.push(data);
+  }
+
+  close() {
+    this.readyState = WebSocket.CLOSED as typeof WebSocket.OPEN;
+    this.emit('close');
+  }
+}
+
+test('worker ping/pong echo resolves with latency', async () => {
+  const machinesService = createMachinesService({
+    createId: () => 'machine-1',
+    generateToken: () => 'mw_abc',
+    hashToken: (token) => token,
+    createMachine: ({ id, name, tokenPrefix }) => ({
+      id,
+      name,
+      tokenHash: 'mw_abc',
+      tokenPrefix,
+      status: 'offline',
+      lastSeenAt: null,
+      hostname: null,
+      createdAt: 'now',
+      revokedAt: null,
+    }),
+    listMachines: () => [],
+    getMachineById: () => ({
+      id: 'machine-1',
+      name: 'box',
+      tokenHash: 'mw_abc',
+      tokenPrefix: 'mw_abc',
+      status: 'online',
+      lastSeenAt: null,
+      hostname: null,
+      createdAt: 'now',
+      revokedAt: null,
+    }),
+    findActiveMachineByToken: () => ({
+      id: 'machine-1',
+      name: 'box',
+      tokenHash: 'mw_abc',
+      tokenPrefix: 'mw_abc',
+      status: 'offline',
+      lastSeenAt: null,
+      hostname: null,
+      createdAt: 'now',
+      revokedAt: null,
+    }),
+    renameMachine: () => null,
+    revokeMachine: () => true,
+    markOnline: () => ({
+      id: 'machine-1',
+      name: 'box',
+      tokenHash: 'mw_abc',
+      tokenPrefix: 'mw_abc',
+      status: 'online',
+      lastSeenAt: null,
+      hostname: null,
+      createdAt: 'now',
+      revokedAt: null,
+    }),
+    markOffline: () => ({
+      id: 'machine-1',
+      name: 'box',
+      tokenHash: 'mw_abc',
+      tokenPrefix: 'mw_abc',
+      status: 'offline',
+      lastSeenAt: null,
+      hostname: null,
+      createdAt: 'now',
+      revokedAt: null,
+    }),
+    touchHeartbeat: () => undefined,
+  });
+
+  const registry = createWorkerConnectionRegistry({
+    machinesService,
+    createRequestId: () => 'req-1',
+    pingTimeoutMs: 1000,
+  });
+
+  const socket = new FakeSocket();
+  registry.handleConnection(socket as never, {
+    machine: { id: 'machine-1', name: 'box' },
+  } as never);
+
+  const welcome = JSON.parse(socket.sent[0]);
+  assert.equal(welcome.type, 'worker.welcome');
+
+  const pingPromise = registry.pingMachine('machine-1');
+  const pingMessage = JSON.parse(socket.sent[1]);
+  assert.equal(pingMessage.type, 'worker.ping');
+  assert.equal(pingMessage.requestId, 'req-1');
+
+  socket.emit('message', Buffer.from(JSON.stringify({
+    type: 'worker.pong',
+    requestId: 'req-1',
+    payload: pingMessage.payload,
+  })));
+
+  const result = await pingPromise;
+  assert.equal(result.ok, true);
+  assert.equal(result.payload, pingMessage.payload);
+  assert.ok(result.latencyMs >= 0);
+});

--- a/server/shared/types.ts
+++ b/server/shared/types.ts
@@ -49,13 +49,112 @@ export type AuthenticatedWebSocketUser = {
 };
 
 /**
+ * Authenticated worker machine attached to `/worker` websocket upgrades.
+ *
+ * Populated by `verifyClient` after a machine token is validated. Chat and shell
+ * sockets continue to use `user` instead.
+ */
+export type AuthenticatedWorkerMachine = {
+  id: string;
+  name: string;
+};
+
+/**
  * HTTP upgrade request shape after websocket authentication succeeds.
  *
- * `verifyClient` populates `request.user` with the authenticated payload, and
- * downstream websocket handlers rely on this extended request type.
+ * `verifyClient` populates `request.user` for browser sockets or
+ * `request.machine` for worker sockets. Downstream handlers rely on this
+ * extended request type.
  */
 export type AuthenticatedWebSocketRequest = IncomingMessage & {
   user?: AuthenticatedWebSocketUser;
+  machine?: AuthenticatedWorkerMachine;
+};
+
+//----------------- WORKER CONTROL-PLANE PROTOCOL ------------
+/**
+ * Machine presence status stored by the control-plane machines table and shown
+ * in the web UI machine list.
+ */
+export type MachineConnectionStatus = 'online' | 'offline';
+
+/**
+ * Public machine record returned by control-plane machine APIs.
+ *
+ * Never includes the plaintext worker token. `tokenPrefix` is only a display
+ * hint so operators can recognize which token was issued.
+ */
+export type ControlPlaneMachine = {
+  id: string;
+  name: string;
+  tokenPrefix: string;
+  status: MachineConnectionStatus;
+  lastSeenAt: string | null;
+  hostname: string | null;
+  createdAt: string;
+  revokedAt: string | null;
+};
+
+/**
+ * Worker websocket envelope used between the cloud Server and each Worker.
+ *
+ * Phase 1 supports hello/heartbeat/welcome plus ping/pong echo for connectivity
+ * checks. Chat run routing is added in a later phase.
+ */
+export type WorkerProtocolMessageType =
+  | 'worker.hello'
+  | 'worker.welcome'
+  | 'worker.heartbeat'
+  | 'worker.ping'
+  | 'worker.pong'
+  | 'worker.error'
+  | 'chat.run'
+  | 'chat.abort'
+  | 'chat.permission_response'
+  | 'worker.event'
+  | 'worker.run_complete'
+  | 'session.ensure_native'
+  | 'session.native_ready';
+
+/**
+ * JSON envelope exchanged on the `/worker` websocket.
+ *
+ * `type` selects the handler. `requestId` correlates ping/pong, ensure_native,
+ * and chat runs. Chat routing fields (`sessionId`, `provider`, `command`,
+ * `options`, `event`) are used when the control plane dispatches runs to Workers.
+ */
+export type WorkerProtocolMessage = {
+  type: WorkerProtocolMessageType;
+  requestId?: string;
+  hostname?: string;
+  name?: string;
+  machineId?: string;
+  error?: string;
+  payload?: string;
+  sessionId?: string;
+  provider?: LLMProvider;
+  providerSessionId?: string | null;
+  projectPath?: string | null;
+  command?: string;
+  options?: AnyRecord;
+  event?: NormalizedMessage;
+  /** Cloud-normalized history used by `session.ensure_native` write-back. */
+  messages?: NormalizedMessage[];
+  jsonlPath?: string | null;
+  success?: boolean;
+  /** True when ensure_native rewrote missing local provider artifacts. */
+  restored?: boolean;
+  /**
+   * When true, local artifacts could not be restored for this provider and the
+   * Server should drop `provider_session_id` so the next run starts fresh.
+   */
+  dropProviderSessionId?: boolean;
+  exitCode?: number;
+  aborted?: boolean;
+  allow?: boolean;
+  updatedInput?: unknown;
+  message?: string;
+  rememberEntry?: unknown;
 };
 
 // ---------------------------

--- a/server/shared/utils.ts
+++ b/server/shared/utils.ts
@@ -110,6 +110,28 @@ export class AppError extends Error {
  */
 export const WORKSPACES_ROOT = process.env.WORKSPACES_ROOT || os.homedir();
 
+// ---------------------------
+//----------------- DEPLOYMENT MODE ------------
+/**
+ * Returns true when this Node process is running as a cloud control plane.
+ *
+ * Control-plane rules:
+ * - Never execute local Claude/Cursor/Codex/OpenCode runtimes
+ * - Never watch or synchronize local provider transcript directories
+ * - Chat requires a bound Worker (`sessions.machine_id`)
+ * - Web history comes from `session_messages`, not Server-local files
+ *
+ * Set `CONTROL_PLANE=1`. `DISABLE_SESSION_WATCHERS=1` remains accepted as a
+ * temporary alias used during the multi-machine rollout.
+ *
+ * Used by `server/index.ts`, chat websocket routing, sessions service, and
+ * projects list fetching.
+ */
+export function isControlPlaneMode(): boolean {
+  return process.env.CONTROL_PLANE === '1'
+    || process.env.DISABLE_SESSION_WATCHERS === '1';
+}
+
 /**
  * System-critical paths that must never be used as workspace roots.
  *

--- a/src/components/chat/hooks/useChatComposerState.ts
+++ b/src/components/chat/hooks/useChatComposerState.ts
@@ -837,16 +837,38 @@ export function useChatComposerState({
       // handoff later — this id stays valid for the conversation's lifetime.
       let targetSessionId = selectedSession?.id || currentSessionId || null;
       if (!targetSessionId) {
+        const selectedMachineId = localStorage.getItem('selected-machine-id') || '';
+        if (!selectedMachineId) {
+          addMessage({
+            type: 'error',
+            content: 'Select a Worker machine in Settings → Machines (“Use for chat”) before starting a new chat.',
+            timestamp: new Date(),
+          });
+          return;
+        }
+
         try {
           const response = await authenticatedFetch('/api/providers/sessions', {
             method: 'POST',
             body: JSON.stringify({
               provider,
               projectPath: resolvedProjectPath,
+              machineId: selectedMachineId,
             }),
           });
           if (!response.ok) {
-            throw new Error(`Failed to create session (${response.status})`);
+            let detail = `Failed to create session (${response.status})`;
+            try {
+              const errorBody = await response.json();
+              if (errorBody?.error?.message) {
+                detail = errorBody.error.message;
+              } else if (typeof errorBody?.error === 'string') {
+                detail = errorBody.error;
+              }
+            } catch {
+              // Keep the status-based message when the body is not JSON.
+            }
+            throw new Error(detail);
           }
           const body = await response.json();
           targetSessionId = body?.data?.sessionId || null;
@@ -1232,10 +1254,12 @@ export function useChatComposerState({
         return;
       }
 
+      const targetSessionId = selectedSession?.id || currentSessionId || null;
       validIds.forEach((requestId) => {
         sendMessage({
           type: 'chat.permission-response',
           requestId,
+          sessionId: targetSessionId,
           allow: Boolean(decision?.allow),
           updatedInput: decision?.updatedInput,
           message: decision?.message,
@@ -1247,7 +1271,7 @@ export function useChatComposerState({
         previous.filter((request) => !validIds.includes(request.requestId)),
       );
     },
-    [sendMessage, setPendingPermissionRequests],
+    [currentSessionId, selectedSession?.id, sendMessage, setPendingPermissionRequests],
   );
 
   const [isInputFocused, setIsInputFocused] = useState(false);

--- a/src/components/settings/hooks/useSettingsController.ts
+++ b/src/components/settings/hooks/useSettingsController.ts
@@ -53,7 +53,7 @@ type NotificationPreferencesResponse = {
 
 type ActiveLoginProvider = AgentProvider | '';
 
-const KNOWN_MAIN_TABS: SettingsMainTab[] = ['agents', 'appearance', 'git', 'api', 'tasks', 'browser', 'notifications', 'plugins', 'about'];
+const KNOWN_MAIN_TABS: SettingsMainTab[] = ['agents', 'appearance', 'git', 'api', 'machines', 'voice', 'tasks', 'browser', 'notifications', 'plugins', 'about'];
 
 const normalizeMainTab = (tab: string): SettingsMainTab => {
   // Keep backwards compatibility with older callers that still pass "tools".

--- a/src/components/settings/types/types.ts
+++ b/src/components/settings/types/types.ts
@@ -3,7 +3,7 @@ import type { Dispatch, SetStateAction } from 'react';
 import type { LLMProvider } from '../../../types/app';
 import type { ProviderAuthStatus } from '../../provider-auth/types';
 
-export type SettingsMainTab = 'agents' | 'appearance' | 'git' | 'api' | 'voice' | 'tasks' | 'browser' | 'notifications' | 'plugins' | 'about';
+export type SettingsMainTab = 'agents' | 'appearance' | 'git' | 'api' | 'voice' | 'tasks' | 'browser' | 'machines' | 'notifications' | 'plugins' | 'about';
 export type AgentProvider = LLMProvider;
 export type AgentCategory = 'account' | 'permissions' | 'mcp' | 'skills';
 export type ProjectSortOrder = 'name' | 'date';

--- a/src/components/settings/view/Settings.tsx
+++ b/src/components/settings/view/Settings.tsx
@@ -15,6 +15,7 @@ import NotificationsSettingsTab from '../view/tabs/NotificationsSettingsTab';
 import TasksSettingsTab from '../view/tabs/tasks-settings/TasksSettingsTab';
 import PluginSettingsTab from '../../plugins/view/PluginSettingsTab';
 import AboutTab from '../view/tabs/AboutTab';
+import MachinesSettingsTab from '../view/tabs/MachinesSettingsTab';
 import { useSettingsController } from '../hooks/useSettingsController';
 import { useWebPush } from '../../../hooks/useWebPush';
 import type { SettingsProps } from '../types/types';
@@ -210,6 +211,8 @@ function Settings({ isOpen, onClose, projects = [], initialTab = 'agents' }: Set
               )}
 
               {activeTab === 'api' && <CredentialsSettingsTab />}
+
+              {activeTab === 'machines' && <MachinesSettingsTab />}
 
               {activeTab === 'voice' && <VoiceSettingsTab />}
 

--- a/src/components/settings/view/SettingsSidebar.tsx
+++ b/src/components/settings/view/SettingsSidebar.tsx
@@ -1,4 +1,4 @@
-import { Bell, Bot, GitBranch, Info, Key, ListChecks, Mic, MonitorPlay, Palette, Puzzle } from 'lucide-react';
+import { Bell, Bot, GitBranch, Info, Key, ListChecks, Mic, MonitorPlay, Palette, Puzzle, Server } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 
 import { cn } from '../../../lib/utils';
@@ -21,6 +21,7 @@ const NAV_ITEMS: NavItem[] = [
   { id: 'appearance', labelKey: 'mainTabs.appearance', icon: Palette },
   { id: 'git', labelKey: 'mainTabs.git', icon: GitBranch },
   { id: 'api', labelKey: 'mainTabs.apiTokens', icon: Key },
+  { id: 'machines', labelKey: 'mainTabs.machines', icon: Server },
   { id: 'voice', labelKey: 'mainTabs.voice', icon: Mic },
   { id: 'tasks', labelKey: 'mainTabs.tasks', icon: ListChecks },
   { id: 'browser', labelKey: 'mainTabs.browser', icon: MonitorPlay },

--- a/src/components/settings/view/tabs/MachinesSettingsTab.tsx
+++ b/src/components/settings/view/tabs/MachinesSettingsTab.tsx
@@ -1,0 +1,292 @@
+import { Copy, Plus, Server, Trash2, Wifi } from 'lucide-react';
+import { useCallback, useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { Button, Input } from '../../../../shared/view/ui';
+import { authenticatedFetch } from '../../../../utils/api';
+import SettingsCard from '../SettingsCard';
+import SettingsSection from '../SettingsSection';
+
+type MachineRecord = {
+  id: string;
+  name: string;
+  tokenPrefix: string;
+  status: 'online' | 'offline';
+  lastSeenAt: string | null;
+  hostname: string | null;
+  createdAt: string;
+};
+
+type CreateMachineResponse = {
+  success: boolean;
+  data: {
+    machine: MachineRecord;
+    token: string;
+  };
+};
+
+type ListMachinesResponse = {
+  success: boolean;
+  data: {
+    machines: MachineRecord[];
+  };
+};
+
+type PingMachineResponse = {
+  success: boolean;
+  data: {
+    machineId: string;
+    ok: boolean;
+    latencyMs: number;
+    payload: string;
+  };
+};
+
+async function readJson<T>(response: Response): Promise<T> {
+  const payload = await response.json();
+  if (!response.ok || payload?.success === false) {
+    throw new Error(payload?.error?.message || `Request failed (${response.status})`);
+  }
+  return payload as T;
+}
+
+export default function MachinesSettingsTab() {
+  const { t } = useTranslation('settings');
+  const [machines, setMachines] = useState<MachineRecord[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [showCreateForm, setShowCreateForm] = useState(false);
+  const [newMachineName, setNewMachineName] = useState('');
+  const [createdToken, setCreatedToken] = useState<string | null>(null);
+  const [pingResult, setPingResult] = useState<string | null>(null);
+
+  const loadMachines = useCallback(async () => {
+    const response = await authenticatedFetch('/api/machines');
+    const payload = await readJson<ListMachinesResponse>(response);
+    setMachines(payload.data.machines);
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    setIsLoading(true);
+    void loadMachines()
+      .catch((loadError: unknown) => {
+        if (!cancelled) {
+          setError(loadError instanceof Error ? loadError.message : String(loadError));
+        }
+      })
+      .finally(() => {
+        if (!cancelled) {
+          setIsLoading(false);
+        }
+      });
+
+    const timer = window.setInterval(() => {
+      void loadMachines().catch(() => undefined);
+    }, 5_000);
+
+    return () => {
+      cancelled = true;
+      window.clearInterval(timer);
+    };
+  }, [loadMachines]);
+
+  const handleCreate = async () => {
+    setError(null);
+    setPingResult(null);
+    try {
+      const response = await authenticatedFetch('/api/machines', {
+        method: 'POST',
+        body: JSON.stringify({ name: newMachineName }),
+      });
+      const payload = await readJson<CreateMachineResponse>(response);
+      setCreatedToken(payload.data.token);
+      setNewMachineName('');
+      setShowCreateForm(false);
+      await loadMachines();
+    } catch (createError) {
+      setError(createError instanceof Error ? createError.message : String(createError));
+    }
+  };
+
+  const handleRevoke = async (machineId: string) => {
+    setError(null);
+    try {
+      const response = await authenticatedFetch(`/api/machines/${encodeURIComponent(machineId)}`, {
+        method: 'DELETE',
+      });
+      await readJson(response);
+      if (createdToken) {
+        setCreatedToken(null);
+      }
+      await loadMachines();
+    } catch (revokeError) {
+      setError(revokeError instanceof Error ? revokeError.message : String(revokeError));
+    }
+  };
+
+  const handlePing = async (machineId: string) => {
+    setError(null);
+    setPingResult(null);
+    try {
+      const response = await authenticatedFetch(`/api/machines/${encodeURIComponent(machineId)}/ping`, {
+        method: 'POST',
+      });
+      const payload = await readJson<PingMachineResponse>(response);
+      setPingResult(
+        t('machines.pingSuccess', {
+          defaultValue: 'Ping ok — {{latency}} ms',
+          latency: payload.data.latencyMs,
+        }),
+      );
+      await loadMachines();
+    } catch (pingError) {
+      setError(pingError instanceof Error ? pingError.message : String(pingError));
+    }
+  };
+
+  const copyToken = async () => {
+    if (!createdToken) {
+      return;
+    }
+    await navigator.clipboard.writeText(createdToken);
+  };
+
+  return (
+    <SettingsSection
+      title={t('machines.title', { defaultValue: 'Machines' })}
+      description={t('machines.description', {
+        defaultValue: 'Register worker machines that connect outbound to this server. Tokens are shown once.',
+      })}
+    >
+      <SettingsCard className="p-4">
+        <div className="mb-4 flex items-center justify-between gap-3">
+          <div className="flex items-center gap-2 text-sm text-muted-foreground">
+            <Server className="h-4 w-4" />
+            {t('machines.listHint', {
+              defaultValue: 'Workers: cloudcli worker start --server <url> --token <mw_...>',
+            })}
+          </div>
+          <Button size="sm" onClick={() => setShowCreateForm((value) => !value)}>
+            <Plus className="mr-1 h-4 w-4" />
+            {t('machines.newButton', { defaultValue: 'New machine' })}
+          </Button>
+        </div>
+
+        {showCreateForm && (
+          <div className="mb-4 rounded-lg border bg-card p-4">
+            <Input
+              placeholder={t('machines.form.placeholder', { defaultValue: 'Machine name' })}
+              value={newMachineName}
+              onChange={(event) => setNewMachineName(event.target.value)}
+              className="mb-2"
+            />
+            <div className="flex gap-2">
+              <Button onClick={() => void handleCreate()}>
+                {t('machines.form.createButton', { defaultValue: 'Create' })}
+              </Button>
+              <Button
+                variant="outline"
+                onClick={() => {
+                  setShowCreateForm(false);
+                  setNewMachineName('');
+                }}
+              >
+                {t('machines.form.cancelButton', { defaultValue: 'Cancel' })}
+              </Button>
+            </div>
+          </div>
+        )}
+
+        {createdToken && (
+          <div className="mb-4 rounded-lg border border-amber-500/40 bg-amber-500/10 p-4">
+            <p className="mb-2 text-sm font-medium">
+              {t('machines.tokenOnce', {
+                defaultValue: 'Copy this token now. It will not be shown again.',
+              })}
+            </p>
+            <div className="flex items-center gap-2">
+              <code className="flex-1 overflow-x-auto rounded bg-background px-2 py-1 text-xs">
+                {createdToken}
+              </code>
+              <Button size="sm" variant="outline" onClick={() => void copyToken()}>
+                <Copy className="h-4 w-4" />
+              </Button>
+            </div>
+          </div>
+        )}
+
+        {error && <p className="mb-3 text-sm text-destructive">{error}</p>}
+        {pingResult && <p className="mb-3 text-sm text-emerald-600 dark:text-emerald-400">{pingResult}</p>}
+
+        {isLoading ? (
+          <p className="text-sm text-muted-foreground">
+            {t('machines.loading', { defaultValue: 'Loading machines…' })}
+          </p>
+        ) : machines.length === 0 ? (
+          <p className="text-sm italic text-muted-foreground">
+            {t('machines.empty', { defaultValue: 'No machines registered yet.' })}
+          </p>
+        ) : (
+          <div className="space-y-2">
+            {machines.map((machine) => (
+              <div
+                key={machine.id}
+                className="flex flex-col gap-3 rounded-lg border p-3 sm:flex-row sm:items-center sm:justify-between"
+              >
+                <div className="min-w-0">
+                  <div className="flex items-center gap-2">
+                    <span
+                      className={`inline-block h-2.5 w-2.5 rounded-full ${
+                        machine.status === 'online' ? 'bg-emerald-500' : 'bg-muted-foreground/40'
+                      }`}
+                    />
+                    <p className="truncate font-medium">{machine.name}</p>
+                    <span className="text-xs uppercase text-muted-foreground">{machine.status}</span>
+                  </div>
+                  <p className="mt-1 truncate text-xs text-muted-foreground">
+                    {machine.hostname || '—'} · {machine.tokenPrefix}… · {machine.id}
+                  </p>
+                </div>
+                <div className="flex gap-2">
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    onClick={() => {
+                      localStorage.setItem('selected-machine-id', machine.id);
+                      localStorage.setItem('selected-machine-name', machine.name);
+                      setPingResult(
+                        t('machines.selectedForChat', {
+                          defaultValue: 'Selected for new chats: {{name}}',
+                          name: machine.name,
+                        }),
+                      );
+                    }}
+                  >
+                    {t('machines.useForChat', { defaultValue: 'Use for chat' })}
+                  </Button>
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    disabled={machine.status !== 'online'}
+                    onClick={() => void handlePing(machine.id)}
+                  >
+                    <Wifi className="mr-1 h-4 w-4" />
+                    {t('machines.ping', { defaultValue: 'Ping' })}
+                  </Button>
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    onClick={() => void handleRevoke(machine.id)}
+                  >
+                    <Trash2 className="h-4 w-4" />
+                  </Button>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </SettingsCard>
+    </SettingsSection>
+  );
+}

--- a/src/i18n/locales/en/settings.json
+++ b/src/i18n/locales/en/settings.json
@@ -107,12 +107,29 @@
     "appearance": "Appearance",
     "git": "Git",
     "apiTokens": "API & Tokens",
+    "machines": "Machines",
     "voice": "Voice",
     "tasks": "Tasks",
     "browser": "Browser",
     "notifications": "Notifications",
     "plugins": "Plugins",
     "about": "About"
+  },
+  "machines": {
+    "title": "Machines",
+    "description": "Register worker machines that connect outbound to this server. Tokens are shown once.",
+    "listHint": "Workers: cloudcli worker start --server <url> --token <mw_...>",
+    "newButton": "New machine",
+    "form": {
+      "placeholder": "Machine name",
+      "createButton": "Create",
+      "cancelButton": "Cancel"
+    },
+    "tokenOnce": "Copy this token now. It will not be shown again.",
+    "loading": "Loading machines…",
+    "empty": "No machines registered yet.",
+    "ping": "Ping",
+    "pingSuccess": "Ping ok — {{latency}} ms"
   },
   "notifications": {
     "title": "Notifications",

--- a/src/i18n/locales/zh-CN/settings.json
+++ b/src/i18n/locales/zh-CN/settings.json
@@ -107,12 +107,29 @@
     "appearance": "外观",
     "git": "Git",
     "apiTokens": "API 和令牌",
+    "machines": "机器",
     "voice": "语音",
     "tasks": "任务",
     "browser": "浏览器",
     "notifications": "通知",
     "plugins": "插件",
     "about": "关于"
+  },
+  "machines": {
+    "title": "机器",
+    "description": "注册主动连到本 Server 的 Worker 机器。令牌只显示一次。",
+    "listHint": "Worker：cloudcli worker start --server <url> --token <mw_...>",
+    "newButton": "新建机器",
+    "form": {
+      "placeholder": "机器名称",
+      "createButton": "创建",
+      "cancelButton": "取消"
+    },
+    "tokenOnce": "请立即复制此令牌，之后不会再显示。",
+    "loading": "正在加载机器…",
+    "empty": "还没有注册机器。",
+    "ping": "Ping",
+    "pingSuccess": "Ping 成功 — {{latency}} ms"
   },
   "notifications": {
     "title": "通知",


### PR DESCRIPTION
Enable multi-machine agents: Server stores cloud sessions/messages and dispatches chat to Workers over WS, while Workers run local provider CLIs for native resume. CONTROL_PLANE=1 disables Server-local CLI execution and transcript watching so LAN/cloud hosts stay lightweight.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added experimental multi-machine support with separate Server and Worker roles.
  * Added a Machines settings tab for registering, selecting, monitoring, pinging, and revoking Workers.
  * Added token-based Worker startup through CLI options or environment variables.
  * Added remote session routing, live status updates, heartbeats, reconnection, chat execution, permissions, and session restoration.
  * Added English and Simplified Chinese translations and setup documentation.

* **Bug Fixes**
  * Improved session history handling for Worker-connected sessions with cloud-stored message fallback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->