### PR TITLE
fix(composer): let the footer hint truncate instead of pushing the layout

### DIFF
--- a/src/components/chat/view/subcomponents/ChatComposer.tsx
+++ b/src/components/chat/view/subcomponents/ChatComposer.tsx
@@ -379,8 +379,8 @@ export default function ChatComposer({
             />
         </PromptInputBody>
 
-        <PromptInputFooter>
-          <PromptInputTools className="min-w-0">
+        <PromptInputFooter className="gap-2">
+          <PromptInputTools className="shrink-0">
             <PromptInputButton
               tooltip={{ content: t('input.attachFiles') }}
               onClick={openAttachmentPicker}
@@ -422,9 +422,9 @@ export default function ChatComposer({
 
           </PromptInputTools>
 
-          <div className="flex shrink-0 items-center gap-1.5 sm:gap-2">
+          <div className="flex min-w-0 items-center gap-1.5 sm:gap-2">
             <div
-              className={`hidden text-xs text-muted-foreground/50 transition-opacity duration-200 lg:block ${
+              className={`hidden min-w-0 truncate text-xs text-muted-foreground/50 transition-opacity duration-200 xl:block ${
                 input.trim() && !canQueueDraft ? 'opacity-0' : 'opacity-100'
               }`}
             >


### PR DESCRIPTION
## Problem

The two flex children of `PromptInputFooter` had their sizing constraints the wrong way round:

- `PromptInputTools` (left) was `min-w-0` — free to compress
- the row holding the hint text (right) was `shrink-0` — refusing to

So with a long hint, the text could not shrink and pushed against the tools row instead of giving way. The hint also had no `truncate`, so it overflowed rather than ellipsing.

## Change

- Swap which side compresses: tools become `shrink-0`, the hint row becomes `min-w-0`.
- Add `truncate` (and `min-w-0`) to the hint so it ellipses inside the space it is given.
- Add `gap-2` to the footer so the two sides keep a gap once they are genuinely adjacent.
- Move the hint from `lg:block` to `xl:block` — at `lg` there is not enough room for it to be useful even truncated.

## Notes

Layout-only; no behaviour or state changes. `npm run lint` passes (ran via the repo's lint-staged hook on commit).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved responsive chat composer layout.
  * Preserved tool controls while allowing submit controls to resize and truncate on smaller screens.
  * Submission hints now appear only on extra-large screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->