### PR TITLE
fix: unbounded session transcript refetch causes severe bandwidth usage on long sessions

### DIFF
--- a/src/components/chat/hooks/useChatRealtimeHandlers.ts
+++ b/src/components/chat/hooks/useChatRealtimeHandlers.ts
@@ -40,6 +40,8 @@ interface UseChatRealtimeHandlersArgs {
   onSessionIdle?: MarkSessionIdle;
   onWebSocketReconnect?: () => void;
   sessionStore: SessionStore;
+  /** Whether the chat tab is the currently visible tab. Defaults to true. */
+  isActiveTab?: boolean;
 }
 
 /* ------------------------------------------------------------------ */
@@ -71,6 +73,7 @@ export function useChatRealtimeHandlers({
   onSessionIdle,
   onWebSocketReconnect,
   sessionStore,
+  isActiveTab = true,
 }: UseChatRealtimeHandlersArgs) {
   // Session switches can send `chat.subscribe` before this effect has a chance
   // to rebind the websocket listener. Read the visible session id from a ref
@@ -258,7 +261,7 @@ export function useChatRealtimeHandlers({
           // before the first send), so the only follow-up is syncing the
           // viewed conversation with the now-persisted transcript.
           if (sid && sid === activeViewSessionId) {
-            void sessionStore.refreshFromServer(sid);
+            void sessionStore.requestRefreshFromServer(sid, { visible: isActiveTab });
           }
 
           break;
@@ -344,5 +347,6 @@ export function useChatRealtimeHandlers({
     onSessionIdle,
     onWebSocketReconnect,
     sessionStore,
+    isActiveTab,
   ]);
 }

--- a/src/components/chat/hooks/useChatSessionState.ts
+++ b/src/components/chat/hooks/useChatSessionState.ts
@@ -4,13 +4,12 @@ import type { MutableRefObject } from 'react';
 import { authenticatedFetch } from '../../../utils/api';
 import type { MarkSessionIdle, SessionActivityMap } from '../../../hooks/useSessionProtection';
 import type { Project, ProjectSession, LLMProvider } from '../../../types/app';
-import type { SessionStore, NormalizedMessage } from '../../../stores/useSessionStore';
+import { MESSAGES_PER_PAGE, type SessionStore, type NormalizedMessage } from '../../../stores/useSessionStore';
 import type { ChatMessage } from '../types/types';
 import { createCachedDiffCalculator, type DiffCalculator } from '../utils/messageTransforms';
 
 import { normalizedToChatMessages } from './useChatMessages';
 
-const MESSAGES_PER_PAGE = 20;
 const INITIAL_VISIBLE_MESSAGES = 100;
 
 interface UseChatSessionStateArgs {

--- a/src/components/chat/hooks/useChatSessionState.ts
+++ b/src/components/chat/hooks/useChatSessionState.ts
@@ -28,6 +28,8 @@ interface UseChatSessionStateArgs {
   /** Highest live seq observed per session; sent as `lastSeq` on subscribe. */
   lastSeqRef: MutableRefObject<Map<string, number>>;
   sessionStore: SessionStore;
+  /** Whether the chat tab is the currently visible tab. Defaults to true. */
+  isActiveTab?: boolean;
 }
 
 interface ScrollRestoreState {
@@ -107,6 +109,7 @@ export function useChatSessionState({
   statusCheckSentAtRef,
   lastSeqRef,
   sessionStore,
+  isActiveTab = true,
 }: UseChatSessionStateArgs) {
   const [currentSessionId, setCurrentSessionId] = useState<string | null>(selectedSession?.id || null);
   const [isLoadingSessionMessages, setIsLoadingSessionMessages] = useState(false);
@@ -589,9 +592,9 @@ export function useChatSessionState({
       try {
         // Skip store refresh during active streaming
         if (!isProcessing) {
-          await sessionStore.refreshFromServer(selectedSession.id);
+          await sessionStore.requestRefreshFromServer(selectedSession.id, { visible: isActiveTab });
 
-          if (isNearBottom()) {
+          if (isActiveTab && isNearBottom()) {
             setTimeout(() => scrollToBottom(), 200);
           }
         }
@@ -609,7 +612,16 @@ export function useChatSessionState({
     selectedSession,
     sessionStore,
     isProcessing,
+    isActiveTab,
   ]);
+
+  // Chat became the visible tab again: run any full-transcript refresh that
+  // was deferred (via requestRefreshFromServer) while it was hidden. No-op if
+  // nothing is pending.
+  useEffect(() => {
+    if (!isActiveTab || !selectedSession) return;
+    sessionStore.flushPendingRefresh(selectedSession.id);
+  }, [isActiveTab, selectedSession, sessionStore]);
 
   // Search navigation target
   useEffect(() => {

--- a/src/components/chat/types/types.ts
+++ b/src/components/chat/types/types.ts
@@ -123,6 +123,14 @@ export type SessionEstablishedContext = {
 };
 
 export interface ChatInterfaceProps {
+  /**
+   * Whether the chat tab is the currently visible tab. ChatInterface stays
+   * mounted (CSS-hidden) when another tab like Shell is active, so this is
+   * the only signal for whether its background refresh work is worth doing
+   * right now. Defaults to true when omitted so existing callers/tests are
+   * unaffected.
+   */
+  isActiveTab?: boolean;
   selectedProject: Project | null;
   selectedSession: ProjectSession | null;
   ws: WebSocket | null;

--- a/src/components/chat/view/ChatInterface.tsx
+++ b/src/components/chat/view/ChatInterface.tsx
@@ -17,6 +17,7 @@ import ChatComposer from './subcomponents/ChatComposer';
 import CommandResultModal from './subcomponents/CommandResultModal';
 
 function ChatInterface({
+  isActiveTab = true,
   selectedProject,
   selectedSession,
   ws,
@@ -135,6 +136,7 @@ function ChatInterface({
     statusCheckSentAtRef,
     lastSeqRef,
     sessionStore,
+    isActiveTab,
   });
 
   // Brand-new conversation: the composer allocated a stable session id via
@@ -227,7 +229,7 @@ function ChatInterface({
   // missed live events, and re-attaches a still-running stream to this socket.
   const handleWebSocketReconnect = useCallback(async () => {
     if (!selectedProject || !selectedSession) return;
-    await sessionStore.refreshFromServer(selectedSession.id);
+    await sessionStore.requestRefreshFromServer(selectedSession.id, { visible: isActiveTab });
     statusCheckSentAtRef.current.set(selectedSession.id, Date.now());
     sendMessage({
       type: 'chat.subscribe',
@@ -236,7 +238,7 @@ function ChatInterface({
         lastSeq: lastSeqRef.current.get(selectedSession.id) ?? 0,
       }],
     });
-  }, [selectedProject, selectedSession, sendMessage, sessionStore]);
+  }, [selectedProject, selectedSession, sendMessage, sessionStore, isActiveTab]);
 
   useChatRealtimeHandlers({
     subscribe,
@@ -254,6 +256,7 @@ function ChatInterface({
     onSessionIdle,
     onWebSocketReconnect: handleWebSocketReconnect,
     sessionStore,
+    isActiveTab,
   });
 
   useEffect(() => {

--- a/src/components/main-content/view/MainContent.tsx
+++ b/src/components/main-content/view/MainContent.tsx
@@ -160,6 +160,7 @@ function MainContent({
           <div className={`h-full ${activeTab === 'chat' ? 'block' : 'hidden'}`}>
             <ErrorBoundary showDetails>
               <ChatInterface
+                isActiveTab={activeTab === 'chat'}
                 selectedProject={selectedProject}
                 selectedSession={selectedSession}
                 ws={ws}

--- a/src/stores/useSessionStore.ts
+++ b/src/stores/useSessionStore.ts
@@ -514,7 +514,7 @@ export function useSessionStore() {
 
     const fetchTicket = ++slot._fetchSeq;
     const params = new URLSearchParams();
-    const limit = opts.limit ?? 20;
+    const limit = opts.limit ?? MESSAGES_PER_PAGE;
     params.append('limit', String(limit));
     params.append('offset', String(slot.offset));
 

--- a/src/stores/useSessionStore.ts
+++ b/src/stores/useSessionStore.ts
@@ -110,6 +110,14 @@ export interface SessionSlot {
    */
   _fetchSeq: number;
   _appliedFetchSeq: number;
+  /**
+   * @internal Set when a `refreshFromServer` was requested while the chat
+   * view for this session wasn't visible (e.g. user parked on the Shell
+   * tab). The full-transcript refetch is deferred rather than dropped, and
+   * runs once the chat view becomes visible again - see
+   * `requestRefreshFromServer` / `flushPendingRefresh`.
+   */
+  _refreshPending: boolean;
   status: SessionStatus;
   fetchedAt: number;
   total: number;
@@ -135,6 +143,7 @@ function createEmptySlot(): SessionSlot {
     tokenUsage: null,
     _fetchSeq: 0,
     _appliedFetchSeq: 0,
+    _refreshPending: false,
   };
 }
 
@@ -614,6 +623,39 @@ export function useSessionStore() {
   }, [getSlot, notify]);
 
   /**
+   * Same full-transcript re-sync as `refreshFromServer`, but skips the fetch
+   * (marking it pending instead) when the caller reports its view isn't
+   * currently visible. Callers that always run while visible (e.g. the chat
+   * view refreshing itself) see identical behavior to calling
+   * `refreshFromServer` directly - this only changes what happens while
+   * nothing is actually rendering the transcript.
+   */
+  const requestRefreshFromServer = useCallback((
+    sessionId: string,
+    options: { visible: boolean },
+  ): Promise<void> => {
+    if (!options.visible) {
+      getSlot(sessionId)._refreshPending = true;
+      return Promise.resolve();
+    }
+    getSlot(sessionId)._refreshPending = false;
+    return refreshFromServer(sessionId);
+  }, [getSlot, refreshFromServer]);
+
+  /**
+   * Runs the deferred refresh from `requestRefreshFromServer`, if one is
+   * pending, once the caller's view becomes visible again. No-op otherwise.
+   */
+  const flushPendingRefresh = useCallback((sessionId: string) => {
+    const slot = getSlot(sessionId);
+    if (!slot._refreshPending) {
+      return;
+    }
+    slot._refreshPending = false;
+    void refreshFromServer(sessionId);
+  }, [getSlot, refreshFromServer]);
+
+  /**
    * Update session status.
    */
   const setStatus = useCallback((sessionId: string, status: SessionStatus) => {
@@ -714,6 +756,8 @@ export function useSessionStore() {
     appendRealtime,
     appendRealtimeBatch,
     refreshFromServer,
+    requestRefreshFromServer,
+    flushPendingRefresh,
     setActiveSession,
     setStatus,
     isStale,
@@ -725,6 +769,7 @@ export function useSessionStore() {
   }), [
     getSlot, has, fetchFromServer, fetchMore,
     appendRealtime, appendRealtimeBatch, refreshFromServer,
+    requestRefreshFromServer, flushPendingRefresh,
     setActiveSession, setStatus, isStale, updateStreaming, finalizeStreaming,
     clearRealtime, getMessages, getSessionSlot,
   ]);

--- a/src/stores/useSessionStore.ts
+++ b/src/stores/useSessionStore.ts
@@ -126,6 +126,13 @@ export interface SessionSlot {
   tokenUsage: unknown;
 }
 
+/**
+ * Page size for the initial session load and for refreshFromServer's
+ * bounded tail refetch - see performRefreshFromServer. Shared with
+ * useChatSessionState's own pagination so both agree on what "a page" means.
+ */
+export const MESSAGES_PER_PAGE = 20;
+
 const EMPTY: NormalizedMessage[] = [];
 
 function createEmptySlot(): SessionSlot {
@@ -581,7 +588,16 @@ export function useSessionStore() {
   }, [getSlot, notify]);
 
   /**
-   * Re-fetch serverMessages from the provider sessions endpoint.
+   * Re-sync serverMessages with the provider sessions endpoint.
+   *
+   * Fetches only the most recent MESSAGES_PER_PAGE messages (a `complete`
+   * event or external update can only plausibly have changed the tail of
+   * the conversation, never history further back) and merges it into
+   * whatever is already loaded, rather than replacing the whole array. For
+   * a session with tens of thousands of messages, refetching everything on
+   * every turn is both a severe bandwidth cost and pointless: older pages
+   * the user already scrolled through, or loaded in full via "Load all
+   * messages", aren't going to change underneath them.
    */
   const performRefreshFromServer = useCallback(async (
     sessionId: string,
@@ -589,12 +605,16 @@ export function useSessionStore() {
     const slot = getSlot(sessionId);
     const fetchTicket = ++slot._fetchSeq;
     try {
-      const url = `/api/providers/sessions/${encodeURIComponent(sessionId)}/messages`;
+      const params = new URLSearchParams();
+      params.append('limit', String(MESSAGES_PER_PAGE));
+      params.append('offset', '0');
+      const url = `/api/providers/sessions/${encodeURIComponent(sessionId)}/messages?${params.toString()}`;
       const response = await authenticatedFetch(url);
 
       if (!response.ok) throw new Error(`HTTP ${response.status}`);
       const body = await response.json();
       const data = body?.data ?? body;
+      const freshTail: NormalizedMessage[] = data.messages || [];
 
       // A later-started fetch already applied: applying this stale transcript
       // would erase rows the user has already seen (and re-prune realtime
@@ -604,9 +624,27 @@ export function useSessionStore() {
       }
       slot._appliedFetchSeq = fetchTicket;
 
-      slot.serverMessages = data.messages || [];
-      slot.total = data.total ?? slot.serverMessages.length;
-      slot.hasMore = Boolean(data.hasMore);
+      // Drop whichever previously-loaded rows the fresh tail supersedes
+      // (matched by id, stable across fetches - see raw.uuid in the Claude
+      // provider), then append the fresh tail. Anything older than the tail
+      // - already-loaded pages, or a full "Load all messages" history - is
+      // left untouched.
+      const freshIds = new Set(freshTail.map((message) => message.id));
+      const previousMessages = slot.serverMessages.filter((message) => !freshIds.has(message.id));
+      slot.serverMessages = [...previousMessages, ...freshTail];
+      slot.total = data.total ?? slot.total;
+
+      // A bounded tail page's own hasMore only describes that one page. Once
+      // everything has actually been loaded locally (hasMore already false -
+      // e.g. after "Load all messages", or a short session that fit in one
+      // page), merging in a fresher tail can't make the rest of the history
+      // disappear, so leave hasMore/offset alone. Otherwise keep tracking
+      // how much is actually loaded, same as the initial paginated load.
+      const hadLoadedAnything = slot.fetchedAt > 0;
+      if (!hadLoadedAnything || slot.hasMore) {
+        slot.hasMore = Boolean(data.hasMore);
+        slot.offset = slot.serverMessages.length;
+      }
       slot.fetchedAt = Date.now();
       // Only drop realtime rows the server transcript now owns. A blind clear
       // here caused the chat pane to flash "Continue your conversation" after

--- a/src/stores/useSessionStore.ts
+++ b/src/stores/useSessionStore.ts
@@ -583,9 +583,9 @@ export function useSessionStore() {
   /**
    * Re-fetch serverMessages from the provider sessions endpoint.
    */
-  const refreshFromServer = useCallback(async (
+  const performRefreshFromServer = useCallback(async (
     sessionId: string,
-  ) => {
+  ): Promise<void> => {
     const slot = getSlot(sessionId);
     const fetchTicket = ++slot._fetchSeq;
     try {
@@ -621,6 +621,30 @@ export function useSessionStore() {
       console.error(`[SessionStore] refresh failed for ${sessionId}:`, error);
     }
   }, [getSlot, notify]);
+
+  /**
+   * Multiple independent signals (a `complete` websocket event and a
+   * `session_upserted`-driven `externalMessageUpdate` effect, for example)
+   * can both react to the same underlying turn and call `refreshFromServer`
+   * within milliseconds of each other. Since that fetch is unbounded (the
+   * full transcript, by design), sharing one in-flight request instead of
+   * firing a second one avoids doubling an already-expensive full-history
+   * download for no benefit - both callers only care that the store ends up
+   * current, not which of them triggered it.
+   */
+  const inFlightRefreshRef = useRef(new Map<string, Promise<void>>());
+  const refreshFromServer = useCallback((sessionId: string): Promise<void> => {
+    const existing = inFlightRefreshRef.current.get(sessionId);
+    if (existing) {
+      return existing;
+    }
+
+    const promise = performRefreshFromServer(sessionId).finally(() => {
+      inFlightRefreshRef.current.delete(sessionId);
+    });
+    inFlightRefreshRef.current.set(sessionId, promise);
+    return promise;
+  }, [performRefreshFromServer]);
 
   /**
    * Same full-transcript re-sync as `refreshFromServer`, but skips the fetch


### PR DESCRIPTION
## What changed

`refreshFromServer` (in `src/stores/useSessionStore.ts`) re-syncs a session's messages after a `complete` websocket event, an external JSONL change, or a websocket reconnect. It fetched the **entire session transcript with no `limit`/`offset`** every time it ran, and re-replaced `serverMessages` outright.

For a long-running session this compounds badly:

1. **It ran even while the Chat tab wasn't visible.** `ChatInterface` stays mounted (CSS-hidden) when another tab like Shell is active (`MainContent.tsx`), so its websocket listeners kept firing in the background regardless of which tab the user was actually looking at.
2. **It could fire twice for the same event.** The `complete` handler and the `externalMessageUpdate` effect can both react to the same turn within milliseconds of each other, each independently starting its own full fetch.
3. **It always fetched the full history, never just what changed.** A turn completing can only plausibly change the *tail* of a conversation, never messages further back — but the fetch had no bound, so every refresh re-downloaded everything from message #1.

For a real-world session with ~82,000 messages, a single refresh was measured at **~24MB**, firing on every turn. Confirmed via server-side instrumentation that this is what was consuming multiple GB of data over short sessions, not the shell/terminal WebSocket (which was suspected initially but ruled out by direct measurement).

## The fix (3 commits)

- **`c16eda4`** — `refreshFromServer` is now called through `requestRefreshFromServer(sessionId, { visible })`. When the chat view isn't visible, the refresh is deferred (`_refreshPending`) instead of dropped, and runs once via `flushPendingRefresh` when the chat view becomes visible again. Behavior while the chat view *is* visible is unchanged.
- **`ddc7855`** — Concurrent calls to `refreshFromServer` for the same session now share a single in-flight request instead of each firing its own, since near-simultaneous triggers (e.g. `complete` + `externalMessageUpdate`) only need the store to end up current once.
- **`f6c0b0c`** — `refreshFromServer` now fetches only the most recent `MESSAGES_PER_PAGE` messages and **merges** them into whatever's already loaded (matched by each message's stable id) instead of replacing the array outright. Older pages the user paged through, or the full history loaded via "Load all messages", are left untouched. `MESSAGES_PER_PAGE` is now defined once in `useSessionStore` and imported by `useChatSessionState` rather than duplicated.

None of this touches the initial session load (already paginated) or the explicit "Load all messages" action (already a deliberate one-time full load) — both were and remain unbounded-by-design where that's actually intended.

## How to reproduce (before the fix)

1. Open a long-running session (the longer the transcript, the more visible the effect).
2. Open the Shell tab (or any tab other than Chat) for that session while it keeps producing turns (e.g. an interactive `claude --resume` session in a terminal).
3. Watch network usage climb continuously and unboundedly, tracking roughly 1:1 with each turn/JSONL change, even though the Chat view isn't on screen.

## Testing

Verified live against a real deployment with server-side bandwidth instrumentation (temporary diagnostic logging, not included in this PR) measuring actual bytes sent per request/channel:

- Before: continuous unbounded growth, tens of MB every ~10s while parked on a non-chat tab, for a session with a multi-MB transcript.
- After all three fixes: a 4-minute conversation, including switching to the Chat tab multiple times, used ~5MB total.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chat message synchronization during realtime updates and reconnects.
  * Prevented duplicate refresh requests and preserved message history while loading newer content.
  * Deferred refreshes for inactive chat tabs and applied them when the tab becomes visible.
  * Limited automatic scrolling to the currently active chat tab.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->