### PR TITLE
fix: bound refreshFromServer to a tail refetch instead of full history (reopen, needs bug details)

### DIFF
--- a/src/components/chat/hooks/useChatSessionState.ts
+++ b/src/components/chat/hooks/useChatSessionState.ts
@@ -4,13 +4,12 @@ import type { MutableRefObject } from 'react';
 import { authenticatedFetch } from '../../../utils/api';
 import type { MarkSessionIdle, SessionActivityMap } from '../../../hooks/useSessionProtection';
 import type { Project, ProjectSession, LLMProvider } from '../../../types/app';
-import type { SessionStore, NormalizedMessage } from '../../../stores/useSessionStore';
+import { MESSAGES_PER_PAGE, type SessionStore, type NormalizedMessage } from '../../../stores/useSessionStore';
 import type { ChatMessage } from '../types/types';
 import { createCachedDiffCalculator, type DiffCalculator } from '../utils/messageTransforms';
 
 import { normalizedToChatMessages } from './useChatMessages';
 
-const MESSAGES_PER_PAGE = 20;
 const INITIAL_VISIBLE_MESSAGES = 100;
 
 interface UseChatSessionStateArgs {

--- a/src/stores/useSessionStore.ts
+++ b/src/stores/useSessionStore.ts
@@ -118,6 +118,13 @@ export interface SessionSlot {
   tokenUsage: unknown;
 }
 
+/**
+ * Page size for the initial session load and for refreshFromServer's
+ * bounded tail refetch - see performRefreshFromServer. Shared with
+ * useChatSessionState's own pagination so both agree on what "a page" means.
+ */
+export const MESSAGES_PER_PAGE = 20;
+
 const EMPTY: NormalizedMessage[] = [];
 
 function createEmptySlot(): SessionSlot {
@@ -572,7 +579,16 @@ export function useSessionStore() {
   }, [getSlot, notify]);
 
   /**
-   * Re-fetch serverMessages from the provider sessions endpoint.
+   * Re-sync serverMessages with the provider sessions endpoint.
+   *
+   * Fetches only the most recent MESSAGES_PER_PAGE messages (a `complete`
+   * event or external update can only plausibly have changed the tail of
+   * the conversation, never history further back) and merges it into
+   * whatever is already loaded, rather than replacing the whole array. For
+   * a session with tens of thousands of messages, refetching everything on
+   * every turn is both a severe bandwidth cost and pointless: older pages
+   * the user already scrolled through, or loaded in full via "Load all
+   * messages", aren't going to change underneath them.
    */
   const refreshFromServer = useCallback(async (
     sessionId: string,
@@ -580,12 +596,16 @@ export function useSessionStore() {
     const slot = getSlot(sessionId);
     const fetchTicket = ++slot._fetchSeq;
     try {
-      const url = `/api/providers/sessions/${encodeURIComponent(sessionId)}/messages`;
+      const params = new URLSearchParams();
+      params.append('limit', String(MESSAGES_PER_PAGE));
+      params.append('offset', '0');
+      const url = `/api/providers/sessions/${encodeURIComponent(sessionId)}/messages?${params.toString()}`;
       const response = await authenticatedFetch(url);
 
       if (!response.ok) throw new Error(`HTTP ${response.status}`);
       const body = await response.json();
       const data = body?.data ?? body;
+      const freshTail: NormalizedMessage[] = data.messages || [];
 
       // A later-started fetch already applied: applying this stale transcript
       // would erase rows the user has already seen (and re-prune realtime
@@ -595,9 +615,27 @@ export function useSessionStore() {
       }
       slot._appliedFetchSeq = fetchTicket;
 
-      slot.serverMessages = data.messages || [];
-      slot.total = data.total ?? slot.serverMessages.length;
-      slot.hasMore = Boolean(data.hasMore);
+      // Drop whichever previously-loaded rows the fresh tail supersedes
+      // (matched by id, stable across fetches - see raw.uuid in the Claude
+      // provider), then append the fresh tail. Anything older than the tail
+      // - already-loaded pages, or a full "Load all messages" history - is
+      // left untouched.
+      const freshIds = new Set(freshTail.map((message) => message.id));
+      const previousMessages = slot.serverMessages.filter((message) => !freshIds.has(message.id));
+      slot.serverMessages = [...previousMessages, ...freshTail];
+      slot.total = data.total ?? slot.total;
+
+      // A bounded tail page's own hasMore only describes that one page. Once
+      // everything has actually been loaded locally (hasMore already false -
+      // e.g. after "Load all messages", or a short session that fit in one
+      // page), merging in a fresher tail can't make the rest of the history
+      // disappear, so leave hasMore/offset alone. Otherwise keep tracking
+      // how much is actually loaded, same as the initial paginated load.
+      const hadLoadedAnything = slot.fetchedAt > 0;
+      if (!hadLoadedAnything || slot.hasMore) {
+        slot.hasMore = Boolean(data.hasMore);
+        slot.offset = slot.serverMessages.length;
+      }
       slot.fetchedAt = Date.now();
       // Only drop realtime rows the server transcript now owns. A blind clear
       // here caused the chat pane to flash "Continue your conversation" after

--- a/src/stores/useSessionStore.ts
+++ b/src/stores/useSessionStore.ts
@@ -505,7 +505,7 @@ export function useSessionStore() {
 
     const fetchTicket = ++slot._fetchSeq;
     const params = new URLSearchParams();
-    const limit = opts.limit ?? 20;
+    const limit = opts.limit ?? MESSAGES_PER_PAGE;
     params.append('limit', String(limit));
     params.append('offset', String(slot.offset));
 


### PR DESCRIPTION
Split out of #1087 at @blackmammoth's request. This PR contains the other 2 of that PR's 4 commits, which were flagged as introducing bugs ("especially the last 2 commits") without further detail:

1. `f6c0b0c` fix: bound refreshFromServer to a tail refetch instead of full history
2. `147a522` fix: use shared MESSAGES_PER_PAGE constant in fetchMore's default limit

Tracking issue for the reported bugs: #1100 - @blackmammoth (or whoever hit them), repro steps / what broke would help get this landed correctly. Without this, switching from Shell back to Chat still triggers a full-transcript refetch, which on a large session (~50MB in testing) is the same bandwidth cost #1087's other half already eliminated for the hidden-tab case.

## What this PR does

For a session with tens of thousands of messages, `refreshFromServer` was redownloading the entire transcript (confirmed live: ~24MB per call) on every complete/external-update event, even though a turn completing can only plausibly change the tail of the conversation.

- Fetches only the most recent `MESSAGES_PER_PAGE` messages and merges them into whatever's already loaded (matched by `id`, stable across fetches - Claude history messages carry the JSONL record's own `uuid`) instead of replacing the array outright.
- Older pages loaded via "load more", or the full history loaded via "Load all X messages", are left untouched; `hasMore`/`offset` are only touched when nothing complete was loaded yet, so an already-fully-loaded session can't have its completeness silently reverted by a routine tail sync.
- `MESSAGES_PER_PAGE` is now defined once in `useSessionStore` and imported by `useChatSessionState`, rather than duplicated in both (commit 2, a CodeRabbit suggestion).

Not merging blind - opening this to get the specific regression(s) identified (see #1100) rather than resubmitting silently and hoping it's fine this time.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chat history refresh behavior by preserving previously loaded messages.
  * Refreshes now update existing messages accurately while retaining older conversation history.
  * Pagination state is better preserved when the full history is already available.

* **Refactor**
  * Standardized chat history page sizes across session loading and pagination.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->