### PR TITLE
feat(i18n): add complete Spanish (es) translation

### DIFF
--- a/src/i18n/config.js
+++ b/src/i18n/config.js
@@ -24,6 +24,15 @@ import enCodeEditor from './locales/en/codeEditor.json';
 // eslint-disable-next-line import-x/order
 import enTasks from './locales/en/tasks.json';
 
+import esCommon from './locales/es/common.json';
+import esSettings from './locales/es/settings.json';
+import esAuth from './locales/es/auth.json';
+import esSidebar from './locales/es/sidebar.json';
+import esChat from './locales/es/chat.json';
+import esCodeEditor from './locales/es/codeEditor.json';
+// eslint-disable-next-line import-x/order
+import esTasks from './locales/es/tasks.json';
+
 import koCommon from './locales/ko/common.json';
 import koSettings from './locales/ko/settings.json';
 import koAuth from './locales/ko/auth.json';
@@ -127,6 +136,15 @@ i18n
         chat: enChat,
         codeEditor: enCodeEditor,
         tasks: enTasks,
+      },
+      es: {
+        common: esCommon,
+        settings: esSettings,
+        auth: esAuth,
+        sidebar: esSidebar,
+        chat: esChat,
+        codeEditor: esCodeEditor,
+        tasks: esTasks,
       },
       ko: {
         common: koCommon,

--- a/src/i18n/languages.js
+++ b/src/i18n/languages.js
@@ -20,6 +20,11 @@ export const languages = [
     nativeName: 'Français',
   },
   {
+    value: 'es',
+    label: 'Spanish',
+    nativeName: 'Español',
+  },
+  {
     value: 'ko',
     label: 'Korean',
     nativeName: '한국어',

--- a/src/i18n/locales/es/auth.json
+++ b/src/i18n/locales/es/auth.json
@@ -1,0 +1,37 @@
+{
+  "login": {
+    "title": "Bienvenido de nuevo",
+    "description": "Inicia sesión en tu cuenta autoalojada de CloudCLI",
+    "username": "Usuario",
+    "password": "Contraseña",
+    "submit": "Iniciar sesión",
+    "loading": "Iniciando sesión...",
+    "errors": {
+      "invalidCredentials": "Usuario o contraseña incorrectos",
+      "requiredFields": "Completa todos los campos",
+      "networkError": "Error de red. Inténtalo de nuevo."
+    },
+    "placeholders": {
+      "username": "Escribe tu usuario",
+      "password": "Escribe tu contraseña"
+    }
+  },
+  "register": {
+    "title": "Crear cuenta",
+    "username": "Usuario",
+    "password": "Contraseña",
+    "confirmPassword": "Confirmar contraseña",
+    "submit": "Crear cuenta",
+    "loading": "Creando cuenta...",
+    "errors": {
+      "passwordMismatch": "Las contraseñas no coinciden",
+      "usernameTaken": "El nombre de usuario ya está en uso",
+      "weakPassword": "La contraseña es demasiado débil"
+    }
+  },
+  "logout": {
+    "title": "Cerrar sesión",
+    "confirm": "¿Seguro que quieres cerrar sesión?",
+    "button": "Cerrar sesión"
+  }
+}

--- a/src/i18n/locales/es/chat.json
+++ b/src/i18n/locales/es/chat.json
@@ -1,0 +1,248 @@
+{
+  "codeBlock": {
+    "copy": "Copiar",
+    "copied": "Copiado",
+    "copyCode": "Copiar código"
+  },
+  "copyMessage": {
+    "copy": "Copiar mensaje",
+    "copied": "Mensaje copiado",
+    "selectFormat": "Selecciona el formato de copia",
+    "copyAsMarkdown": "Copiar como markdown",
+    "copyAsText": "Copiar como texto"
+  },
+  "messageTypes": {
+    "user": "U",
+    "error": "Error",
+    "tool": "Herramienta",
+    "claude": "Claude",
+    "cursor": "Cursor",
+    "codex": "Codex",
+    "opencode": "OpenCode"
+  },
+  "tools": {
+    "settings": "Ajustes de herramientas",
+    "error": "Error de herramienta",
+    "result": "Resultado de herramienta",
+    "viewParams": "Ver parámetros de entrada",
+    "viewRawParams": "Ver parámetros sin procesar",
+    "viewDiff": "Ver diff de edición de",
+    "creatingFile": "Creando archivo nuevo:",
+    "updatingTodo": "Actualizando lista de pendientes",
+    "read": "Leer",
+    "readFile": "Leer archivo",
+    "updateTodo": "Actualizar lista de pendientes",
+    "readTodo": "Leer lista de pendientes",
+    "searchResults": "resultados"
+  },
+  "search": {
+    "found": "Se encontraron {{count}} {{type}}",
+    "file": "archivo",
+    "files": "archivos",
+    "pattern": "patrón:",
+    "in": "en:"
+  },
+  "fileOperations": {
+    "updated": "Archivo actualizado correctamente",
+    "created": "Archivo creado correctamente",
+    "written": "Archivo escrito correctamente",
+    "diff": "Diff",
+    "newFile": "Archivo nuevo",
+    "viewContent": "Ver contenido del archivo",
+    "viewFullOutput": "Ver salida completa ({{count}} caracteres)",
+    "contentDisplayed": "El contenido del archivo se muestra en la vista de diff de arriba"
+  },
+  "interactive": {
+    "title": "Prompt interactivo",
+    "waiting": "Esperando tu respuesta en la CLI",
+    "instruction": "Selecciona una opción en la terminal donde está corriendo Claude.",
+    "selectedOption": "✓ Claude seleccionó la opción {{number}}",
+    "instructionDetail": "En la CLI seleccionarías esta opción de forma interactiva con las flechas o escribiendo el número."
+  },
+  "thinking": {
+    "title": "Pensando...",
+    "emoji": "💭 Pensando..."
+  },
+  "json": {
+    "response": "Respuesta JSON"
+  },
+  "permissions": {
+    "grant": "Conceder permiso para {{tool}}",
+    "added": "Permiso añadido",
+    "addTo": "Añade {{entry}} a las herramientas permitidas.",
+    "retry": "Permiso guardado. Reintenta la solicitud para usar la herramienta.",
+    "error": "No se pudieron actualizar los permisos. Inténtalo de nuevo.",
+    "openSettings": "Abrir ajustes"
+  },
+  "todo": {
+    "updated": "La lista de pendientes se actualizó correctamente",
+    "current": "Lista de pendientes actual"
+  },
+  "plan": {
+    "viewPlan": "📋 Ver plan de implementación",
+    "title": "Plan de implementación"
+  },
+  "usageLimit": {
+    "resetAt": "Se alcanzó el límite de uso de Claude. Tu límite se restablecerá a las **{{time}} {{timezone}}** - {{date}}"
+  },
+  "codex": {
+    "permissionMode": "Modo de permisos",
+    "modes": {
+      "default": "Modo por defecto",
+      "auto": "Modo automático",
+      "acceptEdits": "Aceptar ediciones",
+      "bypassPermissions": "Omitir permisos",
+      "plan": "Modo de planificación"
+    },
+    "descriptions": {
+      "default": "Solo los comandos de confianza (ls, cat, grep, git status, etc.) se ejecutan automáticamente. Los demás comandos se omiten. Puede escribir en el espacio de trabajo.",
+      "auto": "Un clasificador del modelo decide en cada llamada si aprobar o denegar. Sin intervención, pero más seguro que Omitir — las denegaciones siguen ocurriendo.",
+      "acceptEdits": "Todos los comandos se ejecutan automáticamente dentro del espacio de trabajo. Modo automático completo con ejecución en sandbox.",
+      "bypassPermissions": "Acceso completo al sistema sin restricciones. Todos los comandos se ejecutan automáticamente con acceso total a disco y red. Úsalo con precaución.",
+      "plan": "Modo de planificación: no se ejecutan comandos"
+    },
+    "technicalDetails": "Detalles técnicos"
+  },
+  "voice": {
+    "input": "Entrada de voz",
+    "stopRecording": "Detener grabación",
+    "transcribing": "Transcribiendo…",
+    "speak": "Leer en voz alta",
+    "stopSpeaking": "Detener",
+    "loading": "Cargando…"
+  },
+  "input": {
+    "placeholder": "Escribe / para comandos, @ para archivos, o pregúntale lo que quieras a {{provider}}...",
+    "placeholderDefault": "Escribe tu mensaje...",
+    "disabled": "Entrada deshabilitada",
+    "attachFiles": "Adjuntar archivos",
+    "attachImages": "Adjuntar imágenes",
+    "send": "Enviar",
+    "stop": "Detener",
+    "hintText": {
+      "ctrlEnter": "Ctrl+Enter para enviar • Shift+Enter para nueva línea • Tab para cambiar de modo • / para comandos",
+      "enter": "Enter para enviar • Shift+Enter para nueva línea • Tab para cambiar de modo • / para comandos",
+      "queue": "Enter para poner en cola tu siguiente mensaje",
+      "updateQueued": "Enter para actualizar el mensaje en cola"
+    },
+    "clickToChangeMode": "Haz clic para cambiar el modo de permisos (o pulsa Tab en el campo de texto)",
+    "showAllCommands": "Mostrar todos los comandos",
+    "clearInput": "Limpiar entrada",
+    "scrollToBottom": "Ir al final",
+    "queue": {
+      "sendNext": "Poner en cola el siguiente mensaje",
+      "update": "Actualizar mensaje en cola",
+      "label": "En cola",
+      "willSend": "Se enviará cuando esto termine",
+      "edit": "Editar mensaje en cola",
+      "delete": "Eliminar mensaje en cola"
+    }
+  },
+  "composer": {
+    "reasoning": "Razonamiento",
+    "model": "Modelo",
+    "effortDefault": "Por defecto",
+    "loadingModels": "Cargando modelos…",
+    "modelMenu": "Seleccionar modelo y esfuerzo de razonamiento",
+    "permissionHeading": "¿Cómo se deben aprobar las acciones de {{provider}}?"
+  },
+  "providerSelection": {
+    "title": "Elige tu asistente de IA",
+    "description": "Selecciona un proveedor para iniciar una conversación nueva",
+    "selectModel": "Seleccionar modelo",
+    "providerInfo": {
+      "anthropic": "de Anthropic",
+      "openai": "de OpenAI",
+      "cursorEditor": "Editor de código con IA",
+      "google": "de Google"
+    },
+    "readyPrompt": {
+      "claude": "Listo para usar Claude con {{model}}. Escribe tu mensaje abajo.",
+      "cursor": "Listo para usar Cursor con {{model}}. Escribe tu mensaje abajo.",
+      "codex": "Listo para usar Codex con {{model}}. Escribe tu mensaje abajo.",
+      "opencode": "Listo para usar OpenCode con {{model}}. Escribe tu mensaje abajo.",
+      "default": "Selecciona un proveedor arriba para empezar"
+    },
+    "pressToSearch": "Pulsa <kbd>{{shortcut}}</kbd> para buscar sesiones, archivos y commits"
+  },
+  "session": {
+    "continue": {
+      "title": "Continúa tu conversación",
+      "description": "Haz preguntas sobre tu código, pide cambios u obtén ayuda con tareas de desarrollo"
+    },
+    "loading": {
+      "olderMessages": "Cargando mensajes anteriores...",
+      "sessionMessages": "Cargando mensajes de la sesión..."
+    },
+    "messages": {
+      "showingOf": "Mostrando {{shown}} de {{total}} mensajes",
+      "scrollToLoad": "Desplázate hacia arriba para cargar más",
+      "showingLast": "Mostrando los últimos {{count}} mensajes ({{total}} en total)",
+      "loadEarlier": "Cargar mensajes anteriores",
+      "loadAll": "Cargar todos los mensajes",
+      "loadingAll": "Cargando todos los mensajes...",
+      "allLoaded": "Todos los mensajes cargados",
+      "perfWarning": "Todos los mensajes cargados — el desplazamiento puede ser más lento. Haz clic en \"Ir al final\" para recuperar el rendimiento."
+    }
+  },
+  "shell": {
+    "selectProject": {
+      "title": "Selecciona un proyecto",
+      "description": "Elige un proyecto para abrir una shell interactiva en ese directorio"
+    },
+    "status": {
+      "newSession": "Sesión nueva",
+      "initializing": "Inicializando...",
+      "restarting": "Reiniciando..."
+    },
+    "actions": {
+      "disconnect": "Desconectar",
+      "disconnectTitle": "Desconectar de la shell",
+      "restart": "Reiniciar",
+      "restartTitle": "Reiniciar shell",
+      "connect": "Continuar en la shell",
+      "connectTitle": "Conectar a la shell"
+    },
+    "loading": "Cargando terminal...",
+    "connecting": "Conectando a la shell...",
+    "startSession": "Iniciar una sesión nueva de Claude",
+    "resumeSession": "Reanudar sesión: {{displayName}}...",
+    "runCommand": "Ejecutar {{command}} en {{projectName}}",
+    "startCli": "Iniciando Claude CLI en {{projectName}}",
+    "defaultCommand": "comando"
+  },
+  "claudeStatus": {
+    "actions": {
+      "thinking": "Pensando",
+      "processing": "Procesando",
+      "analyzing": "Analizando",
+      "working": "Trabajando",
+      "computing": "Calculando",
+      "reasoning": "Razonando"
+    },
+    "state": {
+      "live": "En vivo",
+      "paused": "En pausa"
+    },
+    "elapsed": {
+      "seconds": "{{count}}s",
+      "minutesSeconds": "{{minutes}}m {{seconds}}s",
+      "label": "{{time}} transcurridos",
+      "startingNow": "Empezando ahora"
+    },
+    "stop": "Detener",
+    "controls": {
+      "stopGeneration": "Detener generación",
+      "pressEscToStop": "Pulsa Esc en cualquier momento para detener"
+    },
+    "providers": {
+      "assistant": "Asistente"
+    }
+  },
+  "projectSelection": {
+    "startChatWithProvider": "Selecciona un proyecto para empezar a chatear con {{provider}}"
+  },
+  "tasks": {
+    "nextTaskPrompt": "Empezar la siguiente tarea"
+  }
+}

--- a/src/i18n/locales/es/codeEditor.json
+++ b/src/i18n/locales/es/codeEditor.json
@@ -1,0 +1,41 @@
+{
+  "toolbar": {
+    "changes": "cambios",
+    "previousChange": "Cambio anterior",
+    "nextChange": "Cambio siguiente",
+    "hideDiff": "Ocultar resaltado de diferencias",
+    "showDiff": "Mostrar resaltado de diferencias",
+    "settings": "Ajustes del editor",
+    "collapse": "Contraer editor",
+    "expand": "Expandir editor a ancho completo"
+  },
+  "loading": "Cargando {{fileName}}...",
+  "header": {
+    "showingChanges": "Mostrando cambios"
+  },
+  "actions": {
+    "download": "Descargar archivo",
+    "save": "Guardar",
+    "saving": "Guardando...",
+    "saved": "¡Guardado!",
+    "exitFullscreen": "Salir de pantalla completa",
+    "fullscreen": "Pantalla completa",
+    "close": "Cerrar",
+    "previewMarkdown": "Vista previa de markdown",
+    "editMarkdown": "Editar markdown"
+  },
+  "footer": {
+    "lines": "Líneas:",
+    "characters": "Caracteres:",
+    "shortcuts": "Ctrl+S para guardar • Esc para cerrar"
+  },
+  "binaryFile": {
+    "title": "Archivo binario",
+    "message": "El archivo \"{{fileName}}\" no se puede mostrar en el editor de texto porque es un archivo binario."
+  },
+  "filePreview": {
+    "loading": "Cargando vista previa...",
+    "error": "No se puede mostrar este archivo.",
+    "openInNewTab": "Abrir en una pestaña nueva"
+  }
+}

--- a/src/i18n/locales/es/common.json
+++ b/src/i18n/locales/es/common.json
@@ -1,0 +1,269 @@
+{
+  "buttons": {
+    "save": "Guardar",
+    "cancel": "Cancelar",
+    "delete": "Eliminar",
+    "create": "Crear",
+    "edit": "Editar",
+    "close": "Cerrar",
+    "confirm": "Confirmar",
+    "submit": "Enviar",
+    "retry": "Reintentar",
+    "refresh": "Actualizar",
+    "search": "Buscar",
+    "clear": "Limpiar",
+    "copy": "Copiar",
+    "download": "Descargar",
+    "upload": "Subir",
+    "browse": "Explorar"
+  },
+  "tabs": {
+    "chat": "Chat",
+    "shell": "Shell",
+    "files": "Archivos",
+    "git": "Control de versiones",
+    "tasks": "Tareas",
+    "browser": "Navegador",
+    "computer": "Equipo"
+  },
+  "status": {
+    "loading": "Cargando...",
+    "success": "Éxito",
+    "error": "Error",
+    "failed": "Falló",
+    "pending": "Pendiente",
+    "completed": "Completado",
+    "inProgress": "En curso"
+  },
+  "messages": {
+    "savedSuccessfully": "Guardado correctamente",
+    "deletedSuccessfully": "Eliminado correctamente",
+    "updatedSuccessfully": "Actualizado correctamente",
+    "operationFailed": "La operación falló",
+    "networkError": "Error de red. Comprueba tu conexión.",
+    "unauthorized": "No autorizado. Inicia sesión.",
+    "notFound": "No encontrado",
+    "invalidInput": "Entrada no válida",
+    "requiredField": "Este campo es obligatorio",
+    "unknownError": "Ocurrió un error desconocido"
+  },
+  "navigation": {
+    "settings": "Ajustes",
+    "home": "Inicio",
+    "back": "Atrás",
+    "next": "Siguiente",
+    "previous": "Anterior",
+    "logout": "Cerrar sesión"
+  },
+  "common": {
+    "language": "Idioma",
+    "theme": "Tema",
+    "darkMode": "Modo oscuro",
+    "lightMode": "Modo claro",
+    "name": "Nombre",
+    "description": "Descripción",
+    "enabled": "Activado",
+    "disabled": "Desactivado",
+    "optional": "Opcional",
+    "version": "Versión",
+    "select": "Seleccionar",
+    "selectAll": "Seleccionar todo",
+    "deselectAll": "Deseleccionar todo"
+  },
+  "time": {
+    "justNow": "Justo ahora",
+    "minutesAgo": "hace {{count}} min",
+    "hoursAgo": "hace {{count}} horas",
+    "daysAgo": "hace {{count}} días",
+    "yesterday": "Ayer"
+  },
+  "fileOperations": {
+    "newFile": "Archivo nuevo",
+    "newFolder": "Carpeta nueva",
+    "rename": "Renombrar",
+    "move": "Mover",
+    "copyPath": "Copiar ruta",
+    "openInEditor": "Abrir en el editor"
+  },
+  "mainContent": {
+    "loading": "Cargando CloudCLI",
+    "settingUpWorkspace": "Preparando tu espacio de trabajo...",
+    "chooseProject": "Elige tu proyecto",
+    "selectProjectDescription": "Selecciona un proyecto en la barra lateral para empezar a programar con Claude. Cada proyecto contiene tus sesiones de chat e historial de archivos.",
+    "tip": "Consejo",
+    "createProjectMobile": "Toca el botón de menú de arriba para acceder a los proyectos",
+    "createProjectDesktop": "Crea un proyecto nuevo haciendo clic en el icono de carpeta de la barra lateral",
+    "newSession": "Nueva sesión",
+    "untitledSession": "Sesión sin título",
+    "projectFiles": "Archivos del proyecto"
+  },
+  "fileTree": {
+    "loading": "Cargando archivos...",
+    "files": "Archivos",
+    "simpleView": "Vista simple",
+    "compactView": "Vista compacta",
+    "detailedView": "Vista detallada",
+    "searchPlaceholder": "Buscar archivos y carpetas...",
+    "clearSearch": "Limpiar búsqueda",
+    "name": "Nombre",
+    "size": "Tamaño",
+    "modified": "Modificado",
+    "permissions": "Permisos",
+    "noFilesFound": "No se encontraron archivos",
+    "checkProjectPath": "Comprueba si la ruta del proyecto es accesible",
+    "noMatchesFound": "No se encontraron coincidencias",
+    "tryDifferentSearch": "Prueba con otro término o limpia la búsqueda",
+    "justNow": "justo ahora",
+    "minAgo": "hace {{count}} min",
+    "hoursAgo": "hace {{count}} horas",
+    "daysAgo": "hace {{count}} días",
+    "newFile": "Archivo nuevo (Cmd+N)",
+    "newFolder": "Carpeta nueva (Cmd+Shift+N)",
+    "refresh": "Actualizar",
+    "collapseAll": "Contraer todo",
+    "context": {
+      "rename": "Renombrar",
+      "delete": "Eliminar",
+      "copyPath": "Copiar ruta",
+      "download": "Descargar",
+      "newFile": "Archivo nuevo",
+      "newFolder": "Carpeta nueva",
+      "refresh": "Actualizar",
+      "menuLabel": "Menú contextual de archivo",
+      "loading": "Cargando..."
+    }
+  },
+  "projectWizard": {
+    "title": "Crear proyecto nuevo",
+    "steps": {
+      "type": "Tipo",
+      "configure": "Configurar",
+      "confirm": "Confirmar"
+    },
+    "step1": {
+      "question": "¿Ya tienes un espacio de trabajo o quieres crear uno nuevo?",
+      "existing": {
+        "title": "Espacio de trabajo existente",
+        "description": "Ya tengo un espacio de trabajo en mi servidor y solo necesito añadirlo a la lista de proyectos"
+      },
+      "new": {
+        "title": "Espacio de trabajo nuevo",
+        "description": "Crea un espacio de trabajo nuevo, opcionalmente clonando un repositorio de GitHub"
+      }
+    },
+    "step2": {
+      "existingPath": "Ruta del espacio de trabajo",
+      "newPath": "Ruta del espacio de trabajo",
+      "existingPlaceholder": "/ruta/al/espacio/existente",
+      "newPlaceholder": "/ruta/al/espacio/nuevo",
+      "existingHelp": "Ruta completa al directorio de tu espacio de trabajo existente",
+      "newHelp": "Ruta completa al directorio de tu espacio de trabajo",
+      "githubUrl": "URL de GitHub (opcional)",
+      "githubPlaceholder": "https://github.com/usuario/repositorio",
+      "githubHelp": "Opcional: proporciona una URL de GitHub para clonar un repositorio",
+      "githubAuth": "Autenticación de GitHub (opcional)",
+      "githubAuthHelp": "Solo se requiere para repositorios privados. Los repos públicos se pueden clonar sin autenticación.",
+      "loadingTokens": "Cargando tokens guardados...",
+      "storedToken": "Token guardado",
+      "newToken": "Token nuevo",
+      "nonePublic": "Ninguno (público)",
+      "selectToken": "Seleccionar token",
+      "selectTokenPlaceholder": "-- Selecciona un token --",
+      "tokenPlaceholder": "ghp_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+      "tokenHelp": "Este token se usará solo para esta operación",
+      "publicRepoInfo": "Los repositorios públicos no requieren autenticación. Puedes omitir el token si clonas un repo público.",
+      "noTokensHelp": "No hay tokens guardados disponibles. Puedes añadir tokens en Ajustes → Claves API para reutilizarlos fácilmente.",
+      "optionalTokenPublic": "Token de GitHub (opcional para repos públicos)",
+      "tokenPublicPlaceholder": "ghp_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx (déjalo vacío para repos públicos)"
+    },
+    "step3": {
+      "reviewConfig": "Revisa tu configuración",
+      "existingWorkspace": "Espacio de trabajo existente",
+      "newWorkspace": "Espacio de trabajo nuevo",
+      "path": "Ruta:",
+      "cloneFrom": "Clonar desde:",
+      "authentication": "Autenticación:",
+      "usingStoredToken": "Usando token guardado:",
+      "usingProvidedToken": "Usando token proporcionado",
+      "noAuthentication": "Sin autenticación",
+      "sshKey": "Clave SSH",
+      "existingInfo": "El espacio de trabajo se añadirá a tu lista de proyectos y estará disponible para sesiones de Claude/Cursor.",
+      "newWithClone": "El repositorio se clonará desde esta carpeta.",
+      "newEmpty": "El espacio de trabajo se añadirá a tu lista de proyectos y estará disponible para sesiones de Claude/Cursor.",
+      "cloningRepository": "Clonando repositorio..."
+    },
+    "buttons": {
+      "cancel": "Cancelar",
+      "back": "Atrás",
+      "next": "Siguiente",
+      "createProject": "Crear proyecto",
+      "creating": "Creando...",
+      "cloning": "Clonando..."
+    },
+    "errors": {
+      "selectType": "Selecciona si tienes un espacio de trabajo existente o quieres crear uno nuevo",
+      "providePath": "Proporciona la ruta del espacio de trabajo",
+      "failedToCreate": "No se pudo crear el espacio de trabajo",
+      "failedToCreateFolder": "No se pudo crear la carpeta"
+    }
+  },
+  "notifications": {
+    "genericTool": "una herramienta",
+    "codes": {
+      "generic": {
+        "info": {
+          "title": "Notificación"
+        }
+      },
+      "permission": {
+        "required": {
+          "title": "Acción requerida",
+          "body": "{{toolName}} está esperando tu decisión."
+        }
+      },
+      "run": {
+        "stopped": {
+          "title": "Ejecución detenida",
+          "body": "Motivo: {{reason}}"
+        },
+        "failed": {
+          "title": "La ejecución falló"
+        }
+      },
+      "agent": {
+        "notification": {
+          "title": "Notificación del agente"
+        }
+      }
+    }
+  },
+  "versionUpdate": {
+    "title": "Actualización disponible",
+    "newVersionReady": "Hay una versión nueva lista",
+    "currentVersion": "Versión actual",
+    "latestVersion": "Última versión",
+    "whatsNew": "Novedades:",
+    "viewFullRelease": "Ver la publicación completa",
+    "updateProgress": "Progreso de la actualización:",
+    "manualUpgrade": "Actualización manual:",
+    "npmUpgradeCommand": "npm install -g @cloudcli-ai/cloudcli@latest",
+    "manualUpgradeHint": "O haz clic en \"Actualizar ahora\" para ejecutar la actualización automáticamente.",
+    "updateCompleted": "¡Actualización completada correctamente!",
+    "restartServer": "Reinicia el servidor para aplicar los cambios.",
+    "updateFailed": "La actualización falló",
+    "buttons": {
+      "close": "Cerrar",
+      "later": "Más tarde",
+      "copyCommand": "Copiar comando",
+      "updateNow": "Actualizar ahora",
+      "updating": "Actualizando..."
+    },
+    "ariaLabels": {
+      "closeModal": "Cerrar el modal de actualización de versión",
+      "showSidebar": "Mostrar barra lateral",
+      "settings": "Ajustes",
+      "updateAvailable": "Actualización disponible",
+      "closeSidebar": "Cerrar barra lateral"
+    }
+  }
+}

--- a/src/i18n/locales/es/settings.json
+++ b/src/i18n/locales/es/settings.json
@@ -1,0 +1,578 @@
+{
+  "title": "Ajustes",
+  "tabs": {
+    "account": "Cuenta",
+    "permissions": "Permisos",
+    "mcpServers": "Servidores MCP",
+    "skills": "Skills",
+    "appearance": "Apariencia"
+  },
+  "account": {
+    "title": "Cuenta",
+    "language": "Idioma",
+    "languageLabel": "Idioma de la interfaz",
+    "languageDescription": "Elige tu idioma preferido para la interfaz",
+    "username": "Usuario",
+    "email": "Correo electrónico",
+    "profile": "Perfil",
+    "changePassword": "Cambiar contraseña"
+  },
+  "mcp": {
+    "title": "Servidores MCP",
+    "addServer": "Añadir servidor",
+    "editServer": "Editar servidor",
+    "deleteServer": "Eliminar servidor",
+    "serverName": "Nombre del servidor",
+    "serverType": "Tipo de servidor",
+    "config": "Configuración",
+    "testConnection": "Probar conexión",
+    "status": "Estado",
+    "connected": "Conectado",
+    "disconnected": "Desconectado",
+    "scope": {
+      "label": "Ámbito",
+      "user": "Usuario",
+      "project": "Proyecto"
+    }
+  },
+  "appearance": {
+    "title": "Apariencia",
+    "theme": "Tema",
+    "codeEditor": "Editor de código",
+    "editorTheme": "Tema del editor",
+    "wordWrap": "Ajuste de línea",
+    "showMinimap": "Mostrar minimapa",
+    "lineNumbers": "Números de línea",
+    "fontSize": "Tamaño de fuente"
+  },
+  "actions": {
+    "saveChanges": "Guardar cambios",
+    "resetToDefaults": "Restablecer valores por defecto",
+    "cancelChanges": "Cancelar cambios"
+  },
+  "voiceSettings": {
+    "title": "Voz",
+    "description": "Entrada de voz a texto y lectura en voz alta, mediante un backend de audio compatible con OpenAI.",
+    "enable": "Activar voz",
+    "enableDescription": "Muestra el botón del micrófono y el botón de lectura en voz alta en los mensajes.",
+    "backendTitle": "Backend",
+    "backendDescription": "Apunta a OpenAI, Groq o un servidor local (LocalAI, Speaches, Kokoro-FastAPI). Déjalo en blanco para usar el valor por defecto del servidor.",
+    "baseUrl": "URL base",
+    "apiKey": "Clave API",
+    "sttModel": "Modelo de voz a texto",
+    "ttsModel": "Modelo de texto a voz",
+    "voice": "Voz",
+    "format": "Formato de audio",
+    "note": "Una URL base personalizada la llama directamente tu navegador y debe permitir solicitudes CORS. Déjala en blanco para usar el backend configurado en el servidor."
+  },
+  "quickSettings": {
+    "title": "Ajustes rápidos",
+    "sections": {
+      "appearance": "Apariencia",
+      "toolDisplay": "Visualización de herramientas",
+      "inputSettings": "Ajustes de entrada"
+    },
+    "darkMode": "Modo oscuro",
+    "showRawParameters": "Mostrar parámetros sin procesar",
+    "showThinking": "Mostrar razonamiento",
+    "sendByCtrlEnter": "Enviar con Ctrl+Enter",
+    "voiceEnabled": "Voz (micro + lectura en voz alta)",
+    "sendByCtrlEnterDescription": "Si está activado, Ctrl+Enter envía el mensaje en lugar de solo Enter. Útil para usuarios de IME y evitar envíos accidentales.",
+    "dragHandle": {
+      "dragging": "Arrastrando el control",
+      "closePanel": "Cerrar panel de ajustes",
+      "openPanel": "Abrir panel de ajustes",
+      "draggingStatus": "Arrastrando...",
+      "toggleAndMove": "Clic para alternar, arrastra para mover"
+    }
+  },
+  "terminalShortcuts": {
+    "title": "Atajos de terminal",
+    "sectionKeys": "Teclas",
+    "sectionNavigation": "Navegación",
+    "escape": "Escape",
+    "tab": "Tab",
+    "shiftTab": "Shift+Tab",
+    "arrowUp": "Flecha arriba",
+    "arrowDown": "Flecha abajo",
+    "scrollDown": "Desplazar hacia abajo",
+    "handle": {
+      "closePanel": "Cerrar panel de atajos",
+      "openPanel": "Abrir panel de atajos"
+    }
+  },
+  "mainTabs": {
+    "label": "Ajustes",
+    "agents": "Agentes",
+    "appearance": "Apariencia",
+    "git": "Git",
+    "apiTokens": "API y tokens",
+    "voice": "Voz",
+    "tasks": "Tareas",
+    "browser": "Navegador",
+    "notifications": "Notificaciones",
+    "plugins": "Plugins",
+    "about": "Acerca de"
+  },
+  "notifications": {
+    "title": "Notificaciones",
+    "description": "Controla qué eventos de notificación recibes.",
+    "webPush": {
+      "title": "Notificar en este navegador",
+      "enable": "Activar notificaciones",
+      "disable": "Desactivar notificaciones",
+      "enabled": "Las notificaciones están activadas en este navegador",
+      "loading": "Actualizando...",
+      "unsupported": "Las notificaciones push no son compatibles con este navegador.",
+      "denied": "Las notificaciones push están bloqueadas. Permítelas en los ajustes de tu navegador."
+    },
+    "desktop": {
+      "title": "Notificar en esta app de escritorio",
+      "enable": "Activar notificaciones",
+      "disable": "Desactivar notificaciones",
+      "enabled": "Las notificaciones están activadas en esta app de escritorio",
+      "unsupported": "Las notificaciones de escritorio no son compatibles con este sistema."
+    },
+    "sound": {
+      "title": "Sonido",
+      "description": "Reproduce un tono corto cuando una ejecución del chat termina o necesita aprobación de una herramienta.",
+      "enabled": "Activado",
+      "test": "Probar sonido"
+    },
+    "events": {
+      "title": "Tipos de evento",
+      "actionRequired": "Acción requerida",
+      "stop": "Ejecución detenida",
+      "error": "Ejecución fallida"
+    }
+  },
+  "appearanceSettings": {
+    "darkMode": {
+      "label": "Modo oscuro",
+      "description": "Alterna entre el tema claro y el oscuro"
+    },
+    "projectSorting": {
+      "label": "Orden de proyectos",
+      "description": "Cómo se ordenan los proyectos en la barra lateral",
+      "alphabetical": "Alfabético",
+      "recentActivity": "Actividad reciente"
+    },
+    "codeEditor": {
+      "title": "Editor de código",
+      "theme": {
+        "label": "Tema del editor",
+        "description": "Tema por defecto del editor de código"
+      },
+      "wordWrap": {
+        "label": "Ajuste de línea",
+        "description": "Activa el ajuste de línea por defecto en el editor"
+      },
+      "showMinimap": {
+        "label": "Mostrar minimapa",
+        "description": "Muestra un minimapa para navegar más fácil en la vista de diff"
+      },
+      "lineNumbers": {
+        "label": "Mostrar números de línea",
+        "description": "Muestra los números de línea en el editor"
+      },
+      "fontSize": {
+        "label": "Tamaño de fuente",
+        "description": "Tamaño de fuente del editor en píxeles"
+      }
+    }
+  },
+  "mcpForm": {
+    "title": {
+      "add": "Añadir servidor MCP",
+      "edit": "Editar servidor MCP"
+    },
+    "importMode": {
+      "form": "Formulario",
+      "json": "Importar JSON"
+    },
+    "scope": {
+      "label": "Ámbito",
+      "userGlobal": "Usuario (global)",
+      "projectLocal": "Proyecto (local)",
+      "userDescription": "Ámbito de usuario: disponible en todos los proyectos de tu máquina",
+      "projectDescription": "Ámbito local: solo disponible en el proyecto seleccionado",
+      "cannotChange": "El ámbito no se puede cambiar al editar un servidor existente"
+    },
+    "fields": {
+      "serverName": "Nombre del servidor",
+      "transportType": "Tipo de transporte",
+      "command": "Comando",
+      "arguments": "Argumentos (uno por línea)",
+      "jsonConfig": "Configuración JSON",
+      "url": "URL",
+      "envVars": "Variables de entorno (CLAVE=valor, una por línea)",
+      "headers": "Cabeceras (CLAVE=valor, una por línea)",
+      "selectProject": "Selecciona un proyecto..."
+    },
+    "placeholders": {
+      "serverName": "mi-servidor"
+    },
+    "validation": {
+      "missingType": "Falta el campo obligatorio: type",
+      "stdioRequiresCommand": "El tipo stdio requiere un campo command",
+      "httpRequiresUrl": "El tipo {{type}} requiere un campo url",
+      "invalidJson": "Formato JSON no válido",
+      "jsonHelp": "Pega la configuración de tu servidor MCP en formato JSON. Formatos de ejemplo:",
+      "jsonExampleStdio": "• stdio: {\"type\":\"stdio\",\"command\":\"npx\",\"args\":[\"@upstash/context7-mcp\"]}",
+      "jsonExampleHttp": "• http/sse: {\"type\":\"http\",\"url\":\"https://api.example.com/mcp\"}"
+    },
+    "configDetails": "Detalles de configuración (de {{configFile}})",
+    "projectPath": "Ruta: {{path}}",
+    "actions": {
+      "cancel": "Cancelar",
+      "saving": "Guardando...",
+      "addServer": "Añadir servidor",
+      "updateServer": "Actualizar servidor"
+    }
+  },
+  "saveStatus": {
+    "success": "¡Ajustes guardados correctamente!",
+    "error": "No se pudieron guardar los ajustes",
+    "saving": "Guardando..."
+  },
+  "footerActions": {
+    "save": "Guardar ajustes",
+    "cancel": "Cancelar"
+  },
+  "git": {
+    "title": "Configuración de Git",
+    "description": "Configura tu identidad de git para los commits. Estos ajustes se aplicarán globalmente mediante git config --global",
+    "name": {
+      "label": "Nombre para Git",
+      "help": "Tu nombre para los commits de git"
+    },
+    "email": {
+      "label": "Correo para Git",
+      "help": "Tu correo para los commits de git"
+    },
+    "actions": {
+      "save": "Guardar configuración",
+      "saving": "Guardando..."
+    },
+    "status": {
+      "success": "Guardado correctamente"
+    }
+  },
+  "apiKeys": {
+    "title": "Claves API",
+    "description": "Genera claves API para acceder a la API externa desde otras aplicaciones.",
+    "newKey": {
+      "alertTitle": "⚠️ Guarda tu clave API",
+      "alertMessage": "Esta es la única vez que verás esta clave. Guárdala en un lugar seguro.",
+      "iveSavedIt": "Ya la guardé"
+    },
+    "form": {
+      "placeholder": "Nombre de la clave API (p. ej., Servidor de producción)",
+      "createButton": "Crear",
+      "cancelButton": "Cancelar"
+    },
+    "newButton": "Nueva clave API",
+    "empty": "Aún no se han creado claves API.",
+    "list": {
+      "created": "Creada:",
+      "lastUsed": "Último uso:"
+    },
+    "confirmDelete": "¿Seguro que quieres eliminar esta clave API?",
+    "status": {
+      "active": "Activa",
+      "inactive": "Inactiva"
+    },
+    "github": {
+      "title": "Tokens de GitHub",
+      "description": "Añade tokens de acceso personal de GitHub para clonar repositorios privados mediante la API externa.",
+      "descriptionAlt": "Añade tokens de acceso personal de GitHub para clonar repositorios privados. También puedes pasar tokens directamente en las solicitudes de API sin guardarlos.",
+      "addButton": "Añadir token",
+      "form": {
+        "namePlaceholder": "Nombre del token (p. ej., Repos personales)",
+        "tokenPlaceholder": "Token de acceso personal de GitHub (ghp_...)",
+        "descriptionPlaceholder": "Descripción (opcional)",
+        "addButton": "Añadir token",
+        "cancelButton": "Cancelar",
+        "howToCreate": "Cómo crear un token de acceso personal de GitHub →"
+      },
+      "empty": "Aún no se han añadido tokens de GitHub.",
+      "added": "Añadido:",
+      "confirmDelete": "¿Seguro que quieres eliminar este token de GitHub?"
+    },
+    "apiDocsLink": "Documentación de la API",
+    "documentation": {
+      "title": "Documentación de la API externa",
+      "description": "Aprende a usar la API externa para lanzar sesiones de Claude/Cursor desde tus aplicaciones.",
+      "viewLink": "Ver documentación de la API →"
+    },
+    "loading": "Cargando...",
+    "version": {
+      "updateAvailable": "Actualización disponible: v{{version}}"
+    }
+  },
+  "tasks": {
+    "checking": "Comprobando la instalación de TaskMaster...",
+    "notInstalled": {
+      "title": "La CLI de TaskMaster AI no está instalada",
+      "description": "La CLI de TaskMaster es necesaria para usar las funciones de gestión de tareas. Instálala para empezar:",
+      "installCommand": "npm install -g task-master-ai",
+      "viewOnGitHub": "Ver en GitHub",
+      "afterInstallation": "Después de la instalación:",
+      "steps": {
+        "restart": "Reinicia esta aplicación",
+        "autoAvailable": "Las funciones de TaskMaster estarán disponibles automáticamente",
+        "initCommand": "Usa task-master init en el directorio de tu proyecto"
+      }
+    },
+    "settings": {
+      "enableLabel": "Activar integración con TaskMaster",
+      "enableDescription": "Muestra tareas, banners e indicadores de TaskMaster en la barra lateral y el resto de la interfaz"
+    }
+  },
+  "agents": {
+    "authStatus": {
+      "checking": "Comprobando...",
+      "connected": "Conectado",
+      "notConnected": "No conectado",
+      "disconnected": "Desconectado",
+      "checkingAuth": "Comprobando el estado de autenticación...",
+      "loggedInAs": "Sesión iniciada como {{email}}",
+      "authenticatedUser": "usuario autenticado"
+    },
+    "account": {
+      "claude": {
+        "description": "Asistente de IA Claude de Anthropic"
+      },
+      "cursor": {
+        "description": "Editor de código con IA Cursor"
+      },
+      "codex": {
+        "description": "Asistente de IA Codex de OpenAI"
+      },
+      "opencode": {
+        "description": "Asistente CLI OpenCode"
+      }
+    },
+    "connectionStatus": "Estado de la conexión",
+    "login": {
+      "title": "Iniciar sesión",
+      "reAuthenticate": "Volver a autenticar",
+      "description": "Inicia sesión en tu cuenta de {{agent}} para activar las funciones de IA",
+      "reAuthDescription": "Inicia sesión con otra cuenta o actualiza las credenciales",
+      "button": "Iniciar sesión",
+      "reLoginButton": "Volver a iniciar sesión"
+    },
+    "error": "Error: {{error}}"
+  },
+  "permissions": {
+    "title": "Ajustes de permisos",
+    "skipPermissions": {
+      "label": "Omitir avisos de permisos (usar con precaución)",
+      "claudeDescription": "Equivalente al flag --dangerously-skip-permissions",
+      "cursorDescription": "Equivalente al flag -f en la CLI de Cursor"
+    },
+    "allowedTools": {
+      "title": "Herramientas permitidas",
+      "description": "Herramientas que se permiten automáticamente sin pedir permiso",
+      "placeholder": "p. ej., \"Bash(git log:*)\" o \"Write\"",
+      "quickAdd": "Añadir rápido herramientas comunes:",
+      "empty": "No hay herramientas permitidas configuradas"
+    },
+    "blockedTools": {
+      "title": "Herramientas bloqueadas",
+      "description": "Herramientas que se bloquean automáticamente sin pedir permiso",
+      "placeholder": "p. ej., \"Bash(rm:*)\"",
+      "empty": "No hay herramientas bloqueadas configuradas"
+    },
+    "allowedCommands": {
+      "title": "Comandos de shell permitidos",
+      "description": "Comandos de shell que se permiten automáticamente sin preguntar",
+      "placeholder": "p. ej., \"Shell(ls)\" o \"Shell(git status)\"",
+      "quickAdd": "Añadir rápido comandos comunes:",
+      "empty": "No hay comandos permitidos configurados"
+    },
+    "blockedCommands": {
+      "title": "Comandos de shell bloqueados",
+      "description": "Comandos de shell que se bloquean automáticamente",
+      "placeholder": "p. ej., \"Shell(rm -rf)\" o \"Shell(sudo)\"",
+      "empty": "No hay comandos bloqueados configurados"
+    },
+    "toolExamples": {
+      "title": "Ejemplos de patrones de herramientas:",
+      "bashGitLog": "- Permitir todos los comandos git log",
+      "bashGitDiff": "- Permitir todos los comandos git diff",
+      "write": "- Permitir todo uso de la herramienta Write",
+      "bashRm": "- Bloquear todos los comandos rm (peligroso)"
+    },
+    "shellExamples": {
+      "title": "Ejemplos de comandos de shell:",
+      "ls": "- Permitir el comando ls",
+      "gitStatus": "- Permitir git status",
+      "npmInstall": "- Permitir npm install",
+      "rmRf": "- Bloquear el borrado recursivo"
+    },
+    "codex": {
+      "permissionMode": "Modo de permisos",
+      "description": "Controla cómo Codex gestiona las modificaciones de archivos y la ejecución de comandos",
+      "modes": {
+        "default": {
+          "title": "Por defecto",
+          "description": "Solo los comandos de confianza (ls, cat, grep, git status, etc.) se ejecutan automáticamente. Los demás comandos se omiten. Puede escribir en el espacio de trabajo."
+        },
+        "acceptEdits": {
+          "title": "Aceptar ediciones",
+          "description": "Todos los comandos se ejecutan automáticamente dentro del espacio de trabajo. Modo automático completo con ejecución en sandbox."
+        },
+        "bypassPermissions": {
+          "title": "Omitir permisos",
+          "description": "Acceso completo al sistema sin restricciones. Todos los comandos se ejecutan automáticamente con acceso total a disco y red. Úsalo con precaución."
+        }
+      },
+      "technicalDetails": "Detalles técnicos",
+      "technicalInfo": {
+        "default": "sandboxMode=workspace-write, approvalPolicy=untrusted. Comandos de confianza: cat, cd, grep, head, ls, pwd, tail, git status/log/diff/show, find (sin -exec), etc.",
+        "acceptEdits": "sandboxMode=workspace-write, approvalPolicy=never. Todos los comandos se autoejecutan dentro del directorio del proyecto.",
+        "bypassPermissions": "sandboxMode=danger-full-access, approvalPolicy=never. Acceso completo al sistema; úsalo solo en entornos de confianza.",
+        "overrideNote": "Puedes cambiar esto por sesión con el botón de modo en la interfaz del chat."
+      }
+    },
+    "actions": {
+      "add": "Añadir"
+    }
+  },
+  "mcpServers": {
+    "title": "Servidores MCP",
+    "description": {
+      "claude": "Los servidores del Model Context Protocol proporcionan herramientas y fuentes de datos adicionales a Claude",
+      "cursor": "Los servidores del Model Context Protocol proporcionan herramientas y fuentes de datos adicionales a Cursor",
+      "codex": "Los servidores del Model Context Protocol proporcionan herramientas y fuentes de datos adicionales a Codex",
+      "opencode": "Los servidores del Model Context Protocol proporcionan herramientas y fuentes de datos adicionales a OpenCode"
+    },
+    "addButton": "Añadir servidor MCP",
+    "empty": "No hay servidores MCP configurados",
+    "serverType": "Tipo",
+    "scope": {
+      "local": "local",
+      "user": "usuario"
+    },
+    "config": {
+      "command": "Comando",
+      "url": "URL",
+      "args": "Argumentos",
+      "environment": "Entorno"
+    },
+    "tools": {
+      "title": "Herramientas",
+      "count": "({{count}}):",
+      "more": "+{{count}} más"
+    },
+    "actions": {
+      "edit": "Editar servidor",
+      "delete": "Eliminar servidor"
+    },
+    "managed": {
+      "badge": "Gestionado",
+      "hint": "Gestionado por CloudCLI."
+    },
+    "help": {
+      "title": "Acerca de MCP en Codex",
+      "description": "Codex admite servidores MCP basados en stdio. Puedes añadir servidores que amplíen las capacidades de Codex con herramientas y recursos adicionales."
+    }
+  },
+  "pluginSettings": {
+    "title": "Plugins",
+    "description": "Amplía la interfaz con plugins personalizados. Instala desde git o suelta una carpeta en ~/.claude-code-ui/plugins/",
+    "installPlaceholder": "https://github.com/usuario/mi-plugin",
+    "installButton": "Instalar",
+    "installing": "Instalando…",
+    "securityWarning": "Instala solo plugins cuyo código fuente hayas revisado o de autores en los que confíes.",
+    "scanningPlugins": "Buscando plugins…",
+    "noPluginsInstalled": "No hay plugins instalados",
+    "pullLatest": "Traer lo último desde git",
+    "noGitRemote": "Sin remoto de git — actualización no disponible",
+    "uninstallPlugin": "Desinstalar plugin",
+    "confirmUninstall": "Haz clic de nuevo para confirmar",
+    "confirmUninstallMessage": "¿Quitar {{name}}? Esto no se puede deshacer.",
+    "cancel": "Cancelar",
+    "remove": "Quitar",
+    "updateFailed": "La actualización falló",
+    "installFailed": "La instalación falló",
+    "uninstallFailed": "La desinstalación falló",
+    "toggleFailed": "El cambio de estado falló",
+    "starterPluginLabel": "Plugin de inicio",
+    "starter": "Inicio",
+    "docs": "Docs",
+    "sections": {
+      "officialTitle": "Plugins oficiales",
+      "officialDescription": "Mantenidos por el equipo de CloudCLI y listos para instalar directamente.",
+      "unofficialTitle": "Otros plugins",
+      "unofficialDescription": "Plugins e integraciones no oficiales de otros usuarios. Revisa el código fuente antes de instalar."
+    },
+    "starterPlugin": {
+      "name": "Estadísticas del proyecto",
+      "badge": "inicio",
+      "description": "Recuento de archivos, líneas de código, desglose por tipo de archivo y actividad reciente de tu proyecto.",
+      "install": "Instalar"
+    },
+    "terminalPlugin": {
+      "name": "Terminal",
+      "badge": "oficial",
+      "description": "Terminal integrada con acceso completo a la shell directamente en la interfaz.",
+      "install": "Instalar"
+    },
+    "scheduledPromptPlugin": {
+      "name": "Prompts programados",
+      "badge": "no oficial",
+      "description": "Programa prompts del espacio de trabajo, revisa el historial de ejecuciones y gestiona tareas locales recurrentes.",
+      "install": "Instalar"
+    },
+    "claudeWatchPlugin": {
+      "name": "Claude Watch",
+      "badge": "no oficial",
+      "description": "Vigila sesiones largas de Claude Code por si se cuelgan y expone controles del proceso.",
+      "install": "Instalar"
+    },
+    "prismCloudCLI": {
+      "name": "PRISM CloudCLI",
+      "badge": "no oficial",
+      "description": "Inteligencia de sesiones para Claude Code, dentro de CloudCLI. Descubre por qué tus sesiones queman tokens sin salir del navegador.",
+      "install": "Instalar"
+    },
+    "sessionManagerPlugin": {
+      "name": "Sesiones",
+      "badge": "no oficial",
+      "description": "Ver, gestionar y terminar sesiones activas de Claude Code.",
+      "install": "Instalar"
+    },
+    "tokenCostCalculatorPlugin": {
+      "name": "Calculadora de costes de tokens",
+      "badge": "no oficial",
+      "description": "Calcula costes de API a partir de precios de modelos y uso de tokens, con precios de modelos predefinidos.",
+      "install": "Instalar"
+    },
+    "taskQueuePlugin": {
+      "name": "Cola de tareas",
+      "badge": "no oficial",
+      "description": "Panel de cola de tareas para ver, filtrar y lanzar tareas de agentes.",
+      "install": "Instalar"
+    },
+    "githubIssuesBoardPlugin": {
+      "name": "Tablero de GitHub Issues",
+      "badge": "no oficial",
+      "description": "Tablero Kanban para GitHub Issues con sincronización bidireccional con TaskMaster e instalación automática de la skill CLI /github-task",
+      "install": "Instalar"
+    },
+    "claudeUsagePlugin": {
+      "name": "Uso de Claude",
+      "badge": "no oficial",
+      "description": "Sigue en vivo los límites del plan de Claude Code y explora el historial de tokens y costes de 30 días.",
+      "install": "Instalar"
+    },
+    "morePlugins": "Más",
+    "enable": "Activar",
+    "disable": "Desactivar",
+    "installAriaLabel": "URL del repositorio git del plugin",
+    "tab": "pestaña",
+    "runningStatus": "en ejecución"
+  }
+}

--- a/src/i18n/locales/es/sidebar.json
+++ b/src/i18n/locales/es/sidebar.json
@@ -1,0 +1,145 @@
+{
+  "projects": {
+    "title": "Proyectos",
+    "newProject": "Nuevo proyecto",
+    "deleteProject": "Quitar proyecto",
+    "renameProject": "Renombrar proyecto",
+    "noProjects": "No se encontraron proyectos",
+    "loadingProjects": "Cargando proyectos...",
+    "searchPlaceholder": "Buscar proyectos...",
+    "projectNamePlaceholder": "Nombre del proyecto",
+    "starred": "Favoritos",
+    "all": "Todos",
+    "untitledSession": "Sesión sin título",
+    "newSession": "Nueva sesión",
+    "codexSession": "Sesión de Codex",
+    "fetchingProjects": "Obteniendo tus proyectos y sesiones de Claude",
+    "projects": "proyectos",
+    "noMatchingProjects": "No hay proyectos que coincidan",
+    "tryDifferentSearch": "Prueba con otro término de búsqueda",
+    "runClaudeCli": "Ejecuta Claude CLI en el directorio de un proyecto para empezar"
+  },
+  "app": {
+    "title": "CloudCLI",
+    "subtitle": "Interfaz de asistente de programación con IA"
+  },
+  "sessions": {
+    "title": "Sesiones",
+    "newSession": "Nueva sesión",
+    "deleteSession": "Eliminar sesión",
+    "renameSession": "Renombrar sesión",
+    "noSessions": "Aún no hay sesiones",
+    "loadingSessions": "Cargando sesiones...",
+    "unnamed": "Sin nombre",
+    "loading": "Cargando...",
+    "showMore": "Mostrar más sesiones"
+  },
+  "tooltips": {
+    "viewEnvironments": "Ver entornos",
+    "hideSidebar": "Ocultar barra lateral",
+    "createProject": "Crear proyecto nuevo",
+    "refresh": "Actualizar proyectos y sesiones (Ctrl+R)",
+    "renameProject": "Renombrar proyecto (F2)",
+    "deleteProject": "Quitar proyecto de la barra lateral (Supr)",
+    "addToFavorites": "Añadir a favoritos",
+    "removeFromFavorites": "Quitar de favoritos",
+    "editSessionName": "Editar manualmente el nombre de la sesión",
+    "deleteSession": "Eliminar esta sesión de forma permanente",
+    "activeSessionIndicator": "Sesión activa recientemente (últimos 10 minutos)",
+    "save": "Guardar",
+    "cancel": "Cancelar",
+    "clearSearch": "Limpiar búsqueda",
+    "openCommandPalette": "Abrir paleta de comandos",
+    "attentionRequiredIndicator": "La sesión requiere atención"
+  },
+  "navigation": {
+    "chat": "Chat",
+    "files": "Archivos",
+    "git": "Git",
+    "terminal": "Terminal",
+    "tasks": "Tareas"
+  },
+  "actions": {
+    "refresh": "Actualizar",
+    "settings": "Ajustes",
+    "collapseAll": "Contraer todo",
+    "expandAll": "Expandir todo",
+    "cancel": "Cancelar",
+    "save": "Guardar",
+    "delete": "Eliminar",
+    "rename": "Renombrar",
+    "joinCommunity": "Unirse a la comunidad",
+    "reportIssue": "Informar de un problema",
+    "starOnGithub": "Dar estrella en GitHub"
+  },
+  "branding": {
+    "openSource": "Código abierto"
+  },
+  "status": {
+    "active": "Activa",
+    "inactive": "Inactiva",
+    "thinking": "Pensando...",
+    "error": "Error",
+    "aborted": "Cancelada",
+    "unknown": "Desconocido"
+  },
+  "time": {
+    "justNow": "Justo ahora",
+    "oneMinuteAgo": "hace 1 min",
+    "minutesAgo": "hace {{count}} min",
+    "oneHourAgo": "hace 1 hora",
+    "hoursAgo": "hace {{count}} horas",
+    "oneDayAgo": "hace 1 día",
+    "daysAgo": "hace {{count}} días"
+  },
+  "messages": {
+    "deleteConfirm": "¿Seguro que quieres eliminar esto?",
+    "renameSuccess": "Renombrado correctamente",
+    "deleteSuccess": "Eliminado correctamente",
+    "errorOccurred": "Ocurrió un error",
+    "deleteSessionConfirm": "¿Seguro que quieres eliminar esta sesión? Esta acción no se puede deshacer.",
+    "deleteProjectConfirm": "¿Quitar este proyecto de la barra lateral? Tus archivos, memorias y datos de sesión no se eliminarán.",
+    "enterProjectPath": "Introduce la ruta del proyecto",
+    "deleteSessionFailed": "No se pudo eliminar la sesión. Inténtalo de nuevo.",
+    "deleteSessionError": "Error al eliminar la sesión. Inténtalo de nuevo.",
+    "renameSessionFailed": "No se pudo renombrar la sesión. Inténtalo de nuevo.",
+    "renameSessionError": "Error al renombrar la sesión. Inténtalo de nuevo.",
+    "deleteProjectFailed": "No se pudo quitar el proyecto. Inténtalo de nuevo.",
+    "deleteProjectError": "Error al quitar el proyecto. Inténtalo de nuevo.",
+    "createProjectFailed": "No se pudo crear el proyecto. Inténtalo de nuevo.",
+    "createProjectError": "Error al crear el proyecto. Inténtalo de nuevo.",
+    "updateProjectError": "Error al actualizar el proyecto. Inténtalo de nuevo.",
+    "refreshError": "No se pudo actualizar. Inténtalo de nuevo.",
+    "restoreProjectFailed": "No se pudo restaurar el proyecto. Inténtalo de nuevo.",
+    "restoreProjectError": "Error al restaurar el proyecto. Inténtalo de nuevo.",
+    "restoreSessionFailed": "No se pudo restaurar la sesión. Inténtalo de nuevo.",
+    "restoreSessionError": "Error al restaurar la sesión. Inténtalo de nuevo."
+  },
+  "version": {
+    "updateAvailable": "Actualización disponible",
+    "restartRequired": "Actualización instalada — reinicia el servidor para aplicarla"
+  },
+  "search": {
+    "modeProjects": "Proyectos",
+    "modeConversations": "Conversaciones",
+    "conversationsPlaceholder": "Buscar en conversaciones...",
+    "searching": "Buscando...",
+    "noResults": "No se encontraron resultados",
+    "tryDifferentQuery": "Prueba con otra búsqueda",
+    "matches_one": "{{count}} coincidencia",
+    "matches_other": "{{count}} coincidencias",
+    "projectsScanned_one": "{{count}} proyecto examinado",
+    "projectsScanned_other": "{{count}} proyectos examinados"
+  },
+  "deleteConfirmation": {
+    "deleteProject": "Quitar proyecto",
+    "deleteSession": "Eliminar sesión",
+    "confirmDelete": "¿Qué quieres hacer con",
+    "sessionCount_one": "Este proyecto contiene {{count}} conversación.",
+    "sessionCount_other": "Este proyecto contiene {{count}} conversaciones.",
+    "removeFromSidebar": "Solo quitar de la barra lateral",
+    "deleteAllData": "Eliminar todos los datos permanentemente",
+    "allConversationsDeleted": "El proyecto se quitará de la barra lateral. Tus archivos, memorias y datos de sesión se conservarán.",
+    "cannotUndo": "Puedes volver a añadir el proyecto más tarde."
+  }
+}

--- a/src/i18n/locales/es/tasks.json
+++ b/src/i18n/locales/es/tasks.json
@@ -1,0 +1,142 @@
+{
+  "notConfigured": {
+    "title": "TaskMaster AI no está configurado",
+    "description": "TaskMaster ayuda a descomponer proyectos complejos en tareas manejables con asistencia de IA",
+    "whatIsTitle": "🎯 ¿Qué es TaskMaster?",
+    "features": {
+      "aiPowered": "Gestión de tareas con IA: descompone proyectos complejos en subtareas manejables",
+      "prdTemplates": "Plantillas PRD: genera tareas a partir de Documentos de Requisitos de Producto",
+      "dependencyTracking": "Seguimiento de dependencias: entiende las relaciones entre tareas y el orden de ejecución",
+      "progressVisualization": "Visualización del progreso: tableros Kanban y analíticas detalladas de tareas",
+      "cliIntegration": "Integración CLI: usa comandos de taskmaster para flujos de trabajo avanzados"
+    },
+    "initializeButton": "Inicializar TaskMaster AI"
+  },
+  "gettingStarted": {
+    "title": "Primeros pasos con TaskMaster",
+    "subtitle": "¡TaskMaster está inicializado! Esto es lo que puedes hacer ahora:",
+    "steps": {
+      "createPRD": {
+        "title": "Crea un Documento de Requisitos de Producto (PRD)",
+        "description": "Conversa sobre la idea de tu proyecto y crea un PRD que describa lo que quieres construir.",
+        "addButton": "Añadir PRD",
+        "existingPRDs": "PRDs existentes:"
+      },
+      "generateTasks": {
+        "title": "Genera tareas desde el PRD",
+        "description": "Cuando tengas un PRD, pídele a tu asistente de IA que lo analice y TaskMaster lo descompondrá automáticamente en tareas manejables con detalles de implementación."
+      },
+      "analyzeTasks": {
+        "title": "Analiza y expande tareas",
+        "description": "Pídele a tu asistente de IA que analice la complejidad de las tareas y las expanda en subtareas detalladas para facilitar la implementación."
+      },
+      "startBuilding": {
+        "title": "Empieza a construir",
+        "description": "Pídele a tu asistente de IA que empiece a trabajar en las tareas, actualice su estado y añada tareas nuevas a medida que tu proyecto evoluciona."
+      }
+    },
+    "tip": "💡 Consejo: empieza con un PRD para sacar el máximo partido a la generación de tareas con IA de TaskMaster"
+  },
+  "setupModal": {
+    "title": "Configuración de TaskMaster",
+    "subtitle": "CLI interactiva para {{projectName}}",
+    "willStart": "La inicialización de TaskMaster comenzará automáticamente",
+    "completed": "¡Configuración de TaskMaster completada! Ya puedes cerrar esta ventana.",
+    "closeButton": "Cerrar",
+    "closeContinueButton": "Cerrar y continuar"
+  },
+  "helpGuide": {
+    "title": "Primeros pasos con TaskMaster",
+    "subtitle": "Tu guía para una gestión de tareas productiva",
+    "examples": {
+      "parsePRD": "💬 Ejemplo:\n\"Acabo de inicializar un proyecto nuevo con Claude Task Master. Tengo un PRD en .taskmaster/docs/prd.txt. ¿Me ayudas a analizarlo y configurar las tareas iniciales?\"",
+      "expandTask": "💬 Ejemplo:\n\"La tarea 5 parece compleja. ¿Puedes descomponerla en subtareas?\"",
+      "addTask": "💬 Ejemplo:\n\"Añade una tarea nueva para implementar la subida de imágenes de perfil de usuario con Cloudinary, e investiga el mejor enfoque.\""
+    },
+    "moreExamples": "Ver más ejemplos y patrones de uso →",
+    "proTips": {
+      "title": "💡 Consejos pro",
+      "search": "Usa la barra de búsqueda para encontrar tareas específicas rápidamente",
+      "views": "Cambia entre las vistas Kanban, Lista y Cuadrícula con los selectores de vista",
+      "filters": "Usa los filtros para centrarte en estados o prioridades específicas",
+      "details": "Haz clic en cualquier tarea para ver información detallada y gestionar subtareas"
+    },
+    "learnMore": {
+      "title": "📚 Más información",
+      "description": "TaskMaster AI es un sistema avanzado de gestión de tareas creado para desarrolladores. Consulta la documentación, ejemplos y contribuye al proyecto.",
+      "githubButton": "Ver en GitHub"
+    }
+  },
+  "search": {
+    "placeholder": "Buscar tareas..."
+  },
+  "filters": {
+    "button": "Filtros",
+    "status": "Estado",
+    "priority": "Prioridad",
+    "sortBy": "Ordenar por",
+    "allStatuses": "Todos los estados",
+    "allPriorities": "Todas las prioridades",
+    "showing": "Mostrando {{filtered}} de {{total}} tareas",
+    "clearFilters": "Limpiar filtros"
+  },
+  "sort": {
+    "id": "ID",
+    "status": "Estado",
+    "priority": "Prioridad",
+    "idAsc": "ID (ascendente)",
+    "idDesc": "ID (descendente)",
+    "titleAsc": "Título (A-Z)",
+    "titleDesc": "Título (Z-A)",
+    "statusAsc": "Estado (pendientes primero)",
+    "statusDesc": "Estado (completadas primero)",
+    "priorityAsc": "Prioridad (alta primero)",
+    "priorityDesc": "Prioridad (baja primero)"
+  },
+  "views": {
+    "kanban": "Vista Kanban",
+    "list": "Vista de lista",
+    "grid": "Vista de cuadrícula"
+  },
+  "kanban": {
+    "pending": "📋 Por hacer",
+    "inProgress": "🚀 En curso",
+    "done": "✅ Hechas",
+    "blocked": "🚫 Bloqueadas",
+    "deferred": "⏳ Aplazadas",
+    "cancelled": "❌ Canceladas",
+    "noTasksYet": "Aún no hay tareas",
+    "tasksWillAppear": "Las tareas aparecerán aquí",
+    "moveTasksHere": "Mueve las tareas aquí cuando empiecen",
+    "completedTasksHere": "Las tareas completadas aparecen aquí",
+    "statusTasksHere": "Las tareas con este estado aparecerán aquí"
+  },
+  "buttons": {
+    "help": "Guía de primeros pasos de TaskMaster",
+    "prds": "PRDs",
+    "addPRD": "Añadir PRD",
+    "addTask": "Añadir tarea",
+    "createNewPRD": "Crear PRD nuevo",
+    "prdsAvailable": "{{count}} PRD(s) disponibles"
+  },
+  "prd": {
+    "modified": "Modificado: {{date}}"
+  },
+  "statuses": {
+    "pending": "Pendiente",
+    "in-progress": "En curso",
+    "done": "Hecha",
+    "blocked": "Bloqueada",
+    "deferred": "Aplazada",
+    "cancelled": "Cancelada"
+  },
+  "priorities": {
+    "high": "Alta",
+    "medium": "Media",
+    "low": "Baja"
+  },
+  "noMatchingTasks": {
+    "title": "Ninguna tarea coincide con tus filtros",
+    "description": "Prueba a ajustar la búsqueda o los criterios de filtrado."
+  }
+}


### PR DESCRIPTION
## Summary

Adds a complete **Spanish (es)** locale — currently the app ships English, French, Italian, German, Russian, Korean, Japanese, Turkish and Chinese (Simplified/Traditional), but no Spanish.

- All 7 namespaces fully translated: `common`, `settings`, `auth`, `sidebar`, `chat`, `codeEditor`, `tasks`
- Registered in `src/i18n/config.js` (imports + resources) following the exact pattern of the existing locales
- Added to the language selector in `src/i18n/languages.js` (`Spanish / Español`)

## Test plan

- `npm run build` passes
- Verified in the running app: selecting *Español* in Settings translates the full UI (sidebar, main content, settings, chat)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Spanish as a supported application language.
  * Added Spanish translations across authentication, chat, code editing, settings, navigation, tasks, and shared interface content.
  * Included localized labels, messages, statuses, validation feedback, prompts, and empty states throughout the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->