### PR TITLE
fix: stop unbounded full-transcript refetch while chat tab is hidden + dedupe concurrent refreshes

### DIFF
--- a/src/components/chat/hooks/useChatRealtimeHandlers.ts
+++ b/src/components/chat/hooks/useChatRealtimeHandlers.ts
@@ -40,6 +40,8 @@ interface UseChatRealtimeHandlersArgs {
   onSessionIdle?: MarkSessionIdle;
   onWebSocketReconnect?: () => void;
   sessionStore: SessionStore;
+  /** Whether the chat tab is the currently visible tab. Defaults to true. */
+  isActiveTab?: boolean;
 }
 
 /* ------------------------------------------------------------------ */
@@ -71,6 +73,7 @@ export function useChatRealtimeHandlers({
   onSessionIdle,
   onWebSocketReconnect,
   sessionStore,
+  isActiveTab = true,
 }: UseChatRealtimeHandlersArgs) {
   // Session switches can send `chat.subscribe` before this effect has a chance
   // to rebind the websocket listener. Read the visible session id from a ref
@@ -258,7 +261,7 @@ export function useChatRealtimeHandlers({
           // before the first send), so the only follow-up is syncing the
           // viewed conversation with the now-persisted transcript.
           if (sid && sid === activeViewSessionId) {
-            void sessionStore.refreshFromServer(sid);
+            void sessionStore.requestRefreshFromServer(sid, { visible: isActiveTab });
           }
 
           break;
@@ -344,5 +347,6 @@ export function useChatRealtimeHandlers({
     onSessionIdle,
     onWebSocketReconnect,
     sessionStore,
+    isActiveTab,
   ]);
 }

--- a/src/components/chat/hooks/useChatSessionState.ts
+++ b/src/components/chat/hooks/useChatSessionState.ts
@@ -28,6 +28,8 @@ interface UseChatSessionStateArgs {
   /** Highest live seq observed per session; sent as `lastSeq` on subscribe. */
   lastSeqRef: MutableRefObject<Map<string, number>>;
   sessionStore: SessionStore;
+  /** Whether the chat tab is the currently visible tab. Defaults to true. */
+  isActiveTab?: boolean;
 }
 
 interface ScrollRestoreState {
@@ -107,6 +109,7 @@ export function useChatSessionState({
   statusCheckSentAtRef,
   lastSeqRef,
   sessionStore,
+  isActiveTab = true,
 }: UseChatSessionStateArgs) {
   const [currentSessionId, setCurrentSessionId] = useState<string | null>(selectedSession?.id || null);
   const [isLoadingSessionMessages, setIsLoadingSessionMessages] = useState(false);
@@ -589,9 +592,9 @@ export function useChatSessionState({
       try {
         // Skip store refresh during active streaming
         if (!isProcessing) {
-          await sessionStore.refreshFromServer(selectedSession.id);
+          await sessionStore.requestRefreshFromServer(selectedSession.id, { visible: isActiveTab });
 
-          if (isNearBottom()) {
+          if (isActiveTab && isNearBottom()) {
             setTimeout(() => scrollToBottom(), 200);
           }
         }
@@ -609,7 +612,16 @@ export function useChatSessionState({
     selectedSession,
     sessionStore,
     isProcessing,
+    isActiveTab,
   ]);
+
+  // Chat became the visible tab again: run any full-transcript refresh that
+  // was deferred (via requestRefreshFromServer) while it was hidden. No-op if
+  // nothing is pending.
+  useEffect(() => {
+    if (!isActiveTab || !selectedSession) return;
+    sessionStore.flushPendingRefresh(selectedSession.id);
+  }, [isActiveTab, selectedSession, sessionStore]);
 
   // Search navigation target
   useEffect(() => {

--- a/src/components/chat/types/types.ts
+++ b/src/components/chat/types/types.ts
@@ -123,6 +123,14 @@ export type SessionEstablishedContext = {
 };
 
 export interface ChatInterfaceProps {
+  /**
+   * Whether the chat tab is the currently visible tab. ChatInterface stays
+   * mounted (CSS-hidden) when another tab like Shell is active, so this is
+   * the only signal for whether its background refresh work is worth doing
+   * right now. Defaults to true when omitted so existing callers/tests are
+   * unaffected.
+   */
+  isActiveTab?: boolean;
   selectedProject: Project | null;
   selectedSession: ProjectSession | null;
   ws: WebSocket | null;

--- a/src/components/chat/view/ChatInterface.tsx
+++ b/src/components/chat/view/ChatInterface.tsx
@@ -17,6 +17,7 @@ import ChatComposer from './subcomponents/ChatComposer';
 import CommandResultModal from './subcomponents/CommandResultModal';
 
 function ChatInterface({
+  isActiveTab = true,
   selectedProject,
   selectedSession,
   ws,
@@ -135,6 +136,7 @@ function ChatInterface({
     statusCheckSentAtRef,
     lastSeqRef,
     sessionStore,
+    isActiveTab,
   });
 
   // Brand-new conversation: the composer allocated a stable session id via
@@ -227,7 +229,7 @@ function ChatInterface({
   // missed live events, and re-attaches a still-running stream to this socket.
   const handleWebSocketReconnect = useCallback(async () => {
     if (!selectedProject || !selectedSession) return;
-    await sessionStore.refreshFromServer(selectedSession.id);
+    await sessionStore.requestRefreshFromServer(selectedSession.id, { visible: isActiveTab });
     statusCheckSentAtRef.current.set(selectedSession.id, Date.now());
     sendMessage({
       type: 'chat.subscribe',
@@ -236,7 +238,7 @@ function ChatInterface({
         lastSeq: lastSeqRef.current.get(selectedSession.id) ?? 0,
       }],
     });
-  }, [selectedProject, selectedSession, sendMessage, sessionStore]);
+  }, [selectedProject, selectedSession, sendMessage, sessionStore, isActiveTab]);
 
   useChatRealtimeHandlers({
     subscribe,
@@ -254,6 +256,7 @@ function ChatInterface({
     onSessionIdle,
     onWebSocketReconnect: handleWebSocketReconnect,
     sessionStore,
+    isActiveTab,
   });
 
   useEffect(() => {

--- a/src/components/main-content/view/MainContent.tsx
+++ b/src/components/main-content/view/MainContent.tsx
@@ -160,6 +160,7 @@ function MainContent({
           <div className={`h-full ${activeTab === 'chat' ? 'block' : 'hidden'}`}>
             <ErrorBoundary showDetails>
               <ChatInterface
+                isActiveTab={activeTab === 'chat'}
                 selectedProject={selectedProject}
                 selectedSession={selectedSession}
                 ws={ws}

--- a/src/stores/useSessionStore.ts
+++ b/src/stores/useSessionStore.ts
@@ -110,6 +110,14 @@ export interface SessionSlot {
    */
   _fetchSeq: number;
   _appliedFetchSeq: number;
+  /**
+   * @internal Set when a `refreshFromServer` was requested while the chat
+   * view for this session wasn't visible (e.g. user parked on the Shell
+   * tab). The full-transcript refetch is deferred rather than dropped, and
+   * runs once the chat view becomes visible again - see
+   * `requestRefreshFromServer` / `flushPendingRefresh`.
+   */
+  _refreshPending: boolean;
   status: SessionStatus;
   fetchedAt: number;
   total: number;
@@ -135,6 +143,7 @@ function createEmptySlot(): SessionSlot {
     tokenUsage: null,
     _fetchSeq: 0,
     _appliedFetchSeq: 0,
+    _refreshPending: false,
   };
 }
 
@@ -614,6 +623,39 @@ export function useSessionStore() {
   }, [getSlot, notify]);
 
   /**
+   * Same full-transcript re-sync as `refreshFromServer`, but skips the fetch
+   * (marking it pending instead) when the caller reports its view isn't
+   * currently visible. Callers that always run while visible (e.g. the chat
+   * view refreshing itself) see identical behavior to calling
+   * `refreshFromServer` directly - this only changes what happens while
+   * nothing is actually rendering the transcript.
+   */
+  const requestRefreshFromServer = useCallback((
+    sessionId: string,
+    options: { visible: boolean },
+  ): Promise<void> => {
+    if (!options.visible) {
+      getSlot(sessionId)._refreshPending = true;
+      return Promise.resolve();
+    }
+    getSlot(sessionId)._refreshPending = false;
+    return refreshFromServer(sessionId);
+  }, [getSlot, refreshFromServer]);
+
+  /**
+   * Runs the deferred refresh from `requestRefreshFromServer`, if one is
+   * pending, once the caller's view becomes visible again. No-op otherwise.
+   */
+  const flushPendingRefresh = useCallback((sessionId: string) => {
+    const slot = getSlot(sessionId);
+    if (!slot._refreshPending) {
+      return;
+    }
+    slot._refreshPending = false;
+    void refreshFromServer(sessionId);
+  }, [getSlot, refreshFromServer]);
+
+  /**
    * Update session status.
    */
   const setStatus = useCallback((sessionId: string, status: SessionStatus) => {
@@ -714,6 +756,8 @@ export function useSessionStore() {
     appendRealtime,
     appendRealtimeBatch,
     refreshFromServer,
+    requestRefreshFromServer,
+    flushPendingRefresh,
     setActiveSession,
     setStatus,
     isStale,
@@ -725,6 +769,7 @@ export function useSessionStore() {
   }), [
     getSlot, has, fetchFromServer, fetchMore,
     appendRealtime, appendRealtimeBatch, refreshFromServer,
+    requestRefreshFromServer, flushPendingRefresh,
     setActiveSession, setStatus, isStale, updateStreaming, finalizeStreaming,
     clearRealtime, getMessages, getSessionSlot,
   ]);

--- a/src/stores/useSessionStore.ts
+++ b/src/stores/useSessionStore.ts
@@ -583,9 +583,9 @@ export function useSessionStore() {
   /**
    * Re-fetch serverMessages from the provider sessions endpoint.
    */
-  const refreshFromServer = useCallback(async (
+  const performRefreshFromServer = useCallback(async (
     sessionId: string,
-  ) => {
+  ): Promise<void> => {
     const slot = getSlot(sessionId);
     const fetchTicket = ++slot._fetchSeq;
     try {
@@ -621,6 +621,30 @@ export function useSessionStore() {
       console.error(`[SessionStore] refresh failed for ${sessionId}:`, error);
     }
   }, [getSlot, notify]);
+
+  /**
+   * Multiple independent signals (a `complete` websocket event and a
+   * `session_upserted`-driven `externalMessageUpdate` effect, for example)
+   * can both react to the same underlying turn and call `refreshFromServer`
+   * within milliseconds of each other. Since that fetch is unbounded (the
+   * full transcript, by design), sharing one in-flight request instead of
+   * firing a second one avoids doubling an already-expensive full-history
+   * download for no benefit - both callers only care that the store ends up
+   * current, not which of them triggered it.
+   */
+  const inFlightRefreshRef = useRef(new Map<string, Promise<void>>());
+  const refreshFromServer = useCallback((sessionId: string): Promise<void> => {
+    const existing = inFlightRefreshRef.current.get(sessionId);
+    if (existing) {
+      return existing;
+    }
+
+    const promise = performRefreshFromServer(sessionId).finally(() => {
+      inFlightRefreshRef.current.delete(sessionId);
+    });
+    inFlightRefreshRef.current.set(sessionId, promise);
+    return promise;
+  }, [performRefreshFromServer]);
 
   /**
    * Same full-transcript re-sync as `refreshFromServer`, but skips the fetch


### PR DESCRIPTION
Split out of #1087 at @blackmammoth's request - this PR contains only the first 2 of that PR's 4 commits, which were confirmed fine to merge as-is:

1. `c16eda4` fix: stop unbounded full-transcript refetch while chat tab is hidden
2. `ddc7855` fix: dedupe concurrent refreshFromServer calls for the same session

The other 2 commits (bounding `refreshFromServer` to a tail refetch, and the related constant rename) are reopened separately in #TBD since they were reported to introduce bugs - tracked in #1100.

## What this PR does

`ChatInterface` stays mounted (CSS-hidden) when another tab like Shell is active, so its websocket-driven `refreshFromServer()` calls kept firing on every turn/JSONL change regardless of visibility, each re-downloading the entire session transcript unbounded. For a long-running session that's a repeated multi-MB background download.

- Adds `requestRefreshFromServer()`, which defers the refetch (instead of dropping it) when the caller reports the chat view isn't visible, and `flushPendingRefresh()`, which runs the deferred refetch exactly once when the chat tab becomes visible again. Visible-tab behavior is unchanged.
- Dedupes concurrent `refreshFromServer` calls for the same session so two near-simultaneous triggers (complete-event handler + externalMessageUpdate effect firing within milliseconds of each other) share a single in-flight request instead of paying for the unbounded fetch twice.

Original diagnostics from #1087 (pre/post patch bandwidth totals) still apply to this subset.

Closes part of #1087.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved chat updates when switching between active and hidden tabs.
  * Deferred refreshes now automatically run when returning to a chat tab.
  * Prevented duplicate transcript refreshes during concurrent updates.

* **Bug Fixes**
  * Reduced unnecessary auto-scrolling and refresh activity while a chat tab is hidden.
  * Improved transcript synchronization after reconnecting or receiving external messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->