### PR TITLE
Fix/update codex sdk and fix data usage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "@codemirror/theme-one-dark": "^6.1.2",
         "@iarna/toml": "^2.2.5",
         "@octokit/rest": "^22.0.0",
-        "@openai/codex-sdk": "^0.144.0",
+        "@openai/codex-sdk": "^0.146.0",
         "@replit/codemirror-minimap": "^0.5.2",
         "@tailwindcss/typography": "^0.5.16",
         "@uiw/react-codemirror": "^4.23.13",
@@ -4695,9 +4695,9 @@
       }
     },
     "node_modules/@openai/codex": {
-      "version": "0.144.1",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.1.tgz",
-      "integrity": "sha512-Xir1zqPfpenhdoAoshN53uonzbBXj18COyzRkFlVZpSNyEl5XtkuYu9oddELePFN7K/0sXUcSO34Ad5IeCXPbw==",
+      "version": "0.146.0",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.146.0.tgz",
+      "integrity": "sha512-yG3sPWNda/2YAIQIDq9MrrjoCTIQ7rxYM5IasrG3VBcuhCLTkgeg/JzqmJq1V98RE4MJ5jCxDXXQlOjrditFRw==",
       "license": "Apache-2.0",
       "bin": {
         "codex": "bin/codex.js"
@@ -4706,19 +4706,19 @@
         "node": ">=16"
       },
       "optionalDependencies": {
-        "@openai/codex-darwin-arm64": "npm:@openai/codex@0.144.1-darwin-arm64",
-        "@openai/codex-darwin-x64": "npm:@openai/codex@0.144.1-darwin-x64",
-        "@openai/codex-linux-arm64": "npm:@openai/codex@0.144.1-linux-arm64",
-        "@openai/codex-linux-x64": "npm:@openai/codex@0.144.1-linux-x64",
-        "@openai/codex-win32-arm64": "npm:@openai/codex@0.144.1-win32-arm64",
-        "@openai/codex-win32-x64": "npm:@openai/codex@0.144.1-win32-x64"
+        "@openai/codex-darwin-arm64": "npm:@openai/codex@0.146.0-darwin-arm64",
+        "@openai/codex-darwin-x64": "npm:@openai/codex@0.146.0-darwin-x64",
+        "@openai/codex-linux-arm64": "npm:@openai/codex@0.146.0-linux-arm64",
+        "@openai/codex-linux-x64": "npm:@openai/codex@0.146.0-linux-x64",
+        "@openai/codex-win32-arm64": "npm:@openai/codex@0.146.0-win32-arm64",
+        "@openai/codex-win32-x64": "npm:@openai/codex@0.146.0-win32-x64"
       }
     },
     "node_modules/@openai/codex-darwin-arm64": {
       "name": "@openai/codex",
-      "version": "0.144.1-darwin-arm64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.1-darwin-arm64.tgz",
-      "integrity": "sha512-dABeDK+ATqMG54MGBd3VjpKfh5EOoqx9PKVQB2QYDaEXx3F6CdUCXue5QIMfr4OxziUj8pUcLAQyd+KFqiTUFw==",
+      "version": "0.146.0-darwin-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.146.0-darwin-arm64.tgz",
+      "integrity": "sha512-nb61yX4r5L6Z0dlC4o3u0GAK1YCd4TUvjaB382bajDoh84V+uv2hTBIVZ++fgXWV9yoeuNrNnNcn7GoTGOe2Tg==",
       "cpu": [
         "arm64"
       ],
@@ -4733,9 +4733,9 @@
     },
     "node_modules/@openai/codex-darwin-x64": {
       "name": "@openai/codex",
-      "version": "0.144.1-darwin-x64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.1-darwin-x64.tgz",
-      "integrity": "sha512-K2g3Q3tNxzFhV0SuzO6HcsYK7EQrp/o4HyeReyhkwVrwwUPoYwyIbB0IRjHIiDzRhbKriDccid2iyF5aPqdTcg==",
+      "version": "0.146.0-darwin-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.146.0-darwin-x64.tgz",
+      "integrity": "sha512-hTQR5jy/ObfTf1MDnuJCZJAe+SljKE8DDwQWN6lDFgjsPhMQz852U2tILt8Ei+G5GkQSzemHYKl2AYPwW0Y5xw==",
       "cpu": [
         "x64"
       ],
@@ -4750,9 +4750,9 @@
     },
     "node_modules/@openai/codex-linux-arm64": {
       "name": "@openai/codex",
-      "version": "0.144.1-linux-arm64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.1-linux-arm64.tgz",
-      "integrity": "sha512-451o15+XtaXCCb35t/KCyyPqXHnTPxPxtdqEYOnE3e4sH5AfnI/uVJwfdjOksMG6vRLy6R+fLvSDOMguRFLmQw==",
+      "version": "0.146.0-linux-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.146.0-linux-arm64.tgz",
+      "integrity": "sha512-qiYDxkkEFnXG7joadJW6Q+XcgyDXCpGdpa9nk/c+i0gEomur1j7bHvx12NfWWCF/y8Tqri6ay+FLuC2MjdehtA==",
       "cpu": [
         "arm64"
       ],
@@ -4767,9 +4767,9 @@
     },
     "node_modules/@openai/codex-linux-x64": {
       "name": "@openai/codex",
-      "version": "0.144.1-linux-x64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.1-linux-x64.tgz",
-      "integrity": "sha512-HNGVI+BulrOaC/0IzBvd6EL62j7LrlbFKibrhw6hZjjCjAeUYzRB2jB4qDzXN1NfqDi6Xrvniof3kwbwab24lg==",
+      "version": "0.146.0-linux-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.146.0-linux-x64.tgz",
+      "integrity": "sha512-fswvyGprAPCMiOEue/7MKMk7pCjh9kZIJfJX5i9atmfnmGYbYCcUhZsEH9LEP0+0t5xyPqDbfNXY7NSxIVuXxA==",
       "cpu": [
         "x64"
       ],
@@ -4783,12 +4783,12 @@
       }
     },
     "node_modules/@openai/codex-sdk": {
-      "version": "0.144.1",
-      "resolved": "https://registry.npmjs.org/@openai/codex-sdk/-/codex-sdk-0.144.1.tgz",
-      "integrity": "sha512-NVb1R5+QJBecLrLrtljHkS7djXu/fGWVaA0FUhop6KgPTdeDzvgMo9uhgAuLi+4mwgf29IhMyNGU/kHG3aV4NA==",
+      "version": "0.146.0",
+      "resolved": "https://registry.npmjs.org/@openai/codex-sdk/-/codex-sdk-0.146.0.tgz",
+      "integrity": "sha512-lhlcfmufd4EvjquERH3HNG0/fuxPQJBjFsAjtP2LJjAsuyMZk245ci8xfvT4QoZ7Vnbe15y7rj/NtMNcUJIJOg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@openai/codex": "0.144.1"
+        "@openai/codex": "0.146.0"
       },
       "engines": {
         "node": ">=18"
@@ -4796,9 +4796,9 @@
     },
     "node_modules/@openai/codex-win32-arm64": {
       "name": "@openai/codex",
-      "version": "0.144.1-win32-arm64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.1-win32-arm64.tgz",
-      "integrity": "sha512-L4aDVEh9o1u7WYoxpSyv3un9Bz26YZYocOFqE2oHdEQDL2s6/LdtutLQc3oUZruLlEbkNsjSU0HI1OKsP0+Ctg==",
+      "version": "0.146.0-win32-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.146.0-win32-arm64.tgz",
+      "integrity": "sha512-EW6zdjDe+SLX2Iw+xymJ5+Pz2+DGexdstfFHXh4Ub+TfJsQPiMjGfZfNaoWgdJ2FsqSIzVKu2+G0KCMGYz2W8g==",
       "cpu": [
         "arm64"
       ],
@@ -4813,9 +4813,9 @@
     },
     "node_modules/@openai/codex-win32-x64": {
       "name": "@openai/codex",
-      "version": "0.144.1-win32-x64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.1-win32-x64.tgz",
-      "integrity": "sha512-qv2HOp6v/nVP31p5I5GxYyL0wa79PMzim1+W9CKSV0UldjFV9AMbualA8PeXcYhbvvh9Y1UASXxwjuQdlyfAvw==",
+      "version": "0.146.0-win32-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.146.0-win32-x64.tgz",
+      "integrity": "sha512-b3lxMYeR0+IhstNo4JjX1P9cPc1xwVcCVkPd1lD1wpWPJ0SBhpIkPczwbu3ZRkJcdyl342+rgyf4DUrbZLdrGA==",
       "cpu": [
         "x64"
       ],

--- a/package.json
+++ b/package.json
@@ -146,7 +146,7 @@
     "@codemirror/theme-one-dark": "^6.1.2",
     "@iarna/toml": "^2.2.5",
     "@octokit/rest": "^22.0.0",
-    "@openai/codex-sdk": "^0.144.0",
+    "@openai/codex-sdk": "^0.146.0",
     "@replit/codemirror-minimap": "^0.5.2",
     "@tailwindcss/typography": "^0.5.16",
     "@uiw/react-codemirror": "^4.23.13",

--- a/server/modules/commands/commands.routes.ts
+++ b/server/modules/commands/commands.routes.ts
@@ -63,14 +63,15 @@ const resolveCommandModel = async (modelsService, provider, context) => {
 
 const executeModelsCommand = async (args, context, modelsService) => {
   const currentProvider = readModelProvider(context?.provider);
-  const result = await modelsService.getProviderModels(currentProvider);
-  const catalog = result.models;
+  const catalog = await modelsService.getProviderModels(currentProvider);
   const currentModel = await resolveCommandModel(modelsService, currentProvider, context);
   const availableModels = catalog.OPTIONS.map((option) => option.value);
   const availableOptions = catalog.OPTIONS.map((option) => ({
     value: option.value,
     label: option.label,
     description: option.description,
+    recordId: option.recordId,
+    isCustom: option.isCustom,
   }));
 
   return {
@@ -88,7 +89,6 @@ const executeModelsCommand = async (args, context, modelsService) => {
       availableModels,
       availableOptions,
       defaultModel: catalog.DEFAULT,
-      cache: result.cache,
       message: `Current model: ${currentModel}`,
     },
   };

--- a/server/modules/commands/tests/commands.test.ts
+++ b/server/modules/commands/tests/commands.test.ts
@@ -16,12 +16,8 @@ import { createCommandsRouter } from '../commands.routes.js';
 function createModelsService(sessionModels: Record<string, string> = {}) {
   return {
     getProviderModels: async () => ({
-      models: { OPTIONS: [{ value: 'default', label: 'Default' }], DEFAULT: 'default' },
-      cache: {
-        updatedAt: '2026-01-01T00:00:00.000Z',
-        expiresAt: '2026-01-02T00:00:00.000Z',
-        source: 'fresh' as const,
-      },
+      OPTIONS: [{ value: 'default', label: 'Default' }],
+      DEFAULT: 'default',
     }),
     getCurrentActiveModel: async () => ({ model: 'default' }),
     setSessionModel: () => null,
@@ -39,7 +35,6 @@ function createModelsService(sessionModels: Record<string, string> = {}) {
       };
     },
     resolveResumeModel: async () => undefined,
-    clearCache: () => undefined,
   };
 }
 

--- a/server/modules/database/index.ts
+++ b/server/modules/database/index.ts
@@ -6,6 +6,8 @@ export { credentialsDb } from '@/modules/database/repositories/credentials.js';
 export { githubTokensDb } from '@/modules/database/repositories/github-tokens.js';
 export { notificationChannelEndpointsDb } from '@/modules/database/repositories/notification-channel-endpoints.js';
 export { notificationPreferencesDb } from '@/modules/database/repositories/notification-preferences.js';
+// providerModelsDb: used by Providers to persist user-managed custom model rows.
+export { providerModelsDb } from '@/modules/database/repositories/provider-models.js';
 // projectsDb: used by Projects, Worktrees, Git, WebSocket, and notification modules to persist and resolve project records.
 export { projectsDb } from '@/modules/database/repositories/projects.db.js';
 export { pushSubscriptionsDb } from '@/modules/database/repositories/push-subscriptions.js';

--- a/server/modules/database/migrations.ts
+++ b/server/modules/database/migrations.ts
@@ -475,7 +475,7 @@ export const runMigrations = (db: Database) => {
     db.exec(PROVIDER_MODELS_TABLE_SCHEMA_SQL);
     db.exec(`
       CREATE INDEX IF NOT EXISTS idx_provider_models_provider_order
-      ON provider_models(provider, is_custom, sort_order, id)
+      ON provider_models(provider, sort_order, id)
     `);
 
     db.exec(PROJECTS_TABLE_SCHEMA_SQL);

--- a/server/modules/database/migrations.ts
+++ b/server/modules/database/migrations.ts
@@ -5,6 +5,7 @@ import {
   LAST_SCANNED_AT_SQL,
   NOTIFICATION_CHANNEL_ENDPOINTS_TABLE_SCHEMA_SQL,
   PROJECTS_TABLE_SCHEMA_SQL,
+  PROVIDER_MODELS_TABLE_SCHEMA_SQL,
   PUSH_SUBSCRIPTIONS_TABLE_SCHEMA_SQL,
   SESSIONS_TABLE_SCHEMA_SQL,
   USER_NOTIFICATION_PREFERENCES_TABLE_SCHEMA_SQL,
@@ -458,6 +459,11 @@ export const runMigrations = (db: Database) => {
     db.exec(NOTIFICATION_CHANNEL_ENDPOINTS_TABLE_SCHEMA_SQL);
     db.exec('CREATE INDEX IF NOT EXISTS idx_notification_channel_endpoints_user_channel ON notification_channel_endpoints(user_id, channel)');
     db.exec('CREATE INDEX IF NOT EXISTS idx_notification_channel_endpoints_enabled ON notification_channel_endpoints(enabled)');
+    db.exec(PROVIDER_MODELS_TABLE_SCHEMA_SQL);
+    db.exec(`
+      CREATE INDEX IF NOT EXISTS idx_provider_models_provider_order
+      ON provider_models(provider, is_custom, sort_order, id)
+    `);
 
     db.exec(PROJECTS_TABLE_SCHEMA_SQL);
     rebuildProjectsTableWithPrimaryKeySchema(db);

--- a/server/modules/database/migrations.ts
+++ b/server/modules/database/migrations.ts
@@ -417,6 +417,19 @@ const addSessionModelColumn = (db: Database): void => {
   addColumnToTableIfNotExists(db, 'sessions', columnNames, 'model', 'TEXT');
 };
 
+/**
+ * Adds the `effort` column that records a session's reasoning-effort choice.
+ *
+ * Existing rows stay NULL so clients can continue falling back to their
+ * per-provider preference until the user selects an effort or sends a turn.
+ */
+const addSessionEffortColumn = (db: Database): void => {
+  const sessionsTableInfo = getTableInfo(db, 'sessions');
+  const columnNames = sessionsTableInfo.map((column) => column.name);
+
+  addColumnToTableIfNotExists(db, 'sessions', columnNames, 'effort', 'TEXT');
+};
+
 const ensureProjectsForSessionPaths = (db: Database): void => {
   if (!tableExists(db, 'sessions')) {
     return;
@@ -473,6 +486,7 @@ export const runMigrations = (db: Database) => {
     migrateLegacySessionNames(db);
     addProviderSessionIdMapping(db);
     addSessionModelColumn(db);
+    addSessionEffortColumn(db);
     ensureProjectsForSessionPaths(db);
 
     db.exec('CREATE INDEX IF NOT EXISTS idx_session_ids_lookup ON sessions(session_id)');

--- a/server/modules/database/repositories/provider-models.ts
+++ b/server/modules/database/repositories/provider-models.ts
@@ -1,0 +1,166 @@
+import { getConnection } from '@/modules/database/connection.js';
+import type {
+  CustomProviderModelInput,
+  CustomProviderModelRecord,
+  LLMProvider,
+} from '@/shared/types.js';
+
+type CustomProviderModelRow = {
+  id: number;
+  provider: LLMProvider;
+  model_id: string;
+  model_name: string;
+  sort_order: number;
+};
+
+const toCustomProviderModelRecord = (
+  row: CustomProviderModelRow,
+): CustomProviderModelRecord => ({
+  recordId: row.id,
+  provider: row.provider,
+  modelId: row.model_id,
+  model: row.model_name,
+  sortOrder: row.sort_order,
+});
+
+const readCustomProviderModelRow = (
+  provider: LLMProvider,
+  recordId: number,
+): CustomProviderModelRow | null => {
+  const row = getConnection().prepare(`
+    SELECT id, provider, model_id, model_name, sort_order
+    FROM provider_models
+    WHERE provider = ? AND id = ?
+  `).get(provider, recordId) as CustomProviderModelRow | undefined;
+
+  return row ?? null;
+};
+
+/**
+ * Custom provider-model persistence API consumed by the Providers module.
+ *
+ * Every row in this repository is user-created. Predefined models are owned by
+ * provider adapters and never enter this table. Model-id changes are propagated
+ * to stored sessions, while deletion replaces affected session selections with
+ * the predefined default supplied by the Providers service.
+ */
+export const providerModelsDb = {
+  listCustomProviderModels(provider: LLMProvider): CustomProviderModelRecord[] {
+    const rows = getConnection().prepare(`
+      SELECT id, provider, model_id, model_name, sort_order
+      FROM provider_models
+      WHERE provider = ?
+      ORDER BY sort_order ASC, lower(model_name) ASC, id ASC
+    `).all(provider) as CustomProviderModelRow[];
+
+    return rows.map(toCustomProviderModelRecord);
+  },
+
+  getCustomProviderModel(
+    provider: LLMProvider,
+    recordId: number,
+  ): CustomProviderModelRecord | null {
+    const row = readCustomProviderModelRow(provider, recordId);
+    return row ? toCustomProviderModelRecord(row) : null;
+  },
+
+  findCustomProviderModelByModelId(
+    provider: LLMProvider,
+    modelId: string,
+  ): CustomProviderModelRecord | null {
+    const row = getConnection().prepare(`
+      SELECT id, provider, model_id, model_name, sort_order
+      FROM provider_models
+      WHERE provider = ? AND model_id = ?
+    `).get(provider, modelId) as CustomProviderModelRow | undefined;
+
+    return row ? toCustomProviderModelRecord(row) : null;
+  },
+
+  createCustomProviderModel(
+    provider: LLMProvider,
+    input: CustomProviderModelInput,
+  ): CustomProviderModelRecord {
+    const db = getConnection();
+    const nextOrder = db.prepare(`
+      SELECT COALESCE(MAX(sort_order), -1) + 1 AS next_order
+      FROM provider_models
+      WHERE provider = ?
+    `).get(provider) as { next_order: number };
+
+    const result = db.prepare(`
+      INSERT INTO provider_models (provider, model_id, model_name, sort_order)
+      VALUES (?, ?, ?, ?)
+    `).run(provider, input.id, input.model, nextOrder.next_order);
+
+    const row = readCustomProviderModelRow(provider, Number(result.lastInsertRowid));
+    if (!row) {
+      throw new Error('Created provider model could not be read back.');
+    }
+
+    return toCustomProviderModelRecord(row);
+  },
+
+  updateCustomProviderModel(
+    provider: LLMProvider,
+    recordId: number,
+    input: CustomProviderModelInput,
+  ): CustomProviderModelRecord | null {
+    const db = getConnection();
+    const update = db.transaction(() => {
+      const previous = readCustomProviderModelRow(provider, recordId);
+      if (!previous) {
+        return null;
+      }
+
+      db.prepare(`
+        UPDATE provider_models
+        SET model_id = ?, model_name = ?, updated_at = CURRENT_TIMESTAMP
+        WHERE provider = ? AND id = ?
+      `).run(input.id, input.model, provider, recordId);
+
+      if (previous.model_id !== input.id) {
+        db.prepare(`
+          UPDATE sessions
+          SET model = ?, updated_at = CURRENT_TIMESTAMP
+          WHERE provider = ? AND model = ?
+        `).run(input.id, provider, previous.model_id);
+      }
+
+      return readCustomProviderModelRow(provider, recordId);
+    });
+
+    const row = update();
+    return row ? toCustomProviderModelRecord(row) : null;
+  },
+
+  deleteCustomProviderModel(
+    provider: LLMProvider,
+    recordId: number,
+    fallbackModelId: string,
+  ): CustomProviderModelRecord | null {
+    const db = getConnection();
+    const remove = db.transaction(() => {
+      const row = readCustomProviderModelRow(provider, recordId);
+      if (!row) {
+        return null;
+      }
+
+      db.prepare(`
+        UPDATE sessions
+        SET model = ?, updated_at = CURRENT_TIMESTAMP
+        WHERE provider = ? AND model = ?
+      `).run(fallbackModelId, provider, row.model_id);
+
+      db.prepare(`
+        DELETE FROM provider_models
+        WHERE provider = ? AND id = ?
+      `).run(provider, recordId);
+
+      return row;
+    });
+
+    const row = remove();
+    return row ? toCustomProviderModelRecord(row) : null;
+  },
+};

--- a/server/modules/database/repositories/provider-models.ts
+++ b/server/modules/database/repositories/provider-models.ts
@@ -146,9 +146,11 @@ export const providerModelsDb = {
         return null;
       }
 
+      // The effort is cleared alongside the model because it was chosen for the
+      // deleted model; replaced sessions resume on the fallback model's default.
       db.prepare(`
         UPDATE sessions
-        SET model = ?, updated_at = CURRENT_TIMESTAMP
+        SET model = ?, effort = NULL, updated_at = CURRENT_TIMESTAMP
         WHERE provider = ? AND model = ?
       `).run(fallbackModelId, provider, row.model_id);
 

--- a/server/modules/database/repositories/sessions.db.ts
+++ b/server/modules/database/repositories/sessions.db.ts
@@ -67,7 +67,9 @@ export const sessionsDb = {
    * The given id is the provider-native session id. Rows are keyed by
    * `provider_session_id` so a session that was first created by the app
    * (with an app-allocated `session_id`) is updated in place once its
-   * transcript shows up on disk, instead of producing a duplicate row.
+   * transcript shows up on disk, instead of producing a duplicate row. An
+   * app-created row keeps its existing name; synchronizer names only update
+   * rows that were themselves created by indexing provider storage.
    */
   createSession(
     providerSessionId: string,
@@ -103,7 +105,10 @@ export const sessionsDb = {
            project_path = ?,
            jsonl_path = ?,
            isArchived = 0,
-           custom_name = COALESCE(?, custom_name)
+           custom_name = CASE
+             WHEN session_id <> provider_session_id AND custom_name IS NOT NULL THEN custom_name
+             ELSE COALESCE(?, custom_name)
+           END
          WHERE session_id = ?`
       ).run(
         provider,
@@ -130,7 +135,11 @@ export const sessionsDb = {
          project_path = excluded.project_path,
          jsonl_path = excluded.jsonl_path,
          isArchived = 0,
-         custom_name = COALESCE(excluded.custom_name, sessions.custom_name)`
+         custom_name = CASE
+           WHEN sessions.session_id <> sessions.provider_session_id AND sessions.custom_name IS NOT NULL
+             THEN sessions.custom_name
+           ELSE COALESCE(excluded.custom_name, sessions.custom_name)
+         END`
     ).run(
       providerSessionId,
       provider,
@@ -151,9 +160,15 @@ export const sessionsDb = {
    * The session gateway uses this when the frontend starts a brand-new chat:
    * `session_id` is the stable app-facing id, while `provider_session_id`
    * stays NULL until the provider runtime announces its own id and
-   * `assignProviderSessionId` records the mapping.
+   * `assignProviderSessionId` records the mapping. `customName` is derived
+   * from the first visible CloudCLI message by the sessions service.
    */
-  createAppSession(sessionId: string, provider: string, projectPath: string): string {
+  createAppSession(
+    sessionId: string,
+    provider: string,
+    projectPath: string,
+    customName?: string,
+  ): string {
     const db = getConnection();
     const normalizedProjectPath = normalizeProjectPathForProvider(provider, projectPath);
 
@@ -161,8 +176,8 @@ export const sessionsDb = {
 
     db.prepare(
       `INSERT INTO sessions (session_id, provider, provider_session_id, custom_name, project_path, jsonl_path, isArchived, created_at, updated_at)
-       VALUES (?, ?, NULL, NULL, ?, NULL, 0, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)`
-    ).run(sessionId, provider, normalizedProjectPath);
+       VALUES (?, ?, NULL, ?, ?, NULL, 0, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)`
+    ).run(sessionId, provider, customName ?? null, normalizedProjectPath);
 
     return sessionId;
   },

--- a/server/modules/database/repositories/sessions.db.ts
+++ b/server/modules/database/repositories/sessions.db.ts
@@ -11,13 +11,15 @@ type SessionRow = {
   custom_name: string | null;
   /** Model this session runs with; NULL until the app records one for it. */
   model: string | null;
+  /** Reasoning effort this session runs with; NULL until the app records one. */
+  effort: string | null;
   isArchived: number;
   created_at: string;
   updated_at: string;
 };
 
 const SESSION_ROW_COLUMNS =
-  'session_id, provider, provider_session_id, project_path, jsonl_path, custom_name, model, isArchived, created_at, updated_at';
+  'session_id, provider, provider_session_id, project_path, jsonl_path, custom_name, model, effort, isArchived, created_at, updated_at';
 
 const SQLITE_UTC_TIMESTAMP_REGEX = /^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/;
 
@@ -242,6 +244,21 @@ export const sessionsDb = {
        SET model = ?
        WHERE session_id = ?`
     ).run(model, sessionId);
+  },
+
+  /**
+   * Records the reasoning effort one session runs with.
+   *
+   * `default` is stored as an explicit choice rather than NULL so reopening
+   * the session does not inherit a later per-provider effort preference.
+   */
+  setSessionEffort(sessionId: string, effort: string): void {
+    const db = getConnection();
+    db.prepare(
+      `UPDATE sessions
+       SET effort = ?
+       WHERE session_id = ?`
+    ).run(effort, sessionId);
   },
 
   updateSessionCustomName(sessionId: string, customName: string): void {

--- a/server/modules/database/schema.ts
+++ b/server/modules/database/schema.ts
@@ -138,6 +138,27 @@ CREATE TABLE IF NOT EXISTS app_config (
 );
 `;
 
+/**
+ * Persistent custom-model library used by the Providers module.
+ *
+ * Only user-created models are stored here. Predefined models remain source-
+ * controlled in each provider's `-models.provider.ts` adapter so they can be
+ * updated without migrating application data. `model_id` is unique only within
+ * a provider because different CLIs can accept the same identifier.
+ */
+export const PROVIDER_MODELS_TABLE_SCHEMA_SQL = `
+CREATE TABLE IF NOT EXISTS provider_models (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    provider TEXT NOT NULL CHECK (provider IN ('claude', 'cursor', 'codex', 'opencode')),
+    model_id TEXT NOT NULL,
+    model_name TEXT NOT NULL,
+    sort_order INTEGER NOT NULL DEFAULT 0,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE(provider, model_id)
+);
+`;
+
 export const INIT_SCHEMA_SQL = `
 -- Initialize authentication database
 PRAGMA foreign_keys = ON;
@@ -181,4 +202,8 @@ CREATE INDEX IF NOT EXISTS idx_session_ids_lookup ON sessions(session_id);
 ${LAST_SCANNED_AT_SQL}
 
 ${APP_CONFIG_TABLE_SCHEMA_SQL}
+
+${PROVIDER_MODELS_TABLE_SCHEMA_SQL}
+CREATE INDEX IF NOT EXISTS idx_provider_models_provider_order
+ON provider_models(provider, sort_order, id);
 `;

--- a/server/modules/database/schema.ts
+++ b/server/modules/database/schema.ts
@@ -109,10 +109,11 @@ CREATE TABLE IF NOT EXISTS sessions (
     custom_name TEXT,
     project_path TEXT,
     jsonl_path TEXT,
-    -- Model this session runs with. Written when the user picks a model for the
-    -- session and on every send, so reopening a session restores the model it
-    -- was last used with instead of falling back to the catalog default.
+    -- Model and reasoning effort this session runs with. Written when the user
+    -- changes either selection and on every send, so reopening a session
+    -- restores its exact runtime configuration instead of provider defaults.
     model TEXT,
+    effort TEXT,
     isArchived BOOLEAN DEFAULT 0,
     created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
     updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,

--- a/server/modules/database/tests/provider-models.db.integration.test.ts
+++ b/server/modules/database/tests/provider-models.db.integration.test.ts
@@ -1,0 +1,84 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+
+import {
+  closeConnection,
+  getConnection,
+  initializeDatabase,
+  providerModelsDb,
+  sessionsDb,
+} from '@/modules/database/index.js';
+
+test('provider model repository stores custom rows only and maintains session references', async () => {
+  const previousDatabasePath = process.env.DATABASE_PATH;
+  const tempDirectory = await mkdtemp(path.join(os.tmpdir(), 'provider-model-db-'));
+  const databasePath = path.join(tempDirectory, 'auth.db');
+
+  closeConnection();
+  process.env.DATABASE_PATH = databasePath;
+  await writeFile(databasePath, '');
+  await initializeDatabase();
+
+  try {
+    const columns = getConnection().prepare('PRAGMA table_info(provider_models)').all() as Array<{
+      name: string;
+    }>;
+    assert.deepEqual(columns.map((column) => column.name), [
+      'id',
+      'provider',
+      'model_id',
+      'model_name',
+      'sort_order',
+      'created_at',
+      'updated_at',
+    ]);
+    assert.deepEqual(providerModelsDb.listCustomProviderModels('codex'), []);
+
+    const custom = providerModelsDb.createCustomProviderModel('codex', {
+      model: 'Private Gateway Model',
+      id: 'gateway/model-v1',
+    });
+    assert.equal(custom.modelId, 'gateway/model-v1');
+    assert.equal(
+      providerModelsDb.findCustomProviderModelByModelId('codex', 'gateway/model-v1')?.recordId,
+      custom.recordId,
+    );
+
+    const db = getConnection();
+    db.prepare(`
+      INSERT INTO projects (project_id, project_path)
+      VALUES ('project-1', '/tmp/project-1')
+    `).run();
+    db.prepare(`
+      INSERT INTO sessions (session_id, provider, project_path, model)
+      VALUES ('session-1', 'codex', '/tmp/project-1', 'gateway/model-v1')
+    `).run();
+
+    const updated = providerModelsDb.updateCustomProviderModel('codex', custom.recordId, {
+      model: 'Private Gateway Model 2',
+      id: 'gateway/model-v2',
+    });
+    assert.equal(updated?.modelId, 'gateway/model-v2');
+    assert.equal(sessionsDb.getSessionById('session-1')?.model, 'gateway/model-v2');
+
+    const removed = providerModelsDb.deleteCustomProviderModel(
+      'codex',
+      custom.recordId,
+      'gpt-default',
+    );
+    assert.equal(removed?.modelId, 'gateway/model-v2');
+    assert.equal(sessionsDb.getSessionById('session-1')?.model, 'gpt-default');
+    assert.equal(providerModelsDb.getCustomProviderModel('codex', custom.recordId), null);
+  } finally {
+    closeConnection();
+    if (previousDatabasePath === undefined) {
+      delete process.env.DATABASE_PATH;
+    } else {
+      process.env.DATABASE_PATH = previousDatabasePath;
+    }
+    await rm(tempDirectory, { recursive: true, force: true });
+  }
+});

--- a/server/modules/database/tests/provider-models.db.integration.test.ts
+++ b/server/modules/database/tests/provider-models.db.integration.test.ts
@@ -11,6 +11,7 @@ import {
   providerModelsDb,
   sessionsDb,
 } from '@/modules/database/index.js';
+import { runMigrations } from '@/modules/database/migrations.js';
 
 test('provider model repository stores custom rows only and maintains session references', async () => {
   const previousDatabasePath = process.env.DATABASE_PATH;
@@ -53,8 +54,8 @@ test('provider model repository stores custom rows only and maintains session re
       VALUES ('project-1', '/tmp/project-1')
     `).run();
     db.prepare(`
-      INSERT INTO sessions (session_id, provider, project_path, model)
-      VALUES ('session-1', 'codex', '/tmp/project-1', 'gateway/model-v1')
+      INSERT INTO sessions (session_id, provider, project_path, model, effort)
+      VALUES ('session-1', 'codex', '/tmp/project-1', 'gateway/model-v1', 'high')
     `).run();
 
     const updated = providerModelsDb.updateCustomProviderModel('codex', custom.recordId, {
@@ -63,6 +64,8 @@ test('provider model repository stores custom rows only and maintains session re
     });
     assert.equal(updated?.modelId, 'gateway/model-v2');
     assert.equal(sessionsDb.getSessionById('session-1')?.model, 'gateway/model-v2');
+    // A rename keeps the same underlying model, so its effort stays applicable.
+    assert.equal(sessionsDb.getSessionById('session-1')?.effort, 'high');
 
     const removed = providerModelsDb.deleteCustomProviderModel(
       'codex',
@@ -71,7 +74,45 @@ test('provider model repository stores custom rows only and maintains session re
     );
     assert.equal(removed?.modelId, 'gateway/model-v2');
     assert.equal(sessionsDb.getSessionById('session-1')?.model, 'gpt-default');
+    // The effort belonged to the deleted model and must not survive onto the
+    // fallback, which has its own default.
+    assert.equal(sessionsDb.getSessionById('session-1')?.effort, null);
     assert.equal(providerModelsDb.getCustomProviderModel('codex', custom.recordId), null);
+  } finally {
+    closeConnection();
+    if (previousDatabasePath === undefined) {
+      delete process.env.DATABASE_PATH;
+    } else {
+      process.env.DATABASE_PATH = previousDatabasePath;
+    }
+    await rm(tempDirectory, { recursive: true, force: true });
+  }
+});
+
+test('migrations create the provider model index on an install that lacks it', async () => {
+  const previousDatabasePath = process.env.DATABASE_PATH;
+  const tempDirectory = await mkdtemp(path.join(os.tmpdir(), 'provider-model-index-'));
+  const databasePath = path.join(tempDirectory, 'auth.db');
+
+  closeConnection();
+  process.env.DATABASE_PATH = databasePath;
+  await writeFile(databasePath, '');
+  await initializeDatabase();
+
+  try {
+    const db = getConnection();
+    // Upgraded installs reach runMigrations with provider_models present but no
+    // index, so the CREATE INDEX statement is compiled against the real table
+    // instead of short-circuiting on the existing index name.
+    db.exec('DROP INDEX IF EXISTS idx_provider_models_provider_order');
+
+    runMigrations(db);
+
+    const indexedColumns = (db
+      .prepare('PRAGMA index_info(idx_provider_models_provider_order)')
+      .all() as Array<{ name: string }>)
+      .map((column) => column.name);
+    assert.deepEqual(indexedColumns, ['provider', 'sort_order', 'id']);
   } finally {
     closeConnection();
     if (previousDatabasePath === undefined) {

--- a/server/modules/database/tests/sessions-provider-mapping.test.ts
+++ b/server/modules/database/tests/sessions-provider-mapping.test.ts
@@ -45,7 +45,7 @@ test('disk-discovered sessions are keyed by the provider id for both columns', a
 
 test('app sessions get the provider id assigned without creating a duplicate row', async () => {
   await withIsolatedDatabase(() => {
-    sessionsDb.createAppSession('app-id-1', 'claude', '/workspace/demo');
+    sessionsDb.createAppSession('app-id-1', 'claude', '/workspace/demo', 'Initial CloudCLI message');
     sessionsDb.assignProviderSessionId('app-id-1', 'provider-xyz');
 
     // A later synchronizer pass that discovers the transcript on disk must
@@ -66,6 +66,7 @@ test('app sessions get the provider id assigned without creating a duplicate row
     const row = sessionsDb.getSessionById('app-id-1');
     assert.equal(row?.provider_session_id, 'provider-xyz');
     assert.equal(row?.jsonl_path, '/fake/path/provider-xyz.jsonl');
+    assert.equal(row?.custom_name, 'Initial CloudCLI message');
   });
 });
 

--- a/server/modules/file-tree/file-tree.module.ts
+++ b/server/modules/file-tree/file-tree.module.ts
@@ -36,7 +36,11 @@ const fileTreeFileSystem: FileTreeFileSystem = {
   access: (candidatePath) => fsPromises.access(candidatePath),
   stat: (candidatePath) => fsPromises.stat(candidatePath),
   lstat: (candidatePath) => fsPromises.lstat(candidatePath),
-  readdir: (directoryPath) => fsPromises.readdir(directoryPath, { withFileTypes: true }),
+  // `opendir` streams entries in batches and the handle is closed by the
+  // iterator protocol, including when the caller stops early at the entry cap.
+  openDirectory: async function* (directoryPath) {
+    yield* await fsPromises.opendir(directoryPath);
+  },
   realpath: (candidatePath) => fsPromises.realpath(candidatePath),
   readTextFile: (filePath) => fsPromises.readFile(filePath, 'utf8'),
   writeTextFile: (filePath, content) => fsPromises.writeFile(filePath, content, 'utf8'),

--- a/server/modules/file-tree/file-tree.service.ts
+++ b/server/modules/file-tree/file-tree.service.ts
@@ -3,6 +3,7 @@ import path from 'node:path';
 import ignore from 'ignore';
 
 import type {
+  FileTreeDirectoryEntry,
   FileTreeNode,
   FileTreeServiceDependencies,
   FileTreeServices,
@@ -172,6 +173,62 @@ export function createFileTreeService(dependencies: FileTreeServiceDependencies)
     return projectRoot;
   }
 
+  /**
+   * Streams one directory and keeps only the entries the tree will show.
+   *
+   * Entries are filtered and charged against the shared budget one at a time,
+   * so a pathologically large directory stops the walk at the cap instead of
+   * being read into memory in full first.
+   */
+  async function collectVisibleEntries(
+    directoryPath: string,
+    includeEntry: FileTreeEntryFilter,
+    remainingEntries: { value: number },
+  ): Promise<FileTreeDirectoryEntry[]> {
+    const visibleEntries: FileTreeDirectoryEntry[] = [];
+
+    await acquire();
+    try {
+      for await (const entry of fileSystem.openDirectory(directoryPath)) {
+        const isDirectory = entry.isDirectory();
+        if (isDirectory && IGNORED_DIRECTORY_NAMES.has(entry.name)) {
+          continue;
+        }
+        if (!includeEntry(path.join(directoryPath, entry.name), isDirectory)) {
+          continue;
+        }
+
+        // Charged after ignore filtering so generated directories and
+        // .gitignore exclusions never consume the budget. Every recursive
+        // branch shares one counter, so the cap applies to the whole tree
+        // rather than per directory.
+        if (remainingEntries.value <= 0) {
+          throw createFileTreeError(
+            `Project file tree exceeds the ${MAXIMUM_FILE_TREE_ENTRIES.toLocaleString()} entry limit. Choose a narrower project directory or add ignore rules.`,
+            413,
+            'FILE_TREE_TOO_LARGE',
+          );
+        }
+        remainingEntries.value -= 1;
+        visibleEntries.push(entry);
+      }
+    } catch (error) {
+      // The entry cap is a caller-visible outcome, not an unreadable directory.
+      if (error instanceof AppError) {
+        throw error;
+      }
+      const errorCode = readErrorCode(error);
+      if (errorCode !== 'EACCES' && errorCode !== 'EPERM') {
+        dependencies.logger.error(`Error reading directory "${directoryPath}"`, error);
+      }
+      return [];
+    } finally {
+      release();
+    }
+
+    return visibleEntries;
+  }
+
   async function buildFileTree(
     directoryPath: string,
     maximumDepth: number,
@@ -179,41 +236,7 @@ export function createFileTreeService(dependencies: FileTreeServiceDependencies)
     includeEntry: FileTreeEntryFilter = () => true,
     remainingEntries = { value: MAXIMUM_FILE_TREE_ENTRIES },
   ): Promise<FileTreeNode[]> {
-    let entries;
-    try {
-      await acquire();
-      try {
-        entries = await fileSystem.readdir(directoryPath);
-      } finally {
-        release();
-      }
-    } catch (error) {
-      const errorCode = readErrorCode(error);
-      if (errorCode !== 'EACCES' && errorCode !== 'EPERM') {
-        dependencies.logger.error(`Error reading directory "${directoryPath}"`, error);
-      }
-      return [];
-    }
-
-    const visibleEntries = entries.filter((entry) => {
-      const isDirectory = entry.isDirectory();
-      if (isDirectory && IGNORED_DIRECTORY_NAMES.has(entry.name)) {
-        return false;
-      }
-      return includeEntry(path.join(directoryPath, entry.name), isDirectory);
-    });
-
-    // Charged after ignore filtering so generated directories and .gitignore
-    // exclusions never consume the budget. Every recursive branch shares one
-    // counter, so the cap applies to the whole tree rather than per directory.
-    if (visibleEntries.length > remainingEntries.value) {
-      throw createFileTreeError(
-        `Project file tree exceeds the ${MAXIMUM_FILE_TREE_ENTRIES.toLocaleString()} entry limit. Choose a narrower project directory or add ignore rules.`,
-        413,
-        'FILE_TREE_TOO_LARGE',
-      );
-    }
-    remainingEntries.value -= visibleEntries.length;
+    const visibleEntries = await collectVisibleEntries(directoryPath, includeEntry, remainingEntries);
 
     const items = await Promise.all(visibleEntries.map(async (entry): Promise<FileTreeNode> => {
       const itemPath = path.join(directoryPath, entry.name);

--- a/server/modules/file-tree/file-tree.service.ts
+++ b/server/modules/file-tree/file-tree.service.ts
@@ -28,6 +28,11 @@ const COMMON_WORKSPACE_DIRECTORY_NAMES = [
   'workspace',
 ];
 
+// File Tree consumes this guard when recursively listing a project so a very
+// broad workspace (for example, a user's home directory) cannot exhaust the
+// server heap before the browser has a chance to switch to a narrower project.
+const MAXIMUM_FILE_TREE_ENTRIES = 10_000;
+
 type FileTreeEntryFilter = (entryPath: string, isDirectory: boolean) => boolean;
 
 function createFileTreeError(message: string, statusCode: number, code: string): AppError {
@@ -172,6 +177,7 @@ export function createFileTreeService(dependencies: FileTreeServiceDependencies)
     maximumDepth: number,
     currentDepth = 0,
     includeEntry: FileTreeEntryFilter = () => true,
+    remainingEntries = { value: MAXIMUM_FILE_TREE_ENTRIES },
   ): Promise<FileTreeNode[]> {
     let entries;
     try {
@@ -196,6 +202,18 @@ export function createFileTreeService(dependencies: FileTreeServiceDependencies)
       }
       return includeEntry(path.join(directoryPath, entry.name), isDirectory);
     });
+
+    // Charged after ignore filtering so generated directories and .gitignore
+    // exclusions never consume the budget. Every recursive branch shares one
+    // counter, so the cap applies to the whole tree rather than per directory.
+    if (visibleEntries.length > remainingEntries.value) {
+      throw createFileTreeError(
+        `Project file tree exceeds the ${MAXIMUM_FILE_TREE_ENTRIES.toLocaleString()} entry limit. Choose a narrower project directory or add ignore rules.`,
+        413,
+        'FILE_TREE_TOO_LARGE',
+      );
+    }
+    remainingEntries.value -= visibleEntries.length;
 
     const items = await Promise.all(visibleEntries.map(async (entry): Promise<FileTreeNode> => {
       const itemPath = path.join(directoryPath, entry.name);
@@ -245,6 +263,7 @@ export function createFileTreeService(dependencies: FileTreeServiceDependencies)
           maximumDepth,
           currentDepth + 1,
           includeEntry,
+          remainingEntries,
         );
       }
 

--- a/server/modules/file-tree/tests/file-tree.service.test.ts
+++ b/server/modules/file-tree/tests/file-tree.service.test.ts
@@ -19,6 +19,18 @@ function createDirectoryEntry(name: string, directory: boolean): FileTreeDirecto
   };
 }
 
+/**
+ * Adapts a path-keyed listing to the streaming directory contract so tests keep
+ * describing directories as plain arrays.
+ */
+function createDirectoryReader(
+  listDirectory: (directoryPath: string) => FileTreeDirectoryEntry[],
+): FileTreeFileSystem['openDirectory'] {
+  return async function* openDirectory(directoryPath) {
+    yield* listDirectory(directoryPath);
+  };
+}
+
 function createStats(directory: boolean, mode: number): FileTreeStats {
   return {
     size: directory ? 0 : 24,
@@ -40,7 +52,9 @@ function createFakeFileSystem(
     access: unexpectedOperation,
     stat: unexpectedOperation,
     lstat: unexpectedOperation,
-    readdir: unexpectedOperation,
+    openDirectory: () => ({
+      [Symbol.asyncIterator]: () => ({ next: unexpectedOperation }),
+    }),
     realpath: unexpectedOperation,
     readTextFile: unexpectedOperation,
     writeTextFile: unexpectedOperation,
@@ -78,7 +92,7 @@ test('listProjectFiles builds a sorted tree and skips generated directories', as
   const sourceDirectory = path.join(projectRoot, 'src');
   const fileSystem = createFakeFileSystem({
     access: async () => undefined,
-    readdir: async (directoryPath) => {
+    openDirectory: createDirectoryReader((directoryPath) => {
       if (directoryPath === projectRoot) {
         return [
           createDirectoryEntry('node_modules', true),
@@ -90,7 +104,7 @@ test('listProjectFiles builds a sorted tree and skips generated directories', as
         return [createDirectoryEntry('index.ts', false)];
       }
       return [];
-    },
+    }),
     lstat: async (candidatePath) => createStats(candidatePath === sourceDirectory, 0o754),
   });
   const service = createFileTreeService(createDependencies(fileSystem, projectRoot));
@@ -117,7 +131,7 @@ test('listProjectFiles excludes gitignored entries only when requested', async (
       assert.equal(filePath, path.join(projectRoot, '.gitignore'));
       return ['*.log', '!keep.log', 'cache/', 'src/generated.ts'].join('\n');
     },
-    readdir: async (directoryPath) => {
+    openDirectory: createDirectoryReader((directoryPath) => {
       readDirectories.push(directoryPath);
       if (directoryPath === projectRoot) {
         return [
@@ -138,7 +152,7 @@ test('listProjectFiles excludes gitignored entries only when requested', async (
         ];
       }
       return [];
-    },
+    }),
     lstat: async (candidatePath) => createStats(
       candidatePath === cacheDirectory || candidatePath === sourceDirectory,
       0o644,
@@ -160,9 +174,9 @@ test('listProjectFiles returns the normal tree when no gitignore exists', async 
     readTextFile: async () => {
       throw Object.assign(new Error('missing'), { code: 'ENOENT' });
     },
-    readdir: async (directoryPath) => directoryPath === projectRoot
+    openDirectory: createDirectoryReader((directoryPath) => directoryPath === projectRoot
       ? [createDirectoryEntry('debug.log', false)]
-      : [],
+      : []),
     lstat: async () => createStats(false, 0o644),
   });
   const service = createFileTreeService(createDependencies(fileSystem, projectRoot));
@@ -176,9 +190,9 @@ test('listProjectFiles rejects a tree that exceeds the server entry limit', asyn
   const projectRoot = path.resolve('file-tree-test-project');
   const fileSystem = createFakeFileSystem({
     access: async () => undefined,
-    readdir: async (directoryPath) => directoryPath === projectRoot
+    openDirectory: createDirectoryReader((directoryPath) => directoryPath === projectRoot
       ? Array.from({ length: 10_001 }, (_, index) => createDirectoryEntry(`file-${index}.txt`, false))
-      : [],
+      : []),
     lstat: async () => createStats(false, 0o644),
   });
   const service = createFileTreeService(createDependencies(fileSystem, projectRoot));
@@ -191,6 +205,36 @@ test('listProjectFiles rejects a tree that exceeds the server entry limit', asyn
   );
 });
 
+test('listProjectFiles abandons a directory stream as soon as the entry limit is passed', async () => {
+  const projectRoot = path.resolve('file-tree-test-project');
+  let streamedEntries = 0;
+  const fileSystem = createFakeFileSystem({
+    access: async () => undefined,
+    // Endless on purpose: the walk has to stop consuming the stream itself
+    // instead of waiting for the directory listing to be materialized.
+    openDirectory: async function* (directoryPath) {
+      if (directoryPath !== projectRoot) {
+        return;
+      }
+      for (let index = 0; ; index += 1) {
+        streamedEntries += 1;
+        yield createDirectoryEntry(`file-${index}.txt`, false);
+      }
+    },
+    lstat: async () => createStats(false, 0o644),
+  });
+  const service = createFileTreeService(createDependencies(fileSystem, projectRoot));
+
+  await assert.rejects(
+    service.listProjectFiles('project-1'),
+    (error: unknown) => error instanceof AppError
+      && error.code === 'FILE_TREE_TOO_LARGE'
+      && error.statusCode === 413,
+  );
+  // The budget plus the single entry that proves it was exceeded.
+  assert.equal(streamedEntries, 10_001);
+});
+
 test('listProjectFiles shares the entry limit across nested directories', async () => {
   const projectRoot = path.resolve('file-tree-test-project');
   const firstDirectory = path.join(projectRoot, 'first');
@@ -198,7 +242,7 @@ test('listProjectFiles shares the entry limit across nested directories', async 
   const directoryPaths = new Set([firstDirectory, secondDirectory]);
   const fileSystem = createFakeFileSystem({
     access: async () => undefined,
-    readdir: async (directoryPath) => {
+    openDirectory: createDirectoryReader((directoryPath) => {
       if (directoryPath === projectRoot) {
         return [
           createDirectoryEntry('first', true),
@@ -212,7 +256,7 @@ test('listProjectFiles shares the entry limit across nested directories', async 
         );
       }
       return [];
-    },
+    }),
     lstat: async (candidatePath) => createStats(directoryPaths.has(candidatePath), 0o644),
   });
   const service = createFileTreeService(createDependencies(fileSystem, projectRoot));

--- a/server/modules/file-tree/tests/file-tree.service.test.ts
+++ b/server/modules/file-tree/tests/file-tree.service.test.ts
@@ -172,6 +172,59 @@ test('listProjectFiles returns the normal tree when no gitignore exists', async 
   assert.deepEqual(tree.map((entry) => entry.name), ['debug.log']);
 });
 
+test('listProjectFiles rejects a tree that exceeds the server entry limit', async () => {
+  const projectRoot = path.resolve('file-tree-test-project');
+  const fileSystem = createFakeFileSystem({
+    access: async () => undefined,
+    readdir: async (directoryPath) => directoryPath === projectRoot
+      ? Array.from({ length: 10_001 }, (_, index) => createDirectoryEntry(`file-${index}.txt`, false))
+      : [],
+    lstat: async () => createStats(false, 0o644),
+  });
+  const service = createFileTreeService(createDependencies(fileSystem, projectRoot));
+
+  await assert.rejects(
+    service.listProjectFiles('project-1'),
+    (error: unknown) => error instanceof AppError
+      && error.code === 'FILE_TREE_TOO_LARGE'
+      && error.statusCode === 413,
+  );
+});
+
+test('listProjectFiles shares the entry limit across nested directories', async () => {
+  const projectRoot = path.resolve('file-tree-test-project');
+  const firstDirectory = path.join(projectRoot, 'first');
+  const secondDirectory = path.join(projectRoot, 'second');
+  const directoryPaths = new Set([firstDirectory, secondDirectory]);
+  const fileSystem = createFakeFileSystem({
+    access: async () => undefined,
+    readdir: async (directoryPath) => {
+      if (directoryPath === projectRoot) {
+        return [
+          createDirectoryEntry('first', true),
+          createDirectoryEntry('second', true),
+        ];
+      }
+      if (directoryPaths.has(directoryPath)) {
+        return Array.from(
+          { length: 5_000 },
+          (_, index) => createDirectoryEntry(`${path.basename(directoryPath)}-${index}.txt`, false),
+        );
+      }
+      return [];
+    },
+    lstat: async (candidatePath) => createStats(directoryPaths.has(candidatePath), 0o644),
+  });
+  const service = createFileTreeService(createDependencies(fileSystem, projectRoot));
+
+  await assert.rejects(
+    service.listProjectFiles('project-1'),
+    (error: unknown) => error instanceof AppError
+      && error.code === 'FILE_TREE_TOO_LARGE'
+      && error.statusCode === 413,
+  );
+});
+
 test('readTextFile rejects traversal before invoking the filesystem adapter', async () => {
   const projectRoot = path.resolve('file-tree-test-project');
   const readPaths: string[] = [];

--- a/server/modules/providers/list/claude/claude-models.provider.ts
+++ b/server/modules/providers/list/claude/claude-models.provider.ts
@@ -9,12 +9,12 @@ import type {
 } from '@/shared/types.js';
 import { buildDefaultProviderCurrentActiveModel } from '@/shared/utils.js';
 
-export const CLAUDE_FALLBACK_MODELS: ProviderModelsDefinition = {
+export const CLAUDE_PREDEFINED_MODELS: ProviderModelsDefinition = {
   OPTIONS: [
     {
       value: 'default',
       label: 'Default (recommended)',
-      description: 'Use the Claude Code default model (currently Sonnet 5)',
+      description: 'Use the recommended model for your Claude account and deployment.',
       effort: {
         default: 'high',
         values: [
@@ -26,9 +26,9 @@ export const CLAUDE_FALLBACK_MODELS: ProviderModelsDefinition = {
       },
     },
     {
-      value: 'fable',
-      label: 'Fable',
-      description: 'Fable 5 · Most capable for your hardest and longest-running tasks · Uses your limits ~2× faster than Opus',
+      value: 'best',
+      label: 'Best available',
+      description: 'Use Fable 5 when available, otherwise the latest Opus model.',
       effort: {
         default: 'high',
         values: [
@@ -41,15 +41,31 @@ export const CLAUDE_FALLBACK_MODELS: ProviderModelsDefinition = {
       },
     },
     {
-      value: "sonnet",
-      label: "Sonnet",
-      description: "Sonnet 5 · Best for everyday tasks · $3/$15 per Mtok",
+      value: 'fable',
+      label: 'Fable 5',
+      description: 'Most capable Claude model for the hardest, longest-running tasks.',
       effort: {
         default: 'high',
         values: [
           { value: 'low' },
           { value: 'medium' },
           { value: 'high' },
+          { value: 'xhigh' },
+          { value: 'max' },
+        ],
+      },
+    },
+    {
+      value: 'sonnet',
+      label: 'Sonnet',
+      description: 'Latest Sonnet model for everyday coding tasks.',
+      effort: {
+        default: 'high',
+        values: [
+          { value: 'low' },
+          { value: 'medium' },
+          { value: 'high' },
+          { value: 'xhigh' },
           { value: 'max' },
         ],
       },
@@ -57,13 +73,14 @@ export const CLAUDE_FALLBACK_MODELS: ProviderModelsDefinition = {
     {
       value: 'sonnet[1m]',
       label: 'Sonnet (1M context)',
-      description: 'Sonnet 5 for long sessions · $3/$15 per Mtok',
+      description: 'Latest Sonnet model with a 1M context window.',
       effort: {
         default: 'high',
         values: [
           { value: 'low' },
           { value: 'medium' },
           { value: 'high' },
+          { value: 'xhigh' },
           { value: 'max' },
         ],
       },
@@ -71,7 +88,7 @@ export const CLAUDE_FALLBACK_MODELS: ProviderModelsDefinition = {
     {
       value: 'opus',
       label: 'Opus',
-      description: 'Opus 4.8 · Best for everyday, complex tasks · ~2× usage vs Sonnet',
+      description: 'Latest Opus model for complex reasoning and coding tasks.',
       effort: {
         default: 'high',
         values: [
@@ -85,8 +102,8 @@ export const CLAUDE_FALLBACK_MODELS: ProviderModelsDefinition = {
     },
     {
       value: 'opus[1m]',
-      label: 'Opus 4.8 (1M context)',
-      description: 'Opus 4.8 with 1M context · Most capable for complex work · $5/$25 per Mtok',
+      label: 'Opus (1M context)',
+      description: 'Latest Opus model with a 1M context window.',
       effort: {
         default: 'high',
         values: [
@@ -101,7 +118,22 @@ export const CLAUDE_FALLBACK_MODELS: ProviderModelsDefinition = {
     {
       value: 'haiku',
       label: 'Haiku',
-      description: 'Haiku 4.5 · Fastest for quick answers · $1/$5 per Mtok',
+      description: 'Fast and efficient Claude model for simple tasks.',
+    },
+    {
+      value: 'opusplan',
+      label: 'Opus Plan',
+      description: 'Use Opus while planning, then switch to Sonnet for execution.',
+      effort: {
+        default: 'high',
+        values: [
+          { value: 'low' },
+          { value: 'medium' },
+          { value: 'high' },
+          { value: 'xhigh' },
+          { value: 'max' },
+        ],
+      },
     },
   ],
   DEFAULT: 'default',
@@ -113,7 +145,7 @@ export const findClaudeModelOption = (model: string | undefined | null): Provide
     return null;
   }
 
-  return CLAUDE_FALLBACK_MODELS.OPTIONS.find((option) => option.value === normalizedModel) ?? null;
+  return CLAUDE_PREDEFINED_MODELS.OPTIONS.find((option) => option.value === normalizedModel) ?? null;
 };
 type ClaudeInitEvent = {
   sessionId?: string;
@@ -237,7 +269,7 @@ export class ClaudeProviderModels implements IProviderModels {
     // const supportedModels = await queryInstance.supportedModels();
     // queryInstance.close();
     // return buildClaudeModelsDefinition(supportedModels);
-    return CLAUDE_FALLBACK_MODELS;
+    return CLAUDE_PREDEFINED_MODELS;
   }
 
   async getCurrentActiveModel(sessionId?: string): Promise<ProviderCurrentActiveModel> {

--- a/server/modules/providers/list/claude/claude-runtime.provider.js
+++ b/server/modules/providers/list/claude/claude-runtime.provider.js
@@ -24,7 +24,7 @@ import {
   buildClaudeUserContent,
   normalizeImageDescriptors
 } from '@/shared/image-attachments.js';
-import { CLAUDE_FALLBACK_MODELS } from '@/modules/providers/list/claude/claude-models.provider.js';
+import { CLAUDE_PREDEFINED_MODELS } from '@/modules/providers/list/claude/claude-models.provider.js';
 import { resolveClaudeCodeExecutablePath } from '@/shared/claude-cli-path.js';
 import {
   createNotificationEvent,
@@ -45,7 +45,7 @@ const TOOL_APPROVAL_TIMEOUT_MS = parseInt(process.env.CLAUDE_TOOL_APPROVAL_TIMEO
 
 const TOOLS_REQUIRING_INTERACTION = new Set(['AskUserQuestion', 'ExitPlanMode']);
 
-function resolveClaudeEffort(model, effort, modelsDefinition = CLAUDE_FALLBACK_MODELS) {
+function resolveClaudeEffort(model, effort, modelsDefinition = CLAUDE_PREDEFINED_MODELS) {
   const selectedModel = modelsDefinition?.OPTIONS?.find((option) => option.value === model) || null;
   const allowedEfforts = selectedModel?.effort?.values
     ?.map((value) => value.value) || [];
@@ -209,12 +209,12 @@ function mapCliOptionsToSDK(options = {}) {
 
   sdkOptions.disallowedTools = settings.disallowedTools || [];
 
-  sdkOptions.model = options.model || CLAUDE_FALLBACK_MODELS.DEFAULT;
+  sdkOptions.model = options.model || CLAUDE_PREDEFINED_MODELS.DEFAULT;
 
   const resolvedEffort = resolveClaudeEffort(
     sdkOptions.model,
     effort,
-    options.effortModels || CLAUDE_FALLBACK_MODELS,
+    options.effortModels || CLAUDE_PREDEFINED_MODELS,
   );
   if (resolvedEffort) {
     sdkOptions.effort = resolvedEffort;
@@ -485,7 +485,7 @@ async function queryClaudeSDK(command, options = {}, ws, context) {
 
   try {
     const resolvedModel = await context.resolveResumeModel(sessionId, options.model);
-    let effortModels = CLAUDE_FALLBACK_MODELS;
+    let effortModels = CLAUDE_PREDEFINED_MODELS;
     try {
       effortModels = await context.getProviderModels();
     } catch (error) {

--- a/server/modules/providers/list/codex/codex-models.provider.ts
+++ b/server/modules/providers/list/codex/codex-models.provider.ts
@@ -7,7 +7,6 @@ import TOML from '@iarna/toml';
 import type { IProviderModels } from '@/shared/interfaces.js';
 import type {
   ProviderCurrentActiveModel,
-  ProviderModelOption,
   ProviderModelsDefinition,
 } from '@/shared/types.js';
 import {
@@ -16,11 +15,60 @@ import {
   readOptionalString,
 } from '@/shared/utils.js';
 
-export const CODEX_FALLBACK_MODELS: ProviderModelsDefinition = {
+/** Curated Codex catalog shipped as immutable CloudCLI defaults. */
+export const CODEX_PREDEFINED_MODELS: ProviderModelsDefinition = {
   OPTIONS: [
     {
+      value: 'gpt-5.6-sol',
+      label: 'GPT-5.6 Sol',
+      description: 'Latest frontier agentic coding model.',
+      effort: {
+        default: 'low',
+        values: [
+          { value: 'low' },
+          { value: 'medium' },
+          { value: 'high' },
+          { value: 'xhigh' },
+          { value: 'max' },
+          { value: 'ultra' },
+        ],
+      },
+    },
+    {
+      value: 'gpt-5.6-terra',
+      label: 'GPT-5.6 Terra',
+      description: 'Balanced agentic coding model for everyday work.',
+      effort: {
+        default: 'medium',
+        values: [
+          { value: 'low' },
+          { value: 'medium' },
+          { value: 'high' },
+          { value: 'xhigh' },
+          { value: 'max' },
+          { value: 'ultra' },
+        ],
+      },
+    },
+    {
+      value: 'gpt-5.6-luna',
+      label: 'GPT-5.6 Luna',
+      description: 'Fast and affordable agentic coding model.',
+      effort: {
+        default: 'medium',
+        values: [
+          { value: 'low' },
+          { value: 'medium' },
+          { value: 'high' },
+          { value: 'xhigh' },
+          { value: 'max' },
+        ],
+      },
+    },
+    {
       value: 'gpt-5.5',
-      label: 'gpt-5.5',
+      label: 'GPT-5.5',
+      description: 'Frontier model for complex coding, research, and real-world work.',
       effort: {
         default: 'medium',
         values: [{ value: 'low' }, { value: 'medium' }, { value: 'high' }, { value: 'xhigh' }],
@@ -28,7 +76,8 @@ export const CODEX_FALLBACK_MODELS: ProviderModelsDefinition = {
     },
     {
       value: 'gpt-5.4',
-      label: 'gpt-5.4',
+      label: 'GPT-5.4',
+      description: 'Strong model for everyday coding.',
       effort: {
         default: 'medium',
         values: [{ value: 'low' }, { value: 'medium' }, { value: 'high' }, { value: 'xhigh' }],
@@ -36,113 +85,23 @@ export const CODEX_FALLBACK_MODELS: ProviderModelsDefinition = {
     },
     {
       value: 'gpt-5.4-mini',
-      label: 'gpt-5.4-mini',
+      label: 'GPT-5.4 Mini',
+      description: 'Small, fast, and cost-efficient model for simpler coding tasks.',
       effort: {
         default: 'medium',
         values: [{ value: 'low' }, { value: 'medium' }, { value: 'high' }, { value: 'xhigh' }],
       },
     },
   ],
-  DEFAULT: 'gpt-5.4',
+  DEFAULT: 'gpt-5.6-sol',
 };
 
-type CodexCachedModel = {
-  slug?: string;
-  display_name?: string;
-  description?: string;
-  priority?: number;
-  visibility?: string;
-  supported_in_api?: boolean;
-  default_reasoning_level?: string;
-  supported_reasoning_levels?: Array<{
-    effort?: string;
-    description?: string;
-  }>;
-};
-
-const CODEX_MODELS_CACHE_PATH = path.join(os.homedir(), '.codex', 'models_cache.json');
 const CODEX_CONFIG_PATH = path.join(os.homedir(), '.codex', 'config.toml');
 
-const isCodexCachedModel = (value: unknown): value is CodexCachedModel => {
-  const record = readObjectRecord(value);
-  return Boolean(record && readOptionalString(record.slug));
-};
-
-const readCodexPriority = (value: unknown): number => (
-  typeof value === 'number' && Number.isFinite(value) ? value : Number.MAX_SAFE_INTEGER
-);
-
-const mapCodexModel = (model: CodexCachedModel): ProviderModelOption => {
-  const effortValues = Array.isArray(model.supported_reasoning_levels)
-    ? model.supported_reasoning_levels
-      .map((level) => {
-        const value = readOptionalString(level?.effort);
-        if (!value) {
-          return null;
-        }
-
-        return {
-          value,
-          description: readOptionalString(level?.description),
-        };
-      })
-      .filter((level): level is NonNullable<typeof level> => Boolean(level))
-    : [];
-
-  return {
-    value: model.slug as string,
-    label: readOptionalString(model.display_name) ?? (model.slug as string),
-    description: readOptionalString(model.description),
-    effort: effortValues.length > 0
-      ? {
-          default: readOptionalString(model.default_reasoning_level) ?? undefined,
-          values: effortValues,
-        }
-      : undefined,
-  };
-};
-
-const buildCodexModelsDefinition = (models: CodexCachedModel[]): ProviderModelsDefinition => {
-  const sortedModels = [...models]
-    .filter((model) => model.visibility === 'list' && model.supported_in_api !== false)
-    .sort((left, right) => readCodexPriority(left.priority) - readCodexPriority(right.priority));
-
-  const options: ProviderModelOption[] = [];
-  const seenValues = new Set<string>();
-
-  for (const model of sortedModels) {
-    const mappedModel = mapCodexModel(model);
-    if (seenValues.has(mappedModel.value)) {
-      continue;
-    }
-
-    seenValues.add(mappedModel.value);
-    options.push(mappedModel);
-  }
-
-  if (options.length === 0) {
-    return CODEX_FALLBACK_MODELS;
-  }
-
-  return {
-    OPTIONS: options,
-    DEFAULT: options[0]?.value ?? CODEX_FALLBACK_MODELS.DEFAULT,
-  };
-};
-
+/** Provider registry model adapter for Codex predefined models and active config. */
 export class CodexProviderModels implements IProviderModels {
   async getSupportedModels(): Promise<ProviderModelsDefinition> {
-    try {
-      const raw = await readFile(CODEX_MODELS_CACHE_PATH, 'utf8');
-      const parsed = readObjectRecord(JSON.parse(raw));
-      const models = Array.isArray(parsed?.models)
-        ? parsed.models.filter(isCodexCachedModel)
-        : [];
-
-      return buildCodexModelsDefinition(models);
-    } catch {
-      return CODEX_FALLBACK_MODELS;
-    }
+    return CODEX_PREDEFINED_MODELS;
   }
 
   async getCurrentActiveModel(): Promise<ProviderCurrentActiveModel> {

--- a/server/modules/providers/list/codex/codex-session-synchronizer.provider.ts
+++ b/server/modules/providers/list/codex/codex-session-synchronizer.provider.ts
@@ -134,23 +134,7 @@ export class CodexSessionSynchronizer implements IProviderSessionSynchronizer {
       };
     }
 
-    // Sessions started by sending a message from cloudcli carry a distinct
-    // app-allocated session_id mapped to the provider id. For these we title the
-    // conversation from the first user message the user typed, instead of the
-    // generic "Untitled Codex Session" placeholder. Sessions discovered purely
-    // by indexing (session_id === provider_session_id) keep the existing
-    // thread_name/last-agent-message setup below.
-    const isAppCreated =
-      existingSession != null &&
-      existingSession.provider_session_id != null &&
-      existingSession.session_id !== existingSession.provider_session_id;
-
-    let sessionName = isAppCreated
-      ? await this.extractFirstUserMessageFromStart(filePath)
-      : undefined;
-    if (!sessionName) {
-      sessionName = nameMap.get(parsed.sessionId);
-    }
+    let sessionName = nameMap.get(parsed.sessionId);
     if (!sessionName) {
       sessionName = await this.extractLastAgentMessageFromEnd(filePath);
     }
@@ -178,49 +162,6 @@ export class CodexSessionSynchronizer implements IProviderSessionSynchronizer {
 
     const source = payload.source;
     return typeof source === 'object' && source !== null && 'subagent' in source;
-  }
-
-  /**
-   * Returns the first user message text in a Codex transcript, used to title
-   * app-created sessions from the prompt the user sent from cloudcli.
-   *
-   * Reads the `event_msg`/`user_message` payload rather than the raw
-   * `response_item` user turn so injected `<environment_context>` boilerplate is
-   * never mistaken for the user's prompt.
-   */
-  private async extractFirstUserMessageFromStart(filePath: string): Promise<string | undefined> {
-    try {
-      const content = await readFile(filePath, 'utf8');
-      const lines = content.split(/\r?\n/);
-
-      for (const rawLine of lines) {
-        const line = rawLine.trim();
-        if (!line) {
-          continue;
-        }
-
-        let parsed: unknown;
-        try {
-          parsed = JSON.parse(line);
-        } catch {
-          continue;
-        }
-
-        const data = parsed as Record<string, unknown>;
-        const eventType = typeof data.type === 'string' ? data.type : undefined;
-        const payload = data.payload as Record<string, unknown> | undefined;
-        const payloadType = typeof payload?.type === 'string' ? payload.type : undefined;
-        const message = typeof payload?.message === 'string' ? payload.message : undefined;
-
-        if (eventType === 'event_msg' && payloadType === 'user_message' && message?.trim()) {
-          return message;
-        }
-      }
-    } catch {
-      // Ignore missing/unreadable files so sync can continue.
-    }
-
-    return undefined;
   }
 
   private async extractLastAgentMessageFromEnd(filePath: string): Promise<string | undefined> {

--- a/server/modules/providers/list/codex/codex-sessions.provider.ts
+++ b/server/modules/providers/list/codex/codex-sessions.provider.ts
@@ -143,7 +143,7 @@ function decodeJavaScriptStringLiteral(literal: string): string {
 
 function extractNestedCodexCommands(source: string): string[] {
   const commands: string[] = [];
-  const commandPattern = /\bcommand\s*:\s*("(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|`(?:\\.|[^`\\])*`)/gs;
+  const commandPattern = /(?:["']command["']|\bcommand)\s*:\s*("(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|`(?:\\.|[^`\\])*`)/gs;
   for (const match of source.matchAll(commandPattern)) {
     commands.push(decodeJavaScriptStringLiteral(match[1]));
   }
@@ -173,7 +173,7 @@ function extractNestedCodexCommands(source: string): string[] {
  */
 function translateCodexExecInput(input: unknown): { toolName: string; toolInput: string } | null {
   const source = typeof input === 'string' ? input : String(input || '');
-  if (/\btools\.shell_command\s*\(/.test(source)) {
+  if (/\btools\.(?:shell_command|exec_command)\s*\(/.test(source)) {
     const commands = extractNestedCodexCommands(source);
     if (commands.length > 0) {
       return {
@@ -506,19 +506,19 @@ async function getCodexSessionMessages(
         if (entry.type === 'response_item' && entry.payload?.type === 'custom_tool_call') {
           let toolName = entry.payload.name || 'custom_tool';
           const input = entry.payload.input || '';
+          let toolInput = input;
 
           if (toolName === 'exec') {
             const translated = translateCodexExecInput(input);
-            if (!translated) {
-              ignoredToolCallIds.add(entry.payload.call_id);
-              continue;
+            if (translated) {
+              toolName = translated.toolName;
+              toolInput = translated.toolInput;
             }
-            toolName = translated.toolName;
             messages.push({
               type: 'tool_use',
               timestamp: entry.timestamp,
               toolName,
-              toolInput: translated.toolInput,
+              toolInput,
               toolCallId: entry.payload.call_id,
             });
             execToolCallIds.add(entry.payload.call_id);

--- a/server/modules/providers/list/cursor/cursor-models.provider.ts
+++ b/server/modules/providers/list/cursor/cursor-models.provider.ts
@@ -2,12 +2,9 @@ import { access, readdir } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 
-import crossSpawn from 'cross-spawn';
-
 import type { IProviderModels } from '@/shared/interfaces.js';
 import type {
   ProviderCurrentActiveModel,
-  ProviderModelOption,
   ProviderModelsDefinition,
 } from '@/shared/types.js';
 import {
@@ -15,705 +12,36 @@ import {
   sanitizeLeafDirectoryName,
 } from '@/shared/utils.js';
 
-export const CURSOR_FALLBACK_MODELS: ProviderModelsDefinition = {
+/** Curated Cursor catalog shipped as immutable CloudCLI defaults. */
+export const CURSOR_PREDEFINED_MODELS: ProviderModelsDefinition = {
   OPTIONS: [
-    {
-      value: "auto",
-      label: "auto",
-      description: "Auto",
-    },
-    {
-      value: "composer-2-fast",
-      label: "composer-2-fast",
-      description: "Composer 2 Fast",
-    },
-    {
-      value: "composer-2",
-      label: "composer-2",
-      description: "Composer 2",
-    },
-    {
-      value: "gpt-5.3-codex-low",
-      label: "gpt-5.3-codex-low",
-      description: "Codex 5.3 Low",
-    },
-    {
-      value: "gpt-5.3-codex-low-fast",
-      label: "gpt-5.3-codex-low-fast",
-      description: "Codex 5.3 Low Fast",
-    },
-    {
-      value: "gpt-5.3-codex",
-      label: "gpt-5.3-codex",
-      description: "Codex 5.3",
-    },
-    {
-      value: "gpt-5.3-codex-fast",
-      label: "gpt-5.3-codex-fast",
-      description: "Codex 5.3 Fast",
-    },
-    {
-      value: "gpt-5.3-codex-high",
-      label: "gpt-5.3-codex-high",
-      description: "Codex 5.3 High",
-    },
-    {
-      value: "gpt-5.3-codex-high-fast",
-      label: "gpt-5.3-codex-high-fast",
-      description: "Codex 5.3 High Fast",
-    },
-    {
-      value: "gpt-5.3-codex-xhigh",
-      label: "gpt-5.3-codex-xhigh",
-      description: "Codex 5.3 Extra High",
-    },
-    {
-      value: "gpt-5.3-codex-xhigh-fast",
-      label: "gpt-5.3-codex-xhigh-fast",
-      description: "Codex 5.3 Extra High Fast",
-    },
-    {
-      value: "gpt-5.2",
-      label: "gpt-5.2",
-      description: "GPT-5.2",
-    },
-    {
-      value: "gpt-5.2-codex-low",
-      label: "gpt-5.2-codex-low",
-      description: "Codex 5.2 Low",
-    },
-    {
-      value: "gpt-5.2-codex-low-fast",
-      label: "gpt-5.2-codex-low-fast",
-      description: "Codex 5.2 Low Fast",
-    },
-    {
-      value: "gpt-5.2-codex",
-      label: "gpt-5.2-codex",
-      description: "Codex 5.2",
-    },
-    {
-      value: "gpt-5.2-codex-fast",
-      label: "gpt-5.2-codex-fast",
-      description: "Codex 5.2 Fast",
-    },
-    {
-      value: "gpt-5.2-codex-high",
-      label: "gpt-5.2-codex-high",
-      description: "Codex 5.2 High",
-    },
-    {
-      value: "gpt-5.2-codex-high-fast",
-      label: "gpt-5.2-codex-high-fast",
-      description: "Codex 5.2 High Fast",
-    },
-    {
-      value: "gpt-5.2-codex-xhigh",
-      label: "gpt-5.2-codex-xhigh",
-      description: "Codex 5.2 Extra High",
-    },
-    {
-      value: "gpt-5.2-codex-xhigh-fast",
-      label: "gpt-5.2-codex-xhigh-fast",
-      description: "Codex 5.2 Extra High Fast",
-    },
-    {
-      value: "gpt-5.1-codex-max-low",
-      label: "gpt-5.1-codex-max-low",
-      description: "Codex 5.1 Max Low",
-    },
-    {
-      value: "gpt-5.1-codex-max-low-fast",
-      label: "gpt-5.1-codex-max-low-fast",
-      description: "Codex 5.1 Max Low Fast",
-    },
-    {
-      value: "gpt-5.1-codex-max-medium",
-      label: "gpt-5.1-codex-max-medium",
-      description: "Codex 5.1 Max",
-    },
-    {
-      value: "gpt-5.1-codex-max-medium-fast",
-      label: "gpt-5.1-codex-max-medium-fast",
-      description: "Codex 5.1 Max Medium Fast",
-    },
-    {
-      value: "gpt-5.1-codex-max-high",
-      label: "gpt-5.1-codex-max-high",
-      description: "Codex 5.1 Max High",
-    },
-    {
-      value: "gpt-5.1-codex-max-high-fast",
-      label: "gpt-5.1-codex-max-high-fast",
-      description: "Codex 5.1 Max High Fast",
-    },
-    {
-      value: "gpt-5.1-codex-max-xhigh",
-      label: "gpt-5.1-codex-max-xhigh",
-      description: "Codex 5.1 Max Extra High",
-    },
-    {
-      value: "gpt-5.1-codex-max-xhigh-fast",
-      label: "gpt-5.1-codex-max-xhigh-fast",
-      description: "Codex 5.1 Max Extra High Fast",
-    },
-    {
-      value: "composer-2.5",
-      label: "composer-2.5",
-      description: "Composer 2.5",
-    },
-    {
-      value: "gpt-5.5-high",
-      label: "gpt-5.5-high",
-      description: "GPT-5.5 1M High",
-    },
-    {
-      value: "gpt-5.5-high-fast",
-      label: "gpt-5.5-high-fast",
-      description: "GPT-5.5 High Fast",
-    },
-    {
-      value: "claude-opus-4-7-thinking-high",
-      label: "claude-opus-4-7-thinking-high",
-      description: "Opus 4.7 1M High Thinking",
-    },
-    {
-      value: "gpt-5.4-high",
-      label: "gpt-5.4-high",
-      description: "GPT-5.4 1M High",
-    },
-    {
-      value: "gpt-5.4-high-fast",
-      label: "gpt-5.4-high-fast",
-      description: "GPT-5.4 High Fast",
-    },
-    {
-      value: "claude-4.6-opus-high-thinking",
-      label: "claude-4.6-opus-high-thinking",
-      description: "Opus 4.6 1M Thinking",
-    },
-    {
-      value: "claude-4.6-opus-high-thinking-fast",
-      label: "claude-4.6-opus-high-thinking-fast",
-      description: "Opus 4.6 1M Thinking Fast",
-    },
-    {
-      value: "composer-2.5-fast",
-      label: "composer-2.5-fast",
-      description: "Composer 2.5 Fast",
-    },
-    {
-      value: "gpt-5.5-none",
-      label: "gpt-5.5-none",
-      description: "GPT-5.5 1M None",
-    },
-    {
-      value: "gpt-5.5-none-fast",
-      label: "gpt-5.5-none-fast",
-      description: "GPT-5.5 None Fast",
-    },
-    {
-      value: "gpt-5.5-low",
-      label: "gpt-5.5-low",
-      description: "GPT-5.5 1M Low",
-    },
-    {
-      value: "gpt-5.5-low-fast",
-      label: "gpt-5.5-low-fast",
-      description: "GPT-5.5 Low Fast",
-    },
-    {
-      value: "gpt-5.5-medium",
-      label: "gpt-5.5-medium",
-      description: "GPT-5.5 1M",
-    },
-    {
-      value: "gpt-5.5-medium-fast",
-      label: "gpt-5.5-medium-fast",
-      description: "GPT-5.5 Fast",
-    },
-    {
-      value: "gpt-5.5-extra-high",
-      label: "gpt-5.5-extra-high",
-      description: "GPT-5.5 1M Extra High",
-    },
-    {
-      value: "gpt-5.5-extra-high-fast",
-      label: "gpt-5.5-extra-high-fast",
-      description: "GPT-5.5 Extra High Fast",
-    },
-    {
-      value: "claude-4.6-sonnet-medium",
-      label: "claude-4.6-sonnet-medium",
-      description: "Sonnet 4.6 1M",
-    },
-    {
-      value: "claude-4.6-sonnet-medium-thinking",
-      label: "claude-4.6-sonnet-medium-thinking",
-      description: "Sonnet 4.6 1M Thinking",
-    },
-    {
-      value: "claude-opus-4-7-low",
-      label: "claude-opus-4-7-low",
-      description: "Opus 4.7 1M Low",
-    },
-    {
-      value: "claude-opus-4-7-low-fast",
-      label: "claude-opus-4-7-low-fast",
-      description: "Opus 4.7 1M Low Fast",
-    },
-    {
-      value: "claude-opus-4-7-medium",
-      label: "claude-opus-4-7-medium",
-      description: "Opus 4.7 1M Medium",
-    },
-    {
-      value: "claude-opus-4-7-medium-fast",
-      label: "claude-opus-4-7-medium-fast",
-      description: "Opus 4.7 1M Medium Fast",
-    },
-    {
-      value: "claude-opus-4-7-high",
-      label: "claude-opus-4-7-high",
-      description: "Opus 4.7 1M High",
-    },
-    {
-      value: "claude-opus-4-7-high-fast",
-      label: "claude-opus-4-7-high-fast",
-      description: "Opus 4.7 1M High Fast",
-    },
-    {
-      value: "claude-opus-4-7-xhigh",
-      label: "claude-opus-4-7-xhigh",
-      description: "Opus 4.7 1M",
-    },
-    {
-      value: "claude-opus-4-7-xhigh-fast",
-      label: "claude-opus-4-7-xhigh-fast",
-      description: "Opus 4.7 1M Fast",
-    },
-    {
-      value: "claude-opus-4-7-max",
-      label: "claude-opus-4-7-max",
-      description: "Opus 4.7 1M Max",
-    },
-    {
-      value: "claude-opus-4-7-max-fast",
-      label: "claude-opus-4-7-max-fast",
-      description: "Opus 4.7 1M Max Fast",
-    },
-    {
-      value: "claude-opus-4-7-thinking-low",
-      label: "claude-opus-4-7-thinking-low",
-      description: "Opus 4.7 1M Low Thinking",
-    },
-    {
-      value: "claude-opus-4-7-thinking-low-fast",
-      label: "claude-opus-4-7-thinking-low-fast",
-      description: "Opus 4.7 1M Low Thinking Fast",
-    },
-    {
-      value: "claude-opus-4-7-thinking-medium",
-      label: "claude-opus-4-7-thinking-medium",
-      description: "Opus 4.7 1M Medium Thinking",
-    },
-    {
-      value: "claude-opus-4-7-thinking-medium-fast",
-      label: "claude-opus-4-7-thinking-medium-fast",
-      description: "Opus 4.7 1M Medium Thinking Fast",
-    },
-    {
-      value: "claude-opus-4-7-thinking-high-fast",
-      label: "claude-opus-4-7-thinking-high-fast",
-      description: "Opus 4.7 1M High Thinking Fast",
-    },
-    {
-      value: "claude-opus-4-7-thinking-xhigh",
-      label: "claude-opus-4-7-thinking-xhigh",
-      description: "Opus 4.7 1M Thinking",
-    },
-    {
-      value: "claude-opus-4-7-thinking-xhigh-fast",
-      label: "claude-opus-4-7-thinking-xhigh-fast",
-      description: "Opus 4.7 1M Thinking Fast",
-    },
-    {
-      value: "claude-opus-4-7-thinking-max",
-      label: "claude-opus-4-7-thinking-max",
-      description: "Opus 4.7 1M Max Thinking",
-    },
-    {
-      value: "claude-opus-4-7-thinking-max-fast",
-      label: "claude-opus-4-7-thinking-max-fast",
-      description: "Opus 4.7 1M Max Thinking Fast",
-    },
-    {
-      value: "grok-build-0.1",
-      label: "grok-build-0.1",
-      description: "Grok Build 0.1 1M",
-    },
-    {
-      value: "gpt-5.4-low",
-      label: "gpt-5.4-low",
-      description: "GPT-5.4 1M Low",
-    },
-    {
-      value: "gpt-5.4-medium",
-      label: "gpt-5.4-medium",
-      description: "GPT-5.4 1M",
-    },
-    {
-      value: "gpt-5.4-medium-fast",
-      label: "gpt-5.4-medium-fast",
-      description: "GPT-5.4 Fast",
-    },
-    {
-      value: "gpt-5.4-xhigh",
-      label: "gpt-5.4-xhigh",
-      description: "GPT-5.4 1M Extra High",
-    },
-    {
-      value: "gpt-5.4-xhigh-fast",
-      label: "gpt-5.4-xhigh-fast",
-      description: "GPT-5.4 Extra High Fast",
-    },
-    {
-      value: "claude-4.6-opus-high",
-      label: "claude-4.6-opus-high",
-      description: "Opus 4.6 1M",
-    },
-    {
-      value: "claude-4.6-opus-max",
-      label: "claude-4.6-opus-max",
-      description: "Opus 4.6 1M Max",
-    },
-    {
-      value: "claude-4.6-opus-max-thinking",
-      label: "claude-4.6-opus-max-thinking",
-      description: "Opus 4.6 1M Max Thinking",
-    },
-    {
-      value: "claude-4.6-opus-max-thinking-fast",
-      label: "claude-4.6-opus-max-thinking-fast",
-      description: "Opus 4.6 1M Max Thinking Fast",
-    },
-    {
-      value: "claude-4.5-opus-high",
-      label: "claude-4.5-opus-high",
-      description: "Opus 4.5",
-    },
-    {
-      value: "claude-4.5-opus-high-thinking",
-      label: "claude-4.5-opus-high-thinking",
-      description: "Opus 4.5 Thinking",
-    },
-    {
-      value: "gpt-5.2-low",
-      label: "gpt-5.2-low",
-      description: "GPT-5.2 Low",
-    },
-    {
-      value: "gpt-5.2-low-fast",
-      label: "gpt-5.2-low-fast",
-      description: "GPT-5.2 Low Fast",
-    },
-    {
-      value: "gpt-5.2-fast",
-      label: "gpt-5.2-fast",
-      description: "GPT-5.2 Fast",
-    },
-    {
-      value: "gpt-5.2-high",
-      label: "gpt-5.2-high",
-      description: "GPT-5.2 High",
-    },
-    {
-      value: "gpt-5.2-high-fast",
-      label: "gpt-5.2-high-fast",
-      description: "GPT-5.2 High Fast",
-    },
-    {
-      value: "gpt-5.2-xhigh",
-      label: "gpt-5.2-xhigh",
-      description: "GPT-5.2 Extra High",
-    },
-    {
-      value: "gpt-5.2-xhigh-fast",
-      label: "gpt-5.2-xhigh-fast",
-      description: "GPT-5.2 Extra High Fast",
-    },
-    {
-      value: "gpt-5.4-mini-none",
-      label: "gpt-5.4-mini-none",
-      description: "GPT-5.4 Mini None",
-    },
-    {
-      value: "gpt-5.4-mini-low",
-      label: "gpt-5.4-mini-low",
-      description: "GPT-5.4 Mini Low",
-    },
-    {
-      value: "gpt-5.4-mini-medium",
-      label: "gpt-5.4-mini-medium",
-      description: "GPT-5.4 Mini",
-    },
-    {
-      value: "gpt-5.4-mini-high",
-      label: "gpt-5.4-mini-high",
-      description: "GPT-5.4 Mini High",
-    },
-    {
-      value: "gpt-5.4-mini-xhigh",
-      label: "gpt-5.4-mini-xhigh",
-      description: "GPT-5.4 Mini Extra High",
-    },
-    {
-      value: "gpt-5.4-nano-none",
-      label: "gpt-5.4-nano-none",
-      description: "GPT-5.4 Nano None",
-    },
-    {
-      value: "gpt-5.4-nano-low",
-      label: "gpt-5.4-nano-low",
-      description: "GPT-5.4 Nano Low",
-    },
-    {
-      value: "gpt-5.4-nano-medium",
-      label: "gpt-5.4-nano-medium",
-      description: "GPT-5.4 Nano",
-    },
-    {
-      value: "gpt-5.4-nano-high",
-      label: "gpt-5.4-nano-high",
-      description: "GPT-5.4 Nano High",
-    },
-    {
-      value: "gpt-5.4-nano-xhigh",
-      label: "gpt-5.4-nano-xhigh",
-      description: "GPT-5.4 Nano Extra High",
-    },
-    {
-      value: "grok-4.3",
-      label: "grok-4.3",
-      description: "Grok 4.3 1M",
-    },
-    {
-      value: "claude-4.5-sonnet",
-      label: "claude-4.5-sonnet",
-      description: "Sonnet 4.5",
-    },
-    {
-      value: "claude-4.5-sonnet-thinking",
-      label: "claude-4.5-sonnet-thinking",
-      description: "Sonnet 4.5 Thinking",
-    },
-    {
-      value: "gpt-5.1-low",
-      label: "gpt-5.1-low",
-      description: "GPT-5.1 Low",
-    },
-    {
-      value: "gpt-5.1",
-      label: "gpt-5.1",
-      description: "GPT-5.1",
-    },
-    {
-      value: "gpt-5.1-high",
-      label: "gpt-5.1-high",
-      description: "GPT-5.1 High",
-    },
-    {
-      value: "gpt-5.1-codex-mini-low",
-      label: "gpt-5.1-codex-mini-low",
-      description: "Codex 5.1 Mini Low",
-    },
-    {
-      value: "gpt-5.1-codex-mini",
-      label: "gpt-5.1-codex-mini",
-      description: "Codex 5.1 Mini",
-    },
-    {
-      value: "gpt-5.1-codex-mini-high",
-      label: "gpt-5.1-codex-mini-high",
-      description: "Codex 5.1 Mini High",
-    },
-    {
-      value: "claude-4-sonnet",
-      label: "claude-4-sonnet",
-      description: "Sonnet 4",
-    },
-    {
-      value: "claude-4-sonnet-thinking",
-      label: "claude-4-sonnet-thinking",
-      description: "Sonnet 4 Thinking",
-    },
-    {
-      value: "gpt-5-mini",
-      label: "gpt-5-mini",
-      description: "GPT-5 Mini",
-    },
-    {
-      value: "kimi-k2.5",
-      label: "kimi-k2.5",
-      description: "Kimi K2.5",
-    },
+    { value: 'auto', label: 'Auto', description: 'Let Cursor choose the model.' },
+    {
+      value: 'composer-2.5-fast',
+      label: 'Composer 2.5 Fast',
+      description: 'Cursor Composer 2.5 with faster inference.',
+    },
+    {
+      value: 'composer-2.5',
+      label: 'Composer 2.5',
+      description: 'Cursor model for efficient, long-running coding tasks.',
+    },
+    { value: 'gpt-5.6-sol', label: 'GPT-5.6 Sol' },
+    { value: 'gpt-5.6-terra', label: 'GPT-5.6 Terra' },
+    { value: 'gpt-5.6-luna', label: 'GPT-5.6 Luna' },
+    { value: 'gpt-5.5', label: 'GPT-5.5' },
+    { value: 'claude-fable-5', label: 'Claude Fable 5' },
+    { value: 'claude-opus-5', label: 'Claude Opus 5' },
+    { value: 'claude-opus-4-8', label: 'Claude Opus 4.8' },
+    { value: 'claude-sonnet-5', label: 'Claude Sonnet 5' },
+    { value: 'grok-4.5', label: 'Grok 4.5' },
+    { value: 'gemini-3.1-pro', label: 'Gemini 3.1 Pro' },
+    { value: 'kimi-k2.5', label: 'Kimi K2.5' },
   ],
-  DEFAULT: "composer-2.5-fast",
+  DEFAULT: 'auto',
 };
 
-type CursorModelRow = {
-  name: string;
-  description: string;
-  current: boolean;
-  default: boolean;
-};
-
-const CURSOR_MODELS_TIMEOUT_MS = 10_000;
 const CURSOR_CHATS_ROOT = path.join(os.homedir(), '.cursor', 'chats');
-// cross-spawn resolves .cmd shims/PATHEXT on Windows and delegates to
-// child_process.spawn everywhere else.
-const spawnFunction = crossSpawn;
-const ANSI_PATTERN = new RegExp(
-  // eslint-disable-next-line no-control-regex
-  '[\\u001B\\u009B][[\\]()#;?]*(?:'
-  + '(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-ORZcf-nqry=><]'
-  + '|(?:[\\dA-PR-TZcf-ntqry=><~]))',
-  'g',
-);
-
-const stripAnsi = (value: string): string => value.replace(ANSI_PATTERN, '');
-
-const parseModelLine = (line: string): CursorModelRow | null => {
-  const trimmed = line.trim();
-
-  if (
-    !trimmed
-    || trimmed === 'Available models'
-    || trimmed.startsWith('Loading models')
-    || trimmed.startsWith('Tip:')
-  ) {
-    return null;
-  }
-
-  const match = trimmed.match(/^(.+?)\s+-\s+(.+)$/);
-  if (!match) {
-    return null;
-  }
-
-  const name = match[1].trim();
-  let description = match[2].trim();
-  const current = /\(current\)/i.test(description);
-  const defaultModel = /\(default\)/i.test(description);
-
-  description = description.replace(/\s*\((current|default)\)/gi, '').replace(/\s{2,}/g, ' ').trim();
-
-  return {
-    name,
-    description,
-    current,
-    default: defaultModel,
-  };
-};
-
-const parseModelsOutput = (text: string): CursorModelRow[] => {
-  const models: CursorModelRow[] = [];
-
-  for (const line of stripAnsi(text).split(/\r?\n/)) {
-    const parsed = parseModelLine(line);
-    if (parsed) {
-      models.push(parsed);
-    }
-  }
-
-  return models;
-};
-
-const runCursorListModels = (): Promise<string> => new Promise((resolve, reject) => {
-  const cursorProcess = spawnFunction('cursor-agent', ['--list-models'], {
-    env: { ...process.env },
-  });
-
-  let stdout = '';
-  let stderr = '';
-  let settled = false;
-
-  const timer = setTimeout(() => {
-    cursorProcess.kill('SIGTERM');
-    if (!settled) {
-      settled = true;
-      reject(new Error('cursor-agent --list-models timed out'));
-    }
-  }, CURSOR_MODELS_TIMEOUT_MS);
-
-  const finish = (error: Error | null, output: string) => {
-    if (settled) {
-      return;
-    }
-
-    settled = true;
-    clearTimeout(timer);
-
-    if (error) {
-      reject(error);
-      return;
-    }
-
-    resolve(output);
-  };
-
-  cursorProcess.stdout?.on('data', (chunk: Buffer) => {
-    stdout += chunk.toString();
-  });
-
-  cursorProcess.stderr?.on('data', (chunk: Buffer) => {
-    stderr += chunk.toString();
-  });
-
-  cursorProcess.on('error', (error) => {
-    finish(error instanceof Error ? error : new Error(String(error)), '');
-  });
-
-  cursorProcess.on('close', (code) => {
-    if (code !== 0) {
-      finish(new Error(stderr.trim() || `cursor-agent --list-models exited with code ${code}`), '');
-      return;
-    }
-
-    finish(null, stdout);
-  });
-});
-
-const buildCursorModelsDefinition = (models: CursorModelRow[]): ProviderModelsDefinition => {
-  const options: ProviderModelOption[] = [];
-  const seenValues = new Set<string>();
-
-  for (const model of models) {
-    if (seenValues.has(model.name)) {
-      continue;
-    }
-
-    seenValues.add(model.name);
-    options.push({
-      value: model.name,
-      label: model.name,
-      description: model.description || undefined,
-    });
-  }
-
-  if (options.length === 0) {
-    return CURSOR_FALLBACK_MODELS;
-  }
-
-  const defaultValue = models.find((model) => model.default)?.name
-    ?? models.find((model) => model.current)?.name
-    ?? options[0]?.value
-    ?? CURSOR_FALLBACK_MODELS.DEFAULT;
-
-  return {
-    OPTIONS: options,
-    DEFAULT: defaultValue,
-  };
-};
 
 const resolveCursorSessionStorePath = async (sessionId: string): Promise<string | null> => {
   const safeSessionId = sanitizeLeafDirectoryName(sessionId, 'cursor session id');
@@ -740,26 +68,21 @@ const resolveCursorSessionStorePath = async (sessionId: string): Promise<string 
   return null;
 };
 
+/** Provider registry model adapter for Cursor predefined models and session metadata. */
 export class CursorProviderModels implements IProviderModels {
   async getSupportedModels(): Promise<ProviderModelsDefinition> {
-    try {
-      const stdout = await runCursorListModels();
-      const models = parseModelsOutput(stdout);
-      return buildCursorModelsDefinition(models);
-    } catch {
-      return CURSOR_FALLBACK_MODELS;
-    }
+    return CURSOR_PREDEFINED_MODELS;
   }
 
   async getCurrentActiveModel(sessionId?: string): Promise<ProviderCurrentActiveModel> {
     if (!sessionId?.trim()) {
-      return buildDefaultProviderCurrentActiveModel(await this.getSupportedModels());
+      return buildDefaultProviderCurrentActiveModel(CURSOR_PREDEFINED_MODELS);
     }
 
     try {
       const storeDbPath = await resolveCursorSessionStorePath(sessionId);
       if (!storeDbPath) {
-        return buildDefaultProviderCurrentActiveModel(await this.getSupportedModels());
+        return buildDefaultProviderCurrentActiveModel(CURSOR_PREDEFINED_MODELS);
       }
 
       const { default: Database } = await import('better-sqlite3');
@@ -775,7 +98,7 @@ export class CursorProviderModels implements IProviderModels {
             ? Buffer.from(row.value.trim(), 'hex').toString('utf8')
             : '';
         if (!metadataText) {
-          return buildDefaultProviderCurrentActiveModel(await this.getSupportedModels());
+          return buildDefaultProviderCurrentActiveModel(CURSOR_PREDEFINED_MODELS);
         }
 
         const metadata = JSON.parse(metadataText) as { lastUsedModel?: string };
@@ -788,10 +111,9 @@ export class CursorProviderModels implements IProviderModels {
         db.close();
       }
     } catch {
-      // Fall through to the provider default when Cursor metadata cannot be read.
+      // Fall through to the curated default when Cursor metadata cannot be read.
     }
 
-    return buildDefaultProviderCurrentActiveModel(await this.getSupportedModels());
+    return buildDefaultProviderCurrentActiveModel(CURSOR_PREDEFINED_MODELS);
   }
 }
-

--- a/server/modules/providers/list/opencode/opencode-models.provider.ts
+++ b/server/modules/providers/list/opencode/opencode-models.provider.ts
@@ -1,11 +1,9 @@
 import Database from 'better-sqlite3';
-import crossSpawn from 'cross-spawn';
 
 import { sessionsDb } from '@/modules/database/index.js';
 import type { IProviderModels } from '@/shared/interfaces.js';
 import type {
   ProviderCurrentActiveModel,
-  ProviderModelOption,
   ProviderModelsDefinition,
 } from '@/shared/types.js';
 import {
@@ -15,344 +13,65 @@ import {
   readOptionalString,
 } from '@/shared/utils.js';
 
-export const OPENCODE_FALLBACK_MODELS: ProviderModelsDefinition = {
+/** Curated OpenCode Zen catalog shipped as immutable CloudCLI defaults. */
+export const OPENCODE_PREDEFINED_MODELS: ProviderModelsDefinition = {
   OPTIONS: [
-    {
-      value: 'anthropic/claude-sonnet-4-5',
-      label: 'Claude Sonnet 4.5',
-      description: 'anthropic - anthropic/claude-sonnet-4-5',
-    },
-    {
-      value: 'anthropic/claude-opus-4-1',
-      label: 'Claude Opus 4.1',
-      description: 'anthropic - anthropic/claude-opus-4-1',
-    },
-    {
-      value: 'anthropic/claude-haiku-4-5',
-      label: 'Claude Haiku 4.5',
-      description: 'anthropic - anthropic/claude-haiku-4-5',
-    },
-    {
-      value: 'openai/gpt-5.1',
-      label: 'GPT-5.1',
-      description: 'openai - openai/gpt-5.1',
-    },
-    {
-      value: 'openai/gpt-5.1-codex',
-      label: 'GPT-5.1 Codex',
-      description: 'openai - openai/gpt-5.1-codex',
-    },
-    {
-      value: 'openai/gpt-5.4-mini',
-      label: 'GPT-5.4 Mini',
-      description: 'openai - openai/gpt-5.4-mini',
-    },
+    { value: 'opencode/gpt-5.6-sol', label: 'GPT 5.6 Sol', description: 'OpenCode Zen' },
+    { value: 'opencode/gpt-5.6-terra', label: 'GPT 5.6 Terra', description: 'OpenCode Zen' },
+    { value: 'opencode/gpt-5.6-luna', label: 'GPT 5.6 Luna', description: 'OpenCode Zen' },
+    { value: 'opencode/gpt-5.5', label: 'GPT 5.5', description: 'OpenCode Zen' },
+    { value: 'opencode/gpt-5.5-pro', label: 'GPT 5.5 Pro', description: 'OpenCode Zen' },
+    { value: 'opencode/gpt-5.4', label: 'GPT 5.4', description: 'OpenCode Zen' },
+    { value: 'opencode/gpt-5.4-pro', label: 'GPT 5.4 Pro', description: 'OpenCode Zen' },
+    { value: 'opencode/gpt-5.4-mini', label: 'GPT 5.4 Mini', description: 'OpenCode Zen' },
+    { value: 'opencode/gpt-5.4-nano', label: 'GPT 5.4 Nano', description: 'OpenCode Zen' },
+    { value: 'opencode/gpt-5.3-codex', label: 'GPT 5.3 Codex', description: 'OpenCode Zen' },
+    { value: 'opencode/gpt-5.3-codex-spark', label: 'GPT 5.3 Codex Spark', description: 'OpenCode Zen' },
+    { value: 'opencode/gpt-5.2', label: 'GPT 5.2', description: 'OpenCode Zen' },
+    { value: 'opencode/gpt-5.1', label: 'GPT 5.1', description: 'OpenCode Zen' },
+    { value: 'opencode/gpt-5', label: 'GPT 5', description: 'OpenCode Zen' },
+    { value: 'opencode/gpt-5-nano', label: 'GPT 5 Nano', description: 'OpenCode Zen' },
+    { value: 'opencode/claude-fable-5', label: 'Claude Fable 5', description: 'OpenCode Zen' },
+    { value: 'opencode/claude-opus-5', label: 'Claude Opus 5', description: 'OpenCode Zen' },
+    { value: 'opencode/claude-opus-4-8', label: 'Claude Opus 4.8', description: 'OpenCode Zen' },
+    { value: 'opencode/claude-opus-4-7', label: 'Claude Opus 4.7', description: 'OpenCode Zen' },
+    { value: 'opencode/claude-opus-4-6', label: 'Claude Opus 4.6', description: 'OpenCode Zen' },
+    { value: 'opencode/claude-opus-4-5', label: 'Claude Opus 4.5', description: 'OpenCode Zen' },
+    { value: 'opencode/claude-sonnet-5', label: 'Claude Sonnet 5', description: 'OpenCode Zen' },
+    { value: 'opencode/claude-sonnet-4-6', label: 'Claude Sonnet 4.6', description: 'OpenCode Zen' },
+    { value: 'opencode/claude-sonnet-4-5', label: 'Claude Sonnet 4.5', description: 'OpenCode Zen' },
+    { value: 'opencode/claude-haiku-4-5', label: 'Claude Haiku 4.5', description: 'OpenCode Zen' },
+    { value: 'opencode/gemini-3.6-flash', label: 'Gemini 3.6 Flash', description: 'OpenCode Zen' },
+    { value: 'opencode/gemini-3.5-flash', label: 'Gemini 3.5 Flash', description: 'OpenCode Zen' },
+    { value: 'opencode/gemini-3.5-flash-lite', label: 'Gemini 3.5 Flash Lite', description: 'OpenCode Zen' },
+    { value: 'opencode/gemini-3.1-pro', label: 'Gemini 3.1 Pro', description: 'OpenCode Zen' },
+    { value: 'opencode/gemini-3-flash', label: 'Gemini 3 Flash', description: 'OpenCode Zen' },
+    { value: 'opencode/grok-4.5', label: 'Grok 4.5', description: 'OpenCode Zen' },
+    { value: 'opencode/grok-build-0.1', label: 'Grok Build 0.1', description: 'OpenCode Zen' },
+    { value: 'opencode/qwen3.7-max', label: 'Qwen3.7 Max', description: 'OpenCode Zen' },
+    { value: 'opencode/qwen3.7-plus', label: 'Qwen3.7 Plus', description: 'OpenCode Zen' },
+    { value: 'opencode/qwen3.6-plus', label: 'Qwen3.6 Plus', description: 'OpenCode Zen' },
+    { value: 'opencode/qwen3.5-plus', label: 'Qwen3.5 Plus', description: 'OpenCode Zen' },
+    { value: 'opencode/deepseek-v4-pro', label: 'DeepSeek V4 Pro', description: 'OpenCode Zen' },
+    { value: 'opencode/deepseek-v4-flash', label: 'DeepSeek V4 Flash', description: 'OpenCode Zen' },
+    { value: 'opencode/minimax-m3', label: 'MiniMax M3', description: 'OpenCode Zen' },
+    { value: 'opencode/minimax-m2.7', label: 'MiniMax M2.7', description: 'OpenCode Zen' },
+    { value: 'opencode/minimax-m2.5', label: 'MiniMax M2.5', description: 'OpenCode Zen' },
+    { value: 'opencode/glm-5.2', label: 'GLM 5.2', description: 'OpenCode Zen' },
+    { value: 'opencode/glm-5.1', label: 'GLM 5.1', description: 'OpenCode Zen' },
+    { value: 'opencode/kimi-k2.5', label: 'Kimi K2.5', description: 'OpenCode Zen' },
+    { value: 'opencode/kimi-k2.6', label: 'Kimi K2.6', description: 'OpenCode Zen' },
+    { value: 'opencode/kimi-k2.7-code', label: 'Kimi K2.7 Code', description: 'OpenCode Zen' },
+    { value: 'opencode/kimi-k3', label: 'Kimi K3', description: 'OpenCode Zen' },
+    { value: 'opencode/big-pickle', label: 'Big Pickle', description: 'OpenCode Zen · Free' },
+    { value: 'opencode/mimo-v2.5-free', label: 'MiMo-V2.5 Free', description: 'OpenCode Zen · Free' },
+    { value: 'opencode/laguna-s-2.1-free', label: 'Laguna S 2.1 Free', description: 'OpenCode Zen · Free' },
+    { value: 'opencode/ling-3.0-flash-free', label: 'Ling-3.0-flash Free', description: 'OpenCode Zen · Free' },
+    { value: 'opencode/north-mini-code-free', label: 'North Mini Code Free', description: 'OpenCode Zen · Free' },
+    { value: 'opencode/nemotron-3-ultra-free', label: 'Nemotron 3 Ultra Free', description: 'OpenCode Zen · Free' },
+    { value: 'opencode/deepseek-v4-flash-free', label: 'DeepSeek V4 Flash Free', description: 'OpenCode Zen · Free' },
   ],
-  DEFAULT: 'anthropic/claude-sonnet-4-5',
-};
-
-const OPEN_CODE_MODELS_TIMEOUT_MS = 20_000;
-const MODEL_ID_LINE = /^[a-z0-9][a-z0-9._-]*\/[a-z0-9][a-z0-9._-]*$/i;
-// cross-spawn resolves .cmd shims/PATHEXT on Windows and delegates to
-// child_process.spawn everywhere else.
-const spawnFunction = crossSpawn;
-const DATE_TOKEN = /^\d{8}$/;
-const SIMPLE_NUMBER_TOKEN = /^\d$/;
-const VERSION_TOKEN = /^[a-z]\d+$/i;
-const NUMERIC_TOKEN = /^\d+(?:\.\d+)*$/;
-const SHORT_ACRONYM_TOKEN = /^[a-z]{2,3}$/;
-
-type OpenCodeVerboseModel = {
-  id?: string;
-  name?: string;
-  providerID?: string;
-  variants?: Record<string, unknown>;
-};
-
-export const parseOpenCodeModelsStdout = (stdout: string): string[] => {
-  const ids: string[] = [];
-
-  for (const rawLine of stdout.split(/\r?\n/)) {
-    const line = rawLine.trim();
-    if (!line || line.startsWith('{') || line.startsWith('[')) {
-      continue;
-    }
-
-    if (MODEL_ID_LINE.test(line)) {
-      ids.push(line);
-    }
-  }
-
-  return [...new Set(ids)];
-};
-
-const countJsonBraceDelta = (value: string): number => {
-  let delta = 0;
-  let inString = false;
-  let escaped = false;
-
-  for (const character of value) {
-    if (escaped) {
-      escaped = false;
-      continue;
-    }
-
-    if (character === '\\') {
-      escaped = inString;
-      continue;
-    }
-
-    if (character === '"') {
-      inString = !inString;
-      continue;
-    }
-
-    if (inString) {
-      continue;
-    }
-
-    if (character === '{') {
-      delta += 1;
-    } else if (character === '}') {
-      delta -= 1;
-    }
-  }
-
-  return delta;
-};
-
-const isOpenCodeVerboseModel = (value: unknown): value is OpenCodeVerboseModel => {
-  const record = readObjectRecord(value);
-  return Boolean(record && readOptionalString(record.id));
-};
-
-export const parseOpenCodeVerboseModelsStdout = (stdout: string): OpenCodeVerboseModel[] => {
-  const models: OpenCodeVerboseModel[] = [];
-  let buffer: string[] = [];
-  let depth = 0;
-
-  for (const rawLine of stdout.split(/\r?\n/)) {
-    const line = rawLine.trim();
-    if (buffer.length === 0) {
-      if (line === '{') {
-        buffer = [rawLine];
-        depth = 1;
-      }
-      continue;
-    }
-
-    buffer.push(rawLine);
-    depth += countJsonBraceDelta(rawLine);
-
-    if (depth !== 0) {
-      continue;
-    }
-
-    try {
-      const parsed = JSON.parse(buffer.join('\n'));
-      if (isOpenCodeVerboseModel(parsed)) {
-        models.push(parsed);
-      }
-    } catch {
-      // Ignore malformed verbose blocks and fall back to the plain id parser.
-    }
-
-    buffer = [];
-  }
-
-  return models;
-};
-
-const formatDateToken = (token: string): string => (
-  `${token.slice(0, 4)}-${token.slice(4, 6)}-${token.slice(6, 8)}`
-);
-
-const formatModelToken = (token: string, nextToken?: string): string => {
-  const lower = token.toLowerCase();
-
-  if (VERSION_TOKEN.test(token)) {
-    return token.toUpperCase();
-  }
-
-  if (SHORT_ACRONYM_TOKEN.test(lower) && nextToken && NUMERIC_TOKEN.test(nextToken)) {
-    return token.toUpperCase();
-  }
-
-  return lower.charAt(0).toUpperCase() + lower.slice(1);
-};
-
-const formatOpenCodeModelSlug = (slug: string): string => {
-  const labelParts: string[] = [];
-  const dateParts: string[] = [];
-  const tokens = slug.split('-').filter(Boolean);
-
-  for (let index = 0; index < tokens.length; index += 1) {
-    const token = tokens[index];
-    const nextToken = tokens[index + 1];
-
-    if (DATE_TOKEN.test(token)) {
-      dateParts.push(formatDateToken(token));
-      continue;
-    }
-
-    if (SIMPLE_NUMBER_TOKEN.test(token) && nextToken && SIMPLE_NUMBER_TOKEN.test(nextToken)) {
-      labelParts.push(`${token}.${nextToken}`);
-      index += 1;
-      continue;
-    }
-
-    labelParts.push(formatModelToken(token, nextToken));
-  }
-
-  const label = (labelParts.join(' ').trim() || slug).replace(/^GPT\s+/, 'GPT-');
-  if (dateParts.length === 0) {
-    return label;
-  }
-
-  return `${label} (${dateParts.join(', ')})`;
-};
-
-const readOpenCodeModelParts = (id: string): { upstreamProvider: string; slug: string } => {
-  const separatorIndex = id.indexOf('/');
-  if (separatorIndex < 0) {
-    return {
-      upstreamProvider: '',
-      slug: id,
-    };
-  }
-
-  return {
-    upstreamProvider: id.slice(0, separatorIndex),
-    slug: id.slice(separatorIndex + 1),
-  };
-};
-
-const isSupportedOpenCodeModelId = (id: string): boolean => (
-  readOpenCodeModelParts(id).upstreamProvider.toLowerCase() !== 'google'
-);
-
-const readOpenCodeVerboseModelId = (model: OpenCodeVerboseModel): string | null => {
-  const id = readOptionalString(model.id);
-  if (!id) {
-    return null;
-  }
-
-  if (id.includes('/')) {
-    return id;
-  }
-
-  const upstreamProvider = readOptionalString(model.providerID);
-  return upstreamProvider ? `${upstreamProvider}/${id}` : id;
-};
-
-const labelForOpenCodeModelId = (id: string): string => {
-  const fallbackLabel = OPENCODE_FALLBACK_MODELS.OPTIONS.find((option) => option.value === id)?.label;
-  if (fallbackLabel) {
-    return fallbackLabel;
-  }
-
-  const { slug } = readOpenCodeModelParts(id);
-  return formatOpenCodeModelSlug(slug);
-};
-
-const descriptionForOpenCodeModelId = (id: string): string => {
-  const { upstreamProvider } = readOpenCodeModelParts(id);
-  return upstreamProvider ? `${upstreamProvider} - ${id}` : id;
-};
-
-const readOpenCodeVariantEffort = (key: string, value: unknown): string | null => {
-  const variant = readObjectRecord(value);
-  return readOptionalString(variant?.reasoningEffort)
-    ?? readOptionalString(variant?.effort)
-    ?? key;
-};
-
-const readOpenCodeEffortValues = (
-  variants: OpenCodeVerboseModel['variants'],
-): NonNullable<ProviderModelOption['effort']>['values'] => {
-  const effortValues: NonNullable<ProviderModelOption['effort']>['values'] = [];
-  const seenValues = new Set<string>();
-
-  for (const [key, value] of Object.entries(variants ?? {})) {
-    const effort = readOpenCodeVariantEffort(key, value);
-    if (!effort || seenValues.has(effort)) {
-      continue;
-    }
-
-    seenValues.add(effort);
-    effortValues.push({ value: effort });
-  }
-
-  return effortValues;
-};
-
-const mapOpenCodeVerboseModel = (model: OpenCodeVerboseModel): ProviderModelOption | null => {
-  const value = readOpenCodeVerboseModelId(model);
-  if (!value || !isSupportedOpenCodeModelId(value)) {
-    return null;
-  }
-
-  const effortValues = readOpenCodeEffortValues(model.variants);
-
-  return {
-    value,
-    label: readOptionalString(model.name) ?? labelForOpenCodeModelId(value),
-    description: descriptionForOpenCodeModelId(value),
-    effort: effortValues.length > 0
-      ? {
-          values: effortValues,
-        }
-      : undefined,
-  };
-};
-
-export const buildOpenCodeDefinitionFromIds = (ids: string[]): ProviderModelsDefinition => {
-  const options: ProviderModelOption[] = ids
-    .filter(isSupportedOpenCodeModelId)
-    .map((value) => ({
-      value,
-      label: labelForOpenCodeModelId(value),
-      description: descriptionForOpenCodeModelId(value),
-    }));
-
-  const defaultValue = options.find((option) => option.value === OPENCODE_FALLBACK_MODELS.DEFAULT)?.value
-    ?? options[0]?.value
-    ?? OPENCODE_FALLBACK_MODELS.DEFAULT;
-
-  return {
-    OPTIONS: options,
-    DEFAULT: defaultValue,
-  };
-};
-
-export const buildOpenCodeDefinitionFromVerboseModels = (
-  models: OpenCodeVerboseModel[],
-): ProviderModelsDefinition => {
-  const options: ProviderModelOption[] = [];
-  const seenValues = new Set<string>();
-
-  for (const model of models) {
-    const mappedModel = mapOpenCodeVerboseModel(model);
-    if (!mappedModel || seenValues.has(mappedModel.value)) {
-      continue;
-    }
-
-    seenValues.add(mappedModel.value);
-    options.push(mappedModel);
-  }
-
-  if (options.length === 0) {
-    return OPENCODE_FALLBACK_MODELS;
-  }
-
-  const defaultValue = options.find((option) => option.value === OPENCODE_FALLBACK_MODELS.DEFAULT)?.value
-    ?? options[0]?.value
-    ?? OPENCODE_FALLBACK_MODELS.DEFAULT;
-
-  return {
-    OPTIONS: options,
-    DEFAULT: defaultValue,
-  };
+  DEFAULT: 'opencode/gpt-5.6-terra',
 };
 
 const parseOpenCodeSessionModelValue = (rawModel: unknown): string | null => {
@@ -381,85 +100,15 @@ const parseOpenCodeSessionModelValue = (rawModel: unknown): string | null => {
     ?? null;
 };
 
-const runOpenCodeModelsCommand = (): Promise<string> => new Promise((resolve, reject) => {
-  const openCodeProcess = spawnFunction('opencode', ['models', '--verbose'], {
-    cwd: process.cwd(),
-    env: { ...process.env },
-  });
-
-  let stdout = '';
-  let stderr = '';
-  let settled = false;
-
-  const timer = setTimeout(() => {
-    openCodeProcess.kill('SIGTERM');
-    if (!settled) {
-      settled = true;
-      reject(new Error('opencode models timed out'));
-    }
-  }, OPEN_CODE_MODELS_TIMEOUT_MS);
-
-  const finish = (error: Error | null, output: string) => {
-    if (settled) {
-      return;
-    }
-
-    settled = true;
-    clearTimeout(timer);
-
-    if (error) {
-      reject(error);
-      return;
-    }
-
-    resolve(output);
-  };
-
-  openCodeProcess.stdout?.on('data', (chunk: Buffer) => {
-    stdout += chunk.toString();
-  });
-
-  openCodeProcess.stderr?.on('data', (chunk: Buffer) => {
-    stderr += chunk.toString();
-  });
-
-  openCodeProcess.on('error', (error) => {
-    finish(error instanceof Error ? error : new Error(String(error)), '');
-  });
-
-  openCodeProcess.on('close', (code) => {
-    if (code !== 0) {
-      finish(new Error(stderr.trim() || `opencode models exited with code ${code}`), '');
-      return;
-    }
-
-    finish(null, stdout);
-  });
-});
-
+/** Provider registry model adapter for OpenCode predefined models and session metadata. */
 export class OpenCodeProviderModels implements IProviderModels {
   async getSupportedModels(): Promise<ProviderModelsDefinition> {
-    try {
-      const stdout = await runOpenCodeModelsCommand();
-      const verboseModels = parseOpenCodeVerboseModelsStdout(stdout);
-      if (verboseModels.length > 0) {
-        return buildOpenCodeDefinitionFromVerboseModels(verboseModels);
-      }
-
-      const ids = parseOpenCodeModelsStdout(stdout);
-      if (ids.length === 0) {
-        return OPENCODE_FALLBACK_MODELS;
-      }
-
-      return buildOpenCodeDefinitionFromIds(ids);
-    } catch {
-      return OPENCODE_FALLBACK_MODELS;
-    }
+    return OPENCODE_PREDEFINED_MODELS;
   }
 
   async getCurrentActiveModel(sessionId?: string): Promise<ProviderCurrentActiveModel> {
     if (!sessionId?.trim()) {
-      return buildDefaultProviderCurrentActiveModel(await this.getSupportedModels());
+      return buildDefaultProviderCurrentActiveModel(OPENCODE_PREDEFINED_MODELS);
     }
 
     // OpenCode's `session` table is keyed by its own session id, so the stable
@@ -503,9 +152,9 @@ export class OpenCodeProviderModels implements IProviderModels {
         db.close();
       }
     } catch {
-      // Fall through to the provider default when OpenCode session lookup fails.
+      // Fall through to the curated default when OpenCode session lookup fails.
     }
 
-    return buildDefaultProviderCurrentActiveModel(await this.getSupportedModels());
+    return buildDefaultProviderCurrentActiveModel(OPENCODE_PREDEFINED_MODELS);
   }
 }

--- a/server/modules/providers/list/opencode/opencode-models.provider.ts
+++ b/server/modules/providers/list/opencode/opencode-models.provider.ts
@@ -13,7 +13,14 @@ import {
   readOptionalString,
 } from '@/shared/utils.js';
 
-/** Curated OpenCode Zen catalog shipped as immutable CloudCLI defaults. */
+/**
+ * Curated OpenCode catalog shipped as immutable CloudCLI defaults.
+ *
+ * OpenCode routes by `<providerID>/<modelID>`, so this list mirrors the
+ * providers `opencode models --verbose` reports: the OpenCode Zen gateway plus
+ * the Anthropic and OpenAI providers OpenCode can address directly with the
+ * user's own credentials.
+ */
 export const OPENCODE_PREDEFINED_MODELS: ProviderModelsDefinition = {
   OPTIONS: [
     { value: 'opencode/gpt-5.6-sol', label: 'GPT 5.6 Sol', description: 'OpenCode Zen' },
@@ -70,6 +77,42 @@ export const OPENCODE_PREDEFINED_MODELS: ProviderModelsDefinition = {
     { value: 'opencode/north-mini-code-free', label: 'North Mini Code Free', description: 'OpenCode Zen · Free' },
     { value: 'opencode/nemotron-3-ultra-free', label: 'Nemotron 3 Ultra Free', description: 'OpenCode Zen · Free' },
     { value: 'opencode/deepseek-v4-flash-free', label: 'DeepSeek V4 Flash Free', description: 'OpenCode Zen · Free' },
+    { value: 'anthropic/claude-opus-5', label: 'Claude Opus 5', description: 'Anthropic' },
+    { value: 'anthropic/claude-opus-5-fast', label: 'Claude Opus 5 Fast', description: 'Anthropic' },
+    { value: 'anthropic/claude-fable-5', label: 'Claude Fable 5', description: 'Anthropic' },
+    { value: 'anthropic/claude-sonnet-5', label: 'Claude Sonnet 5', description: 'Anthropic' },
+    { value: 'anthropic/claude-opus-4-8', label: 'Claude Opus 4.8', description: 'Anthropic' },
+    { value: 'anthropic/claude-opus-4-8-fast', label: 'Claude Opus 4.8 Fast', description: 'Anthropic' },
+    { value: 'anthropic/claude-opus-4-7', label: 'Claude Opus 4.7', description: 'Anthropic' },
+    { value: 'anthropic/claude-opus-4-7-fast', label: 'Claude Opus 4.7 Fast', description: 'Anthropic' },
+    { value: 'anthropic/claude-opus-4-6', label: 'Claude Opus 4.6', description: 'Anthropic' },
+    { value: 'anthropic/claude-opus-4-6-fast', label: 'Claude Opus 4.6 Fast', description: 'Anthropic' },
+    { value: 'anthropic/claude-opus-4-5', label: 'Claude Opus 4.5 (latest)', description: 'Anthropic' },
+    { value: 'anthropic/claude-opus-4-5-20251101', label: 'Claude Opus 4.5', description: 'Anthropic' },
+    { value: 'anthropic/claude-sonnet-4-6', label: 'Claude Sonnet 4.6', description: 'Anthropic' },
+    { value: 'anthropic/claude-sonnet-4-5', label: 'Claude Sonnet 4.5 (latest)', description: 'Anthropic' },
+    { value: 'anthropic/claude-sonnet-4-5-20250929', label: 'Claude Sonnet 4.5', description: 'Anthropic' },
+    { value: 'anthropic/claude-haiku-4-5', label: 'Claude Haiku 4.5 (latest)', description: 'Anthropic' },
+    { value: 'anthropic/claude-haiku-4-5-20251001', label: 'Claude Haiku 4.5', description: 'Anthropic' },
+    { value: 'openai/gpt-5.6', label: 'GPT-5.6', description: 'OpenAI' },
+    { value: 'openai/gpt-5.6-fast', label: 'GPT-5.6 Fast', description: 'OpenAI' },
+    { value: 'openai/gpt-5.6-pro', label: 'GPT-5.6 Pro', description: 'OpenAI' },
+    { value: 'openai/gpt-5.6-sol', label: 'GPT-5.6 Sol', description: 'OpenAI' },
+    { value: 'openai/gpt-5.6-sol-fast', label: 'GPT-5.6 Sol Fast', description: 'OpenAI' },
+    { value: 'openai/gpt-5.6-sol-pro', label: 'GPT-5.6 Sol Pro', description: 'OpenAI' },
+    { value: 'openai/gpt-5.6-terra', label: 'GPT-5.6 Terra', description: 'OpenAI' },
+    { value: 'openai/gpt-5.6-terra-fast', label: 'GPT-5.6 Terra Fast', description: 'OpenAI' },
+    { value: 'openai/gpt-5.6-terra-pro', label: 'GPT-5.6 Terra Pro', description: 'OpenAI' },
+    { value: 'openai/gpt-5.6-luna', label: 'GPT-5.6 Luna', description: 'OpenAI' },
+    { value: 'openai/gpt-5.6-luna-fast', label: 'GPT-5.6 Luna Fast', description: 'OpenAI' },
+    { value: 'openai/gpt-5.6-luna-pro', label: 'GPT-5.6 Luna Pro', description: 'OpenAI' },
+    { value: 'openai/gpt-5.5', label: 'GPT-5.5', description: 'OpenAI' },
+    { value: 'openai/gpt-5.5-fast', label: 'GPT-5.5 Fast', description: 'OpenAI' },
+    { value: 'openai/gpt-5.4', label: 'GPT-5.4', description: 'OpenAI' },
+    { value: 'openai/gpt-5.4-fast', label: 'GPT-5.4 Fast', description: 'OpenAI' },
+    { value: 'openai/gpt-5.4-mini', label: 'GPT-5.4 mini', description: 'OpenAI' },
+    { value: 'openai/gpt-5.4-mini-fast', label: 'GPT-5.4 mini Fast', description: 'OpenAI' },
+    { value: 'openai/gpt-5.3-codex-spark', label: 'GPT-5.3 Codex Spark', description: 'OpenAI' },
   ],
   DEFAULT: 'opencode/gpt-5.6-terra',
 };

--- a/server/modules/providers/list/opencode/opencode-session-synchronizer.provider.ts
+++ b/server/modules/providers/list/opencode/opencode-session-synchronizer.provider.ts
@@ -130,22 +130,9 @@ export class OpenCodeSessionSynchronizer implements IProviderSessionSynchronizer
       ?? sessionsDb.getSessionById(sessionId);
     const existingName = existingSession?.custom_name;
 
-    // Sessions started by sending a message from cloudcli carry a distinct
-    // app-allocated session_id mapped to the provider id. For these we title the
-    // conversation from the first user message the user typed, matching how the
-    // app titles a brand-new conversation. Sessions discovered purely by
-    // indexing (session_id === provider_session_id) keep OpenCode's own stored
-    // title.
-    const isAppCreated =
-      existingSession != null &&
-      existingSession.provider_session_id != null &&
-      existingSession.session_id !== existingSession.provider_session_id;
-
     let nextName: string | undefined;
     if (existingName && existingName !== fallbackTitle) {
       nextName = existingName;
-    } else if (isAppCreated) {
-      nextName = this.readFirstUserText(db, sessionId) ?? readOptionalString(row.title);
     } else {
       nextName = readOptionalString(row.title) ?? this.readFirstUserText(db, sessionId);
     }

--- a/server/modules/providers/provider.routes.ts
+++ b/server/modules/providers/provider.routes.ts
@@ -552,7 +552,8 @@ router.post(
     const body = (req.body ?? {}) as Record<string, unknown>;
     const provider = parseProvider(body.provider);
     const projectPath = typeof body.projectPath === 'string' ? body.projectPath : '';
-    const result = sessionsService.createAppSession(provider, projectPath);
+    const initialMessage = typeof body.initialMessage === 'string' ? body.initialMessage : '';
+    const result = sessionsService.createAppSession(provider, projectPath, initialMessage);
     res.status(201).json(createApiSuccessResponse(result));
   }),
 );

--- a/server/modules/providers/provider.routes.ts
+++ b/server/modules/providers/provider.routes.ts
@@ -9,6 +9,7 @@ import { providerSkillsService } from '@/modules/providers/services/skills.servi
 import { sessionConversationsSearchService } from '@/modules/providers/services/session-conversations-search.service.js';
 import { sessionsService } from '@/modules/providers/services/sessions.service.js';
 import type {
+  CustomProviderModelInput,
   LLMProvider,
   McpScope,
   McpTransport,
@@ -372,6 +373,65 @@ const parseSessionModelPayload = (payload: unknown): string => {
   return model;
 };
 
+const parseModelRecordId = (value: unknown): number => {
+  const rawRecordId = readPathParam(value, 'recordId').trim();
+  if (!/^\d+$/.test(rawRecordId)) {
+    throw new AppError('recordId must be a positive integer.', {
+      code: 'INVALID_MODEL_RECORD_ID',
+      statusCode: 400,
+    });
+  }
+
+  const recordId = Number.parseInt(rawRecordId, 10);
+  if (!Number.isSafeInteger(recordId) || recordId < 1) {
+    throw new AppError('recordId must be a positive integer.', {
+      code: 'INVALID_MODEL_RECORD_ID',
+      statusCode: 400,
+    });
+  }
+
+  return recordId;
+};
+
+const parseCustomProviderModelPayload = (payload: unknown): CustomProviderModelInput => {
+  if (!payload || typeof payload !== 'object') {
+    throw new AppError('Request body must be an object.', {
+      code: 'INVALID_REQUEST_BODY',
+      statusCode: 400,
+    });
+  }
+
+  const body = payload as Record<string, unknown>;
+  const model = readOptionalQueryString(body.model);
+  const id = readOptionalQueryString(body.id);
+  if (!model) {
+    throw new AppError('model is required.', {
+      code: 'MODEL_NAME_REQUIRED',
+      statusCode: 400,
+    });
+  }
+  if (!id) {
+    throw new AppError('id is required.', {
+      code: 'MODEL_ID_REQUIRED',
+      statusCode: 400,
+    });
+  }
+  if (model.length > 80) {
+    throw new AppError('model must be 80 characters or fewer.', {
+      code: 'MODEL_NAME_TOO_LONG',
+      statusCode: 400,
+    });
+  }
+  if (id.length > 200 || /\s/.test(id)) {
+    throw new AppError('id must be 200 characters or fewer and cannot contain whitespace.', {
+      code: 'INVALID_MODEL_ID',
+      statusCode: 400,
+    });
+  }
+
+  return { model, id };
+};
+
 router.get(
   '/:provider/auth/status',
   asyncHandler(async (req: Request, res: Response) => {
@@ -385,9 +445,39 @@ router.get(
   '/:provider/models',
   asyncHandler(async (req: Request, res: Response) => {
     const provider = parseProvider(req.params.provider);
-    const bypassCache = parseOptionalBooleanQuery(req.query.bypassCache, 'bypassCache') ?? false;
-    const result = await providerModelsService.getProviderModels(provider, { bypassCache });
-    res.json(createApiSuccessResponse({ provider, models: result.models, cache: result.cache }));
+    const models = await providerModelsService.getProviderModels(provider);
+    res.json(createApiSuccessResponse({ provider, models }));
+  }),
+);
+
+router.post(
+  '/:provider/models',
+  asyncHandler(async (req: Request, res: Response) => {
+    const provider = parseProvider(req.params.provider);
+    const input = parseCustomProviderModelPayload(req.body);
+    const result = await providerModelsService.createCustomModel(provider, input);
+    res.status(201).json(createApiSuccessResponse({ provider, ...result }));
+  }),
+);
+
+router.patch(
+  '/:provider/models/:recordId',
+  asyncHandler(async (req: Request, res: Response) => {
+    const provider = parseProvider(req.params.provider);
+    const recordId = parseModelRecordId(req.params.recordId);
+    const input = parseCustomProviderModelPayload(req.body);
+    const result = await providerModelsService.updateCustomModel(provider, recordId, input);
+    res.json(createApiSuccessResponse({ provider, ...result }));
+  }),
+);
+
+router.delete(
+  '/:provider/models/:recordId',
+  asyncHandler(async (req: Request, res: Response) => {
+    const provider = parseProvider(req.params.provider);
+    const recordId = parseModelRecordId(req.params.recordId);
+    const result = await providerModelsService.deleteCustomModel(provider, recordId);
+    res.json(createApiSuccessResponse({ provider, ...result }));
   }),
 );
 

--- a/server/modules/providers/provider.routes.ts
+++ b/server/modules/providers/provider.routes.ts
@@ -373,6 +373,33 @@ const parseSessionModelPayload = (payload: unknown): string => {
   return model;
 };
 
+const parseSessionEffortPayload = (payload: unknown): string => {
+  if (!payload || typeof payload !== 'object') {
+    throw new AppError('Request body must be an object.', {
+      code: 'INVALID_REQUEST_BODY',
+      statusCode: 400,
+    });
+  }
+
+  const body = payload as Record<string, unknown>;
+  const effort = readOptionalQueryString(body.effort);
+  if (!effort) {
+    throw new AppError('effort is required.', {
+      code: 'EFFORT_REQUIRED',
+      statusCode: 400,
+    });
+  }
+
+  if (effort.length > 32) {
+    throw new AppError('effort must be 32 characters or fewer.', {
+      code: 'INVALID_EFFORT',
+      statusCode: 400,
+    });
+  }
+
+  return effort;
+};
+
 const parseModelRecordId = (value: unknown): number => {
   const rawRecordId = readPathParam(value, 'recordId').trim();
   if (!/^\d+$/.test(rawRecordId)) {
@@ -510,7 +537,23 @@ router.post(
     // A session row only exists once the gateway has allocated one. Report the
     // selection back either way so the client can hold it until the first send.
     res.json(createApiSuccessResponse(
-      stored ?? { provider, sessionId, model, source: 'session' as const },
+      stored ?? { provider, sessionId, model, effort: null, source: 'session' as const },
+    ));
+  }),
+);
+
+/** Records the reasoning-effort choice for one app session. */
+router.post(
+  '/:provider/sessions/:sessionId/active-effort',
+  asyncHandler(async (req: Request, res: Response) => {
+    const provider = parseProvider(req.params.provider);
+    const sessionId = parseSessionId(req.params.sessionId);
+    const effort = parseSessionEffortPayload(req.body);
+    const stored = providerModelsService.setSessionEffort(provider, sessionId, effort);
+    // Mirror active-model behavior for a composer that picked an effort just
+    // before the session gateway created its row.
+    res.json(createApiSuccessResponse(
+      stored ?? { provider, sessionId, effort, source: 'session' as const },
     ));
   }),
 );

--- a/server/modules/providers/services/provider-models.service.ts
+++ b/server/modules/providers/services/provider-models.service.ts
@@ -1,22 +1,16 @@
-import { mkdir, readFile, writeFile } from 'node:fs/promises';
-import os from 'node:os';
-import path from 'node:path';
-
-import { sessionsDb } from '@/modules/database/index.js';
+import { providerModelsDb, sessionsDb } from '@/modules/database/index.js';
 import { providerRegistry } from '@/modules/providers/provider.registry.js';
 import type { IProvider } from '@/shared/interfaces.js';
 import type {
+  CustomProviderModelInput,
+  CustomProviderModelRecord,
   LLMProvider,
   ProviderCurrentActiveModel,
-  ProviderModelsCacheInfo,
+  ProviderModelOption,
   ProviderModelsDefinition,
-  ProviderModelsResult,
   ProviderSessionModel,
 } from '@/shared/types.js';
-
-export const PROVIDER_MODELS_CACHE_TTL_MS = 3 * 24 * 60 * 60 * 1000;
-const PROVIDER_MODELS_CACHE_VERSION = 2;
-const UNCACHED_PROVIDERS = new Set<LLMProvider>(['claude']);
+import { AppError } from '@/shared/utils.js';
 
 /** Session-row access the service needs, narrowed so tests can stub it. */
 type ProviderModelsSessionStore = {
@@ -24,294 +18,197 @@ type ProviderModelsSessionStore = {
   setSessionModel(sessionId: string, model: string): void;
 };
 
+/** SQLite catalog operations used by the Providers service and its unit fakes. */
+type ProviderModelsCatalogStore = Pick<
+  typeof providerModelsDb,
+  | 'listCustomProviderModels'
+  | 'getCustomProviderModel'
+  | 'findCustomProviderModelByModelId'
+  | 'createCustomProviderModel'
+  | 'updateCustomProviderModel'
+  | 'deleteCustomProviderModel'
+>;
+
 type ProviderModelsServiceDependencies = {
   resolveProvider?: (provider: LLMProvider) => Pick<IProvider, 'models'>;
-  cachePath?: string;
+  catalog?: ProviderModelsCatalogStore;
   sessions?: ProviderModelsSessionStore;
-  now?: () => number;
 };
 
-type ProviderModelsOptions = {
-  bypassCache?: boolean;
-};
-
-type ProviderModelsCacheEntry = {
-  updatedAt: number;
-  expiresAt: number;
-  models: ProviderModelsDefinition;
-};
-
-type ProviderModelsCacheFile = {
-  version: number;
-  entries: Record<string, ProviderModelsCacheEntry>;
-};
-
-const getProviderModelsCachePath = (): string => path.join(
-  os.homedir(),
-  '.cloudcli',
-  'provider-models-cache.json',
-);
-
-const toProviderModelsCacheInfo = (
-  entry: ProviderModelsCacheEntry,
-  source: ProviderModelsCacheInfo['source'],
-): ProviderModelsCacheInfo => ({
-  updatedAt: new Date(entry.updatedAt).toISOString(),
-  expiresAt: new Date(entry.expiresAt).toISOString(),
-  source,
+const toCustomProviderModelOption = (
+  record: CustomProviderModelRecord,
+): ProviderModelOption => ({
+  value: record.modelId,
+  label: record.model,
+  recordId: record.recordId,
+  isCustom: true,
 });
 
-const isProviderModelOption = (
-  value: unknown,
-): value is ProviderModelsDefinition['OPTIONS'][number] => (
-  Boolean(value)
-  && typeof value === 'object'
-  && typeof (value as ProviderModelsDefinition['OPTIONS'][number]).value === 'string'
-  && typeof (value as ProviderModelsDefinition['OPTIONS'][number]).label === 'string'
-  && (
-    typeof (value as ProviderModelsDefinition['OPTIONS'][number]).description === 'undefined'
-    || typeof (value as ProviderModelsDefinition['OPTIONS'][number]).description === 'string'
-  )
-);
-
-const isProviderModelsDefinition = (value: unknown): value is ProviderModelsDefinition => (
-  Boolean(value)
-  && typeof value === 'object'
-  && Array.isArray((value as ProviderModelsDefinition).OPTIONS)
-  && (value as ProviderModelsDefinition).OPTIONS.every(isProviderModelOption)
-  && typeof (value as ProviderModelsDefinition).DEFAULT === 'string'
-);
-
-const isProviderModelsCacheEntry = (value: unknown): value is ProviderModelsCacheEntry => (
-  Boolean(value)
-  && typeof value === 'object'
-  && typeof (value as ProviderModelsCacheEntry).updatedAt === 'number'
-  && typeof (value as ProviderModelsCacheEntry).expiresAt === 'number'
-  && isProviderModelsDefinition((value as ProviderModelsCacheEntry).models)
-);
-
-const readProviderModelsCacheFile = async (
-  cachePath: string,
-): Promise<ProviderModelsCacheFile | null> => {
-  try {
-    const raw = await readFile(cachePath, 'utf8');
-    const parsed = JSON.parse(raw) as Partial<ProviderModelsCacheFile>;
-    if (parsed.version !== PROVIDER_MODELS_CACHE_VERSION || !parsed.entries || typeof parsed.entries !== 'object') {
-      return null;
-    }
-
-    const entries = Object.fromEntries(
-      Object.entries(parsed.entries).filter((entry): entry is [string, ProviderModelsCacheEntry] =>
-        isProviderModelsCacheEntry(entry[1]),
-      ),
-    );
-
-    return {
-      version: PROVIDER_MODELS_CACHE_VERSION,
-      entries,
-    };
-  } catch {
-    return null;
-  }
-};
-
-const writeProviderModelsCacheFile = async (
-  cachePath: string,
-  entries: Map<LLMProvider, ProviderModelsCacheEntry>,
-  now: number,
-): Promise<void> => {
-  const serializableEntries = Object.fromEntries(
-    [...entries.entries()].filter(([, entry]) => entry.expiresAt > now),
-  );
-  const payload: ProviderModelsCacheFile = {
-    version: PROVIDER_MODELS_CACHE_VERSION,
-    entries: serializableEntries,
+const mergeProviderModels = (
+  predefined: ProviderModelsDefinition,
+  custom: CustomProviderModelRecord[],
+): ProviderModelsDefinition => {
+  return {
+    OPTIONS: [
+      ...predefined.OPTIONS.map((option) => ({ ...option, isCustom: false })),
+      ...custom.map(toCustomProviderModelOption),
+    ],
+    DEFAULT: predefined.DEFAULT,
   };
-
-  await mkdir(path.dirname(cachePath), { recursive: true });
-  await writeFile(cachePath, `${JSON.stringify(payload, null, 2)}\n`, 'utf8');
 };
+
+const normalizeCustomModelInput = (input: CustomProviderModelInput): CustomProviderModelInput => ({
+  id: input.id.trim(),
+  model: input.model.trim(),
+});
+
+const isUniqueConstraintError = (error: unknown): boolean => (
+  error !== null
+  && error !== undefined
+  && typeof error === 'object'
+  && 'code' in error
+  && String(error.code).startsWith('SQLITE_CONSTRAINT')
+);
 
 /**
- * Provider model lookup service.
+ * Creates the provider model application service used by Providers routes,
+ * Commands, and provider runtimes.
  *
- * Routes and other service callers use this layer instead of resolving provider
- * classes directly so the provider-registry dependency stays centralized in one
- * place.
+ * Curated adapter definitions stay source-controlled and are merged at read
+ * time with custom SQLite rows. This deliberately has no predefined-model
+ * persistence, memory cache, disk cache, TTL, or provider-native discovery.
+ * Tests inject a small custom-model store through the same boundary.
  */
 export const createProviderModelsService = (dependencies: ProviderModelsServiceDependencies = {}) => {
   const resolveProvider = dependencies.resolveProvider ?? providerRegistry.resolveProvider;
-  const cachePath = dependencies.cachePath ?? getProviderModelsCachePath();
+  const catalog = dependencies.catalog ?? providerModelsDb;
   const sessions = dependencies.sessions ?? sessionsDb;
-  const now = dependencies.now ?? (() => Date.now());
-  const memoryCache = new Map<LLMProvider, ProviderModelsCacheEntry>();
-  const pendingRequests = new Map<LLMProvider, Promise<ProviderModelsResult>>();
-  let persistedCacheLoaded = false;
-  let persistedCacheLoadPromise: Promise<void> | null = null;
 
-  const pruneExpiredMemoryEntry = (
-    provider: LLMProvider,
-    currentTime: number,
-    source: ProviderModelsCacheInfo['source'],
-  ): ProviderModelsResult | null => {
-    const cachedEntry = memoryCache.get(provider);
-    if (!cachedEntry) {
-      return null;
-    }
-
-    if (cachedEntry.expiresAt > currentTime) {
-      return {
-        models: cachedEntry.models,
-        cache: toProviderModelsCacheInfo(cachedEntry, source),
-      };
-    }
-
-    memoryCache.delete(provider);
-    return null;
-  };
-
-  const loadPersistedCache = async (): Promise<void> => {
-    if (persistedCacheLoaded) {
-      return;
-    }
-
-    if (!persistedCacheLoadPromise) {
-      persistedCacheLoadPromise = (async () => {
-        const cacheFile = await readProviderModelsCacheFile(cachePath);
-        const currentTime = now();
-
-        for (const [provider, entry] of Object.entries(cacheFile?.entries ?? {})) {
-          if (entry.expiresAt > currentTime) {
-            memoryCache.set(provider as LLMProvider, entry);
-          }
-        }
-
-        persistedCacheLoaded = true;
-      })().finally(() => {
-        persistedCacheLoadPromise = null;
-      });
-    }
-
-    await persistedCacheLoadPromise;
-  };
-
-  const persistCache = async (): Promise<void> => {
-    try {
-      await writeProviderModelsCacheFile(cachePath, memoryCache, now());
-    } catch (error) {
-      console.warn('Unable to persist provider models cache:', error);
-    }
-  };
-
-  const setCacheEntry = async (
-    provider: LLMProvider,
-    models: ProviderModelsDefinition,
-  ): Promise<ProviderModelsCacheEntry> => {
-    const currentTime = now();
-    const entry: ProviderModelsCacheEntry = {
-      updatedAt: currentTime,
-      expiresAt: currentTime + PROVIDER_MODELS_CACHE_TTL_MS,
-      models,
-    };
-
-    memoryCache.set(provider, entry);
-    await persistCache();
-    return entry;
-  };
-
-  const loadAndCacheModels = (
-    provider: LLMProvider,
-  ): Promise<ProviderModelsResult> => {
-    const request = resolveProvider(provider).models.getSupportedModels()
-      .then(async (models) => {
-        const entry = await setCacheEntry(provider, models);
-        return {
-          models,
-          cache: toProviderModelsCacheInfo(entry, 'fresh'),
-        };
-      })
-      .finally(() => {
-        pendingRequests.delete(provider);
-      });
-
-    pendingRequests.set(provider, request);
-    return request;
-  };
-
-  const loadDirectModels = (
-    provider: LLMProvider,
-  ): Promise<ProviderModelsResult> => {
-    const request = resolveProvider(provider).models.getSupportedModels()
-      .then((models) => {
-        const currentTime = now();
-        return {
-          models,
-          cache: {
-            updatedAt: new Date(currentTime).toISOString(),
-            expiresAt: new Date(currentTime).toISOString(),
-            source: 'fresh' as const,
-          },
-        };
-      })
-      .finally(() => {
-        pendingRequests.delete(provider);
-      });
-
-    pendingRequests.set(provider, request);
-    return request;
-  };
-
-  const getProviderModels = async (
-    provider: LLMProvider,
-    options: ProviderModelsOptions = {},
-  ): Promise<ProviderModelsResult> => {
-    if (UNCACHED_PROVIDERS.has(provider)) {
-      const pendingRequest = pendingRequests.get(provider);
-      if (pendingRequest) {
-        return pendingRequest;
-      }
-
-      return loadDirectModels(provider);
-    }
-
-    if (options.bypassCache) {
-      const pendingRequest = pendingRequests.get(provider);
-      if (pendingRequest) {
-        return pendingRequest;
-      }
-
-      return loadAndCacheModels(provider);
-    }
-
-    const cachedModels = pruneExpiredMemoryEntry(provider, now(), 'memory');
-    if (cachedModels) {
-      return cachedModels;
-    }
-
-    const pendingRequest = pendingRequests.get(provider);
-    if (pendingRequest) {
-      return pendingRequest;
-    }
-
-    await loadPersistedCache();
-
-    const persistedModels = pruneExpiredMemoryEntry(provider, now(), 'disk');
-    if (persistedModels) {
-      return persistedModels;
-    }
-
-    const postLoadPendingRequest = pendingRequests.get(provider);
-    if (postLoadPendingRequest) {
-      return postLoadPendingRequest;
-    }
-
-    return loadAndCacheModels(provider);
+  const getProviderModels = async (provider: LLMProvider): Promise<ProviderModelsDefinition> => {
+    const predefined = await resolveProvider(provider).models.getSupportedModels();
+    return mergeProviderModels(predefined, catalog.listCustomProviderModels(provider));
   };
 
   const getCurrentActiveModel = async (
     provider: LLMProvider,
     sessionId?: string,
   ): Promise<ProviderCurrentActiveModel> => resolveProvider(provider).models.getCurrentActiveModel(sessionId);
+
+  const readCustomModel = (
+    provider: LLMProvider,
+    recordId: number,
+  ): CustomProviderModelRecord => {
+    const existing = catalog.getCustomProviderModel(provider, recordId);
+    if (!existing) {
+      throw new AppError('Model not found.', {
+        code: 'MODEL_NOT_FOUND',
+        statusCode: 404,
+      });
+    }
+
+    return existing;
+  };
+
+  const assertModelIdAvailable = (
+    provider: LLMProvider,
+    predefined: ProviderModelsDefinition,
+    modelId: string,
+    currentRecordId?: number,
+  ): void => {
+    if (predefined.OPTIONS.some((option) => option.value === modelId)) {
+      throw new AppError(`A ${provider} model with this ID already exists.`, {
+        code: 'MODEL_ID_ALREADY_EXISTS',
+        statusCode: 409,
+      });
+    }
+
+    const duplicate = catalog.findCustomProviderModelByModelId(provider, modelId);
+    if (duplicate && duplicate.recordId !== currentRecordId) {
+      throw new AppError(`A ${provider} model with this ID already exists.`, {
+        code: 'MODEL_ID_ALREADY_EXISTS',
+        statusCode: 409,
+      });
+    }
+  };
+
+  const createCustomModel = async (
+    provider: LLMProvider,
+    input: CustomProviderModelInput,
+  ): Promise<{ model: ProviderModelOption; models: ProviderModelsDefinition }> => {
+    const predefined = await resolveProvider(provider).models.getSupportedModels();
+    const normalized = normalizeCustomModelInput(input);
+    assertModelIdAvailable(provider, predefined, normalized.id);
+
+    try {
+      const created = catalog.createCustomProviderModel(provider, normalized);
+      return {
+        model: toCustomProviderModelOption(created),
+        models: mergeProviderModels(predefined, catalog.listCustomProviderModels(provider)),
+      };
+    } catch (error) {
+      if (isUniqueConstraintError(error)) {
+        throw new AppError(`A ${provider} model with this ID already exists.`, {
+          code: 'MODEL_ID_ALREADY_EXISTS',
+          statusCode: 409,
+        });
+      }
+      throw error;
+    }
+  };
+
+  const updateCustomModel = async (
+    provider: LLMProvider,
+    recordId: number,
+    input: CustomProviderModelInput,
+  ): Promise<{ model: ProviderModelOption; models: ProviderModelsDefinition }> => {
+    const predefined = await resolveProvider(provider).models.getSupportedModels();
+    readCustomModel(provider, recordId);
+    const normalized = normalizeCustomModelInput(input);
+    assertModelIdAvailable(provider, predefined, normalized.id, recordId);
+
+    try {
+      const updated = catalog.updateCustomProviderModel(provider, recordId, normalized);
+      if (!updated) {
+        throw new AppError('Model not found.', {
+          code: 'MODEL_NOT_FOUND',
+          statusCode: 404,
+        });
+      }
+
+      return {
+        model: toCustomProviderModelOption(updated),
+        models: mergeProviderModels(predefined, catalog.listCustomProviderModels(provider)),
+      };
+    } catch (error) {
+      if (isUniqueConstraintError(error)) {
+        throw new AppError(`A ${provider} model with this ID already exists.`, {
+          code: 'MODEL_ID_ALREADY_EXISTS',
+          statusCode: 409,
+        });
+      }
+      throw error;
+    }
+  };
+
+  const deleteCustomModel = async (
+    provider: LLMProvider,
+    recordId: number,
+  ): Promise<{ model: ProviderModelOption; models: ProviderModelsDefinition }> => {
+    const predefined = await resolveProvider(provider).models.getSupportedModels();
+    readCustomModel(provider, recordId);
+    const removed = catalog.deleteCustomProviderModel(provider, recordId, predefined.DEFAULT);
+    if (!removed) {
+      throw new AppError('Model not found.', {
+        code: 'MODEL_NOT_FOUND',
+        statusCode: 404,
+      });
+    }
+
+    return {
+      model: toCustomProviderModelOption(removed),
+      models: mergeProviderModels(predefined, catalog.listCustomProviderModels(provider)),
+    };
+  };
 
   const readRecordedSessionModel = (sessionId: string): string | null => {
     const session = sessions.getSessionById(sessionId);
@@ -355,13 +252,10 @@ export const createProviderModelsService = (dependencies: ProviderModelsServiceD
    * Answers "which model is this session using?" for every display surface.
    *
    * Precedence, highest first:
-   *   1. the model recorded on the session row — the user's pick, or whatever
-   *      the last send used;
-   *   2. the provider's own session state, for sessions started outside the app
-   *      that we have never recorded a model for;
-   *   3. `requestedModel`, the client's current default, for a chat that has no
-   *      session yet;
-   *   4. the provider catalog default.
+   *   1. the model recorded on the session row;
+   *   2. the provider's own session state for externally-created sessions;
+   *   3. `requestedModel`, the client's current default;
+   *   4. the source-controlled provider catalog default.
    */
   const resolveSessionModel = async (
     provider: LLMProvider,
@@ -383,12 +277,10 @@ export const createProviderModelsService = (dependencies: ProviderModelsServiceD
         };
       }
 
-      // Never sent on through the app. Ask the provider what its own session
-      // state says before falling back to anything client-supplied.
-      const catalog = (await getProviderModels(provider)).models;
+      const providerCatalog = await getProviderModels(provider);
       const providerModel = await getCurrentActiveModel(provider, normalizedSessionId);
       const resolvedProviderModel = providerModel.model?.trim();
-      if (resolvedProviderModel && resolvedProviderModel !== catalog.DEFAULT) {
+      if (resolvedProviderModel && resolvedProviderModel !== providerCatalog.DEFAULT) {
         return {
           provider,
           sessionId: normalizedSessionId,
@@ -400,7 +292,7 @@ export const createProviderModelsService = (dependencies: ProviderModelsServiceD
       return {
         provider,
         sessionId: normalizedSessionId,
-        model: normalizedRequestedModel || catalog.DEFAULT,
+        model: normalizedRequestedModel || providerCatalog.DEFAULT,
         source: normalizedRequestedModel ? 'session' : 'default',
       };
     }
@@ -414,22 +306,20 @@ export const createProviderModelsService = (dependencies: ProviderModelsServiceD
       };
     }
 
-    const catalog = (await getProviderModels(provider)).models;
+    const providerCatalog = await getProviderModels(provider);
     return {
       provider,
       sessionId: null,
-      model: catalog.DEFAULT,
+      model: providerCatalog.DEFAULT,
       source: 'default',
     };
   };
 
   /**
-   * Picks the model one run should use, for provider runtime adapters.
+   * Picks the model one resumed provider run should use.
    *
-   * Deliberately narrower than `resolveSessionModel`: the provider's own
-   * session state is not consulted here. Codex reports a global config value
-   * from `getCurrentActiveModel`, which would silently override the model the
-   * user picked in the composer on every single run.
+   * Provider-global state is deliberately ignored because it must never
+   * override the model explicitly selected in the composer.
    */
   const resolveResumeModel = async (
     provider: LLMProvider,
@@ -447,20 +337,16 @@ export const createProviderModelsService = (dependencies: ProviderModelsServiceD
     return recordedModel || normalizedRequestedModel || undefined;
   };
 
-  const clearCache = (): void => {
-    memoryCache.clear();
-    pendingRequests.clear();
-    persistedCacheLoaded = false;
-    persistedCacheLoadPromise = null;
-  };
-
   return {
     getProviderModels,
+    createCustomModel,
+    updateCustomModel,
+    deleteCustomModel,
     setSessionModel,
     resolveSessionModel,
     resolveResumeModel,
-    clearCache,
   };
 };
 
+/** Shared Providers service used by routes, Commands, and provider runtimes. */
 export const providerModelsService = createProviderModelsService();

--- a/server/modules/providers/services/provider-models.service.ts
+++ b/server/modules/providers/services/provider-models.service.ts
@@ -14,8 +14,9 @@ import { AppError } from '@/shared/utils.js';
 
 /** Session-row access the service needs, narrowed so tests can stub it. */
 type ProviderModelsSessionStore = {
-  getSessionById(sessionId: string): { model: string | null } | null;
+  getSessionById(sessionId: string): { model: string | null; effort: string | null } | null;
   setSessionModel(sessionId: string, model: string): void;
+  setSessionEffort(sessionId: string, effort: string): void;
 };
 
 /** SQLite catalog operations used by the Providers service and its unit fakes. */
@@ -210,9 +211,18 @@ export const createProviderModelsService = (dependencies: ProviderModelsServiceD
     };
   };
 
-  const readRecordedSessionModel = (sessionId: string): string | null => {
+  const readRecordedSessionSelection = (
+    sessionId: string,
+  ): { model: string | null; effort: string | null } | null => {
     const session = sessions.getSessionById(sessionId);
-    return session?.model?.trim() || null;
+    if (!session) {
+      return null;
+    }
+
+    return {
+      model: session.model?.trim() || null,
+      effort: session.effort?.trim() || null,
+    };
   };
 
   /**
@@ -235,7 +245,8 @@ export const createProviderModelsService = (dependencies: ProviderModelsServiceD
       return null;
     }
 
-    if (!sessions.getSessionById(normalizedSessionId)) {
+    const recordedSelection = readRecordedSessionSelection(normalizedSessionId);
+    if (!recordedSelection) {
       return null;
     }
 
@@ -244,6 +255,38 @@ export const createProviderModelsService = (dependencies: ProviderModelsServiceD
       provider,
       sessionId: normalizedSessionId,
       model: normalizedModel,
+      effort: recordedSelection.effort,
+      source: 'session',
+    };
+  };
+
+  /**
+   * Records the reasoning effort one session runs with.
+   *
+   * Like `setSessionModel`, this ignores an id that has not been allocated by
+   * the session gateway yet. The websocket send path records it once the row
+   * exists, so a pre-session composer choice is not lost.
+   */
+  const setSessionEffort = (
+    provider: LLMProvider,
+    sessionId: string,
+    effort: string,
+  ): { provider: LLMProvider; sessionId: string; effort: string; source: 'session' } | null => {
+    const normalizedSessionId = sessionId.trim();
+    const normalizedEffort = effort.trim();
+    if (!normalizedSessionId || !normalizedEffort) {
+      return null;
+    }
+
+    if (!readRecordedSessionSelection(normalizedSessionId)) {
+      return null;
+    }
+
+    sessions.setSessionEffort(normalizedSessionId, normalizedEffort);
+    return {
+      provider,
+      sessionId: normalizedSessionId,
+      effort: normalizedEffort,
       source: 'session',
     };
   };
@@ -267,12 +310,13 @@ export const createProviderModelsService = (dependencies: ProviderModelsServiceD
       : '';
 
     if (normalizedSessionId) {
-      const recordedModel = readRecordedSessionModel(normalizedSessionId);
-      if (recordedModel) {
+      const recordedSelection = readRecordedSessionSelection(normalizedSessionId);
+      if (recordedSelection?.model) {
         return {
           provider,
           sessionId: normalizedSessionId,
-          model: recordedModel,
+          model: recordedSelection.model,
+          effort: recordedSelection.effort,
           source: 'session',
         };
       }
@@ -285,6 +329,7 @@ export const createProviderModelsService = (dependencies: ProviderModelsServiceD
           provider,
           sessionId: normalizedSessionId,
           model: resolvedProviderModel,
+          effort: recordedSelection?.effort ?? null,
           source: 'provider',
         };
       }
@@ -293,6 +338,7 @@ export const createProviderModelsService = (dependencies: ProviderModelsServiceD
         provider,
         sessionId: normalizedSessionId,
         model: normalizedRequestedModel || providerCatalog.DEFAULT,
+        effort: recordedSelection?.effort ?? null,
         source: normalizedRequestedModel ? 'session' : 'default',
       };
     }
@@ -302,6 +348,7 @@ export const createProviderModelsService = (dependencies: ProviderModelsServiceD
         provider,
         sessionId: null,
         model: normalizedRequestedModel,
+        effort: null,
         source: 'session',
       };
     }
@@ -311,6 +358,7 @@ export const createProviderModelsService = (dependencies: ProviderModelsServiceD
       provider,
       sessionId: null,
       model: providerCatalog.DEFAULT,
+      effort: null,
       source: 'default',
     };
   };
@@ -333,7 +381,7 @@ export const createProviderModelsService = (dependencies: ProviderModelsServiceD
       return normalizedRequestedModel || undefined;
     }
 
-    const recordedModel = readRecordedSessionModel(normalizedSessionId);
+    const recordedModel = readRecordedSessionSelection(normalizedSessionId)?.model;
     return recordedModel || normalizedRequestedModel || undefined;
   };
 
@@ -343,6 +391,7 @@ export const createProviderModelsService = (dependencies: ProviderModelsServiceD
     updateCustomModel,
     deleteCustomModel,
     setSessionModel,
+    setSessionEffort,
     resolveSessionModel,
     resolveResumeModel,
   };

--- a/server/modules/providers/services/provider-runtime.service.ts
+++ b/server/modules/providers/services/provider-runtime.service.ts
@@ -29,7 +29,7 @@ const defaultDependencies: ProviderRuntimeServiceDependencies = {
   resolveProviderSessionId: (sessionId) => sessionsService.resolveProviderSessionId(sessionId),
   resolveResumeModel: (provider, sessionId, requestedModel) =>
     providerModelsService.resolveResumeModel(provider, sessionId, requestedModel),
-  getProviderModels: (provider, options) => providerModelsService.getProviderModels(provider, options),
+  getProviderModels: (provider) => providerModelsService.getProviderModels(provider),
 };
 
 /**
@@ -50,8 +50,7 @@ export function createProviderRuntimeService(
     resolveProviderSessionId: dependencies.resolveProviderSessionId,
     resolveResumeModel: (sessionId, requestedModel) =>
       dependencies.resolveResumeModel(provider.id, sessionId, requestedModel),
-    getProviderModels: async () =>
-      (await dependencies.getProviderModels(provider.id)).models,
+    getProviderModels: async () => dependencies.getProviderModels(provider.id),
     normalizeMessage: (raw, sessionId) => provider.sessions.normalizeMessage(raw, sessionId),
     async isProviderInstalled() {
       try {

--- a/server/modules/providers/services/sessions.service.ts
+++ b/server/modules/providers/services/sessions.service.ts
@@ -17,6 +17,7 @@ type CreateAppSessionResult = {
   sessionId: string;
   provider: LLMProvider;
   projectPath: string;
+  sessionName: string;
 };
 
 type ArchivedSessionListItem = {
@@ -50,6 +51,13 @@ type SessionDetails = {
     isArchived: boolean;
   } | null;
 };
+
+const MAX_CLOUDCLI_SESSION_NAME_WORDS = 4;
+
+function buildCloudCliSessionName(initialMessage: string): string {
+  const words = initialMessage.trim().split(/\s+/).filter(Boolean);
+  return words.slice(0, MAX_CLOUDCLI_SESSION_NAME_WORDS).join(' ') || 'Untitled Session';
+}
 
 /**
  * Removes one file if it exists.
@@ -154,9 +162,15 @@ export const sessionsService = {
    * (via `POST /api/providers/sessions`) when the user starts a brand-new
    * chat, navigates to the returned id immediately, and the id never changes
    * for the lifetime of the conversation. The provider-native id is mapped to
-   * this row later, when the provider runtime announces it mid-run.
+   * this row later, when the provider runtime announces it mid-run. Its title
+   * comes directly from the first visible CloudCLI message and is limited to
+   * four whole words before any provider-owned storage exists.
    */
-  createAppSession(provider: LLMProvider, projectPath: string): CreateAppSessionResult {
+  createAppSession(
+    provider: LLMProvider,
+    projectPath: string,
+    initialMessage: string,
+  ): CreateAppSessionResult {
     const normalizedProjectPath = projectPath.trim();
     if (!normalizedProjectPath) {
       throw new AppError('projectPath is required.', {
@@ -166,12 +180,14 @@ export const sessionsService = {
     }
 
     const sessionId = randomUUID();
-    sessionsDb.createAppSession(sessionId, provider, normalizedProjectPath);
+    const sessionName = buildCloudCliSessionName(initialMessage);
+    sessionsDb.createAppSession(sessionId, provider, normalizedProjectPath, sessionName);
 
     return {
       sessionId,
       provider,
       projectPath: normalizedProjectPath,
+      sessionName,
     };
   },
 

--- a/server/modules/providers/tests/codex-sessions.test.ts
+++ b/server/modules/providers/tests/codex-sessions.test.ts
@@ -64,24 +64,24 @@ const writeCodexTranscript = async (
   return filePath;
 };
 
-test('Codex synchronizer titles app-created sessions from the first user message', { concurrency: false }, async () => {
+test('Codex synchronizer preserves the title assigned when CloudCLI creates a session', { concurrency: false }, async () => {
   const tempRoot = await mkdtemp(path.join(os.tmpdir(), 'codex-session-sync-app-'));
   const workspacePath = path.join(tempRoot, 'workspace');
   await mkdir(workspacePath, { recursive: true });
   const restoreHomeDir = patchHomeDir(tempRoot);
 
   try {
-    await writeCodexTranscript(tempRoot, 'codex-app-1', workspacePath, 'Fix the login redirect bug');
+    await writeCodexTranscript(tempRoot, 'codex-app-1', workspacePath, 'Provider transcript title must not win');
     await withIsolatedDatabase(async () => {
       // The app allocates its own id and later maps the provider id onto it,
       // exactly as a message sent from cloudcli does.
-      sessionsDb.createAppSession('app-1', 'codex', workspacePath);
+      sessionsDb.createAppSession('app-1', 'codex', workspacePath, 'Fix the login redirect');
       sessionsDb.assignProviderSessionId('app-1', 'codex-app-1');
 
       const synchronizer = new CodexSessionSynchronizer();
       await synchronizer.synchronize();
 
-      assert.equal(sessionsDb.getSessionById('app-1')?.custom_name, 'Fix the login redirect bug');
+      assert.equal(sessionsDb.getSessionById('app-1')?.custom_name, 'Fix the login redirect');
     });
   } finally {
     restoreHomeDir();

--- a/server/modules/providers/tests/codex-sessions.test.ts
+++ b/server/modules/providers/tests/codex-sessions.test.ts
@@ -152,7 +152,7 @@ test('Codex synchronizer leaves indexed sessions untitled when no name is availa
   }
 });
 
-test('Codex history renders Promise.all shell wrappers as Bash activity', { concurrency: false }, async () => {
+test('Codex history preserves wrapped exec tool calls and results', { concurrency: false }, async () => {
   const tempRoot = await mkdtemp(path.join(os.tmpdir(), 'codex-exec-history-'));
   const workspacePath = path.join(tempRoot, 'workspace');
   await mkdir(workspacePath, { recursive: true });
@@ -161,15 +161,46 @@ test('Codex history renders Promise.all shell wrappers as Bash activity', { conc
   try {
     const providerSessionId = 'codex-exec-1';
     const transcriptPath = await writeCodexTranscript(tempRoot, providerSessionId, workspacePath);
-    const execInput = 'const cmds = ["echo one", "echo two"]; await Promise.all(cmds.map(command => tools.shell_command({ command })));';
-    const planInput = 'await tools.update_plan({ plan: [] });';
-    await writeFile(transcriptPath, [
+    const wrappedCalls = [
+      {
+        callId: 'shell-command-1',
+        input: 'const cmds = ["echo one", "echo two"]; await Promise.all(cmds.map(command => tools.shell_command({ command })));',
+        expectedToolName: 'Bash',
+        expectedToolInput: JSON.stringify({ command: 'echo one\necho two' }),
+      },
+      {
+        callId: 'json-shell-command-1',
+        input: 'const r = await tools.shell_command({"command":"Get-Content -Raw README.md","workdir":"C:\\\\workspace","timeout_ms":10000}); text(r)',
+        expectedToolName: 'Bash',
+        expectedToolInput: JSON.stringify({ command: 'Get-Content -Raw README.md' }),
+      },
+      {
+        callId: 'exec-command-1',
+        input: 'await tools.exec_command({"command":"echo current"});',
+        expectedToolName: 'Bash',
+        expectedToolInput: JSON.stringify({ command: 'echo current' }),
+      },
+      { callId: 'apply-patch-1', input: 'await tools.apply_patch("*** Begin Patch\\n*** End Patch");' },
+      { callId: 'web-run-1', input: 'await tools.web__run({ search_query: [{ q: "Codex" }] });' },
+      { callId: 'update-plan-1', input: 'await tools.update_plan({ plan: [] });' },
+      { callId: 'unknown-1', input: 'await tools.unknown_wrapper({ value: true });' },
+    ];
+    const transcriptLines = [
       JSON.stringify({ type: 'session_meta', payload: { id: providerSessionId, cwd: workspacePath } }),
-      JSON.stringify({ type: 'response_item', payload: { type: 'custom_tool_call', name: 'exec', call_id: 'exec-1', input: execInput } }),
-      JSON.stringify({ type: 'response_item', payload: { type: 'custom_tool_call_output', call_id: 'exec-1', output: 'done' } }),
-      JSON.stringify({ type: 'response_item', payload: { type: 'custom_tool_call', name: 'exec', call_id: 'plan-1', input: planInput } }),
-      JSON.stringify({ type: 'response_item', payload: { type: 'custom_tool_call_output', call_id: 'plan-1', output: 'done' } }),
-    ].join('\n') + '\n', 'utf8');
+    ];
+    for (const call of wrappedCalls) {
+      transcriptLines.push(
+        JSON.stringify({
+          type: 'response_item',
+          payload: { type: 'custom_tool_call', name: 'exec', call_id: call.callId, input: call.input },
+        }),
+        JSON.stringify({
+          type: 'response_item',
+          payload: { type: 'custom_tool_call_output', call_id: call.callId, output: `result:${call.callId}` },
+        }),
+      );
+    }
+    await writeFile(transcriptPath, `${transcriptLines.join('\n')}\n`, 'utf8');
 
     await withIsolatedDatabase(async () => {
       sessionsDb.createAppSession('app-exec-1', 'codex', workspacePath);
@@ -179,11 +210,19 @@ test('Codex history renders Promise.all shell wrappers as Bash activity', { conc
       const history = await new CodexSessionsProvider().fetchHistory('app-exec-1');
       const toolUses = history.messages.filter((message) => message.kind === 'tool_use');
       const toolResults = history.messages.filter((message) => message.kind === 'tool_result');
+      const toolUsesById = new Map(toolUses.map((message) => [message.toolId, message]));
+      const toolResultsById = new Map(toolResults.map((message) => [message.toolId, message]));
 
-      assert.equal(toolUses.length, 1);
-      assert.equal(toolUses[0].toolName, 'Bash');
-      assert.equal(toolUses[0].toolInput, JSON.stringify({ command: 'echo one\necho two' }));
-      assert.equal(toolResults.some((message) => message.toolCallId === 'plan-1'), false);
+      assert.equal(toolUses.length, wrappedCalls.length);
+      assert.equal(toolResults.length, wrappedCalls.length);
+      for (const call of wrappedCalls) {
+        const toolUse = toolUsesById.get(call.callId);
+        assert.ok(toolUse);
+        assert.equal(toolUse.toolName, call.expectedToolName || 'exec');
+        assert.equal(toolUse.toolInput, call.expectedToolInput || call.input);
+        assert.equal(toolUse.toolResult?.content, `result:${call.callId}`);
+        assert.equal(toolResultsById.get(call.callId)?.content, `result:${call.callId}`);
+      }
     });
   } finally {
     restoreHomeDir();

--- a/server/modules/providers/tests/opencode-models.test.ts
+++ b/server/modules/providers/tests/opencode-models.test.ts
@@ -14,12 +14,28 @@ test('OpenCode exposes only the curated predefined catalog', async () => {
     (await adapter.getCurrentActiveModel()).model,
     OPENCODE_PREDEFINED_MODELS.DEFAULT,
   );
+  // OpenCode routes by `<providerID>/<modelID>`, so every option has to carry a
+  // provider prefix that `opencode models --verbose` reports.
+  const providerIds = new Set(
+    OPENCODE_PREDEFINED_MODELS.OPTIONS.map((option) => option.value.split('/')[0]),
+  );
+  assert.deepEqual([...providerIds].sort(), ['anthropic', 'opencode', 'openai'].sort());
   assert.equal(
-    OPENCODE_PREDEFINED_MODELS.OPTIONS.every((option) => option.value.startsWith('opencode/')),
+    OPENCODE_PREDEFINED_MODELS.OPTIONS.every((option) => /^[a-z0-9-]+\/.+/.test(option.value)),
     true,
+  );
+  assert.equal(
+    new Set(OPENCODE_PREDEFINED_MODELS.OPTIONS.map((option) => option.value)).size,
+    OPENCODE_PREDEFINED_MODELS.OPTIONS.length,
   );
   assert.equal(OPENCODE_PREDEFINED_MODELS.DEFAULT, 'opencode/gpt-5.6-terra');
   assert.ok(
     OPENCODE_PREDEFINED_MODELS.OPTIONS.some((option) => option.value === 'opencode/claude-opus-5'),
+  );
+  assert.ok(
+    OPENCODE_PREDEFINED_MODELS.OPTIONS.some((option) => option.value === 'anthropic/claude-opus-5'),
+  );
+  assert.ok(
+    OPENCODE_PREDEFINED_MODELS.OPTIONS.some((option) => option.value === 'openai/gpt-5.6'),
   );
 });

--- a/server/modules/providers/tests/opencode-models.test.ts
+++ b/server/modules/providers/tests/opencode-models.test.ts
@@ -2,141 +2,24 @@ import assert from 'node:assert/strict';
 import test from 'node:test';
 
 import {
-  buildOpenCodeDefinitionFromVerboseModels,
-  buildOpenCodeDefinitionFromIds,
-  parseOpenCodeModelsStdout,
-  parseOpenCodeVerboseModelsStdout,
+  OpenCodeProviderModels,
+  OPENCODE_PREDEFINED_MODELS,
 } from '@/modules/providers/list/opencode/opencode-models.provider.js';
 
-test('OpenCode models provider parses plain CLI output and removes duplicates', () => {
-  const ids = parseOpenCodeModelsStdout(`
-opencode/big-pickle
-not a model
-anthropic/claude-opus-4-7-fast
-anthropic/claude-opus-4-7-fast
-openai/gpt-5.5-pro
-`);
+test('OpenCode exposes only the curated predefined catalog', async () => {
+  const adapter = new OpenCodeProviderModels();
 
-  assert.deepEqual(ids, [
-    'opencode/big-pickle',
-    'anthropic/claude-opus-4-7-fast',
-    'openai/gpt-5.5-pro',
-  ]);
-});
-
-test('OpenCode models provider formats frontend labels from provider-prefixed ids', () => {
-  const definition = buildOpenCodeDefinitionFromIds([
-    'opencode/deepseek-v4-flash-free',
-    'opencode/nemotron-3-super-free',
-    'anthropic/claude-3-5-sonnet-20241022',
-    'anthropic/claude-opus-4-7-fast',
-    'google/model-alpha',
-    'openai/gpt-5.4-mini-fast',
-    'openai/gpt-5.5-pro',
-    'newprovider/alpha-v12-special-20261231',
-  ]);
-
-  assert.deepEqual(definition.OPTIONS, [
-    {
-      value: 'opencode/deepseek-v4-flash-free',
-      label: 'Deepseek V4 Flash Free',
-      description: 'opencode - opencode/deepseek-v4-flash-free',
-    },
-    {
-      value: 'opencode/nemotron-3-super-free',
-      label: 'Nemotron 3 Super Free',
-      description: 'opencode - opencode/nemotron-3-super-free',
-    },
-    {
-      value: 'anthropic/claude-3-5-sonnet-20241022',
-      label: 'Claude 3.5 Sonnet (2024-10-22)',
-      description: 'anthropic - anthropic/claude-3-5-sonnet-20241022',
-    },
-    {
-      value: 'anthropic/claude-opus-4-7-fast',
-      label: 'Claude Opus 4.7 Fast',
-      description: 'anthropic - anthropic/claude-opus-4-7-fast',
-    },
-    {
-      value: 'openai/gpt-5.4-mini-fast',
-      label: 'GPT-5.4 Mini Fast',
-      description: 'openai - openai/gpt-5.4-mini-fast',
-    },
-    {
-      value: 'openai/gpt-5.5-pro',
-      label: 'GPT-5.5 Pro',
-      description: 'openai - openai/gpt-5.5-pro',
-    },
-    {
-      value: 'newprovider/alpha-v12-special-20261231',
-      label: 'Alpha V12 Special (2026-12-31)',
-      description: 'newprovider - newprovider/alpha-v12-special-20261231',
-    },
-  ]);
-});
-
-test('OpenCode models provider maps verbose model variants to effort options', () => {
-  const models = parseOpenCodeVerboseModelsStdout(`
-opencode/deepseek-v4-flash-free
-{
-  "id": "deepseek-v4-flash-free",
-  "providerID": "opencode",
-  "name": "DeepSeek V4 Flash Free",
-  "variants": {
-    "low": {
-      "reasoningEffort": "low"
-    },
-    "high": {
-      "reasoningEffort": "high"
-    }
-  }
-}
-anthropic/claude-sonnet-5
-{
-  "id": "claude-sonnet-5",
-  "providerID": "anthropic",
-  "name": "Claude Sonnet 5",
-  "variants": {
-    "low": {
-      "effort": "low"
-    },
-    "max": {
-      "effort": "max"
-    }
-  }
-}
-google/model-alpha
-{
-  "id": "model-alpha",
-  "providerID": "google",
-  "name": "Model Alpha"
-}
-`);
-
-  const definition = buildOpenCodeDefinitionFromVerboseModels(models);
-
-  assert.deepEqual(definition.OPTIONS, [
-    {
-      value: 'opencode/deepseek-v4-flash-free',
-      label: 'DeepSeek V4 Flash Free',
-      description: 'opencode - opencode/deepseek-v4-flash-free',
-      effort: {
-        values: [
-          { value: 'low' },
-          { value: 'high' },
-        ],
-      },
-    },
-    {
-      value: 'anthropic/claude-sonnet-5',
-      label: 'Claude Sonnet 5',
-      description: 'anthropic - anthropic/claude-sonnet-5',
-      effort: {
-        values: [
-          { value: 'low' },
-          { value: 'max' },
-        ],
-      },
-    },
-  ]);
+  assert.deepEqual(await adapter.getSupportedModels(), OPENCODE_PREDEFINED_MODELS);
+  assert.equal(
+    (await adapter.getCurrentActiveModel()).model,
+    OPENCODE_PREDEFINED_MODELS.DEFAULT,
+  );
+  assert.equal(
+    OPENCODE_PREDEFINED_MODELS.OPTIONS.every((option) => option.value.startsWith('opencode/')),
+    true,
+  );
+  assert.equal(OPENCODE_PREDEFINED_MODELS.DEFAULT, 'opencode/gpt-5.6-terra');
+  assert.ok(
+    OPENCODE_PREDEFINED_MODELS.OPTIONS.some((option) => option.value === 'opencode/claude-opus-5'),
+  );
 });

--- a/server/modules/providers/tests/opencode-sessions.test.ts
+++ b/server/modules/providers/tests/opencode-sessions.test.ts
@@ -477,12 +477,12 @@ test('OpenCode synchronizer preserves the title assigned when CloudCLI creates a
   const restoreHomeDir = patchHomeDir(tempRoot);
 
   try {
-    // Provider-owned values differ from the CloudCLI title so the persisted
-    // app-created name is proven to remain authoritative.
+    // Both provider-owned values differ from the CloudCLI title so either one
+    // leaking through would change the assertion below.
     await seedOpenCodeSession(tempRoot, workspacePath, {
       sessionId: 'oc-app-1',
       title: 'OpenCode generated title',
-      firstUserText: 'Fix the checkout crash',
+      firstUserText: 'OpenCode first user prompt',
     });
     await withIsolatedDatabase(async () => {
       sessionsDb.createAppSession('app-1', 'opencode', workspacePath, 'Fix the checkout crash');

--- a/server/modules/providers/tests/opencode-sessions.test.ts
+++ b/server/modules/providers/tests/opencode-sessions.test.ts
@@ -470,22 +470,22 @@ const seedOpenCodeSession = async (
   }
 };
 
-test('OpenCode synchronizer titles app-created sessions from the first user message', { concurrency: false }, async () => {
+test('OpenCode synchronizer preserves the title assigned when CloudCLI creates a session', { concurrency: false }, async () => {
   const tempRoot = await mkdtemp(path.join(os.tmpdir(), 'opencode-session-sync-app-'));
   const workspacePath = path.join(tempRoot, 'workspace');
   await mkdir(workspacePath, { recursive: true });
   const restoreHomeDir = patchHomeDir(tempRoot);
 
   try {
-    // Stored title differs from the first message so we can prove the first
-    // message wins for sessions started from cloudcli.
+    // Provider-owned values differ from the CloudCLI title so the persisted
+    // app-created name is proven to remain authoritative.
     await seedOpenCodeSession(tempRoot, workspacePath, {
       sessionId: 'oc-app-1',
       title: 'OpenCode generated title',
       firstUserText: 'Fix the checkout crash',
     });
     await withIsolatedDatabase(async () => {
-      sessionsDb.createAppSession('app-1', 'opencode', workspacePath);
+      sessionsDb.createAppSession('app-1', 'opencode', workspacePath, 'Fix the checkout crash');
       sessionsDb.assignProviderSessionId('app-1', 'oc-app-1');
 
       await new OpenCodeSessionSynchronizer().synchronize();

--- a/server/modules/providers/tests/provider-models.service.test.ts
+++ b/server/modules/providers/tests/provider-models.service.test.ts
@@ -1,27 +1,22 @@
 import assert from 'node:assert/strict';
-import { mkdtemp, rm } from 'node:fs/promises';
-import os from 'node:os';
-import path from 'node:path';
 import test from 'node:test';
 
-import {
-  createProviderModelsService,
-  PROVIDER_MODELS_CACHE_TTL_MS,
-} from '@/modules/providers/services/provider-models.service.js';
+import { createProviderModelsService } from '@/modules/providers/services/provider-models.service.js';
 import type {
+  CustomProviderModelInput,
+  CustomProviderModelRecord,
   LLMProvider,
   ProviderCurrentActiveModel,
   ProviderModelsDefinition,
 } from '@/shared/types.js';
+import { AppError } from '@/shared/utils.js';
 
 const createModels = (value: string): ProviderModelsDefinition => ({
   OPTIONS: [{ value, label: value }],
   DEFAULT: value,
 });
 
-const createCurrentActiveModel = (model: string): ProviderCurrentActiveModel => ({
-  model,
-});
+const createCurrentActiveModel = (model: string): ProviderCurrentActiveModel => ({ model });
 
 /** In-memory stand-in for the `sessions` table rows the service reads and writes. */
 const createSessionStore = (rows: Record<string, string | null> = {}) => {
@@ -36,240 +31,168 @@ const createSessionStore = (rows: Record<string, string | null> = {}) => {
   };
 };
 
-const createEphemeralCachePath = (): string => path.join(
-  os.tmpdir(),
-  `provider-model-cache-${process.pid}-${Date.now()}-${Math.random().toString(16).slice(2)}.json`,
-);
+const createCatalogStore = () => {
+  const rows = new Map<LLMProvider, CustomProviderModelRecord[]>();
+  let nextRecordId = 1;
+  const readRows = (provider: LLMProvider) => rows.get(provider) ?? [];
 
-test('provider models service delegates to the resolved provider model adapter', async () => {
-  const calls: LLMProvider[] = [];
-  const service = createProviderModelsService({
-    cachePath: createEphemeralCachePath(),
-    resolveProvider: (provider) => {
-      calls.push(provider);
-      return {
-        models: {
-          getSupportedModels: async () => createModels(`${provider}-models`),
-          getCurrentActiveModel: async () => createCurrentActiveModel(`${provider}-active`),
-        },
-      };
+  return {
+    rows,
+    listCustomProviderModels(provider: LLMProvider) {
+      return [...readRows(provider)];
     },
-  });
-
-  const models = await service.getProviderModels('codex', { bypassCache: true });
-
-  assert.deepEqual(calls, ['codex']);
-  assert.equal(models.models.DEFAULT, 'codex-models');
-  assert.equal(models.cache.source, 'fresh');
-});
-
-test('provider models service returns each provider adapter result without rewriting it', async () => {
-  const expectedModels: ProviderModelsDefinition = {
-    OPTIONS: [
-      { value: 'cursor-a', label: 'Cursor A' },
-      { value: 'cursor-b', label: 'Cursor B' },
-    ],
-    DEFAULT: 'cursor-b',
+    getCustomProviderModel(provider: LLMProvider, recordId: number) {
+      return readRows(provider).find((record) => record.recordId === recordId) ?? null;
+    },
+    findCustomProviderModelByModelId(provider: LLMProvider, modelId: string) {
+      return readRows(provider).find((record) => record.modelId === modelId) ?? null;
+    },
+    createCustomProviderModel(provider: LLMProvider, input: CustomProviderModelInput) {
+      const record: CustomProviderModelRecord = {
+        recordId: nextRecordId++,
+        provider,
+        modelId: input.id,
+        model: input.model,
+        sortOrder: readRows(provider).length,
+      };
+      rows.set(provider, [...readRows(provider), record]);
+      return record;
+    },
+    updateCustomProviderModel(
+      provider: LLMProvider,
+      recordId: number,
+      input: CustomProviderModelInput,
+    ) {
+      const existing = readRows(provider).find((record) => record.recordId === recordId);
+      if (!existing) {
+        return null;
+      }
+      const updated = { ...existing, modelId: input.id, model: input.model };
+      rows.set(provider, readRows(provider).map((record) => (
+        record.recordId === recordId ? updated : record
+      )));
+      return updated;
+    },
+    deleteCustomProviderModel(provider: LLMProvider, recordId: number, _fallbackModelId: string) {
+      const existing = readRows(provider).find((record) => record.recordId === recordId);
+      if (!existing) {
+        return null;
+      }
+      rows.set(provider, readRows(provider).filter((record) => record.recordId !== recordId));
+      return existing;
+    },
   };
+};
 
+const createTestService = (options: {
+  catalog?: ReturnType<typeof createCatalogStore>;
+  sessions?: ReturnType<typeof createSessionStore>;
+  activeModel?: (provider: LLMProvider, sessionId?: string) => string;
+  onCatalogRead?: (provider: LLMProvider) => void;
+} = {}) => {
+  const catalog = options.catalog ?? createCatalogStore();
+  const sessions = options.sessions ?? createSessionStore();
   const service = createProviderModelsService({
-    cachePath: createEphemeralCachePath(),
-    resolveProvider: () => ({
-      models: {
-        getSupportedModels: async () => expectedModels,
-        getCurrentActiveModel: async () => createCurrentActiveModel('cursor-active'),
-      },
-    }),
-  });
-
-  const models = await service.getProviderModels('cursor', { bypassCache: true });
-
-  assert.deepEqual(models.models, expectedModels);
-});
-
-test('provider models are cached for the three-day ttl', async () => {
-  const tempRoot = await mkdtemp(path.join(os.tmpdir(), 'provider-model-cache-ttl-'));
-  let currentTime = 1_000;
-  let loadCount = 0;
-
-  try {
-    const service = createProviderModelsService({
-      cachePath: path.join(tempRoot, 'models-cache.json'),
-      now: () => currentTime,
-      resolveProvider: (provider) => ({
-        models: {
-          getSupportedModels: async () => {
-            loadCount += 1;
-            return createModels(`${provider}-${loadCount}`);
-          },
-          getCurrentActiveModel: async () => createCurrentActiveModel(`${provider}-active`),
-        },
-      }),
-    });
-
-    const first = await service.getProviderModels('codex');
-    const cached = await service.getProviderModels('codex');
-    assert.equal(loadCount, 1);
-    assert.equal(cached.models.DEFAULT, first.models.DEFAULT);
-    assert.equal(cached.cache.source, 'memory');
-
-    currentTime += PROVIDER_MODELS_CACHE_TTL_MS - 1;
-    await service.getProviderModels('codex');
-    assert.equal(loadCount, 1);
-
-    currentTime += 2;
-    const refreshed = await service.getProviderModels('codex');
-    assert.equal(loadCount, 2);
-    assert.equal(refreshed.models.DEFAULT, 'codex-2');
-  } finally {
-    await rm(tempRoot, { recursive: true, force: true });
-  }
-});
-
-test('claude provider models are always loaded directly from the provider', async () => {
-  const tempRoot = await mkdtemp(path.join(os.tmpdir(), 'provider-model-cache-claude-direct-'));
-  let loadCount = 0;
-
-  try {
-    const service = createProviderModelsService({
-      cachePath: path.join(tempRoot, 'models-cache.json'),
-      resolveProvider: (provider) => ({
-        models: {
-          getSupportedModels: async () => {
-            loadCount += 1;
-            return createModels(`${provider}-${loadCount}`);
-          },
-          getCurrentActiveModel: async () => createCurrentActiveModel(`${provider}-active`),
-        },
-      }),
-    });
-
-    const first = await service.getProviderModels('claude');
-    const second = await service.getProviderModels('claude');
-
-    assert.equal(loadCount, 2);
-    assert.equal(first.models.DEFAULT, 'claude-1');
-    assert.equal(second.models.DEFAULT, 'claude-2');
-    assert.equal(second.cache.source, 'fresh');
-  } finally {
-    await rm(tempRoot, { recursive: true, force: true });
-  }
-});
-
-test('provider model cache is persisted across service instances', async () => {
-  const tempRoot = await mkdtemp(path.join(os.tmpdir(), 'provider-model-cache-file-'));
-  const cachePath = path.join(tempRoot, 'models-cache.json');
-
-  try {
-    const writer = createProviderModelsService({
-      cachePath,
-      resolveProvider: () => ({
-        models: {
-          getSupportedModels: async () => createModels('cursor-cached'),
-          getCurrentActiveModel: async () => createCurrentActiveModel('cursor-active'),
-        },
-      }),
-    });
-    await writer.getProviderModels('cursor');
-
-    const reader = createProviderModelsService({
-      cachePath,
-      resolveProvider: () => ({
-        models: {
-          getSupportedModels: async () => {
-            throw new Error('loader should not be called for persisted cache hits');
-          },
-          getCurrentActiveModel: async () => createCurrentActiveModel('cursor-active'),
-        },
-      }),
-    });
-    const models = await reader.getProviderModels('cursor');
-    assert.equal(models.models.DEFAULT, 'cursor-cached');
-    assert.equal(models.cache.source, 'disk');
-  } finally {
-    await rm(tempRoot, { recursive: true, force: true });
-  }
-});
-
-test('concurrent provider model requests share one load operation', async () => {
-  const tempRoot = await mkdtemp(path.join(os.tmpdir(), 'provider-model-cache-pending-'));
-  let loadCount = 0;
-
-  try {
-    const service = createProviderModelsService({
-      cachePath: path.join(tempRoot, 'models-cache.json'),
-      resolveProvider: () => ({
-        models: {
-          getSupportedModels: async () => {
-            loadCount += 1;
-            await new Promise((resolve) => setTimeout(resolve, 20));
-            return createModels('claude-cached');
-          },
-          getCurrentActiveModel: async () => createCurrentActiveModel('claude-active'),
-        },
-      }),
-    });
-
-    const [first, second] = await Promise.all([
-      service.getProviderModels('claude'),
-      service.getProviderModels('claude'),
-    ]);
-
-    assert.equal(loadCount, 1);
-    assert.equal(first.models.DEFAULT, 'claude-cached');
-    assert.equal(second.models.DEFAULT, 'claude-cached');
-  } finally {
-    await rm(tempRoot, { recursive: true, force: true });
-  }
-});
-
-test('bypassCache forces a fresh provider fetch and updates cache metadata', async () => {
-  const tempRoot = await mkdtemp(path.join(os.tmpdir(), 'provider-model-cache-refresh-'));
-  let currentTime = 1_000;
-  let loadCount = 0;
-
-  try {
-    const service = createProviderModelsService({
-      cachePath: path.join(tempRoot, 'models-cache.json'),
-      now: () => currentTime,
-      resolveProvider: (provider) => ({
-        models: {
-          getSupportedModels: async () => {
-            loadCount += 1;
-            return createModels(`${provider}-${loadCount}`);
-          },
-          getCurrentActiveModel: async () => createCurrentActiveModel(`${provider}-active-${loadCount}`),
-        },
-      }),
-    });
-
-    const first = await service.getProviderModels('claude');
-    currentTime += 50;
-    const refreshed = await service.getProviderModels('claude', { bypassCache: true });
-
-    assert.equal(first.models.DEFAULT, 'claude-1');
-    assert.equal(refreshed.models.DEFAULT, 'claude-2');
-    assert.equal(refreshed.cache.source, 'fresh');
-    assert.notEqual(refreshed.cache.updatedAt, first.cache.updatedAt);
-    assert.equal(loadCount, 2);
-  } finally {
-    await rm(tempRoot, { recursive: true, force: true });
-  }
-});
-
-test('resolveSessionModel asks the provider adapter for the session it was given', async () => {
-  const calls: Array<{ provider: LLMProvider; sessionId?: string }> = [];
-  const service = createProviderModelsService({
-    sessions: createSessionStore({ 'session-123': null }),
+    catalog,
+    sessions,
     resolveProvider: (provider) => ({
       models: {
-        getSupportedModels: async () => createModels(`${provider}-models`),
-        getCurrentActiveModel: async (sessionId) => {
-          calls.push({ provider, sessionId });
-          return createCurrentActiveModel(`${provider}-${sessionId}`);
+        getSupportedModels: async () => {
+          options.onCatalogRead?.(provider);
+          return createModels(`${provider}-default`);
         },
+        getCurrentActiveModel: async (sessionId) => createCurrentActiveModel(
+          options.activeModel?.(provider, sessionId) ?? `${provider}-default`,
+        ),
       },
     }),
+  });
+
+  return { service, catalog, sessions };
+};
+
+test('provider catalogs merge source-controlled defaults with custom persistence rows', async () => {
+  const calls: LLMProvider[] = [];
+  const { service, catalog } = createTestService({ onCatalogRead: (provider) => calls.push(provider) });
+
+  const models = await service.getProviderModels('codex');
+
+  assert.deepEqual(calls, ['codex']);
+  assert.equal(models.DEFAULT, 'codex-default');
+  assert.deepEqual(models.OPTIONS[0], {
+    value: 'codex-default',
+    label: 'codex-default',
+    isCustom: false,
+  });
+  assert.deepEqual(catalog.rows.get('codex'), undefined);
+});
+
+test('custom models can be created, edited, and deleted', async () => {
+  const { service } = createTestService();
+  const created = await service.createCustomModel('claude', {
+    model: 'My Claude',
+    id: 'claude-my-model',
+  });
+  const recordId = created.model.recordId as number;
+
+  assert.equal(created.model.isCustom, true);
+  assert.equal(created.models.OPTIONS.at(-1)?.value, 'claude-my-model');
+
+  const updated = await service.updateCustomModel('claude', recordId, {
+    model: 'My Better Claude',
+    id: 'claude-my-model-v2',
+  });
+  assert.equal(updated.model.label, 'My Better Claude');
+  assert.equal(updated.model.value, 'claude-my-model-v2');
+
+  const removed = await service.deleteCustomModel('claude', recordId);
+  assert.equal(removed.model.value, 'claude-my-model-v2');
+  assert.equal(removed.models.OPTIONS.some((option) => option.recordId === recordId), false);
+});
+
+test('duplicate model ids are rejected within one provider', async () => {
+  const { service } = createTestService();
+  await service.createCustomModel('cursor', { model: 'First', id: 'custom-id' });
+
+  await assert.rejects(
+    () => service.createCustomModel('cursor', { model: 'Second', id: 'custom-id' }),
+    (error) => error instanceof AppError
+      && error.code === 'MODEL_ID_ALREADY_EXISTS'
+      && error.statusCode === 409,
+  );
+
+  await assert.rejects(
+    () => service.createCustomModel('cursor', {
+      model: 'Duplicate built-in',
+      id: 'cursor-default',
+    }),
+    (error) => error instanceof AppError
+      && error.code === 'MODEL_ID_ALREADY_EXISTS'
+      && error.statusCode === 409,
+  );
+});
+
+test('predefined models have no database record or mutation target', async () => {
+  const { service, catalog } = createTestService();
+  const models = await service.getProviderModels('opencode');
+  assert.equal(models.OPTIONS[0]?.recordId, undefined);
+  assert.equal(models.OPTIONS[0]?.isCustom, false);
+  assert.deepEqual(catalog.rows.get('opencode'), undefined);
+
+  await assert.rejects(
+    () => service.updateCustomModel('opencode', 999, { model: 'Changed', id: 'changed' }),
+    (error) => error instanceof AppError && error.code === 'MODEL_NOT_FOUND',
+  );
+});
+
+test('resolveSessionModel asks the provider adapter for the requested session', async () => {
+  const calls: Array<{ provider: LLMProvider; sessionId?: string }> = [];
+  const { service } = createTestService({
+    sessions: createSessionStore({ 'session-123': null }),
+    activeModel: (provider, sessionId) => {
+      calls.push({ provider, sessionId });
+      return `${provider}-${sessionId}`;
+    },
   });
 
   const resolved = await service.resolveSessionModel('opencode', { sessionId: 'session-123' });
@@ -277,17 +200,10 @@ test('resolveSessionModel asks the provider adapter for the session it was given
   assert.deepEqual(calls, [{ provider: 'opencode', sessionId: 'session-123' }]);
   assert.equal(resolved.model, 'opencode-session-123');
 });
-test('setSessionModel records the model on the session row', async () => {
+
+test('setSessionModel records the model on the session row', () => {
   const sessions = createSessionStore({ 'session-1': null });
-  const service = createProviderModelsService({
-    sessions,
-    resolveProvider: (provider) => ({
-      models: {
-        getSupportedModels: async () => createModels(`${provider}-models`),
-        getCurrentActiveModel: async () => createCurrentActiveModel(`${provider}-active`),
-      },
-    }),
-  });
+  const { service } = createTestService({ sessions });
 
   const stored = service.setSessionModel('claude', 'session-1', 'opus');
 
@@ -300,31 +216,18 @@ test('resolveSessionModel asks the provider adapter for the session it was given
   assert.equal(sessions.sessions.get('session-1'), 'opus');
 });
 
-test('setSessionModel ignores sessions that have no row yet', async () => {
+test('setSessionModel ignores sessions that have no row yet', () => {
   const sessions = createSessionStore();
-  const service = createProviderModelsService({
-    sessions,
-    resolveProvider: (provider) => ({
-      models: {
-        getSupportedModels: async () => createModels(`${provider}-models`),
-        getCurrentActiveModel: async () => createCurrentActiveModel(`${provider}-active`),
-      },
-    }),
-  });
+  const { service } = createTestService({ sessions });
 
   assert.equal(service.setSessionModel('claude', 'missing-session', 'opus'), null);
   assert.equal(sessions.sessions.size, 0);
 });
 
-test('resolveSessionModel prefers the recorded session model over everything else', async () => {
-  const service = createProviderModelsService({
+test('resolveSessionModel prefers the recorded session model', async () => {
+  const { service } = createTestService({
     sessions: createSessionStore({ 'session-1': 'haiku' }),
-    resolveProvider: (provider) => ({
-      models: {
-        getSupportedModels: async () => createModels(`${provider}-models`),
-        getCurrentActiveModel: async () => createCurrentActiveModel('provider-reported'),
-      },
-    }),
+    activeModel: () => 'provider-reported',
   });
 
   const resolved = await service.resolveSessionModel('claude', {
@@ -336,15 +239,10 @@ test('resolveSessionModel prefers the recorded session model over everything els
   assert.equal(resolved.source, 'session');
 });
 
-test('resolveSessionModel falls back to provider session state for sessions the app never recorded', async () => {
-  const service = createProviderModelsService({
+test('resolveSessionModel uses provider session state for unrecorded external sessions', async () => {
+  const { service } = createTestService({
     sessions: createSessionStore({ 'session-1': null }),
-    resolveProvider: (provider) => ({
-      models: {
-        getSupportedModels: async () => createModels(`${provider}-models`),
-        getCurrentActiveModel: async () => createCurrentActiveModel('provider-reported'),
-      },
-    }),
+    activeModel: () => 'provider-reported',
   });
 
   const resolved = await service.resolveSessionModel('opencode', {
@@ -356,16 +254,9 @@ test('resolveSessionModel falls back to provider session state for sessions the 
   assert.equal(resolved.source, 'provider');
 });
 
-test('resolveSessionModel uses the requested model when the provider only reports its catalog default', async () => {
-  const service = createProviderModelsService({
-    cachePath: createEphemeralCachePath(),
+test('resolveSessionModel uses the requested model when provider reports the catalog default', async () => {
+  const { service } = createTestService({
     sessions: createSessionStore({ 'session-1': null }),
-    resolveProvider: () => ({
-      models: {
-        getSupportedModels: async () => createModels('default'),
-        getCurrentActiveModel: async () => createCurrentActiveModel('default'),
-      },
-    }),
   });
 
   const resolved = await service.resolveSessionModel('claude', {
@@ -377,16 +268,8 @@ test('resolveSessionModel uses the requested model when the provider only report
   assert.equal(resolved.source, 'session');
 });
 
-test('resolveSessionModel answers with the requested model for a chat that has no session yet', async () => {
-  const service = createProviderModelsService({
-    sessions: createSessionStore(),
-    resolveProvider: (provider) => ({
-      models: {
-        getSupportedModels: async () => createModels(`${provider}-models`),
-        getCurrentActiveModel: async () => createCurrentActiveModel('provider-reported'),
-      },
-    }),
-  });
+test('resolveSessionModel returns a requested model before a session exists', async () => {
+  const { service } = createTestService();
 
   const resolved = await service.resolveSessionModel('codex', { requestedModel: 'gpt-5.5' });
 
@@ -395,52 +278,32 @@ test('resolveSessionModel answers with the requested model for a chat that has n
   assert.equal(resolved.source, 'session');
 });
 
-test('resolveSessionModel falls back to the catalog default with nothing else to go on', async () => {
-  const service = createProviderModelsService({
-    cachePath: createEphemeralCachePath(),
-    sessions: createSessionStore(),
-    resolveProvider: (provider) => ({
-      models: {
-        getSupportedModels: async () => createModels(`${provider}-models`),
-        getCurrentActiveModel: async () => createCurrentActiveModel('provider-reported'),
-      },
-    }),
-  });
+test('resolveSessionModel falls back to the provider adapter default', async () => {
+  const { service } = createTestService();
 
   const resolved = await service.resolveSessionModel('codex');
 
-  assert.equal(resolved.model, 'codex-models');
+  assert.equal(resolved.model, 'codex-default');
   assert.equal(resolved.source, 'default');
 });
 
 test('resolveResumeModel prefers the recorded session model over the requested one', async () => {
-  const service = createProviderModelsService({
+  const { service } = createTestService({
     sessions: createSessionStore({ 'session-456': 'composer-2' }),
-    resolveProvider: (provider) => ({
-      models: {
-        getSupportedModels: async () => createModels(`${provider}-models`),
-        getCurrentActiveModel: async () => createCurrentActiveModel(`${provider}-active`),
-      },
-    }),
   });
 
   const model = await service.resolveResumeModel('cursor', 'session-456', 'composer-2-fast');
   assert.equal(model, 'composer-2');
 });
 
-test('resolveResumeModel never lets provider session state override the requested model', async () => {
+test('resolveResumeModel never consults provider-global state', async () => {
   let providerLookups = 0;
-  const service = createProviderModelsService({
+  const { service } = createTestService({
     sessions: createSessionStore({ 'session-456': null }),
-    resolveProvider: (provider) => ({
-      models: {
-        getSupportedModels: async () => createModels(`${provider}-models`),
-        getCurrentActiveModel: async () => {
-          providerLookups += 1;
-          return createCurrentActiveModel('global-config-model');
-        },
-      },
-    }),
+    activeModel: () => {
+      providerLookups += 1;
+      return 'global-config-model';
+    },
   });
 
   const model = await service.resolveResumeModel('codex', 'session-456', 'gpt-5.5');

--- a/server/modules/providers/tests/provider-models.service.test.ts
+++ b/server/modules/providers/tests/provider-models.service.test.ts
@@ -19,14 +19,29 @@ const createModels = (value: string): ProviderModelsDefinition => ({
 const createCurrentActiveModel = (model: string): ProviderCurrentActiveModel => ({ model });
 
 /** In-memory stand-in for the `sessions` table rows the service reads and writes. */
-const createSessionStore = (rows: Record<string, string | null> = {}) => {
-  const sessions = new Map(Object.entries(rows));
+const createSessionStore = (
+  rows: Record<string, string | null> = {},
+  efforts: Record<string, string | null> = {},
+) => {
+  const sessions = new Map(Object.entries(rows).map(([sessionId, model]) => [
+    sessionId,
+    { model, effort: efforts[sessionId] ?? null },
+  ]));
   return {
     sessions,
     getSessionById: (sessionId: string) =>
-      (sessions.has(sessionId) ? { model: sessions.get(sessionId) ?? null } : null),
+      sessions.get(sessionId) ?? null,
     setSessionModel: (sessionId: string, model: string) => {
-      sessions.set(sessionId, model);
+      const session = sessions.get(sessionId);
+      if (session) {
+        session.model = model;
+      }
+    },
+    setSessionEffort: (sessionId: string, effort: string) => {
+      const session = sessions.get(sessionId);
+      if (session) {
+        session.effort = effort;
+      }
     },
   };
 };
@@ -211,9 +226,10 @@ test('setSessionModel records the model on the session row', () => {
     provider: 'claude',
     sessionId: 'session-1',
     model: 'opus',
+    effort: null,
     source: 'session',
   });
-  assert.equal(sessions.sessions.get('session-1'), 'opus');
+  assert.equal(sessions.sessions.get('session-1')?.model, 'opus');
 });
 
 test('setSessionModel ignores sessions that have no row yet', () => {
@@ -224,9 +240,32 @@ test('setSessionModel ignores sessions that have no row yet', () => {
   assert.equal(sessions.sessions.size, 0);
 });
 
+test('setSessionEffort records an explicit effort on the session row', () => {
+  const sessions = createSessionStore({ 'session-1': 'gpt-5.6-sol' });
+  const { service } = createTestService({ sessions });
+
+  const stored = service.setSessionEffort('codex', 'session-1', 'ultra');
+
+  assert.deepEqual(stored, {
+    provider: 'codex',
+    sessionId: 'session-1',
+    effort: 'ultra',
+    source: 'session',
+  });
+  assert.equal(sessions.sessions.get('session-1')?.effort, 'ultra');
+});
+
+test('setSessionEffort ignores sessions that have no row yet', () => {
+  const sessions = createSessionStore();
+  const { service } = createTestService({ sessions });
+
+  assert.equal(service.setSessionEffort('codex', 'missing-session', 'high'), null);
+  assert.equal(sessions.sessions.size, 0);
+});
+
 test('resolveSessionModel prefers the recorded session model', async () => {
   const { service } = createTestService({
-    sessions: createSessionStore({ 'session-1': 'haiku' }),
+    sessions: createSessionStore({ 'session-1': 'haiku' }, { 'session-1': 'high' }),
     activeModel: () => 'provider-reported',
   });
 
@@ -236,6 +275,7 @@ test('resolveSessionModel prefers the recorded session model', async () => {
   });
 
   assert.equal(resolved.model, 'haiku');
+  assert.equal(resolved.effort, 'high');
   assert.equal(resolved.source, 'session');
 });
 

--- a/server/modules/providers/tests/provider-runtime.service.test.ts
+++ b/server/modules/providers/tests/provider-runtime.service.test.ts
@@ -61,12 +61,8 @@ function createService(providers: IProvider[]) {
     },
     async getProviderModels() {
       return {
-        models: { OPTIONS: [], DEFAULT: 'default-model' },
-        cache: {
-          updatedAt: new Date(0).toISOString(),
-          expiresAt: new Date(0).toISOString(),
-          source: 'fresh',
-        },
+        OPTIONS: [],
+        DEFAULT: 'default-model',
       };
     },
   });

--- a/server/modules/providers/tests/provider-token-usage.service.test.ts
+++ b/server/modules/providers/tests/provider-token-usage.service.test.ts
@@ -18,6 +18,7 @@ function createSessionRow(overrides: Record<string, unknown> = {}) {
     jsonl_path: null,
     custom_name: null,
     model: null,
+    effort: null,
     isArchived: 0,
     created_at: '2026-01-01T00:00:00.000Z',
     updated_at: '2026-01-01T00:00:00.000Z',

--- a/server/modules/providers/tests/provider.routes.test.ts
+++ b/server/modules/providers/tests/provider.routes.test.ts
@@ -1,0 +1,67 @@
+import assert from 'node:assert/strict';
+import { once } from 'node:events';
+import { mkdtemp, rm } from 'node:fs/promises';
+import type { AddressInfo } from 'node:net';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+
+import express from 'express';
+
+import { closeConnection, initializeDatabase, sessionsDb } from '@/modules/database/index.js';
+import providerRouter from '@/modules/providers/provider.routes.js';
+
+async function withProviderServer(
+  run: (baseUrl: string, workspacePath: string) => Promise<void>,
+): Promise<void> {
+  const previousDatabasePath = process.env.DATABASE_PATH;
+  const tempDirectory = await mkdtemp(path.join(os.tmpdir(), 'provider-routes-'));
+
+  closeConnection();
+  process.env.DATABASE_PATH = path.join(tempDirectory, 'auth.db');
+  await initializeDatabase();
+
+  const app = express().use(express.json()).use('/api/providers', providerRouter);
+  const server = app.listen(0, '127.0.0.1');
+  await once(server, 'listening');
+
+  try {
+    const address = server.address() as AddressInfo;
+    await run(`http://127.0.0.1:${address.port}`, path.join(tempDirectory, 'workspace'));
+  } finally {
+    await new Promise<void>((resolve, reject) => {
+      server.close((error) => error ? reject(error) : resolve());
+    });
+    closeConnection();
+    if (previousDatabasePath === undefined) {
+      delete process.env.DATABASE_PATH;
+    } else {
+      process.env.DATABASE_PATH = previousDatabasePath;
+    }
+    await rm(tempDirectory, { recursive: true, force: true });
+  }
+}
+
+test('session creation route names a CloudCLI session from the initial message', async () => {
+  await withProviderServer(async (baseUrl, workspacePath) => {
+    const response = await fetch(`${baseUrl}/api/providers/sessions`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        provider: 'codex',
+        projectPath: workspacePath,
+        initialMessage: 'abcd  efg\nhij klm nop',
+      }),
+    });
+    const payload = await response.json() as {
+      data: { sessionId: string; sessionName: string };
+    };
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.data.sessionName, 'abcd efg hij klm');
+    assert.equal(
+      sessionsDb.getSessionById(payload.data.sessionId)?.custom_name,
+      'abcd efg hij klm',
+    );
+  });
+});

--- a/server/modules/providers/tests/provider.routes.test.ts
+++ b/server/modules/providers/tests/provider.routes.test.ts
@@ -1,15 +1,16 @@
 import assert from 'node:assert/strict';
 import { once } from 'node:events';
-import { mkdtemp, rm } from 'node:fs/promises';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
 import type { AddressInfo } from 'node:net';
 import os from 'node:os';
 import path from 'node:path';
 import test from 'node:test';
 
-import express from 'express';
+import express, { type NextFunction, type Request, type Response } from 'express';
 
 import { closeConnection, initializeDatabase, sessionsDb } from '@/modules/database/index.js';
 import providerRouter from '@/modules/providers/provider.routes.js';
+import { AppError } from '@/shared/utils.js';
 
 async function withProviderServer(
   run: (baseUrl: string, workspacePath: string) => Promise<void>,
@@ -19,9 +20,20 @@ async function withProviderServer(
 
   closeConnection();
   process.env.DATABASE_PATH = path.join(tempDirectory, 'auth.db');
+  await writeFile(process.env.DATABASE_PATH, '');
   await initializeDatabase();
 
   const app = express().use(express.json()).use('/api/providers', providerRouter);
+  app.use((error: unknown, _req: Request, res: Response, _next: NextFunction) => {
+    if (error instanceof AppError) {
+      res.status(error.statusCode).json({
+        success: false,
+        error: { code: error.code, message: error.message },
+      });
+      return;
+    }
+    res.status(500).json({ success: false, error: { code: 'INTERNAL_ERROR' } });
+  });
   const server = app.listen(0, '127.0.0.1');
   await once(server, 'listening');
 
@@ -62,6 +74,77 @@ test('session creation route names a CloudCLI session from the initial message',
     assert.equal(
       sessionsDb.getSessionById(payload.data.sessionId)?.custom_name,
       'abcd efg hij klm',
+    );
+  });
+});
+
+test('model routes expose immutable defaults and full custom model CRUD', async () => {
+  await withProviderServer(async (baseUrl) => {
+    const initialResponse = await fetch(`${baseUrl}/api/providers/codex/models`);
+    const initialPayload = await initialResponse.json() as {
+      data: {
+        cache?: unknown;
+        models: {
+          OPTIONS: Array<{ recordId?: number; value: string; isCustom: boolean }>;
+        };
+      };
+    };
+    assert.equal(initialResponse.status, 200);
+    assert.equal('cache' in initialPayload.data, false);
+    const predefined = initialPayload.data.models.OPTIONS[0];
+    assert.equal(predefined.isCustom, false);
+    assert.equal(predefined.recordId, undefined);
+
+    const createResponse = await fetch(`${baseUrl}/api/providers/codex/models`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ model: 'Gateway GPT', id: 'gateway/gpt' }),
+    });
+    const createPayload = await createResponse.json() as {
+      data: { model: { recordId: number; value: string; label: string; isCustom: boolean } };
+    };
+    assert.equal(createResponse.status, 201);
+    assert.equal(createPayload.data.model.isCustom, true);
+    const customRecordId = createPayload.data.model.recordId;
+
+    const updateResponse = await fetch(
+      `${baseUrl}/api/providers/codex/models/${customRecordId}`,
+      {
+        method: 'PATCH',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ model: 'Gateway GPT Updated', id: 'gateway/gpt-v2' }),
+      },
+    );
+    const updatePayload = await updateResponse.json() as {
+      data: { model: { value: string; label: string } };
+    };
+    assert.equal(updateResponse.status, 200);
+    assert.equal(updatePayload.data.model.value, 'gateway/gpt-v2');
+    assert.equal(updatePayload.data.model.label, 'Gateway GPT Updated');
+
+    const immutableResponse = await fetch(
+      `${baseUrl}/api/providers/codex/models/999999`,
+      {
+        method: 'PATCH',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ model: 'Changed', id: 'changed' }),
+      },
+    );
+    const immutablePayload = await immutableResponse.json() as { error: { code: string } };
+    assert.equal(immutableResponse.status, 404);
+    assert.equal(immutablePayload.error.code, 'MODEL_NOT_FOUND');
+
+    const deleteResponse = await fetch(
+      `${baseUrl}/api/providers/codex/models/${customRecordId}`,
+      { method: 'DELETE' },
+    );
+    const deletePayload = await deleteResponse.json() as {
+      data: { models: { OPTIONS: Array<{ recordId: number }> } };
+    };
+    assert.equal(deleteResponse.status, 200);
+    assert.equal(
+      deletePayload.data.models.OPTIONS.some((option) => option.recordId === customRecordId),
+      false,
     );
   });
 });

--- a/server/modules/providers/tests/provider.routes.test.ts
+++ b/server/modules/providers/tests/provider.routes.test.ts
@@ -78,6 +78,39 @@ test('session creation route names a CloudCLI session from the initial message',
   });
 });
 
+test('reasoning effort is persisted and returned with the active session model', async () => {
+  await withProviderServer(async (baseUrl, workspacePath) => {
+    sessionsDb.createAppSession('effort-session', 'codex', workspacePath);
+
+    const updateResponse = await fetch(
+      `${baseUrl}/api/providers/codex/sessions/effort-session/active-effort`,
+      {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ effort: 'ultra' }),
+      },
+    );
+    const updatePayload = await updateResponse.json() as {
+      data: { effort: string; sessionId: string };
+    };
+
+    assert.equal(updateResponse.status, 200);
+    assert.equal(updatePayload.data.effort, 'ultra');
+    assert.equal(sessionsDb.getSessionById('effort-session')?.effort, 'ultra');
+
+    const readResponse = await fetch(
+      `${baseUrl}/api/providers/codex/sessions/effort-session/active-model`,
+    );
+    const readPayload = await readResponse.json() as {
+      data: { effort: string | null; sessionId: string };
+    };
+
+    assert.equal(readResponse.status, 200);
+    assert.equal(readPayload.data.sessionId, 'effort-session');
+    assert.equal(readPayload.data.effort, 'ultra');
+  });
+});
+
 test('model routes expose immutable defaults and full custom model CRUD', async () => {
   await withProviderServer(async (baseUrl) => {
     const initialResponse = await fetch(`${baseUrl}/api/providers/codex/models`);

--- a/server/modules/providers/tests/sessions.service.test.ts
+++ b/server/modules/providers/tests/sessions.service.test.ts
@@ -37,6 +37,31 @@ test('provider session id returns the mapped native id', { concurrency: false },
   });
 });
 
+test('app session names use at most four whole words from the initial message', { concurrency: false }, async () => {
+  await withIsolatedDatabase(() => {
+    const result = sessionsService.createAppSession(
+      'codex',
+      '/tmp/session-name-project',
+      '  supercalifragilisticexpialidocious\nsecond   third fourth fifth  ',
+    );
+
+    assert.equal(result.sessionName, 'supercalifragilisticexpialidocious second third fourth');
+    assert.equal(
+      sessionsDb.getSessionById(result.sessionId)?.custom_name,
+      'supercalifragilisticexpialidocious second third fourth',
+    );
+  });
+});
+
+test('app sessions without message text receive a stable fallback name', { concurrency: false }, async () => {
+  await withIsolatedDatabase(() => {
+    const result = sessionsService.createAppSession('claude', '/tmp/attachment-only-project', '  \n ');
+
+    assert.equal(result.sessionName, 'Untitled Session');
+    assert.equal(sessionsDb.getSessionById(result.sessionId)?.custom_name, 'Untitled Session');
+  });
+});
+
 test('provider session id is unavailable until the provider assigns one', { concurrency: false }, async () => {
   await withIsolatedDatabase(() => {
     sessionsDb.createAppSession('pending-app-session', 'claude', '/tmp/session-id-copy-project');

--- a/server/modules/websocket/services/chat-websocket.service.ts
+++ b/server/modules/websocket/services/chat-websocket.service.ts
@@ -194,9 +194,13 @@ async function handleChatSend(
   const command = typeof data.content === 'string' ? data.content : '';
 
   // Record what this turn runs with so reopening the session later restores the
-  // same model, and so the resume path has a session-scoped answer to use.
+  // same model and reasoning effort, and so the resume path has a
+  // session-scoped model answer to use.
   if (typeof clientOptions.model === 'string' && clientOptions.model.trim()) {
     providerModelsService.setSessionModel(provider, sessionId, clientOptions.model);
+  }
+  if (typeof clientOptions.effort === 'string' && clientOptions.effort.trim()) {
+    providerModelsService.setSessionEffort(provider, sessionId, clientOptions.effort);
   }
 
   const attachmentCandidates = [

--- a/server/shared/interfaces.ts
+++ b/server/shared/interfaces.ts
@@ -60,15 +60,13 @@ export interface IProvider {
 /**
  * Model catalog contract for one provider.
  *
- * Implementations are responsible for resolving the provider's currently
- * supported models and converting them into the shared
- * `ProviderModelsDefinition` shape used by backend routes and frontend model
- * pickers. The `DEFAULT` field should be the most appropriate default selection
- * for that provider at the time the catalog is read.
+ * Implementations supply CloudCLI's curated predefined models and can inspect
+ * provider-native session state. The Providers service merges these immutable
+ * source-controlled definitions with user-created SQLite rows at read time.
  */
 export interface IProviderModels {
   /**
-   * Returns the provider's currently supported model catalog.
+   * Returns the curated predefined catalog owned by this provider adapter.
    */
   getSupportedModels(): Promise<ProviderModelsDefinition>;
 

--- a/server/shared/types.ts
+++ b/server/shared/types.ts
@@ -954,7 +954,9 @@ export type FileTreeFileSystem = {
   access(candidatePath: string): Promise<void>;
   stat(candidatePath: string): Promise<FileTreeStats>;
   lstat(candidatePath: string): Promise<FileTreeStats>;
-  readdir(directoryPath: string): Promise<FileTreeDirectoryEntry[]>;
+  // Streamed rather than returned as an array so a directory with millions of
+  // children is abandoned at the entry limit instead of being materialized.
+  openDirectory(directoryPath: string): AsyncIterable<FileTreeDirectoryEntry>;
   realpath(candidatePath: string): Promise<string>;
   readTextFile(filePath: string): Promise<string>;
   writeTextFile(filePath: string, content: string): Promise<void>;

--- a/server/shared/types.ts
+++ b/server/shared/types.ts
@@ -75,6 +75,10 @@ export type ProviderModelOption = {
   value: string;
   label: string;
   description?: string;
+  /** Stable SQLite row id used only by model-management actions. */
+  recordId?: number;
+  /** True for user-created rows; false for immutable CloudCLI defaults. */
+  isCustom?: boolean;
   effort?: {
     default?: string;
     values: {
@@ -93,28 +97,31 @@ export type ProviderModelsDefinition = {
 };
 
 /**
- * Cache metadata returned alongside one provider model catalog.
+ * One persisted custom-model row in the provider model library.
  *
- * `updatedAt` is when the current cached snapshot was last refreshed from the
- * provider itself. `expiresAt` is the backend cache expiry timestamp, and
- * `source` tells callers whether the current response came from in-memory cache,
- * persisted disk cache, or a fresh provider fetch.
+ * Provider modules use this shape at the database boundary. Predefined models
+ * never use this type because they remain source-controlled in provider
+ * adapters. `modelId` is sent to the provider runtime, while `model` is the
+ * user-supplied display name shown in pickers.
  */
-export type ProviderModelsCacheInfo = {
-  updatedAt: string;
-  expiresAt: string;
-  source: 'memory' | 'disk' | 'fresh';
+export type CustomProviderModelRecord = {
+  recordId: number;
+  provider: LLMProvider;
+  modelId: string;
+  model: string;
+  sortOrder: number;
 };
 
 /**
- * Full provider model lookup result returned by the backend service layer.
+ * User-editable values accepted when creating or changing a custom model.
  *
- * Use this shape when a caller needs both the selectable model catalog and the
- * cache metadata that explains how current the catalog is.
+ * `id` must be the exact provider-facing model identifier and cannot contain
+ * whitespace. `model` is a concise display name. The provider is supplied by
+ * the route path so a row can never be moved across providers accidentally.
  */
-export type ProviderModelsResult = {
-  models: ProviderModelsDefinition;
-  cache: ProviderModelsCacheInfo;
+export type CustomProviderModelInput = {
+  id: string;
+  model: string;
 };
 
 // ---------------------------

--- a/server/shared/types.ts
+++ b/server/shared/types.ts
@@ -154,7 +154,8 @@ export type ProviderCurrentActiveModel = {
 export type ProviderSessionModelSource = 'session' | 'provider' | 'default';
 
 /**
- * The model one session runs with, plus where that answer came from.
+ * The model one session runs with, its persisted reasoning effort when one has
+ * been recorded, and where the model answer came from.
  *
  * Returned by `providerModelsService.resolveSessionModel` and used by the
  * `/models`, `/cost` and `/status` commands, the active-model route, and the
@@ -164,6 +165,8 @@ export type ProviderSessionModel = {
   provider: LLMProvider;
   sessionId: string | null;
   model: string;
+  /** NULL means this session has not recorded an effort choice yet. */
+  effort: string | null;
   source: ProviderSessionModelSource;
 };
 

--- a/src/components/chat/constants/providerEffort.ts
+++ b/src/components/chat/constants/providerEffort.ts
@@ -4,7 +4,10 @@ export const DEFAULT_EFFORT_VALUE = 'default';
 
 export const FALLBACK_PROVIDER_EFFORT_VALUES: Partial<Record<LLMProvider, readonly string[]>> = {
   claude: ['low', 'medium', 'high', 'xhigh', 'max'],
-  codex: ['low', 'medium', 'high', 'xhigh'],
+  // Superset used only before the model catalog loads. Per-model metadata
+  // narrows this once available; including the GPT-5.6 tiers here prevents a
+  // valid Max/Ultra selection from being reset during catalog hydration.
+  codex: ['low', 'medium', 'high', 'xhigh', 'max', 'ultra'],
   opencode: ['none', 'low', 'medium', 'high', 'xhigh', 'max'],
 };
 

--- a/src/components/chat/hooks/useChatComposerState.ts
+++ b/src/components/chat/hooks/useChatComposerState.ts
@@ -847,8 +847,13 @@ export function useChatComposerState({
           }
           const body = await response.json();
           targetSessionId = body?.data?.sessionId || null;
-          if (typeof body?.data?.sessionName === 'string') {
-            createdSessionName = body.data.sessionName;
+          // A blank server name would leave the session unlabeled, so the local
+          // summary stays the fallback unless a real name comes back.
+          const returnedSessionName = typeof body?.data?.sessionName === 'string'
+            ? body.data.sessionName.trim()
+            : '';
+          if (returnedSessionName) {
+            createdSessionName = returnedSessionName;
           }
         } catch (error) {
           const message = error instanceof Error ? error.message : 'Unknown error';

--- a/src/components/chat/hooks/useChatComposerState.ts
+++ b/src/components/chat/hooks/useChatComposerState.ts
@@ -837,12 +837,14 @@ export function useChatComposerState({
       // handoff later — this id stays valid for the conversation's lifetime.
       let targetSessionId = selectedSession?.id || currentSessionId || null;
       if (!targetSessionId) {
+        let createdSessionName = sessionSummary;
         try {
           const response = await authenticatedFetch('/api/providers/sessions', {
             method: 'POST',
             body: JSON.stringify({
               provider,
               projectPath: resolvedProjectPath,
+              initialMessage: messageContent,
             }),
           });
           if (!response.ok) {
@@ -850,6 +852,9 @@ export function useChatComposerState({
           }
           const body = await response.json();
           targetSessionId = body?.data?.sessionId || null;
+          if (typeof body?.data?.sessionName === 'string') {
+            createdSessionName = body.data.sessionName;
+          }
         } catch (error) {
           const message = error instanceof Error ? error.message : 'Unknown error';
           console.error('Session creation failed:', error);
@@ -873,7 +878,7 @@ export function useChatComposerState({
         onSessionEstablished?.(targetSessionId, {
           provider,
           project: selectedProject,
-          summary: sessionSummary,
+          summary: createdSessionName,
         });
       }
 

--- a/src/components/chat/hooks/useChatComposerState.ts
+++ b/src/components/chat/hooks/useChatComposerState.ts
@@ -28,7 +28,7 @@ import type {
   PermissionMode,
   SessionEstablishedContext,
 } from '../types/types';
-import type { Project, ProjectSession, LLMProvider, ProviderModelsCacheInfo } from '../../../types/app';
+import type { Project, ProjectSession, LLMProvider, ProviderModelOption } from '../../../types/app';
 import { escapeRegExp } from '../utils/chatFormatting';
 
 import { useFileMentions } from './useFileMentions';
@@ -94,13 +94,8 @@ export type ModelCommandData = {
   };
   available?: Partial<Record<LLMProvider, string[]>>;
   availableModels?: string[];
-  availableOptions?: Array<{
-    value: string;
-    label?: string;
-    description?: string;
-  }>;
+  availableOptions?: ProviderModelOption[];
   defaultModel?: string;
-  cache?: ProviderModelsCacheInfo;
 };
 
 export type CostCommandData = {

--- a/src/components/chat/hooks/useChatProviderState.ts
+++ b/src/components/chat/hooks/useChatProviderState.ts
@@ -6,8 +6,9 @@ import type {
   ProjectSession,
   LLMProvider,
   Project,
+  CustomProviderModelInput,
+  ProviderModelActions,
   ProviderModelOption,
-  ProviderModelsCacheInfo,
   ProviderModelsDefinition,
 } from '../../../types/app';
 import {
@@ -73,7 +74,17 @@ type ProviderModelsApiResponse = {
   success?: boolean;
   data?: {
     models?: ProviderModelsDefinition;
-    cache?: ProviderModelsCacheInfo;
+  };
+};
+
+type ProviderModelMutationApiResponse = {
+  success?: boolean;
+  data?: {
+    model?: ProviderModelOption;
+    models?: ProviderModelsDefinition;
+  };
+  error?: {
+    message?: string;
   };
 };
 
@@ -129,11 +140,7 @@ export function useChatProviderState({ selectedSession, selectedProject: _select
   const [providerModelCatalog, setProviderModelCatalog] = useState<
     Partial<Record<LLMProvider, ProviderModelsDefinition>>
   >({});
-  const [providerModelCacheCatalog, setProviderModelCacheCatalog] = useState<
-    Partial<Record<LLMProvider, ProviderModelsCacheInfo>>
-  >({});
   const [providerModelsLoading, setProviderModelsLoading] = useState(true);
-  const [providerModelsRefreshing, setProviderModelsRefreshing] = useState(false);
 
   const providerModelsRequestIdRef = useRef(0);
 
@@ -169,33 +176,21 @@ export function useChatProviderState({ selectedSession, selectedProject: _select
     localStorage.setItem(`${targetProvider}-effort`, effort);
   }, []);
 
-  const loadProviderModels = useCallback(async (options: { bypassCache?: boolean } = {}) => {
+  const loadProviderModels = useCallback(async () => {
     const requestId = providerModelsRequestIdRef.current + 1;
     providerModelsRequestIdRef.current = requestId;
-    const isHardRefresh = options.bypassCache === true;
-
-    if (isHardRefresh) {
-      setProviderModelsRefreshing(true);
-    } else {
-      setProviderModelsLoading(true);
-    }
+    setProviderModelsLoading(true);
 
     try {
       const results = await Promise.all(
         PROVIDERS.map(async (p) => {
-          const params = new URLSearchParams();
-          if (options.bypassCache) {
-            params.set('bypassCache', 'true');
-          }
-
-          const queryString = params.toString();
-          const response = await authenticatedFetch(`/api/providers/${p}/models${queryString ? `?${queryString}` : ''}`);
+          const response = await authenticatedFetch(`/api/providers/${p}/models`);
           const body = (await response.json()) as ProviderModelsApiResponse;
-          if (!body.success || !body.data?.models || !body.data?.cache) {
+          if (!body.success || !body.data?.models) {
             return null;
           }
 
-          return body.data;
+          return body.data.models;
         }),
       );
 
@@ -204,7 +199,6 @@ export function useChatProviderState({ selectedSession, selectedProject: _select
       }
 
       const nextCatalog: Partial<Record<LLMProvider, ProviderModelsDefinition>> = {};
-      const nextCacheCatalog: Partial<Record<LLMProvider, ProviderModelsCacheInfo>> = {};
 
       PROVIDERS.forEach((p, i) => {
         const entry = results[i];
@@ -212,18 +206,15 @@ export function useChatProviderState({ selectedSession, selectedProject: _select
           return;
         }
 
-        nextCatalog[p] = entry.models;
-        nextCacheCatalog[p] = entry.cache;
+        nextCatalog[p] = entry;
       });
 
       setProviderModelCatalog(nextCatalog);
-      setProviderModelCacheCatalog(nextCacheCatalog);
     } catch (error) {
       console.error('Error loading provider models:', error);
     } finally {
       if (providerModelsRequestIdRef.current === requestId) {
         setProviderModelsLoading(false);
-        setProviderModelsRefreshing(false);
       }
     }
   }, []);
@@ -603,6 +594,112 @@ export function useChatProviderState({ selectedSession, selectedProject: _select
     [provider, providerModelCatalog],
   );
 
+  const applyProviderCatalog = useCallback((
+    targetProvider: LLMProvider,
+    models: ProviderModelsDefinition,
+  ) => {
+    setProviderModelCatalog((previous) => ({
+      ...previous,
+      [targetProvider]: models,
+    }));
+  }, []);
+
+  const readModelMutationResponse = useCallback(async (
+    response: Response,
+  ): Promise<Required<Pick<NonNullable<ProviderModelMutationApiResponse['data']>, 'model' | 'models'>>> => {
+    const body = (await response.json()) as ProviderModelMutationApiResponse;
+    if (!response.ok || !body.success || !body.data?.model || !body.data.models) {
+      throw new Error(body.error?.message || 'Unable to save this model.');
+    }
+
+    return {
+      model: body.data.model,
+      models: body.data.models,
+    };
+  }, []);
+
+  const createCustomModel = useCallback(async (
+    targetProvider: LLMProvider,
+    input: CustomProviderModelInput,
+  ) => {
+    const response = await authenticatedFetch(`/api/providers/${targetProvider}/models`, {
+      method: 'POST',
+      body: JSON.stringify(input),
+    });
+    const result = await readModelMutationResponse(response);
+    applyProviderCatalog(targetProvider, result.models);
+  }, [applyProviderCatalog, readModelMutationResponse]);
+
+  const updateCustomModel = useCallback(async (
+    targetProvider: LLMProvider,
+    existing: ProviderModelOption,
+    input: CustomProviderModelInput,
+  ) => {
+    if (!existing.recordId) {
+      throw new Error('This model cannot be edited.');
+    }
+
+    const response = await authenticatedFetch(
+      `/api/providers/${targetProvider}/models/${existing.recordId}`,
+      {
+        method: 'PATCH',
+        body: JSON.stringify(input),
+      },
+    );
+    const result = await readModelMutationResponse(response);
+    applyProviderCatalog(targetProvider, result.models);
+
+    if (providerModels[targetProvider] === existing.value) {
+      setStoredProviderModel(targetProvider, result.model.value);
+    }
+    if (provider === targetProvider && sessionModel === existing.value) {
+      setSessionModel(result.model.value);
+    }
+  }, [
+    applyProviderCatalog,
+    provider,
+    providerModels,
+    readModelMutationResponse,
+    sessionModel,
+    setStoredProviderModel,
+  ]);
+
+  const removeCustomModel = useCallback(async (
+    targetProvider: LLMProvider,
+    existing: ProviderModelOption,
+  ) => {
+    if (!existing.recordId) {
+      throw new Error('This model cannot be deleted.');
+    }
+
+    const response = await authenticatedFetch(
+      `/api/providers/${targetProvider}/models/${existing.recordId}`,
+      { method: 'DELETE' },
+    );
+    const result = await readModelMutationResponse(response);
+    applyProviderCatalog(targetProvider, result.models);
+
+    if (providerModels[targetProvider] === existing.value) {
+      setStoredProviderModel(targetProvider, result.models.DEFAULT);
+    }
+    if (provider === targetProvider && sessionModel === existing.value) {
+      setSessionModel(result.models.DEFAULT);
+    }
+  }, [
+    applyProviderCatalog,
+    provider,
+    providerModels,
+    readModelMutationResponse,
+    sessionModel,
+    setStoredProviderModel,
+  ]);
+
+  const providerModelActions = useMemo<ProviderModelActions>(() => ({
+    create: createCustomModel,
+    update: updateCustomModel,
+    remove: removeCustomModel,
+  }), [createCustomModel, removeCustomModel, updateCustomModel]);
+
   return {
     provider,
     setProvider,
@@ -626,10 +723,8 @@ export function useChatProviderState({ selectedSession, selectedProject: _select
     selectPermissionMode,
     cyclePermissionMode,
     providerModelCatalog,
-    providerModelCacheCatalog,
     providerModelsLoading,
-    providerModelsRefreshing,
-    hardRefreshProviderModels: () => loadProviderModels({ bypassCache: true }),
+    providerModelActions,
     selectProviderModel,
     setStoredProviderEffort,
     resolvePermissionModeForProvider,

--- a/src/components/chat/hooks/useChatProviderState.ts
+++ b/src/components/chat/hooks/useChatProviderState.ts
@@ -88,12 +88,13 @@ type ProviderModelMutationApiResponse = {
   };
 };
 
-type SessionModelApiResponse = {
+type SessionSelectionApiResponse = {
   success?: boolean;
   data?: {
     provider?: LLMProvider;
     sessionId?: string | null;
     model?: string | null;
+    effort?: string | null;
     /**
      * `session` and `provider` are real answers for this session; `default`
      * means the backend had nothing recorded and returned the catalog default,
@@ -102,6 +103,17 @@ type SessionModelApiResponse = {
     source?: 'session' | 'provider' | 'default';
   };
 };
+
+type SessionProviderSelection = {
+  provider: LLMProvider;
+  sessionId: string;
+  model: string | null;
+  effort: string | null;
+};
+
+const getSessionSelectionKey = (provider: LLMProvider, sessionId: string): string => (
+  `${provider}:${sessionId}`
+);
 
 export function useChatProviderState({ selectedSession, selectedProject: _selectedProject }: UseChatProviderStateArgs) {
   const [permissionMode, setPermissionMode] = useState<PermissionMode>('default');
@@ -143,6 +155,9 @@ export function useChatProviderState({ selectedSession, selectedProject: _select
   const [providerModelsLoading, setProviderModelsLoading] = useState(true);
 
   const providerModelsRequestIdRef = useRef(0);
+  const sessionSelectionLoadRequestIdRef = useRef(0);
+  const sessionModelMutationIdRef = useRef(0);
+  const sessionEffortMutationIdRef = useRef(0);
 
   const setStoredProviderModel = useCallback((targetProvider: LLMProvider, model: string) => {
     if (targetProvider === 'claude') {
@@ -494,50 +509,81 @@ export function useChatProviderState({ selectedSession, selectedProject: _select
       : getDefaultPermissionModeForProvider(targetProvider);
   }, [getDefaultPermissionModeForProvider, getPermissionModesForProvider]);
 
-  /**
-   * Model the open session runs with, as reported by the backend. Null while no
-   * session is open, or when the backend has nothing recorded for it and only
-   * offered the catalog default — the per-provider selection covers that case.
-   */
-  const [sessionModel, setSessionModel] = useState<string | null>(null);
+  /** Model and reasoning effort recorded for the open session by the backend. */
+  const [sessionSelection, setSessionSelection] = useState<SessionProviderSelection | null>(null);
+  const selectedSessionId = selectedSession?.id?.trim() || null;
+  const selectedSessionProvider = selectedSession?.__provider ?? provider;
+  const selectedSessionKey = selectedSessionId
+    ? getSessionSelectionKey(selectedSessionProvider, selectedSessionId)
+    : null;
+  const selectedSessionKeyRef = useRef<string | null>(selectedSessionKey);
+  selectedSessionKeyRef.current = selectedSessionKey;
+
+  const activeSessionSelection = sessionSelection
+    && selectedSessionId
+    && sessionSelection.sessionId === selectedSessionId
+    && sessionSelection.provider === selectedSessionProvider
+    ? sessionSelection
+    : null;
+  const sessionModel = activeSessionSelection?.model ?? null;
 
   useEffect(() => {
-    const sessionId = selectedSession?.id;
-    if (!sessionId) {
-      setSessionModel(null);
+    const requestId = sessionSelectionLoadRequestIdRef.current + 1;
+    sessionSelectionLoadRequestIdRef.current = requestId;
+
+    if (!selectedSessionId) {
+      setSessionSelection(null);
       return;
     }
 
     let cancelled = false;
-    const targetProvider = selectedSession?.__provider ?? provider;
+    const targetProvider = selectedSessionProvider;
+    const targetSessionKey = getSessionSelectionKey(targetProvider, selectedSessionId);
 
-    const loadSessionModel = async () => {
+    const loadSessionSelection = async () => {
       try {
         const response = await authenticatedFetch(
-          `/api/providers/${targetProvider}/sessions/${encodeURIComponent(sessionId)}/active-model`,
+          `/api/providers/${targetProvider}/sessions/${encodeURIComponent(selectedSessionId)}/active-model`,
         );
-        const body = (await response.json()) as SessionModelApiResponse;
-        if (cancelled) {
+        const body = (await response.json()) as SessionSelectionApiResponse;
+        if (
+          cancelled
+          || sessionSelectionLoadRequestIdRef.current !== requestId
+          || selectedSessionKeyRef.current !== targetSessionKey
+        ) {
           return;
         }
 
         const resolvedModel = body.data?.model?.trim();
-        setSessionModel(
-          body.success && resolvedModel && body.data?.source !== 'default' ? resolvedModel : null,
-        );
+        const resolvedEffort = body.data?.effort?.trim() || null;
+        setSessionSelection({
+          provider: targetProvider,
+          sessionId: selectedSessionId,
+          model: body.success && resolvedModel && body.data?.source !== 'default' ? resolvedModel : null,
+          effort: body.success ? resolvedEffort : null,
+        });
       } catch (error) {
-        if (!cancelled) {
-          console.error('Error loading the session model:', error);
-          setSessionModel(null);
+        if (
+          !cancelled
+          && sessionSelectionLoadRequestIdRef.current === requestId
+          && selectedSessionKeyRef.current === targetSessionKey
+        ) {
+          console.error('Error loading the session model and reasoning effort:', error);
+          setSessionSelection({
+            provider: targetProvider,
+            sessionId: selectedSessionId,
+            model: null,
+            effort: null,
+          });
         }
       }
     };
 
-    void loadSessionModel();
+    void loadSessionSelection();
     return () => {
       cancelled = true;
     };
-  }, [provider, selectedSession?.__provider, selectedSession?.id]);
+  }, [selectedSessionId, selectedSessionProvider]);
 
   /**
    * Applies a model choice.
@@ -558,6 +604,13 @@ export function useChatProviderState({ selectedSession, selectedProject: _select
       return { scope: 'default' as const, model };
     }
 
+    // A pending GET represents the state before this click and must not win
+    // if it resolves after the mutation.
+    sessionSelectionLoadRequestIdRef.current += 1;
+    const mutationId = sessionModelMutationIdRef.current + 1;
+    sessionModelMutationIdRef.current = mutationId;
+    const targetSessionKey = getSessionSelectionKey(targetProvider, normalizedSessionId);
+
     const response = await authenticatedFetch(
       `/api/providers/${targetProvider}/sessions/${encodeURIComponent(normalizedSessionId)}/active-model`,
       {
@@ -566,15 +619,106 @@ export function useChatProviderState({ selectedSession, selectedProject: _select
       },
     );
 
-    const body = (await response.json()) as SessionModelApiResponse;
+    const body = (await response.json()) as SessionSelectionApiResponse;
     if (!response.ok || !body.success) {
       throw new Error('Unable to change the active model for this session.');
     }
 
     const storedModel = body.data?.model?.trim() || model;
-    setSessionModel(storedModel);
+    if (
+      sessionModelMutationIdRef.current === mutationId
+      && selectedSessionKeyRef.current === targetSessionKey
+    ) {
+      setSessionSelection((current) => ({
+        provider: targetProvider,
+        sessionId: normalizedSessionId,
+        model: storedModel,
+        effort: current?.provider === targetProvider && current.sessionId === normalizedSessionId
+          ? current.effort
+          : body.data?.effort?.trim() || null,
+      }));
+    }
     return { scope: 'session' as const, model: storedModel };
   }, [setStoredProviderModel]);
+
+  /**
+   * Applies an effort choice optimistically and persists it for the open
+   * session. Mutation counters keep slower earlier requests from overwriting
+   * the latest click.
+   */
+  const selectProviderEffort = useCallback(async (
+    targetProvider: LLMProvider,
+    effort: string,
+    sessionId?: string | null,
+  ) => {
+    setStoredProviderEffort(targetProvider, effort);
+
+    const normalizedSessionId = typeof sessionId === 'string' ? sessionId.trim() : '';
+    if (!normalizedSessionId) {
+      return { scope: 'default' as const, effort };
+    }
+
+    sessionSelectionLoadRequestIdRef.current += 1;
+    const mutationId = sessionEffortMutationIdRef.current + 1;
+    sessionEffortMutationIdRef.current = mutationId;
+    const targetSessionKey = getSessionSelectionKey(targetProvider, normalizedSessionId);
+    const previousSelection = sessionSelection?.provider === targetProvider
+      && sessionSelection.sessionId === normalizedSessionId
+      ? sessionSelection
+      : null;
+
+    setSessionSelection({
+      provider: targetProvider,
+      sessionId: normalizedSessionId,
+      model: previousSelection?.model ?? null,
+      effort,
+    });
+
+    try {
+      const response = await authenticatedFetch(
+        `/api/providers/${targetProvider}/sessions/${encodeURIComponent(normalizedSessionId)}/active-effort`,
+        {
+          method: 'POST',
+          body: JSON.stringify({ effort }),
+        },
+      );
+      const body = (await response.json()) as SessionSelectionApiResponse;
+      if (!response.ok || !body.success) {
+        throw new Error('Unable to change the reasoning effort for this session.');
+      }
+
+      const storedEffort = body.data?.effort?.trim() || effort;
+      if (
+        sessionEffortMutationIdRef.current === mutationId
+        && selectedSessionKeyRef.current === targetSessionKey
+      ) {
+        setSessionSelection((current) => ({
+          provider: targetProvider,
+          sessionId: normalizedSessionId,
+          model: current?.provider === targetProvider && current.sessionId === normalizedSessionId
+            ? current.model
+            : previousSelection?.model ?? null,
+          effort: storedEffort,
+        }));
+      }
+
+      return { scope: 'session' as const, effort: storedEffort };
+    } catch (error) {
+      if (
+        sessionEffortMutationIdRef.current === mutationId
+        && selectedSessionKeyRef.current === targetSessionKey
+      ) {
+        setSessionSelection((current) => (
+          current?.provider === targetProvider
+          && current.sessionId === normalizedSessionId
+          && current.effort === effort
+            ? previousSelection
+            : current
+        ));
+      }
+      throw error;
+    }
+  }, [sessionSelection, setStoredProviderEffort]);
 
   // The open session's model wins over the per-provider default, so switching
   // sessions shows (and sends) what each session actually runs with.
@@ -586,9 +730,11 @@ export function useChatProviderState({ selectedSession, selectedProject: _select
     return reconcileStoredEffort(
       provider,
       currentProviderModel,
-      providerEfforts[provider] ?? DEFAULT_EFFORT_VALUE,
+      activeSessionSelection?.effort
+        ?? providerEfforts[provider]
+        ?? DEFAULT_EFFORT_VALUE,
     );
-  }, [currentProviderModel, provider, providerEfforts, reconcileStoredEffort]);
+  }, [activeSessionSelection?.effort, currentProviderModel, provider, providerEfforts, reconcileStoredEffort]);
   const currentProviderModelOptions = useMemo(
     () => providerModelCatalog[provider]?.OPTIONS ?? [],
     [provider, providerModelCatalog],
@@ -653,7 +799,10 @@ export function useChatProviderState({ selectedSession, selectedProject: _select
       setStoredProviderModel(targetProvider, result.model.value);
     }
     if (provider === targetProvider && sessionModel === existing.value) {
-      setSessionModel(result.model.value);
+      setSessionSelection((current) => current ? {
+        ...current,
+        model: result.model.value,
+      } : current);
     }
   }, [
     applyProviderCatalog,
@@ -683,7 +832,10 @@ export function useChatProviderState({ selectedSession, selectedProject: _select
       setStoredProviderModel(targetProvider, result.models.DEFAULT);
     }
     if (provider === targetProvider && sessionModel === existing.value) {
-      setSessionModel(result.models.DEFAULT);
+      setSessionSelection((current) => current ? {
+        ...current,
+        model: result.models.DEFAULT,
+      } : current);
     }
   }, [
     applyProviderCatalog,
@@ -726,7 +878,7 @@ export function useChatProviderState({ selectedSession, selectedProject: _select
     providerModelsLoading,
     providerModelActions,
     selectProviderModel,
-    setStoredProviderEffort,
+    selectProviderEffort,
     resolvePermissionModeForProvider,
   };
 }

--- a/src/components/chat/view/ChatInterface.tsx
+++ b/src/components/chat/view/ChatInterface.tsx
@@ -81,10 +81,8 @@ function ChatInterface({
     selectPermissionMode,
     cyclePermissionMode,
     providerModelCatalog,
-    providerModelCacheCatalog,
     providerModelsLoading,
-    providerModelsRefreshing,
-    hardRefreshProviderModels,
+    providerModelActions,
     selectProviderModel,
     setStoredProviderEffort,
     resolvePermissionModeForProvider,
@@ -351,6 +349,7 @@ function ChatInterface({
           opencodeModel={opencodeModel}
           setOpenCodeModel={setOpenCodeModel}
           providerModelCatalog={providerModelCatalog}
+          providerModelActions={providerModelActions}
           providerModelsLoading={providerModelsLoading}
           tasksEnabled={tasksEnabled}
           isTaskMasterInstalled={isTaskMasterInstalled}
@@ -466,9 +465,9 @@ function ChatInterface({
         payload={commandModalPayload}
         onClose={closeCommandModal}
         providerModelCatalog={providerModelCatalog}
-        providerModelCacheCatalog={providerModelCacheCatalog}
-        providerModelsRefreshing={providerModelsRefreshing}
-        onHardRefreshProviderModels={hardRefreshProviderModels}
+        providerModelActions={providerModelActions}
+        activeProvider={provider}
+        activeProviderModel={currentProviderModel}
         currentSessionId={currentSessionId || selectedSession?.id || null}
         onSelectProviderModel={selectProviderModel}
       />

--- a/src/components/chat/view/ChatInterface.tsx
+++ b/src/components/chat/view/ChatInterface.tsx
@@ -84,7 +84,7 @@ function ChatInterface({
     providerModelsLoading,
     providerModelActions,
     selectProviderModel,
-    setStoredProviderEffort,
+    selectProviderEffort,
     resolvePermissionModeForProvider,
   } = useChatProviderState({
     selectedSession,
@@ -295,6 +295,14 @@ function ChatInterface({
     }
   }, [currentSessionId, provider, selectProviderModel, selectedSession?.id]);
 
+  const handleSelectComposerEffort = useCallback(async (effort: string) => {
+    try {
+      await selectProviderEffort(provider, effort, currentSessionId || selectedSession?.id || null);
+    } catch (error) {
+      console.error('Error changing the active session reasoning effort:', error);
+    }
+  }, [currentSessionId, provider, selectProviderEffort, selectedSession?.id]);
+
   // Mirrors ChatComposer's own visibility check so the message pane can
   // reserve enough bottom space to keep the floating status tab from
   // overlapping the last message.
@@ -404,7 +412,7 @@ function ChatInterface({
           providerLabel={selectedProviderLabel}
           effort={currentProviderEffort}
           availableEffortOptions={currentProviderEffortOptions}
-          onSelectEffort={(nextEffort) => setStoredProviderEffort(provider, nextEffort)}
+          onSelectEffort={handleSelectComposerEffort}
           model={currentProviderModel}
           availableModelOptions={currentProviderModelOptions}
           onSelectModel={handleSelectComposerModel}

--- a/src/components/chat/view/subcomponents/ChatMessagesPane.tsx
+++ b/src/components/chat/view/subcomponents/ChatMessagesPane.tsx
@@ -7,6 +7,7 @@ import type {
   Project,
   ProjectSession,
   LLMProvider,
+  ProviderModelActions,
   ProviderModelsDefinition,
 } from '../../../../types/app';
 import { getIntrinsicMessageKey } from '../../utils/messageKeys';
@@ -42,6 +43,7 @@ interface ChatMessagesPaneProps {
   opencodeModel: string;
   setOpenCodeModel: (model: string) => void;
   providerModelCatalog: Partial<Record<LLMProvider, ProviderModelsDefinition>>;
+  providerModelActions: ProviderModelActions;
   providerModelsLoading: boolean;
   tasksEnabled: boolean;
   isTaskMasterInstalled: boolean | null;
@@ -90,6 +92,7 @@ function ChatMessagesPane({
   opencodeModel,
   setOpenCodeModel,
   providerModelCatalog,
+  providerModelActions,
   providerModelsLoading,
   tasksEnabled,
   isTaskMasterInstalled,
@@ -196,6 +199,7 @@ function ChatMessagesPane({
           opencodeModel={opencodeModel}
           setOpenCodeModel={setOpenCodeModel}
           providerModelCatalog={providerModelCatalog}
+          providerModelActions={providerModelActions}
           providerModelsLoading={providerModelsLoading}
           tasksEnabled={tasksEnabled}
           isTaskMasterInstalled={isTaskMasterInstalled}

--- a/src/components/chat/view/subcomponents/CommandResultModal.tsx
+++ b/src/components/chat/view/subcomponents/CommandResultModal.tsx
@@ -7,17 +7,23 @@ import {
   Cpu,
   Gauge,
   Package,
+  Plus,
   Search,
   Server,
   Sparkles,
   TerminalSquare,
   Timer,
-  RefreshCw,
+  Loader2,
   X,
 } from 'lucide-react';
 
 import { Badge, Button, Dialog, DialogContent, DialogTitle, Input } from '../../../../shared/view/ui';
-import type { LLMProvider, ProviderModelsCacheInfo, ProviderModelsDefinition } from '../../../../types/app';
+import type {
+  LLMProvider,
+  ProviderModelActions,
+  ProviderModelOption,
+  ProviderModelsDefinition,
+} from '../../../../types/app';
 import type {
   CommandModalPayload,
   CostCommandData,
@@ -26,13 +32,15 @@ import type {
   StatusCommandData,
 } from '../../hooks/useChatComposerState';
 
+import ModelLibraryPanel from './ModelLibraryPanel';
+
 type CommandResultModalProps = {
   payload: CommandModalPayload | null;
   onClose: () => void;
   providerModelCatalog: Partial<Record<LLMProvider, ProviderModelsDefinition>>;
-  providerModelCacheCatalog: Partial<Record<LLMProvider, ProviderModelsCacheInfo>>;
-  providerModelsRefreshing: boolean;
-  onHardRefreshProviderModels: () => void;
+  providerModelActions: ProviderModelActions;
+  activeProvider: LLMProvider;
+  activeProviderModel: string;
   currentSessionId: string | null;
   onSelectProviderModel: (
     provider: LLMProvider,
@@ -48,12 +56,6 @@ type CommandEntry = {
   name: string;
   description?: string;
   namespace?: string;
-};
-
-type ModelOption = {
-  value: string;
-  label?: string;
-  description?: string;
 };
 
 const PROVIDER_LABELS: Record<string, string> = {
@@ -229,15 +231,17 @@ function HelpContent({ data }: { data: HelpCommandData }) {
 function ModelsContent({
   data,
   providerModelCatalog,
-  providerModelsRefreshing,
-  onHardRefreshProviderModels,
+  providerModelActions,
+  activeProvider,
+  activeProviderModel,
   currentSessionId,
   onSelectProviderModel,
 }: {
   data: ModelCommandData;
   providerModelCatalog: Partial<Record<LLMProvider, ProviderModelsDefinition>>;
-  providerModelsRefreshing: boolean;
-  onHardRefreshProviderModels: () => void;
+  providerModelActions: ProviderModelActions;
+  activeProvider: LLMProvider;
+  activeProviderModel: string;
   currentSessionId: string | null;
   onSelectProviderModel: CommandResultModalProps['onSelectProviderModel'];
 }) {
@@ -245,11 +249,14 @@ function ModelsContent({
   const [changingModel, setChangingModel] = useState<string | null>(null);
   const [pendingSessionModel, setPendingSessionModel] = useState<string | null>(null);
   const [selectionNotice, setSelectionNotice] = useState<string | null>(null);
+  const [managingModels, setManagingModels] = useState(false);
   const currentProvider = (data?.current?.provider || 'claude') as LLMProvider;
-  const currentModel = data?.current?.model || 'Unknown';
+  const currentModel = activeProvider === currentProvider
+    ? activeProviderModel
+    : pendingSessionModel ?? data?.current?.model ?? 'Unknown';
   const providerLabel = data?.current?.providerLabel || getProviderLabel(currentProvider);
   const liveDefinition = providerModelCatalog[currentProvider];
-  const availableOptions = useMemo<ModelOption[]>(() => {
+  const availableOptions = useMemo<ProviderModelOption[]>(() => {
     if (liveDefinition?.OPTIONS && liveDefinition.OPTIONS.length > 0) {
       return liveDefinition.OPTIONS;
     }
@@ -296,9 +303,19 @@ function ModelsContent({
     }
   };
 
+  if (managingModels) {
+    return (
+      <ModelLibraryPanel
+        initialProvider={currentProvider}
+        providerModelCatalog={providerModelCatalog}
+        actions={providerModelActions}
+        onDone={() => setManagingModels(false)}
+      />
+    );
+  }
+
   return (
     <div className="flex h-full min-h-0 flex-col gap-3">
-      {/* Compact context bar: active model + refresh, no clutter */}
       <div className="flex items-center justify-between gap-3 rounded-2xl border border-border/70 bg-muted/20 px-3.5 py-2.5">
         <div className="min-w-0">
           <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">
@@ -315,15 +332,13 @@ function ModelsContent({
         </div>
         <Button
           type="button"
-          variant="ghost"
-          size="icon"
-          onClick={onHardRefreshProviderModels}
-          disabled={providerModelsRefreshing}
-          title="Refresh model list from providers"
-          aria-label="Refresh model list from providers"
-          className="h-9 w-9 shrink-0 rounded-xl text-muted-foreground hover:text-foreground"
+          variant="outline"
+          size="sm"
+          onClick={() => setManagingModels(true)}
+          className="h-9 shrink-0 rounded-xl bg-background px-3 text-xs"
         >
-          <RefreshCw className={`h-4 w-4 ${providerModelsRefreshing ? 'animate-spin' : ''}`} />
+          <Plus className="h-3.5 w-3.5" />
+          Manage models
         </Button>
       </div>
 
@@ -345,7 +360,7 @@ function ModelsContent({
                   onClick={() => handleSelectModel(option.value)}
                   disabled={Boolean(changingModel)}
                   aria-label={`Select model ${option.value}`}
-                  className={`settings-content-enter group flex min-h-[4rem] flex-col rounded-2xl border p-3 text-left shadow-sm transition-all duration-200 hover:-translate-y-0.5 hover:shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-default disabled:opacity-60 ${
+                  className={`settings-content-enter group flex min-h-16 flex-col rounded-2xl border p-3 text-left shadow-sm transition-all duration-200 hover:-translate-y-0.5 hover:shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-default disabled:opacity-60 ${
                     isCurrent
                       ? 'border-primary/45 bg-primary/10'
                       : isPendingSelection
@@ -355,15 +370,18 @@ function ModelsContent({
                   style={{ animationDelay: `${Math.min(index * 14, 180)}ms` }}
                 >
                   <span className="flex items-center justify-between gap-2">
-                    <span className="break-all font-mono text-sm font-semibold text-foreground">{option.value}</span>
-                    {isCurrent ? (
-                      <BadgeCheck className="h-4 w-4 shrink-0 text-primary" />
-                    ) : isChanging ? (
-                      <RefreshCw className="h-4 w-4 shrink-0 animate-spin text-primary" />
-                    ) : null}
+                    <span className="break-words text-sm font-semibold text-foreground">{option.label || option.value}</span>
+                    <span className="flex shrink-0 items-center gap-2">
+                      {option.isCustom && <Badge className="rounded-full px-2 py-0 text-[9px]">Custom</Badge>}
+                      {isCurrent ? (
+                        <BadgeCheck className="h-4 w-4 shrink-0 text-primary" />
+                      ) : isChanging ? (
+                        <Loader2 className="h-4 w-4 shrink-0 animate-spin text-primary" />
+                      ) : null}
+                    </span>
                   </span>
-                  {option.label && option.label !== option.value && (
-                    <span className="mt-1 text-xs font-medium text-foreground/85">{option.label}</span>
+                  {option.label !== option.value && (
+                    <span className="mt-1 break-all font-mono text-[11px] text-muted-foreground">{option.value}</span>
                   )}
                   {option.description && (
                     <span className="mt-1 text-xs leading-5 text-muted-foreground">{option.description}</span>
@@ -517,8 +535,9 @@ export default function CommandResultModal({
   payload,
   onClose,
   providerModelCatalog,
-  providerModelsRefreshing,
-  onHardRefreshProviderModels,
+  providerModelActions,
+  activeProvider,
+  activeProviderModel,
   currentSessionId,
   onSelectProviderModel,
 }: CommandResultModalProps) {
@@ -605,8 +624,9 @@ export default function CommandResultModal({
             <ModelsContent
               data={payload.data as ModelCommandData}
               providerModelCatalog={providerModelCatalog}
-              providerModelsRefreshing={providerModelsRefreshing}
-              onHardRefreshProviderModels={onHardRefreshProviderModels}
+              providerModelActions={providerModelActions}
+              activeProvider={activeProvider}
+              activeProviderModel={activeProviderModel}
               currentSessionId={currentSessionId}
               onSelectProviderModel={onSelectProviderModel}
             />

--- a/src/components/chat/view/subcomponents/ModelLibraryPanel.tsx
+++ b/src/components/chat/view/subcomponents/ModelLibraryPanel.tsx
@@ -1,0 +1,374 @@
+import { useEffect, useMemo, useState, type FormEvent } from 'react';
+import {
+  ArrowLeft,
+  Check,
+  Loader2,
+  LockKeyhole,
+  Pencil,
+  Plus,
+  Trash2,
+  X,
+} from 'lucide-react';
+
+import { Badge, Button, Input } from '../../../../shared/view/ui';
+import type {
+  LLMProvider,
+  ProviderModelActions,
+  ProviderModelOption,
+  ProviderModelsDefinition,
+} from '../../../../types/app';
+import SessionProviderLogo from '../../../llm-logo-provider/SessionProviderLogo';
+
+const PROVIDERS: Array<{ id: LLMProvider; label: string }> = [
+  { id: 'claude', label: 'Claude' },
+  { id: 'codex', label: 'Codex' },
+  { id: 'cursor', label: 'Cursor' },
+  { id: 'opencode', label: 'OpenCode' },
+];
+
+type ModelLibraryPanelProps = {
+  initialProvider: LLMProvider;
+  providerModelCatalog: Partial<Record<LLMProvider, ProviderModelsDefinition>>;
+  actions: ProviderModelActions;
+  onDone?: () => void;
+};
+
+export default function ModelLibraryPanel({
+  initialProvider,
+  providerModelCatalog,
+  actions,
+  onDone,
+}: ModelLibraryPanelProps) {
+  const [selectedProvider, setSelectedProvider] = useState(initialProvider);
+  const [editing, setEditing] = useState<ProviderModelOption | null>(null);
+  const [model, setModel] = useState('');
+  const [modelId, setModelId] = useState('');
+  const [saving, setSaving] = useState(false);
+  const [deletingRecordId, setDeletingRecordId] = useState<number | null>(null);
+  const [confirmDeleteRecordId, setConfirmDeleteRecordId] = useState<number | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [notice, setNotice] = useState<string | null>(null);
+
+  useEffect(() => {
+    setSelectedProvider(initialProvider);
+  }, [initialProvider]);
+
+  const options = useMemo(
+    () => providerModelCatalog[selectedProvider]?.OPTIONS ?? [],
+    [providerModelCatalog, selectedProvider],
+  );
+  const customModels = useMemo(
+    () => options.filter((option) => option.isCustom),
+    [options],
+  );
+  const predefinedModels = useMemo(
+    () => options.filter((option) => !option.isCustom),
+    [options],
+  );
+
+  const resetForm = () => {
+    setEditing(null);
+    setModel('');
+    setModelId('');
+    setError(null);
+  };
+
+  const selectProvider = (provider: LLMProvider) => {
+    setSelectedProvider(provider);
+    setConfirmDeleteRecordId(null);
+    setNotice(null);
+    resetForm();
+  };
+
+  const startEditing = (option: ProviderModelOption) => {
+    setEditing(option);
+    setModel(option.label);
+    setModelId(option.value);
+    setConfirmDeleteRecordId(null);
+    setNotice(null);
+    setError(null);
+  };
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const normalizedModel = model.trim();
+    const normalizedId = modelId.trim();
+    if (!normalizedModel || !normalizedId) {
+      setError('Enter both a model name and model ID.');
+      return;
+    }
+    if (/\s/.test(normalizedId)) {
+      setError('Model IDs cannot contain spaces.');
+      return;
+    }
+
+    setSaving(true);
+    setError(null);
+    setNotice(null);
+    try {
+      if (editing) {
+        await actions.update(selectedProvider, editing, {
+          model: normalizedModel,
+          id: normalizedId,
+        });
+        setNotice(`${normalizedModel} was updated.`);
+      } else {
+        await actions.create(selectedProvider, {
+          model: normalizedModel,
+          id: normalizedId,
+        });
+        setNotice(`${normalizedModel} was added.`);
+      }
+      resetForm();
+    } catch (caughtError) {
+      setError(caughtError instanceof Error ? caughtError.message : 'Unable to save this model.');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleDelete = async (option: ProviderModelOption) => {
+    if (!option.recordId) {
+      return;
+    }
+
+    setDeletingRecordId(option.recordId);
+    setError(null);
+    setNotice(null);
+    try {
+      await actions.remove(selectedProvider, option);
+      if (editing?.recordId === option.recordId) {
+        resetForm();
+      }
+      setConfirmDeleteRecordId(null);
+      setNotice(`${option.label} was deleted.`);
+    } catch (caughtError) {
+      setError(caughtError instanceof Error ? caughtError.message : 'Unable to delete this model.');
+    } finally {
+      setDeletingRecordId(null);
+    }
+  };
+
+  return (
+    <div className="flex h-full min-h-0 flex-col gap-4">
+      <div className="flex shrink-0 flex-col gap-3 border-b border-border/70 pb-4 sm:flex-row sm:items-start sm:justify-between">
+        <div className="min-w-0">
+          <div className="flex items-center gap-2">
+            <span className="grid h-9 w-9 shrink-0 place-items-center rounded-xl border border-primary/25 bg-primary/10 text-primary">
+              <Plus className="h-4 w-4" />
+            </span>
+            <div>
+              <p className="text-base font-semibold tracking-tight text-foreground">Model library</p>
+              <p className="text-xs leading-5 text-muted-foreground">
+                Add model IDs supported by your provider. Built-in models stay locked.
+              </p>
+            </div>
+          </div>
+        </div>
+        {onDone && (
+          <Button type="button" variant="outline" size="sm" onClick={onDone} className="shrink-0 rounded-xl">
+            <ArrowLeft className="h-3.5 w-3.5" />
+            Back to models
+          </Button>
+        )}
+      </div>
+
+      <div className="scrollbar-thin flex shrink-0 gap-1 overflow-x-auto rounded-xl border border-border/70 bg-muted/25 p-1">
+        {PROVIDERS.map((provider) => {
+          const selected = provider.id === selectedProvider;
+          return (
+            <button
+              key={provider.id}
+              type="button"
+              onClick={() => selectProvider(provider.id)}
+              aria-pressed={selected}
+              className={`flex min-w-fit flex-1 items-center justify-center gap-2 rounded-lg px-3 py-2 text-xs font-semibold transition-all ${
+                selected
+                  ? 'bg-background text-foreground shadow-sm ring-1 ring-border/70'
+                  : 'text-muted-foreground hover:bg-background/60 hover:text-foreground'
+              }`}
+            >
+              <SessionProviderLogo provider={provider.id} className="h-4 w-4" />
+              {provider.label}
+            </button>
+          );
+        })}
+      </div>
+
+      <div className="grid min-h-0 flex-1 gap-4 overflow-y-auto pr-1 lg:grid-cols-[minmax(16rem,0.8fr)_minmax(20rem,1.2fr)] lg:overflow-hidden lg:pr-0">
+        <form
+          onSubmit={handleSubmit}
+          className="h-fit rounded-2xl border border-border/70 bg-muted/20 p-4 shadow-sm"
+        >
+          <div className="flex items-start justify-between gap-3">
+            <div>
+              <p className="text-sm font-semibold text-foreground">
+                {editing ? 'Edit custom model' : 'Add a custom model'}
+              </p>
+              <p className="mt-1 text-xs leading-5 text-muted-foreground">
+                The ID is sent to {PROVIDERS.find((entry) => entry.id === selectedProvider)?.label} exactly as written.
+              </p>
+            </div>
+            {editing && (
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon"
+                onClick={resetForm}
+                className="h-8 w-8 rounded-lg"
+                aria-label="Cancel editing"
+              >
+                <X className="h-4 w-4" />
+              </Button>
+            )}
+          </div>
+
+          <label className="mt-4 block text-xs font-semibold text-foreground" htmlFor="custom-model-name">
+            Model name
+          </label>
+          <Input
+            id="custom-model-name"
+            value={model}
+            onChange={(event) => setModel(event.target.value)}
+            maxLength={80}
+            placeholder="e.g. GPT-5.5 Pro"
+            autoComplete="off"
+            className="mt-1.5 h-10 rounded-xl bg-background"
+          />
+
+          <label className="mt-4 block text-xs font-semibold text-foreground" htmlFor="custom-model-id">
+            Model ID
+          </label>
+          <Input
+            id="custom-model-id"
+            value={modelId}
+            onChange={(event) => setModelId(event.target.value)}
+            maxLength={200}
+            placeholder="e.g. gpt-5.5-pro"
+            autoComplete="off"
+            spellCheck={false}
+            className="mt-1.5 h-10 rounded-xl bg-background font-mono"
+          />
+          <p className="mt-1.5 text-[11px] leading-4 text-muted-foreground">
+            Use the exact identifier accepted by the provider CLI. IDs cannot contain spaces.
+          </p>
+
+          {error && (
+            <div role="alert" className="mt-3 rounded-xl border border-destructive/30 bg-destructive/10 px-3 py-2 text-xs text-destructive">
+              {error}
+            </div>
+          )}
+          {notice && !error && (
+            <div className="mt-3 flex items-center gap-2 rounded-xl border border-emerald-500/25 bg-emerald-500/10 px-3 py-2 text-xs text-emerald-700 dark:text-emerald-300">
+              <Check className="h-3.5 w-3.5" />
+              {notice}
+            </div>
+          )}
+
+          <Button type="submit" disabled={saving} className="mt-4 w-full rounded-xl">
+            {saving ? <Loader2 className="h-4 w-4 animate-spin" /> : editing ? <Check className="h-4 w-4" /> : <Plus className="h-4 w-4" />}
+            {saving ? 'Saving…' : editing ? 'Save changes' : 'Add model'}
+          </Button>
+        </form>
+
+        <div className="min-h-0 space-y-4 lg:overflow-y-auto lg:pr-1">
+          <section>
+            <div className="mb-2 flex items-center justify-between gap-3 px-1">
+              <div>
+                <p className="text-xs font-semibold uppercase tracking-[0.14em] text-foreground">Your models</p>
+                <p className="mt-0.5 text-[11px] text-muted-foreground">Editable and stored in auth.db</p>
+              </div>
+              <Badge variant="secondary" className="rounded-full text-[10px]">{customModels.length}</Badge>
+            </div>
+
+            {customModels.length === 0 ? (
+              <div className="rounded-2xl border border-dashed border-border bg-background/60 px-4 py-7 text-center">
+                <p className="text-sm font-medium text-foreground">No custom models yet</p>
+                <p className="mt-1 text-xs text-muted-foreground">Add one with the form and it will appear in every model picker.</p>
+              </div>
+            ) : (
+              <div className="space-y-2">
+                {customModels.map((option) => {
+                  const confirming = confirmDeleteRecordId === option.recordId;
+                  const deleting = deletingRecordId === option.recordId;
+                  return (
+                    <div key={option.recordId ?? option.value} className="rounded-2xl border border-primary/20 bg-primary/[0.04] p-3">
+                      <div className="flex items-start gap-3">
+                        <div className="min-w-0 flex-1">
+                          <div className="flex flex-wrap items-center gap-2">
+                            <p className="truncate text-sm font-semibold text-foreground">{option.label}</p>
+                            <Badge className="rounded-full px-2 py-0 text-[9px]">Custom</Badge>
+                          </div>
+                          <p className="mt-1 break-all font-mono text-[11px] text-muted-foreground">{option.value}</p>
+                        </div>
+                        {!confirming && (
+                          <div className="flex shrink-0 items-center gap-1">
+                            <Button
+                              type="button"
+                              variant="ghost"
+                              size="icon"
+                              onClick={() => startEditing(option)}
+                              className="h-8 w-8 rounded-lg"
+                              aria-label={`Edit ${option.label}`}
+                            >
+                              <Pencil className="h-3.5 w-3.5" />
+                            </Button>
+                            <Button
+                              type="button"
+                              variant="ghost"
+                              size="icon"
+                              onClick={() => setConfirmDeleteRecordId(option.recordId ?? null)}
+                              className="h-8 w-8 rounded-lg text-muted-foreground hover:bg-destructive/10 hover:text-destructive"
+                              aria-label={`Delete ${option.label}`}
+                            >
+                              <Trash2 className="h-3.5 w-3.5" />
+                            </Button>
+                          </div>
+                        )}
+                      </div>
+                      {confirming && (
+                        <div className="mt-3 flex flex-wrap items-center justify-between gap-2 border-t border-border/60 pt-3">
+                          <p className="text-xs text-muted-foreground">Delete this model from all pickers?</p>
+                          <div className="flex items-center gap-2">
+                            <Button type="button" variant="ghost" size="sm" onClick={() => setConfirmDeleteRecordId(null)} className="h-8 rounded-lg">
+                              Cancel
+                            </Button>
+                            <Button type="button" variant="destructive" size="sm" disabled={deleting} onClick={() => void handleDelete(option)} className="h-8 rounded-lg">
+                              {deleting && <Loader2 className="h-3.5 w-3.5 animate-spin" />}
+                              Delete
+                            </Button>
+                          </div>
+                        </div>
+                      )}
+                    </div>
+                  );
+                })}
+              </div>
+            )}
+          </section>
+
+          <section>
+            <div className="mb-2 flex items-center justify-between gap-3 px-1">
+              <div>
+                <p className="text-xs font-semibold uppercase tracking-[0.14em] text-foreground">Built-in models</p>
+                <p className="mt-0.5 text-[11px] text-muted-foreground">Maintained by CloudCLI and read-only</p>
+              </div>
+              <Badge variant="secondary" className="rounded-full text-[10px]">{predefinedModels.length}</Badge>
+            </div>
+            <div className="overflow-hidden rounded-2xl border border-border/70 bg-background/70">
+              {predefinedModels.map((option) => (
+                <div key={option.recordId ?? option.value} className="flex items-center gap-3 border-b border-border/60 px-3 py-2.5 last:border-b-0">
+                  <LockKeyhole className="h-3.5 w-3.5 shrink-0 text-muted-foreground/70" />
+                  <div className="min-w-0 flex-1">
+                    <p className="truncate text-xs font-medium text-foreground">{option.label}</p>
+                    <p className="truncate font-mono text-[10px] text-muted-foreground">{option.value}</p>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </section>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/chat/view/subcomponents/ModelLibraryPanel.tsx
+++ b/src/components/chat/view/subcomponents/ModelLibraryPanel.tsx
@@ -195,7 +195,7 @@ export default function ModelLibraryPanel({
         })}
       </div>
 
-      <div className="grid min-h-0 flex-1 gap-4 overflow-y-auto pr-1 lg:grid-cols-[minmax(16rem,0.8fr)_minmax(20rem,1.2fr)] lg:overflow-hidden lg:pr-0">
+      <div className="scrollbar-thin grid min-h-0 flex-1 items-start gap-4 overflow-y-auto pr-1 lg:grid-cols-[minmax(16rem,0.8fr)_minmax(20rem,1.2fr)]">
         <form
           onSubmit={handleSubmit}
           className="h-fit rounded-2xl border border-border/70 bg-muted/20 p-4 shadow-sm"
@@ -271,7 +271,7 @@ export default function ModelLibraryPanel({
           </Button>
         </form>
 
-        <div className="min-h-0 space-y-4 lg:overflow-y-auto lg:pr-1">
+        <div className="min-h-0 space-y-4">
           <section>
             <div className="mb-2 flex items-center justify-between gap-3 px-1">
               <div>

--- a/src/components/chat/view/subcomponents/ProviderSelectionEmptyState.tsx
+++ b/src/components/chat/view/subcomponents/ProviderSelectionEmptyState.tsx
@@ -1,10 +1,12 @@
 import React, { useCallback, useMemo, useState } from "react";
-import { Check, ChevronDown } from "lucide-react";
+import { Check, ChevronDown, Plus } from "lucide-react";
 import { Trans, useTranslation } from "react-i18next";
 
 import type {
   ProjectSession,
   LLMProvider,
+  ProviderModelActions,
+  ProviderModelOption,
   ProviderModelsDefinition,
 } from "../../../../types/app";
 import SessionProviderLogo from "../../../llm-logo-provider/SessionProviderLogo";
@@ -21,7 +23,11 @@ import {
   CommandGroup,
   CommandItem,
   Card,
+  Badge,
+  Button,
 } from "../../../../shared/view/ui";
+
+import ModelLibraryPanel from "./ModelLibraryPanel";
 
 const PROVIDER_META: { id: LLMProvider; name: string }[] = [
   { id: "claude", name: "Anthropic" },
@@ -59,6 +65,7 @@ type ProviderSelectionEmptyStateProps = {
   opencodeModel: string;
   setOpenCodeModel: (model: string) => void;
   providerModelCatalog: Partial<Record<LLMProvider, ProviderModelsDefinition>>;
+  providerModelActions: ProviderModelActions;
   providerModelsLoading: boolean;
   tasksEnabled: boolean;
   isTaskMasterInstalled: boolean | null;
@@ -69,7 +76,7 @@ type ProviderSelectionEmptyStateProps = {
 type ProviderGroup = {
   id: LLMProvider;
   name: string;
-  models: { value: string; label: string; description?: string }[];
+  models: ProviderModelOption[];
 };
 
 function getModelConfig(
@@ -116,6 +123,7 @@ export default function ProviderSelectionEmptyState({
   opencodeModel,
   setOpenCodeModel,
   providerModelCatalog,
+  providerModelActions,
   providerModelsLoading,
   tasksEnabled,
   isTaskMasterInstalled,
@@ -124,6 +132,7 @@ export default function ProviderSelectionEmptyState({
 }: ProviderSelectionEmptyStateProps) {
   const { t } = useTranslation("chat");
   const [dialogOpen, setDialogOpen] = useState(false);
+  const [modelLibraryOpen, setModelLibraryOpen] = useState(false);
 
   const visibleProviderGroups = useMemo<ProviderGroup[]>(() => {
     return PROVIDER_META.map((p) => ({
@@ -183,6 +192,16 @@ export default function ProviderSelectionEmptyState({
     [setProvider, setModelForProvider, textareaRef],
   );
 
+  const openModelLibrary = () => {
+    setDialogOpen(false);
+    setModelLibraryOpen(true);
+  };
+
+  const closeModelLibrary = () => {
+    setModelLibraryOpen(false);
+    setDialogOpen(true);
+  };
+
   if (!selectedSession && !currentSessionId) {
     return (
       <div className="flex h-full items-center justify-center px-4">
@@ -231,8 +250,21 @@ export default function ProviderSelectionEmptyState({
 
             <DialogContent className="max-w-md overflow-hidden p-0">
               <DialogTitle>Model Selector</DialogTitle>
-              <div className="border-b border-border/60 bg-muted/20 px-4 py-3">
-                <p className="text-sm font-semibold text-foreground">Choose a model</p>
+              <div className="flex items-center justify-between gap-3 border-b border-border/60 bg-muted/20 px-4 py-3">
+                <div>
+                  <p className="text-sm font-semibold text-foreground">Choose a model</p>
+                  <p className="mt-0.5 text-[11px] text-muted-foreground">Built-in and custom models in one list</p>
+                </div>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  onClick={openModelLibrary}
+                  className="h-8 shrink-0 rounded-lg px-2.5 text-xs"
+                >
+                  <Plus className="h-3.5 w-3.5" />
+                  Add model
+                </Button>
               </div>
               <Command filter={modelSearchFilter}>
                 <CommandInput
@@ -276,16 +308,17 @@ export default function ProviderSelectionEmptyState({
                             className="ml-4 border-l border-border/40 pl-4"
                           >
                             <div className="min-w-0 flex-1">
-                              <div className="truncate">{model.label}</div>
-                              {/* 
-                              // * Temporarly commented out because the description of models from claude 
-                              // * was a bit inconsistent.  Will return it back when it becomes more consistent.
-                              */}
-                              {/* {model.description && (
-                                <div className="truncate text-xs text-muted-foreground">
-                                  {model.description}
+                              <div className="flex min-w-0 items-center gap-2">
+                                <span className="truncate">{model.label}</span>
+                                {model.isCustom && (
+                                  <Badge className="h-4 shrink-0 rounded-full px-1.5 text-[8px]">Custom</Badge>
+                                )}
+                              </div>
+                              {model.label !== model.value && (
+                                <div className="truncate font-mono text-[10px] text-muted-foreground">
+                                  {model.value}
                                 </div>
-                              )} */}
+                              )}
                             </div>
                             {isSelected && (
                               <Check className="ml-auto h-4 w-4 shrink-0 text-primary" />
@@ -297,6 +330,27 @@ export default function ProviderSelectionEmptyState({
                   ))}
                 </CommandList>
               </Command>
+            </DialogContent>
+          </Dialog>
+
+          <Dialog
+            open={modelLibraryOpen}
+            onOpenChange={(open) => {
+              if (open) {
+                setModelLibraryOpen(true);
+              } else {
+                closeModelLibrary();
+              }
+            }}
+          >
+            <DialogContent className="flex h-[min(90dvh,46rem)] w-[calc(100vw-1rem)] max-w-4xl flex-col overflow-hidden rounded-3xl p-4 sm:p-5">
+              <DialogTitle>Manage models</DialogTitle>
+              <ModelLibraryPanel
+                initialProvider={provider}
+                providerModelCatalog={providerModelCatalog}
+                actions={providerModelActions}
+                onDone={closeModelLibrary}
+              />
             </DialogContent>
           </Dialog>
 

--- a/src/components/chat/view/subcomponents/ProviderSelectionEmptyState.tsx
+++ b/src/components/chat/view/subcomponents/ProviderSelectionEmptyState.tsx
@@ -252,8 +252,16 @@ export default function ProviderSelectionEmptyState({
               <DialogTitle>Model Selector</DialogTitle>
               <div className="flex items-center justify-between gap-3 border-b border-border/60 bg-muted/20 px-4 py-3">
                 <div>
-                  <p className="text-sm font-semibold text-foreground">Choose a model</p>
-                  <p className="mt-0.5 text-[11px] text-muted-foreground">Built-in and custom models in one list</p>
+                  <p className="text-sm font-semibold text-foreground">
+                    {t("providerSelection.chooseModel", {
+                      defaultValue: "Choose a model",
+                    })}
+                  </p>
+                  <p className="mt-0.5 text-[11px] text-muted-foreground">
+                    {t("providerSelection.chooseModelDescription", {
+                      defaultValue: "Built-in and custom models in one list",
+                    })}
+                  </p>
                 </div>
                 <Button
                   type="button"
@@ -263,7 +271,7 @@ export default function ProviderSelectionEmptyState({
                   className="h-8 shrink-0 rounded-lg px-2.5 text-xs"
                 >
                   <Plus className="h-3.5 w-3.5" />
-                  Add model
+                  {t("providerSelection.addModel", { defaultValue: "Add model" })}
                 </Button>
               </div>
               <Command filter={modelSearchFilter}>
@@ -344,7 +352,11 @@ export default function ProviderSelectionEmptyState({
             }}
           >
             <DialogContent className="flex h-[min(90dvh,46rem)] w-[calc(100vw-1rem)] max-w-4xl flex-col overflow-hidden rounded-3xl p-4 sm:p-5">
-              <DialogTitle>Manage models</DialogTitle>
+              <DialogTitle>
+                {t("providerSelection.manageModels", {
+                  defaultValue: "Manage models",
+                })}
+              </DialogTitle>
               <ModelLibraryPanel
                 initialProvider={provider}
                 providerModelCatalog={providerModelCatalog}

--- a/src/components/file-tree/hooks/useFileTreeData.ts
+++ b/src/components/file-tree/hooks/useFileTreeData.ts
@@ -6,12 +6,31 @@ import type { FileTreeNode } from '../types/types';
 type UseFileTreeDataResult = {
   files: FileTreeNode[];
   loading: boolean;
+  error: string | null;
   refreshFiles: () => void;
 };
+
+const DEFAULT_LOAD_ERROR = 'Unable to load the file tree for this project.';
+
+// The API reports refusals such as FILE_TREE_TOO_LARGE as { error: message }.
+// Surfacing that message tells the user why the tree is missing and what to do
+// about it, instead of leaving them with an unexplained empty tree.
+function readResponseErrorMessage(responseBody: string): string | null {
+  try {
+    const parsedBody = JSON.parse(responseBody) as unknown;
+    const message = typeof parsedBody === 'object' && parsedBody !== null && 'error' in parsedBody
+      ? (parsedBody as { error: unknown }).error
+      : null;
+    return typeof message === 'string' && message.trim() ? message : null;
+  } catch {
+    return null;
+  }
+}
 
 export function useFileTreeData(selectedProject: Project | null): UseFileTreeDataResult {
   const [files, setFiles] = useState<FileTreeNode[]>([]);
   const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
   const [refreshKey, setRefreshKey] = useState(0);
   const abortControllerRef = useRef<AbortController | null>(null);
 
@@ -27,6 +46,7 @@ export function useFileTreeData(selectedProject: Project | null): UseFileTreeDat
     if (!projectId) {
       setFiles([]);
       setLoading(false);
+      setError(null);
       return;
     }
 
@@ -42,6 +62,7 @@ export function useFileTreeData(selectedProject: Project | null): UseFileTreeDat
     const fetchFiles = async () => {
       if (isActive) {
         setLoading(true);
+        setError(null);
       }
       try {
         const response = await api.getFiles(projectId, { signal: abortControllerRef.current!.signal });
@@ -51,6 +72,7 @@ export function useFileTreeData(selectedProject: Project | null): UseFileTreeDat
           console.error('File fetch failed:', response.status, errorText);
           if (isActive) {
             setFiles([]);
+            setError(readResponseErrorMessage(errorText) ?? DEFAULT_LOAD_ERROR);
           }
           return;
         }
@@ -67,6 +89,7 @@ export function useFileTreeData(selectedProject: Project | null): UseFileTreeDat
         console.error('Error fetching files:', error);
         if (isActive) {
           setFiles([]);
+          setError(DEFAULT_LOAD_ERROR);
         }
       } finally {
         if (isActive) {
@@ -86,6 +109,7 @@ export function useFileTreeData(selectedProject: Project | null): UseFileTreeDat
   return {
     files,
     loading,
+    error,
     refreshFiles,
   };
 }

--- a/src/components/file-tree/view/FileTree.tsx
+++ b/src/components/file-tree/view/FileTree.tsx
@@ -48,7 +48,7 @@ export default function FileTree({ selectedProject, onFileOpen }: FileTreeProps)
     }
   }, [toast]);
 
-  const { files, loading, refreshFiles } = useFileTreeData(selectedProject);
+  const { files, loading, error, refreshFiles } = useFileTreeData(selectedProject);
   const { viewMode, changeViewMode } = useFileTreeViewMode();
   const { expandedDirs, toggleDirectory, expandDirectories, collapseAll } = useExpandedDirectories();
   const { searchQuery, setSearchQuery, filteredFiles } = useFileTreeSearch({
@@ -201,6 +201,7 @@ export default function FileTree({ selectedProject, onFileOpen }: FileTreeProps)
         <FileTreeBody
           files={files}
           filteredFiles={filteredFiles}
+          error={error}
           searchQuery={searchQuery}
           viewMode={viewMode}
           expandedDirs={expandedDirs}

--- a/src/components/file-tree/view/FileTreeBody.tsx
+++ b/src/components/file-tree/view/FileTreeBody.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode, RefObject } from 'react';
-import { Folder, Search } from 'lucide-react';
+import { AlertTriangle, Folder, Search } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import type { FileTreeNode, FileTreeViewMode } from '../types/types';
 import FileTreeEmptyState from './FileTreeEmptyState';
@@ -8,6 +8,7 @@ import FileTreeList from './FileTreeList';
 type FileTreeBodyProps = {
   files: FileTreeNode[];
   filteredFiles: FileTreeNode[];
+  error?: string | null;
   searchQuery: string;
   viewMode: FileTreeViewMode;
   expandedDirs: Set<string>;
@@ -35,6 +36,7 @@ type FileTreeBodyProps = {
 export default function FileTreeBody({
   files,
   filteredFiles,
+  error,
   searchQuery,
   viewMode,
   expandedDirs,
@@ -61,7 +63,13 @@ export default function FileTreeBody({
 
   return (
     <>
-      {files.length === 0 ? (
+      {error ? (
+        <FileTreeEmptyState
+          icon={AlertTriangle}
+          title={t('fileTree.loadFailed')}
+          description={error}
+        />
+      ) : files.length === 0 ? (
         <FileTreeEmptyState
           icon={Folder}
           title={t('fileTree.noFilesFound')}

--- a/src/components/sidebar/view/subcomponents/SidebarSessionItem.tsx
+++ b/src/components/sidebar/view/subcomponents/SidebarSessionItem.tsx
@@ -104,9 +104,10 @@ export default function SidebarSessionItem({
   const providerLabel = PROVIDER_LABELS[session.__provider];
 
   // While editing, dismiss only when the user clicks outside the inline rename panel
-  // (matches Escape / cancel-button behaviour).
+  // (matches Escape / cancel-button behaviour). The mobile rename lives inside the
+  // bottom sheet, which owns its own dismissal, so the listener stays off there.
   useEffect(() => {
-    if (!isEditing) {
+    if (!isEditing || isMobileOptionsOpen) {
       return;
     }
 
@@ -119,7 +120,7 @@ export default function SidebarSessionItem({
 
     document.addEventListener('mousedown', handlePointerDown);
     return () => document.removeEventListener('mousedown', handlePointerDown);
-  }, [isEditing, onCancelEditingSession]);
+  }, [isEditing, isMobileOptionsOpen, onCancelEditingSession]);
 
   // Sessions are owned by a project identified by `projectId` (DB primary key)
   // after the projectName → projectId migration.
@@ -175,6 +176,18 @@ export default function SidebarSessionItem({
   const setMobileOptionsOpen = (open: boolean) => {
     setIsMobileOptionsOpen(open);
     setOptionsOpen(open);
+    if (!open && isEditing) {
+      onCancelEditingSession();
+    }
+  };
+
+  const startMobileRename = () => {
+    onStartEditingSession(session.id, sessionView.sessionName);
+  };
+
+  const saveMobileRename = () => {
+    saveEditedSession();
+    setMobileOptionsOpen(false);
   };
 
   const copyProviderSessionId = async () => {
@@ -257,7 +270,12 @@ export default function SidebarSessionItem({
 
             <div className="min-w-0 flex-1">
               <div className="flex items-center gap-2">
-                <div className="min-w-0 flex-1 truncate text-sm font-normal text-foreground">{sessionView.sessionName}</div>
+                <div
+                  className="min-w-0 flex-1 truncate text-sm font-normal text-foreground"
+                  title={sessionView.sessionName}
+                >
+                  {sessionView.sessionName}
+                </div>
                 {isProcessing ? (
                   <span className="ml-auto flex-shrink-0">
                     <Tooltip content={t('tooltips.processingSessionIndicator', 'Processing session')} position="top">
@@ -310,62 +328,118 @@ export default function SidebarSessionItem({
                 <SessionProviderLogo provider={session.__provider} className="h-5 w-5" />
               </div>
               <div className="min-w-0">
-                <p className="truncate text-sm font-medium text-foreground">{sessionView.sessionName}</p>
+                <p className="truncate text-sm font-medium text-foreground" title={sessionView.sessionName}>
+                  {sessionView.sessionName}
+                </p>
                 <p id="mobile-session-options-description" className="text-xs text-muted-foreground">
                   {providerLabel} session
                 </p>
               </div>
             </div>
 
-            <div className="space-y-2">
-              <button
-                type="button"
-                onClick={handleCopyAction}
-                disabled={isCopyPending}
-                className={cn(
-                  'flex min-h-12 w-full items-center gap-3 rounded-xl border px-4 py-3 text-left transition-colors',
-                  copyState === 'copied'
-                    ? 'border-green-500/30 bg-green-500/10 text-green-700 dark:text-green-300'
-                    : copyState === 'error'
-                      ? 'border-red-500/30 bg-red-500/10 text-red-700 dark:text-red-300'
-                      : 'border-border bg-muted/35 text-foreground active:bg-muted',
-                )}
-              >
-                {isCopyPending ? (
-                  <Loader2 className="h-5 w-5 flex-shrink-0 animate-spin" />
-                ) : (
-                  <CopyStateIcon className="h-5 w-5 flex-shrink-0" />
-                )}
-                <span className="min-w-0 flex-1">
-                  <span className="block text-sm font-medium">{copyLabel}</span>
-                  {copyState === 'error' && (
-                    <span className="mt-0.5 block text-xs">Tap to try again.</span>
-                  )}
-                </span>
-              </button>
-
-              {!isProcessing && (
+            {isEditing ? (
+              <div className="mb-3 space-y-2">
+                <label htmlFor={`mobile-session-rename-${session.id}`} className="block px-1 text-xs font-medium text-muted-foreground">
+                  Session name
+                </label>
+                <input
+                  id={`mobile-session-rename-${session.id}`}
+                  type="text"
+                  value={editingSessionName}
+                  onChange={(event) => onEditingSessionNameChange(event.target.value)}
+                  onKeyDown={(event) => {
+                    event.stopPropagation();
+                    if (event.key === 'Enter') {
+                      saveMobileRename();
+                    }
+                  }}
+                  className="w-full rounded-xl border-2 border-primary/40 bg-background px-3 py-3 text-foreground shadow-sm focus:border-primary focus:outline-none"
+                  autoFocus
+                  autoComplete="off"
+                  // 16px keeps iOS Safari from zooming the viewport on focus.
+                  style={{ fontSize: '16px' }}
+                />
+                <div className="flex gap-2">
+                  <button
+                    type="button"
+                    onClick={saveMobileRename}
+                    className="flex min-h-12 flex-1 items-center justify-center gap-2 rounded-xl bg-primary px-4 py-3 text-sm font-medium text-primary-foreground transition-transform active:scale-95"
+                  >
+                    <Check className="h-5 w-5 flex-shrink-0" />
+                    Save
+                  </button>
+                  <button
+                    type="button"
+                    onClick={onCancelEditingSession}
+                    className="flex min-h-12 flex-1 items-center justify-center gap-2 rounded-xl border border-border bg-muted/35 px-4 py-3 text-sm font-medium text-foreground transition-colors active:bg-muted"
+                  >
+                    <X className="h-5 w-5 flex-shrink-0" />
+                    Cancel
+                  </button>
+                </div>
+              </div>
+            ) : (
+              <div className="space-y-2">
                 <button
                   type="button"
-                  onClick={() => {
-                    setMobileOptionsOpen(false);
-                    requestDeleteSession();
-                  }}
-                  className="flex min-h-12 w-full items-center gap-3 rounded-xl px-4 py-3 text-left text-red-600 transition-colors active:bg-red-500/10 dark:text-red-400"
+                  onClick={startMobileRename}
+                  className="flex min-h-12 w-full items-center gap-3 rounded-xl border border-border bg-muted/35 px-4 py-3 text-left text-foreground transition-colors active:bg-muted"
                 >
-                  <Trash2 className="h-5 w-5 flex-shrink-0" />
-                  <span className="text-sm font-medium">Archive or delete session</span>
+                  <Edit2 className="h-5 w-5 flex-shrink-0" />
+                  <span className="text-sm font-medium">Rename session</span>
                 </button>
-              )}
-            </div>
 
-            <button
-              type="button"
-              onClick={() => setMobileOptionsOpen(false)}
-              className="mb-3 mt-2 min-h-11 w-full rounded-xl text-sm font-medium text-muted-foreground transition-colors active:bg-muted"
-            >
-              Cancel
-            </button>
+                <button
+                  type="button"
+                  onClick={handleCopyAction}
+                  disabled={isCopyPending}
+                  className={cn(
+                    'flex min-h-12 w-full items-center gap-3 rounded-xl border px-4 py-3 text-left transition-colors',
+                    copyState === 'copied'
+                      ? 'border-green-500/30 bg-green-500/10 text-green-700 dark:text-green-300'
+                      : copyState === 'error'
+                        ? 'border-red-500/30 bg-red-500/10 text-red-700 dark:text-red-300'
+                        : 'border-border bg-muted/35 text-foreground active:bg-muted',
+                  )}
+                >
+                  {isCopyPending ? (
+                    <Loader2 className="h-5 w-5 flex-shrink-0 animate-spin" />
+                  ) : (
+                    <CopyStateIcon className="h-5 w-5 flex-shrink-0" />
+                  )}
+                  <span className="min-w-0 flex-1">
+                    <span className="block text-sm font-medium">{copyLabel}</span>
+                    {copyState === 'error' && (
+                      <span className="mt-0.5 block text-xs">Tap to try again.</span>
+                    )}
+                  </span>
+                </button>
+
+                {!isProcessing && (
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setMobileOptionsOpen(false);
+                      requestDeleteSession();
+                    }}
+                    className="flex min-h-12 w-full items-center gap-3 rounded-xl px-4 py-3 text-left text-red-600 transition-colors active:bg-red-500/10 dark:text-red-400"
+                  >
+                    <Trash2 className="h-5 w-5 flex-shrink-0" />
+                    <span className="text-sm font-medium">Archive or delete session</span>
+                  </button>
+                )}
+              </div>
+            )}
+
+            {!isEditing && (
+              <button
+                type="button"
+                onClick={() => setMobileOptionsOpen(false)}
+                className="mb-3 mt-2 min-h-11 w-full rounded-xl text-sm font-medium text-muted-foreground transition-colors active:bg-muted"
+              >
+                Cancel
+              </button>
+            )}
           </DialogContent>
         </Dialog>
       </div>
@@ -402,7 +476,12 @@ export default function SidebarSessionItem({
             </div>
             <div className="min-w-0 flex-1">
               <div className="flex items-center gap-2">
-                <div className="min-w-0 flex-1 truncate text-sm font-normal text-foreground">{sessionView.sessionName}</div>
+                <div
+                  className="min-w-0 flex-1 truncate text-sm font-normal text-foreground"
+                  title={sessionView.sessionName}
+                >
+                  {sessionView.sessionName}
+                </div>
                 {isProcessing ? (
                   <span
                     className={cn(
@@ -491,11 +570,19 @@ export default function SidebarSessionItem({
                 menuClassName="w-[260px] rounded-xl p-1.5 shadow-xl"
                 header={(
                   <div className="mb-1 border-b border-border px-3 py-2">
-                    <p className="truncate text-xs font-medium text-foreground">{sessionView.sessionName}</p>
+                    <p className="truncate text-xs font-medium text-foreground" title={sessionView.sessionName}>
+                      {sessionView.sessionName}
+                    </p>
                     <p className="mt-0.5 text-[11px] text-muted-foreground">{providerLabel} session</p>
                   </div>
                 )}
                 items={[
+                  {
+                    key: 'rename',
+                    label: 'Rename session',
+                    icon: Edit2,
+                    onSelect: () => onStartEditingSession(session.id, sessionView.sessionName),
+                  },
                   {
                     key: 'copy',
                     label: copyLabel,
@@ -504,12 +591,6 @@ export default function SidebarSessionItem({
                     loading: isCopyPending,
                     closeOnSelect: false,
                     onSelect: handleCopyAction,
-                  },
-                  {
-                    key: 'rename',
-                    label: 'Rename session',
-                    icon: Edit2,
-                    onSelect: () => onStartEditingSession(session.id, sessionView.sessionName),
                   },
                   ...(!isProcessing ? [{
                     key: 'delete',

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -111,6 +111,7 @@
     "permissions": "Permissions",
     "noFilesFound": "No files found",
     "checkProjectPath": "Check if the project path is accessible",
+    "loadFailed": "Unable to load files",
     "noMatchesFound": "No matches found",
     "tryDifferentSearch": "Try a different search term or clear the search",
     "justNow": "just now",

--- a/src/types/app.ts
+++ b/src/types/app.ts
@@ -4,6 +4,8 @@ export type ProviderModelOption = {
   value: string;
   label: string;
   description?: string;
+  recordId?: number;
+  isCustom?: boolean;
   effort?: {
     default?: string;
     values: {
@@ -18,10 +20,19 @@ export type ProviderModelsDefinition = {
   DEFAULT: string;
 };
 
-export type ProviderModelsCacheInfo = {
-  updatedAt: string;
-  expiresAt: string;
-  source: 'memory' | 'disk' | 'fresh';
+export type CustomProviderModelInput = {
+  model: string;
+  id: string;
+};
+
+export type ProviderModelActions = {
+  create(provider: LLMProvider, input: CustomProviderModelInput): Promise<void>;
+  update(
+    provider: LLMProvider,
+    existing: ProviderModelOption,
+    input: CustomProviderModelInput,
+  ): Promise<void>;
+  remove(provider: LLMProvider, existing: ProviderModelOption): Promise<void>;
 };
 
 export type AppTab = 'chat' | 'files' | 'shell' | 'git' | 'tasks' | 'browser' | `plugin:${string}`;


### PR DESCRIPTION
Closes #1088 
Closes #1082 

Supersedes PR #1083 
Supersedes PR #999 
Supersedes PR #1127 

This pull request introduces a new approach for naming chat sessions created via CloudCLI: the session name is now derived from the user's initial message, limited to four words, and is preserved as the authoritative title even after provider synchronization. The changes affect session creation logic, database handling, API endpoints, and tests to ensure consistent behavior across the stack.

**Session naming improvements:**

* When a new session is created from CloudCLI, the name is now set to the first four whole words of the initial user message, or "Untitled Session" if the message is empty. This name is passed through the stack and stored in the database. (`server/modules/providers/services/sessions.service.ts` [[1]](diffhunk://#diff-e23331b704fea9d841288d3bd8c506187ff5fd65b725cad09e7dac58dfbb2084R55-R61) [[2]](diffhunk://#diff-e23331b704fea9d841288d3bd8c506187ff5fd65b725cad09e7dac58dfbb2084L157-R173) [[3]](diffhunk://#diff-e23331b704fea9d841288d3bd8c506187ff5fd65b725cad09e7dac58dfbb2084L169-R190); `server/modules/database/repositories/sessions.db.ts` [[4]](diffhunk://#diff-1c8865f514e40d9b0f615f35cd097a2819ba18ce4ea68aa22a30bbdef10bf5fcL154-R180); `server/modules/providers/provider.routes.ts` [[5]](diffhunk://#diff-71fc6416a32d886c20cce49a0c5082d012aac009ae1dfbc503f77a00b1857cfaL555-R556); `src/components/chat/hooks/useChatComposerState.ts` [[6]](diffhunk://#diff-100f83f484b27e9ace28d0086f81d0904a7556c8f7ecc8bfad4f8d5877346d59R840-R857)
* The session name is now included in the API response when a session is created, and the frontend uses this value. (`server/modules/providers/services/sessions.service.ts` [[1]](diffhunk://#diff-e23331b704fea9d841288d3bd8c506187ff5fd65b725cad09e7dac58dfbb2084R20); `src/components/chat/hooks/useChatComposerState.ts` [[2]](diffhunk://#diff-100f83f484b27e9ace28d0086f81d0904a7556c8f7ecc8bfad4f8d5877346d59R840-R857)

**Database and synchronizer logic updates:**

* The database logic ensures that the custom session name set at creation is only overwritten by provider synchronizers if the session originated from the provider (not the app/CloudCLI). (`server/modules/database/repositories/sessions.db.ts` [[1]](diffhunk://#diff-1c8865f514e40d9b0f615f35cd097a2819ba18ce4ea68aa22a30bbdef10bf5fcL106-R111) [[2]](diffhunk://#diff-1c8865f514e40d9b0f615f35cd097a2819ba18ce4ea68aa22a30bbdef10bf5fcL133-R142)
* Synchronizer logic for both Codex and OpenCode providers is simplified: they now preserve the app-assigned session name for app-created sessions, never overwriting it with provider-discovered titles. (`server/modules/providers/list/codex/codex-session-synchronizer.provider.ts` [[1]](diffhunk://#diff-d5c0876f85bd9c90c48d2f96244f39cb7536f8d53aa03affbaf129888890f477L137-R137) [[2]](diffhunk://#diff-d5c0876f85bd9c90c48d2f96244f39cb7536f8d53aa03affbaf129888890f477L183-L225); `server/modules/providers/list/opencode/opencode-session-synchronizer.provider.ts` [[3]](diffhunk://#diff-75c060fdf5c0af8ea84cf99095788eb3cfe78c795f7f144dfc1800d0236887a1L133-L148)

**Testing enhancements:**

* New and updated tests ensure that session naming works as intended, including edge cases (e.g., empty messages, word limits) and that synchronizers do not overwrite app-assigned names. (`server/modules/providers/tests/provider.routes.test.ts` [[1]](diffhunk://#diff-2a401a44d56083002ed82425d362f626bb7cb77b7a00d5d0487c991292a3a994R1-R67); `server/modules/providers/tests/sessions.service.test.ts` [[2]](diffhunk://#diff-90fa6f13471f81cf016b300a414295490ec3a961cc12622b8b2af7e5e0e7b2f9R40-R64); `server/modules/database/tests/sessions-provider-mapping.test.ts` [[3]](diffhunk://#diff-49ad9e33742ea59a756335c64f4f6c19c36e37012369caac7e81e7bc3fbfa493L48-R48) [[4]](diffhunk://#diff-49ad9e33742ea59a756335c64f4f6c19c36e37012369caac7e81e7bc3fbfa493R69); `server/modules/providers/tests/codex-sessions.test.ts` [[5]](diffhunk://#diff-0d1471bbc0455ecf6a7602eee1787177315665fa806e19eabd924ad06aaa3bbcL67-R84); `server/modules/providers/tests/opencode-sessions.test.ts` [[6]](diffhunk://#diff-d8ef2b336b395d1578ebe557affd39b1030e380e071f11b32e25a5cd82a98f44L473-R488)

**Dependency update:**

* Upgraded `@openai/codex-sdk` to version `^0.146.0`. (`package.json` [package.jsonL149-R149](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L149-R149))

**Documentation and comments:**

* Clarified documentation and comments to reflect the new session naming logic and data flow. (`server/modules/database/repositories/sessions.db.ts` [[1]](diffhunk://#diff-1c8865f514e40d9b0f615f35cd097a2819ba18ce4ea68aa22a30bbdef10bf5fcL70-R72); `server/modules/database/repositories/sessions.db.ts` [[2]](diffhunk://#diff-1c8865f514e40d9b0f615f35cd097a2819ba18ce4ea68aa22a30bbdef10bf5fcL154-R180)

These changes ensure session titles are user-friendly, consistent, and reliably reflect the user's intent when starting a new chat from CloudCLI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
* Added a model library for creating, editing, and deleting custom provider models.
* Added provider-specific model catalogs, custom-model labels, and improved model selection.
* Reasoning effort selections now persist per session.
* New sessions receive names based on their initial message.
* Added mobile session renaming with save and cancel controls.

## Bug Fixes
* Improved compatibility with wrapped command and execution history.
* File-tree loading now shows clear errors and prevents excessively large trees.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->