### PR TITLE
feat(editor): add copy button for file path with non-secure context fallback

### DIFF
--- a/src/components/code-editor/view/CodeEditor.tsx
+++ b/src/components/code-editor/view/CodeEditor.tsx
@@ -276,6 +276,8 @@ export default function CodeEditor({
               fullscreen: t('actions.fullscreen'),
               exitFullscreen: t('actions.exitFullscreen'),
               close: t('actions.close'),
+              copyPath: t('actions.copyPath', 'Copy path'),
+              pathCopied: t('actions.pathCopied', 'Copied!'),
             }}
           />
 

--- a/src/components/code-editor/view/subcomponents/CodeEditorHeader.tsx
+++ b/src/components/code-editor/view/subcomponents/CodeEditorHeader.tsx
@@ -1,6 +1,36 @@
-import { Code2, Download, Eye, Maximize2, Minimize2, Save, Settings as SettingsIcon, X } from 'lucide-react';
+import { useState } from 'react';
+import { Check, Code2, Copy, Download, Eye, Maximize2, Minimize2, Save, Settings as SettingsIcon, X } from 'lucide-react';
 
 import type { CodeEditorFile } from '../../types/types';
+
+// navigator.clipboard is only defined in secure contexts (HTTPS or localhost);
+// this app is often accessed over plain http on a LAN/Tailscale IP, so we need
+// the old execCommand fallback or the copy button silently no-ops.
+function copyTextToClipboard(text: string): boolean {
+  if (navigator.clipboard && window.isSecureContext) {
+    navigator.clipboard.writeText(text).catch(() => copyTextViaTextarea(text));
+    return true;
+  }
+  return copyTextViaTextarea(text);
+}
+
+function copyTextViaTextarea(text: string): boolean {
+  const textarea = document.createElement('textarea');
+  textarea.value = text;
+  textarea.style.position = 'fixed';
+  textarea.style.opacity = '0';
+  document.body.appendChild(textarea);
+  textarea.focus();
+  textarea.select();
+  let succeeded = false;
+  try {
+    succeeded = document.execCommand('copy');
+  } catch {
+    succeeded = false;
+  }
+  document.body.removeChild(textarea);
+  return succeeded;
+}
 
 type CodeEditorHeaderProps = {
   file: CodeEditorFile;
@@ -31,6 +61,8 @@ type CodeEditorHeaderProps = {
     fullscreen: string;
     exitFullscreen: string;
     close: string;
+    copyPath: string;
+    pathCopied: string;
   };
 };
 
@@ -54,6 +86,15 @@ export default function CodeEditorHeader({
 }: CodeEditorHeaderProps) {
   const saveTitle = saveSuccess ? labels.saved : saving ? labels.saving : labels.save;
 
+  const [pathCopied, setPathCopied] = useState(false);
+
+  const handleCopyPath = () => {
+    if (copyTextToClipboard(file.path)) {
+      setPathCopied(true);
+      setTimeout(() => setPathCopied(false), 2000);
+    }
+  };
+
   return (
     <div className="flex min-w-0 flex-shrink-0 items-center justify-between gap-2 border-b border-border px-3 py-1.5">
       {/* File info - can shrink */}
@@ -67,7 +108,19 @@ export default function CodeEditorHeader({
               </span>
             )}
           </div>
-          <p className="truncate text-xs text-gray-500 dark:text-gray-400">{file.path}</p>
+          <div className="flex min-w-0 items-center gap-1">
+            <p className="truncate text-xs text-gray-500 dark:text-gray-400" title={file.path}>
+              {file.path}
+            </p>
+            <button
+              type="button"
+              onClick={handleCopyPath}
+              className="flex shrink-0 items-center justify-center rounded p-0.5 text-gray-400 hover:bg-gray-100 hover:text-gray-700 dark:text-gray-500 dark:hover:bg-gray-800 dark:hover:text-gray-300"
+              title={pathCopied ? labels.pathCopied : labels.copyPath}
+            >
+              {pathCopied ? <Check className="h-3 w-3 text-green-600 dark:text-green-400" /> : <Copy className="h-3 w-3" />}
+            </button>
+          </div>
         </div>
       </div>
 

--- a/src/i18n/locales/en/codeEditor.json
+++ b/src/i18n/locales/en/codeEditor.json
@@ -22,7 +22,9 @@
     "fullscreen": "Fullscreen",
     "close": "Close",
     "previewMarkdown": "Preview markdown",
-    "editMarkdown": "Edit markdown"
+    "editMarkdown": "Edit markdown",
+    "copyPath": "Copy path",
+    "pathCopied": "Copied!"
   },
   "footer": {
     "lines": "Lines:",


### PR DESCRIPTION
## What

Adds a copy button next to the file path in the code editor header.

## Why

Two reasons:

1. Copying a file path currently means selecting truncated text by hand, and the
   path is often ellipsised so the selection is incomplete.
2. `navigator.clipboard` is only defined in secure contexts. When the UI is
   reached over plain HTTP on a LAN or Tailscale IP - a common setup for this
   project, and the one I run daily - every clipboard call silently no-ops. This
   PR adds the `document.execCommand('copy')` fallback for that case.

## How

- New `copyTextToClipboard` helper: uses the async Clipboard API when
  `window.isSecureContext` is true, falls back to an offscreen textarea +
  `document.execCommand('copy')` otherwise, and also falls back if the async
  call rejects.
- Copy icon sits next to the path, swaps to a check icon for 2 seconds on
  success.
- The path now also carries a `title` attribute so the full path shows on hover
  when truncated.
- Two new keys in `en/codeEditor.json` (`actions.copyPath`, `actions.pathCopied`).
  Other locales fall back automatically because the call sites pass a default:
  `t('actions.copyPath', 'Copy path')`.

## Screenshots

**Default header:**
<img width="729" height="359" alt="Screenshot 2026-08-05 at 15 12 13" src="https://github.com/user-attachments/assets/e39b02d2-a057-47ae-a127-15e3806a8b62" />


**Hover reveals the copy button (tooltip):**
<img width="670" height="307" alt="Screenshot 2026-08-05 at 15 12 06" src="https://github.com/user-attachments/assets/a354487c-d3d7-44d4-a379-bde5bba922c1" />

## Testing

- `npm run lint` - no new warnings (the 2 changed .tsx files lint clean)
- `npm run typecheck` - passes
- `npm run build` - passes
- Verified manually over HTTPS on localhost and over plain HTTP on a Tailscale
  IP, where the button previously did nothing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an option to copy a file’s path directly from the code editor.
  * Added confirmation feedback after the path is copied.
  * Added localized labels for the new action in the editor interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->