### PR TITLE
fix(commands): only flag real `!command` directives as bash commands

### DIFF
--- a/server/modules/commands/commands.routes.ts
+++ b/server/modules/commands/commands.routes.ts
@@ -582,7 +582,12 @@ router.post("/execute", async (req, res) => {
       content: processedContent,
       metadata,
       hasFileIncludes: processedContent.includes("@"),
-      hasBashCommands: processedContent.includes("!"),
+      // Match the documented `!command` syntax (a bang starting a line), not any
+      // bang anywhere in the file. A bare `includes("!")` fires on ordinary prose
+      // and on markdown image embeds, so command files that never invoke bash still
+      // triggered the "contains bash commands" confirmation. `(?!\[)` keeps
+      // line-leading `![alt](src)` image syntax from counting as a bash directive.
+      hasBashCommands: /^\s*!(?!\[)\S/m.test(processedContent),
     });
   } catch (error) {
     if (error.code === "ENOENT") {


### PR DESCRIPTION
### Problem

`POST /api/commands/execute` sets `hasBashCommands` with a bare substring test:

```ts
// server/modules/commands/commands.routes.ts
hasBashCommands: processedContent.includes("!"),
```

That matches **any** exclamation mark anywhere in a command file. The client gates a blocking dialog on it:

```ts
// src/components/chat/hooks/useChatComposerState.ts
if (hasBashCommands) {
  const confirmed = window.confirm(
    'This command contains bash commands that will be executed. Do you want to proceed?',
  );
```

So a command file whose only `!` characters are ordinary prose punctuation — or a markdown image embed like `![alt](src)` — prompts the user on **every single invocation**.

Concretely: a 42 KB command file in my setup contains exactly two `!` characters, neither at the start of a line and neither a bash directive. It prompted on every run.

Worth noting the endpoint doesn't execute bash at all — its own comment says *"prepares the command content but doesn't execute bash commands yet"* — so the dialog is warning about something this path doesn't do. This PR doesn't change that; it just stops the flag firing on files with no directives.

### Fix

Detect the syntax this file's own help text documents (line 237: **Bash Commands**: Use `` `!command` `` to execute bash commands) — a bang that begins a line:

```ts
hasBashCommands: /^\s*!(?!\[)\S/m.test(processedContent),
```

The `(?!\[)` guard stops line-leading `![alt](src)` markdown images counting as directives, which matters for command files that document or emit image embeds.

### Verification

| Input | Before | After | Correct |
|---|---|---|---|
| Real 42 KB command file, 2 inline `!` | `true` | `false` | ✅ |
| `!git status` at line start | `true` | `true` | ✅ |
| `  !npm test` (indented) | `true` | `true` | ✅ |
| `![screenshot](img.png)` at line start | `true` | `false` | ✅ |
| `Stampin Up! is the client.` | `true` | `false` | ✅ |
| `Use a!=b in the query.` | `true` | `false` | ✅ |
| No `!` at all | `false` | `false` | ✅ |

Genuine directives still set the flag; only the false positives stop. `tsc --noEmit -p server/tsconfig.json` passes and the eslint pre-commit hook is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved custom command handling so Bash directives are recognized only when `!command` appears at the start of a line.
  * Exclamation marks used elsewhere are no longer incorrectly interpreted as Bash content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->