### PR TITLE
feat: add opt-in bandwidth monitoring behind BANDWIDTH_MONITOR_ENABLED

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,6 +28,10 @@ HOST=0.0.0.0
 # Uncomment the following line if you have a custom claude cli path other than the default "claude"
 # CLAUDE_CLI_PATH=claude
 
+# Uncomment to log periodic bandwidth totals (HTTP + WebSocket) to the console,
+# bucketed by route. Useful for diagnosing unexpected data usage. Off by default.
+# BANDWIDTH_MONITOR_ENABLED=true
+
 # =============================================================================
 # DATABASE CONFIGURATION
 # =============================================================================

--- a/server/index.ts
+++ b/server/index.ts
@@ -16,7 +16,11 @@ import {
     providerRuntimeService,
 } from '@/modules/providers/index.js';
 import { createWebSocketServer } from '@/modules/websocket/index.js';
-import { estimateByteLength, recordBandwidth } from '@/modules/websocket/services/network-diagnostics.service.js';
+import {
+    estimateByteLength,
+    isBandwidthMonitorEnabled,
+    recordBandwidth,
+} from '@/modules/websocket/services/bandwidth-monitor.service.js';
 
 import { getConnectableHost } from '../shared/networkHosts.js';
 
@@ -120,44 +124,46 @@ const wss = createWebSocketServer(server, {
 // Make WebSocket server available to routes
 app.locals.wss = wss;
 
-// DIAGNOSTIC ONLY - temporary bandwidth instrumentation, remove after investigation.
+// Optional, opt-in bandwidth monitoring (BANDWIDTH_MONITOR_ENABLED=true).
 // Mounted first so it wraps res.write/res.end before any other middleware or
 // static file handler touches them, capturing every byte this server sends
 // over HTTP (API responses, the SPA shell, and static assets alike).
-app.use((req, res, next) => {
-    let bytesSent = 0;
-    const originalWrite = res.write.bind(res);
-    const originalEnd = res.end.bind(res);
+if (isBandwidthMonitorEnabled()) {
+    app.use((req, res, next) => {
+        let bytesSent = 0;
+        const originalWrite = res.write.bind(res);
+        const originalEnd = res.end.bind(res);
 
-    res.write = ((chunk?: unknown, ...rest: unknown[]) => {
-        if (chunk !== undefined) {
-            bytesSent += estimateByteLength(chunk);
-        }
-        // @ts-expect-error - forwarding res.write's overloaded variadic signature as-is
-        return originalWrite(chunk, ...rest);
-    }) as typeof res.write;
+        res.write = ((chunk?: unknown, ...rest: unknown[]) => {
+            if (chunk !== undefined) {
+                bytesSent += estimateByteLength(chunk);
+            }
+            // @ts-expect-error - forwarding res.write's overloaded variadic signature as-is
+            return originalWrite(chunk, ...rest);
+        }) as typeof res.write;
 
-    res.end = ((chunk?: unknown, ...rest: unknown[]) => {
-        if (chunk !== undefined) {
-            bytesSent += estimateByteLength(chunk);
-        }
-        // @ts-expect-error - forwarding res.end's overloaded variadic signature as-is
-        return originalEnd(chunk, ...rest);
-    }) as typeof res.end;
+        res.end = ((chunk?: unknown, ...rest: unknown[]) => {
+            if (chunk !== undefined) {
+                bytesSent += estimateByteLength(chunk);
+            }
+            // @ts-expect-error - forwarding res.end's overloaded variadic signature as-is
+            return originalEnd(chunk, ...rest);
+        }) as typeof res.end;
 
-    res.on('finish', () => {
-        const ext = path.extname(req.path);
-        const segments = req.path.split('/').filter(Boolean);
-        const bucketKey = ext
-            ? `http:static:${ext}`
-            : segments[0] === 'api'
-                ? `http:api:${segments.slice(0, 2).join('/')}`
-                : `http:page:${segments[0] || '/'}`;
-        recordBandwidth(bucketKey, bytesSent);
+        res.on('finish', () => {
+            const ext = path.extname(req.path);
+            const segments = req.path.split('/').filter(Boolean);
+            const bucketKey = ext
+                ? `http:static:${ext}`
+                : segments[0] === 'api'
+                    ? `http:api:${segments.slice(0, 2).join('/')}`
+                    : `http:page:${segments[0] || '/'}`;
+            recordBandwidth(bucketKey, bytesSent);
+        });
+
+        next();
     });
-
-    next();
-});
+}
 
 app.use(cors({ exposedHeaders: ['X-Refreshed-Token', 'X-Auth-Error'] }));
 app.use(express.json({
@@ -174,19 +180,12 @@ app.use(express.json({
 app.use(express.urlencoded({ limit: '50mb', extended: true }));
 
 // Public health check endpoint (no authentication required)
-// DIAGNOSTIC ONLY - lets us confirm from outside the container that a
-// running pod is actually serving this exact commit's code, since a stale
-// build would otherwise look identical from the outside.
-const DEBUG_BUILD_MARKER = 'shell-bandwidth-diag-v3-unbounded-request-logging';
-console.log(`[DIAG build] ${DEBUG_BUILD_MARKER}`);
-
 app.get('/health', (req, res) => {
     res.json({
         status: 'ok',
         timestamp: new Date().toISOString(),
         installMode,
-        version: RUNNING_VERSION,
-        debugBuildMarker: DEBUG_BUILD_MARKER
+        version: RUNNING_VERSION
     });
 });
 

--- a/server/index.ts
+++ b/server/index.ts
@@ -16,6 +16,7 @@ import {
     providerRuntimeService,
 } from '@/modules/providers/index.js';
 import { createWebSocketServer } from '@/modules/websocket/index.js';
+import { estimateByteLength, recordBandwidth } from '@/modules/websocket/services/network-diagnostics.service.js';
 
 import { getConnectableHost } from '../shared/networkHosts.js';
 
@@ -118,6 +119,45 @@ const wss = createWebSocketServer(server, {
 
 // Make WebSocket server available to routes
 app.locals.wss = wss;
+
+// DIAGNOSTIC ONLY - temporary bandwidth instrumentation, remove after investigation.
+// Mounted first so it wraps res.write/res.end before any other middleware or
+// static file handler touches them, capturing every byte this server sends
+// over HTTP (API responses, the SPA shell, and static assets alike).
+app.use((req, res, next) => {
+    let bytesSent = 0;
+    const originalWrite = res.write.bind(res);
+    const originalEnd = res.end.bind(res);
+
+    res.write = ((chunk?: unknown, ...rest: unknown[]) => {
+        if (chunk !== undefined) {
+            bytesSent += estimateByteLength(chunk);
+        }
+        // @ts-expect-error - forwarding res.write's overloaded variadic signature as-is
+        return originalWrite(chunk, ...rest);
+    }) as typeof res.write;
+
+    res.end = ((chunk?: unknown, ...rest: unknown[]) => {
+        if (chunk !== undefined) {
+            bytesSent += estimateByteLength(chunk);
+        }
+        // @ts-expect-error - forwarding res.end's overloaded variadic signature as-is
+        return originalEnd(chunk, ...rest);
+    }) as typeof res.end;
+
+    res.on('finish', () => {
+        const ext = path.extname(req.path);
+        const segments = req.path.split('/').filter(Boolean);
+        const bucketKey = ext
+            ? `http:static:${ext}`
+            : segments[0] === 'api'
+                ? `http:api:${segments.slice(0, 2).join('/')}`
+                : `http:page:${segments[0] || '/'}`;
+        recordBandwidth(bucketKey, bytesSent);
+    });
+
+    next();
+});
 
 app.use(cors({ exposedHeaders: ['X-Refreshed-Token', 'X-Auth-Error'] }));
 app.use(express.json({

--- a/server/index.ts
+++ b/server/index.ts
@@ -174,12 +174,19 @@ app.use(express.json({
 app.use(express.urlencoded({ limit: '50mb', extended: true }));
 
 // Public health check endpoint (no authentication required)
+// DIAGNOSTIC ONLY - lets us confirm from outside the container that a
+// running pod is actually serving this exact commit's code, since a stale
+// build would otherwise look identical from the outside.
+const DEBUG_BUILD_MARKER = 'shell-bandwidth-diag-v3-unbounded-request-logging';
+console.log(`[DIAG build] ${DEBUG_BUILD_MARKER}`);
+
 app.get('/health', (req, res) => {
     res.json({
         status: 'ok',
         timestamp: new Date().toISOString(),
         installMode,
-        version: RUNNING_VERSION
+        version: RUNNING_VERSION,
+        debugBuildMarker: DEBUG_BUILD_MARKER
     });
 });
 

--- a/server/modules/providers/provider.routes.ts
+++ b/server/modules/providers/provider.routes.ts
@@ -666,6 +666,23 @@ router.get(
       offset = parsedOffset;
     }
 
+    // DIAGNOSTIC ONLY - identify every caller of the unbounded (limit=null)
+    // path, since static analysis of the frontend found no remaining
+    // in-repo caller but the endpoint keeps getting hit unbounded in
+    // production. Logs enough of the request to fingerprint the source:
+    // headers a real browser sends vs. an internal/loopback caller.
+    if (limit === null) {
+      console.log(
+        `[DIAG messages] UNBOUNDED hit sessionId=${sessionId} ` +
+          `ua=${JSON.stringify(req.headers['user-agent'] ?? null)} ` +
+          `referer=${JSON.stringify(req.headers['referer'] ?? req.headers['origin'] ?? null)} ` +
+          `remoteAddr=${req.socket.remoteAddress ?? 'unknown'} ` +
+          `xForwardedFor=${JSON.stringify(req.headers['x-forwarded-for'] ?? null)} ` +
+          `authHeaderPresent=${Boolean(req.headers['authorization'])} ` +
+          `stack=${new Error('trace').stack?.split('\n').slice(1, 5).join(' <- ')}`
+      );
+    }
+
     const result = await sessionsService.fetchHistory(sessionId, {
       limit,
       offset,

--- a/server/modules/providers/provider.routes.ts
+++ b/server/modules/providers/provider.routes.ts
@@ -17,6 +17,7 @@ import type {
   UpsertProviderMcpServerInput,
 } from '@/shared/types.js';
 import { AppError, asyncHandler, createApiSuccessResponse } from '@/shared/utils.js';
+import { isBandwidthMonitorEnabled } from '@/modules/websocket/services/bandwidth-monitor.service.js';
 
 const router = express.Router();
 
@@ -666,14 +667,13 @@ router.get(
       offset = parsedOffset;
     }
 
-    // DIAGNOSTIC ONLY - identify every caller of the unbounded (limit=null)
-    // path, since static analysis of the frontend found no remaining
-    // in-repo caller but the endpoint keeps getting hit unbounded in
-    // production. Logs enough of the request to fingerprint the source:
-    // headers a real browser sends vs. an internal/loopback caller.
-    if (limit === null) {
+    // Optional, opt-in bandwidth monitoring (BANDWIDTH_MONITOR_ENABLED=true).
+    // Identifies callers of the unbounded (limit=null) path, useful for
+    // catching bandwidth regressions where a full-history fetch slips back in.
+    // Logs enough of the request to fingerprint the source.
+    if (limit === null && isBandwidthMonitorEnabled()) {
       console.log(
-        `[DIAG messages] UNBOUNDED hit sessionId=${sessionId} ` +
+        `[bandwidth-monitor messages] UNBOUNDED hit sessionId=${sessionId} ` +
           `ua=${JSON.stringify(req.headers['user-agent'] ?? null)} ` +
           `referer=${JSON.stringify(req.headers['referer'] ?? req.headers['origin'] ?? null)} ` +
           `remoteAddr=${req.socket.remoteAddress ?? 'unknown'} ` +

--- a/server/modules/websocket/services/bandwidth-monitor.service.ts
+++ b/server/modules/websocket/services/bandwidth-monitor.service.ts
@@ -1,13 +1,16 @@
 import { WebSocket } from 'ws';
 
 /**
- * DIAGNOSTIC ONLY - temporary instrumentation for investigating unexplained
- * outbound bandwidth. Tracks bytes sent by every response the server emits
- * (HTTP responses and every WebSocket channel: shell, chat, desktop
- * notifications, plugin proxy), bucketed by a coarse key, and logs totals on
- * an interval so the numbers can be correlated against client-side data
- * usage readings. Remove once the investigation concludes.
+ * Optional, opt-in bandwidth monitoring. Tracks bytes sent by every response
+ * the server emits (HTTP responses and every WebSocket channel: shell, chat,
+ * desktop notifications, plugin proxy), bucketed by a coarse key, and logs
+ * totals on an interval so they can be correlated against client-side data
+ * usage readings. Disabled by default - enable with BANDWIDTH_MONITOR_ENABLED=true.
  */
+
+export function isBandwidthMonitorEnabled(): boolean {
+  return process.env.BANDWIDTH_MONITOR_ENABLED === 'true';
+}
 
 type BandwidthBucket = {
   messages: number;
@@ -15,7 +18,7 @@ type BandwidthBucket = {
 };
 
 const buckets = new Map<string, BandwidthBucket>();
-const diagnosticsStartedAt = Date.now();
+const monitorStartedAt = Date.now();
 
 function bucketFor(key: string): BandwidthBucket {
   let bucket = buckets.get(key);
@@ -27,6 +30,9 @@ function bucketFor(key: string): BandwidthBucket {
 }
 
 export function recordBandwidth(key: string, byteLength: number): void {
+  if (!isBandwidthMonitorEnabled()) {
+    return;
+  }
   const bucket = bucketFor(key);
   bucket.messages += 1;
   bucket.bytes += byteLength;
@@ -51,13 +57,13 @@ export function estimateByteLength(data: unknown): number {
 let loggingStarted = false;
 
 export function startBandwidthLogging(intervalMs = 10_000): void {
-  if (loggingStarted) {
+  if (!isBandwidthMonitorEnabled() || loggingStarted) {
     return;
   }
   loggingStarted = true;
 
   const timer = setInterval(() => {
-    const elapsedSec = ((Date.now() - diagnosticsStartedAt) / 1000).toFixed(1);
+    const elapsedSec = ((Date.now() - monitorStartedAt) / 1000).toFixed(1);
     const entries = Array.from(buckets.entries()).sort((a, b) => b[1].bytes - a[1].bytes);
     const totalBytes = entries.reduce((sum, [, bucket]) => sum + bucket.bytes, 0);
     const breakdown = entries
@@ -65,24 +71,25 @@ export function startBandwidthLogging(intervalMs = 10_000): void {
       .join(' | ');
 
     console.log(
-      `[DIAG net] elapsed=${elapsedSec}s TOTAL=${(totalBytes / 1024).toFixed(1)}KB${breakdown ? ' | ' + breakdown : ''}`
+      `[bandwidth-monitor] elapsed=${elapsedSec}s TOTAL=${(totalBytes / 1024).toFixed(1)}KB${breakdown ? ' | ' + breakdown : ''}`
     );
   }, intervalMs);
 
   timer.unref();
 }
 
-type TaggedWebSocket = WebSocket & { _diagRoute?: string };
+type TaggedWebSocket = WebSocket & { _bandwidthRoute?: string };
 
 let webSocketSendPatched = false;
 
 /**
  * Monkey-patches WebSocket.prototype.send once so every outbound WS frame on
  * every channel (shell, chat, desktop-notifications, plugin proxy) is
- * counted, without needing to instrument each service individually.
+ * counted, without needing to instrument each service individually. No-op
+ * unless bandwidth monitoring is enabled.
  */
 export function patchWebSocketBandwidthTracking(): void {
-  if (webSocketSendPatched) {
+  if (!isBandwidthMonitorEnabled() || webSocketSendPatched) {
     return;
   }
   webSocketSendPatched = true;
@@ -95,10 +102,10 @@ export function patchWebSocketBandwidthTracking(): void {
     ...rest: unknown[]
   ) {
     try {
-      const route = this._diagRoute ?? 'ws:unknown';
+      const route = this._bandwidthRoute ?? 'ws:unknown';
       recordBandwidth(route, estimateByteLength(data));
     } catch {
-      // Diagnostics must never break real traffic.
+      // Monitoring must never break real traffic.
     }
 
     // @ts-expect-error - forwarding the library's overloaded variadic signature as-is
@@ -107,5 +114,8 @@ export function patchWebSocketBandwidthTracking(): void {
 }
 
 export function tagWebSocketRoute(ws: WebSocket, route: string): void {
-  (ws as TaggedWebSocket)._diagRoute = `ws:${route}`;
+  if (!isBandwidthMonitorEnabled()) {
+    return;
+  }
+  (ws as TaggedWebSocket)._bandwidthRoute = `ws:${route}`;
 }

--- a/server/modules/websocket/services/network-diagnostics.service.ts
+++ b/server/modules/websocket/services/network-diagnostics.service.ts
@@ -1,0 +1,111 @@
+import { WebSocket } from 'ws';
+
+/**
+ * DIAGNOSTIC ONLY - temporary instrumentation for investigating unexplained
+ * outbound bandwidth. Tracks bytes sent by every response the server emits
+ * (HTTP responses and every WebSocket channel: shell, chat, desktop
+ * notifications, plugin proxy), bucketed by a coarse key, and logs totals on
+ * an interval so the numbers can be correlated against client-side data
+ * usage readings. Remove once the investigation concludes.
+ */
+
+type BandwidthBucket = {
+  messages: number;
+  bytes: number;
+};
+
+const buckets = new Map<string, BandwidthBucket>();
+const diagnosticsStartedAt = Date.now();
+
+function bucketFor(key: string): BandwidthBucket {
+  let bucket = buckets.get(key);
+  if (!bucket) {
+    bucket = { messages: 0, bytes: 0 };
+    buckets.set(key, bucket);
+  }
+  return bucket;
+}
+
+export function recordBandwidth(key: string, byteLength: number): void {
+  const bucket = bucketFor(key);
+  bucket.messages += 1;
+  bucket.bytes += byteLength;
+}
+
+export function estimateByteLength(data: unknown): number {
+  if (typeof data === 'string') {
+    return Buffer.byteLength(data, 'utf8');
+  }
+  if (Buffer.isBuffer(data)) {
+    return data.length;
+  }
+  if (data instanceof ArrayBuffer) {
+    return data.byteLength;
+  }
+  if (ArrayBuffer.isView(data)) {
+    return data.byteLength;
+  }
+  return 0;
+}
+
+let loggingStarted = false;
+
+export function startBandwidthLogging(intervalMs = 10_000): void {
+  if (loggingStarted) {
+    return;
+  }
+  loggingStarted = true;
+
+  const timer = setInterval(() => {
+    const elapsedSec = ((Date.now() - diagnosticsStartedAt) / 1000).toFixed(1);
+    const entries = Array.from(buckets.entries()).sort((a, b) => b[1].bytes - a[1].bytes);
+    const totalBytes = entries.reduce((sum, [, bucket]) => sum + bucket.bytes, 0);
+    const breakdown = entries
+      .map(([key, bucket]) => `${key}: ${bucket.messages} msgs / ${(bucket.bytes / 1024).toFixed(1)}KB`)
+      .join(' | ');
+
+    console.log(
+      `[DIAG net] elapsed=${elapsedSec}s TOTAL=${(totalBytes / 1024).toFixed(1)}KB${breakdown ? ' | ' + breakdown : ''}`
+    );
+  }, intervalMs);
+
+  timer.unref();
+}
+
+type TaggedWebSocket = WebSocket & { _diagRoute?: string };
+
+let webSocketSendPatched = false;
+
+/**
+ * Monkey-patches WebSocket.prototype.send once so every outbound WS frame on
+ * every channel (shell, chat, desktop-notifications, plugin proxy) is
+ * counted, without needing to instrument each service individually.
+ */
+export function patchWebSocketBandwidthTracking(): void {
+  if (webSocketSendPatched) {
+    return;
+  }
+  webSocketSendPatched = true;
+
+  const originalSend = WebSocket.prototype.send;
+
+  WebSocket.prototype.send = function patchedSend(
+    this: TaggedWebSocket,
+    data: Parameters<typeof originalSend>[0],
+    ...rest: unknown[]
+  ) {
+    try {
+      const route = this._diagRoute ?? 'ws:unknown';
+      recordBandwidth(route, estimateByteLength(data));
+    } catch {
+      // Diagnostics must never break real traffic.
+    }
+
+    // @ts-expect-error - forwarding the library's overloaded variadic signature as-is
+    return originalSend.call(this, data, ...rest);
+  };
+}
+
+export function tagWebSocketRoute(ws: WebSocket, route: string): void {
+  (ws as TaggedWebSocket)._diagRoute = `ws:${route}`;
+}

--- a/server/modules/websocket/services/shell-websocket.service.ts
+++ b/server/modules/websocket/services/shell-websocket.service.ts
@@ -297,6 +297,40 @@ export function handleShellConnection(
   let urlDetectionBuffer = '';
   const announcedAuthUrls = new Set<string>();
 
+  // DIAGNOSTIC: temporary bandwidth instrumentation, remove after investigation.
+  const diag = {
+    outputMessages: 0,
+    outputBytes: 0,
+    replayMessages: 0,
+    replayBytes: 0,
+    resizeMessages: 0,
+    inputMessages: 0,
+    inputBytes: 0,
+    startedAt: Date.now(),
+  };
+  const diagLogInterval = setInterval(() => {
+    const elapsedSec = ((Date.now() - diag.startedAt) / 1000).toFixed(1);
+    console.log(
+      `[DIAG shell] key=${ptySessionKey} elapsed=${elapsedSec}s ` +
+        `output: ${diag.outputMessages} msgs / ${(diag.outputBytes / 1024).toFixed(1)}KB | ` +
+        `replay: ${diag.replayMessages} msgs / ${(diag.replayBytes / 1024).toFixed(1)}KB | ` +
+        `resize: ${diag.resizeMessages} msgs | ` +
+        `input: ${diag.inputMessages} msgs / ${diag.inputBytes}B`
+    );
+  }, 5000);
+  ws.on('close', () => {
+    clearInterval(diagLogInterval);
+    const elapsedSec = ((Date.now() - diag.startedAt) / 1000).toFixed(1);
+    console.log(
+      `[DIAG shell] FINAL key=${ptySessionKey} elapsed=${elapsedSec}s ` +
+        `output: ${diag.outputMessages} msgs / ${(diag.outputBytes / 1024).toFixed(1)}KB | ` +
+        `replay: ${diag.replayMessages} msgs / ${(diag.replayBytes / 1024).toFixed(1)}KB | ` +
+        `resize: ${diag.resizeMessages} msgs | ` +
+        `input: ${diag.inputMessages} msgs / ${diag.inputBytes}B | ` +
+        `TOTAL SENT: ${((diag.outputBytes + diag.replayBytes) / 1024).toFixed(1)}KB`
+    );
+  });
+
   ws.on('message', async (rawMessage) => {
     try {
       const data = parseShellMessage(rawMessage);
@@ -360,12 +394,13 @@ export function handleShellConnection(
 
           if (existingSession.buffer.length > 0) {
             existingSession.buffer.forEach((bufferedData) => {
-              ws.send(
-                JSON.stringify({
-                  type: 'output',
-                  data: bufferedData,
-                })
-              );
+              const payload = JSON.stringify({
+                type: 'output',
+                data: bufferedData,
+              });
+              diag.replayMessages += 1;
+              diag.replayBytes += Buffer.byteLength(payload, 'utf8');
+              ws.send(payload);
             });
           }
 
@@ -489,12 +524,13 @@ export function handleShellConnection(
               emitAuthUrl(bestUrl, true);
             }
 
-            session.ws.send(
-              JSON.stringify({
-                type: 'output',
-                data: outputData,
-              })
-            );
+            const outputPayload = JSON.stringify({
+              type: 'output',
+              data: outputData,
+            });
+            diag.outputMessages += 1;
+            diag.outputBytes += Buffer.byteLength(outputPayload, 'utf8');
+            session.ws.send(outputPayload);
           }
         });
 
@@ -552,13 +588,17 @@ export function handleShellConnection(
       }
 
       if (data.type === 'input') {
+        const inputStr = readString(data.data);
+        diag.inputMessages += 1;
+        diag.inputBytes += Buffer.byteLength(inputStr, 'utf8');
         if (shellProcess) {
-          shellProcess.write(readString(data.data));
+          shellProcess.write(inputStr);
         }
         return;
       }
 
       if (data.type === 'resize') {
+        diag.resizeMessages += 1;
         if (shellProcess) {
           shellProcess.resize(readNumber(data.cols, 80), readNumber(data.rows, 24));
         }

--- a/server/modules/websocket/services/shell-websocket.service.ts
+++ b/server/modules/websocket/services/shell-websocket.service.ts
@@ -6,6 +6,7 @@ import pty, { type IPty } from 'node-pty';
 import { WebSocket, type RawData } from 'ws';
 
 import { parseIncomingJsonObject } from '@/shared/utils.js';
+import { isBandwidthMonitorEnabled } from '@/modules/websocket/services/bandwidth-monitor.service.js';
 
 type ShellIncomingMessage = {
   type?: string;
@@ -297,7 +298,8 @@ export function handleShellConnection(
   let urlDetectionBuffer = '';
   const announcedAuthUrls = new Set<string>();
 
-  // DIAGNOSTIC: temporary bandwidth instrumentation, remove after investigation.
+  // Optional, opt-in bandwidth monitoring (BANDWIDTH_MONITOR_ENABLED=true).
+  // Counters are always tracked (cheap); only the periodic/close logging is gated.
   const diag = {
     outputMessages: 0,
     outputBytes: 0,
@@ -308,28 +310,30 @@ export function handleShellConnection(
     inputBytes: 0,
     startedAt: Date.now(),
   };
-  const diagLogInterval = setInterval(() => {
-    const elapsedSec = ((Date.now() - diag.startedAt) / 1000).toFixed(1);
-    console.log(
-      `[DIAG shell] key=${ptySessionKey} elapsed=${elapsedSec}s ` +
-        `output: ${diag.outputMessages} msgs / ${(diag.outputBytes / 1024).toFixed(1)}KB | ` +
-        `replay: ${diag.replayMessages} msgs / ${(diag.replayBytes / 1024).toFixed(1)}KB | ` +
-        `resize: ${diag.resizeMessages} msgs | ` +
-        `input: ${diag.inputMessages} msgs / ${diag.inputBytes}B`
-    );
-  }, 5000);
-  ws.on('close', () => {
-    clearInterval(diagLogInterval);
-    const elapsedSec = ((Date.now() - diag.startedAt) / 1000).toFixed(1);
-    console.log(
-      `[DIAG shell] FINAL key=${ptySessionKey} elapsed=${elapsedSec}s ` +
-        `output: ${diag.outputMessages} msgs / ${(diag.outputBytes / 1024).toFixed(1)}KB | ` +
-        `replay: ${diag.replayMessages} msgs / ${(diag.replayBytes / 1024).toFixed(1)}KB | ` +
-        `resize: ${diag.resizeMessages} msgs | ` +
-        `input: ${diag.inputMessages} msgs / ${diag.inputBytes}B | ` +
-        `TOTAL SENT: ${((diag.outputBytes + diag.replayBytes) / 1024).toFixed(1)}KB`
-    );
-  });
+  if (isBandwidthMonitorEnabled()) {
+    const diagLogInterval = setInterval(() => {
+      const elapsedSec = ((Date.now() - diag.startedAt) / 1000).toFixed(1);
+      console.log(
+        `[bandwidth-monitor shell] key=${ptySessionKey} elapsed=${elapsedSec}s ` +
+          `output: ${diag.outputMessages} msgs / ${(diag.outputBytes / 1024).toFixed(1)}KB | ` +
+          `replay: ${diag.replayMessages} msgs / ${(diag.replayBytes / 1024).toFixed(1)}KB | ` +
+          `resize: ${diag.resizeMessages} msgs | ` +
+          `input: ${diag.inputMessages} msgs / ${diag.inputBytes}B`
+      );
+    }, 5000);
+    ws.on('close', () => {
+      clearInterval(diagLogInterval);
+      const elapsedSec = ((Date.now() - diag.startedAt) / 1000).toFixed(1);
+      console.log(
+        `[bandwidth-monitor shell] FINAL key=${ptySessionKey} elapsed=${elapsedSec}s ` +
+          `output: ${diag.outputMessages} msgs / ${(diag.outputBytes / 1024).toFixed(1)}KB | ` +
+          `replay: ${diag.replayMessages} msgs / ${(diag.replayBytes / 1024).toFixed(1)}KB | ` +
+          `resize: ${diag.resizeMessages} msgs | ` +
+          `input: ${diag.inputMessages} msgs / ${diag.inputBytes}B | ` +
+          `TOTAL SENT: ${((diag.outputBytes + diag.replayBytes) / 1024).toFixed(1)}KB`
+      );
+    });
+  }
 
   ws.on('message', async (rawMessage) => {
     try {

--- a/server/modules/websocket/services/websocket-server.service.ts
+++ b/server/modules/websocket/services/websocket-server.service.ts
@@ -6,6 +6,11 @@ import { handleChatConnection } from '@/modules/websocket/services/chat-websocke
 import { verifyWebSocketClient } from '@/modules/websocket/services/websocket-auth.service.js';
 import { handlePluginWsProxy } from '@/modules/websocket/services/plugin-websocket-proxy.service.js';
 import { handleShellConnection } from '@/modules/websocket/services/shell-websocket.service.js';
+import {
+  patchWebSocketBandwidthTracking,
+  startBandwidthLogging,
+  tagWebSocketRoute,
+} from '@/modules/websocket/services/network-diagnostics.service.js';
 import { handleDesktopNotificationsConnection } from '@/modules/notifications/index.js';
 import type { AuthenticatedWebSocketRequest } from '@/shared/types.js';
 
@@ -84,6 +89,9 @@ export function createWebSocketServer(
   server: HttpServer,
   dependencies: WebSocketServerDependencies
 ): WebSocketServer {
+  patchWebSocketBandwidthTracking();
+  startBandwidthLogging();
+
   const wss = new WebSocketServer({
     server,
     verifyClient: ((
@@ -97,6 +105,8 @@ export function createWebSocketServer(
     const incomingRequest = request as AuthenticatedWebSocketRequest;
     const url = incomingRequest.url ?? '/';
     const pathname = new URL(url, 'http://localhost').pathname;
+
+    tagWebSocketRoute(ws, pathname.startsWith('/plugin-ws/') ? 'plugin-ws' : pathname);
 
     if (pathname === '/shell') {
       handleShellConnection(ws, dependencies.shell);

--- a/server/modules/websocket/services/websocket-server.service.ts
+++ b/server/modules/websocket/services/websocket-server.service.ts
@@ -10,7 +10,7 @@ import {
   patchWebSocketBandwidthTracking,
   startBandwidthLogging,
   tagWebSocketRoute,
-} from '@/modules/websocket/services/network-diagnostics.service.js';
+} from '@/modules/websocket/services/bandwidth-monitor.service.js';
 import { handleDesktopNotificationsConnection } from '@/modules/notifications/index.js';
 import type { AuthenticatedWebSocketRequest } from '@/shared/types.js';
 


### PR DESCRIPTION
## Summary
- Adds an optional, disabled-by-default bandwidth monitoring feature, useful for diagnosing unexpected data usage (this is what was used to root-cause the bug fixed in #1087).
- Gated entirely behind `BANDWIDTH_MONITOR_ENABLED=true` (see `.env.example`); when unset, all instrumentation is a no-op with effectively zero overhead (the HTTP byte-counting middleware isn't even mounted).
- New `server/modules/websocket/services/bandwidth-monitor.service.ts` centralizes bucketed byte counters for HTTP responses and every WebSocket channel (shell, chat, desktop notifications, plugin proxy), logged on a 10s interval as `[bandwidth-monitor] ...`.
- Per-connection shell WebSocket bandwidth breakdown (output/replay/resize/input), logged every 5s and on close as `[bandwidth-monitor shell] ...`.
- Fingerprints any hit of the unbounded (`limit=null`) sessions-messages endpoint, logged as `[bandwidth-monitor messages] UNBOUNDED hit ...`, useful for catching future regressions of the bug fixed in #1087.

## Why
While diagnosing severe mobile data usage on the Shell tab (multiple GB in under an hour), it took bespoke server-wide instrumentation to actually trace the bytes back to the unbounded chat-history refetch fixed in #1087. Keeping a lightweight, opt-in version of that instrumentation around makes it easy to reproduce that kind of investigation in the future without hand-patching the server again.

## Test plan
- [x] Ran with `BANDWIDTH_MONITOR_ENABLED=true` on a live deployment; confirmed `[bandwidth-monitor]`, `[bandwidth-monitor shell]`, and `[bandwidth-monitor messages]` log lines appear and totals track real client-side data usage.
- [x] Confirmed with the env var unset (default) that none of the instrumentation logs appear.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional bandwidth monitoring for HTTP and WebSocket traffic.
  * Tracks transferred bytes and message counts across supported connection types.
  * Provides periodic summaries and final connection totals when monitoring is enabled.
* **Documentation**
  * Documented the `BANDWIDTH_MONITOR_ENABLED` configuration option, disabled by default.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->