### PR TITLE
feat(plugins): recommend Codex Usage plugin

### DIFF
--- a/src/components/plugins/view/PluginSettingsTab.tsx
+++ b/src/components/plugins/view/PluginSettingsTab.tsx
@@ -35,6 +35,7 @@ const TOKEN_COST_CALCULATOR_PLUGIN_URL = 'https://github.com/NightmareAway/cloud
 const TASK_QUEUE_PLUGIN_URL = 'https://github.com/TadMSTR/cloudcli-plugin-task-queue';
 const GITHUB_ISSUES_BOARD_PLUGIN_URL = 'https://github.com/szmidtpiotr/claude-github-issue';
 const CLAUDE_USAGE_PLUGIN_URL = 'https://github.com/HandyS11/cloudcli-plugin-claude-usage';
+const CODEX_USAGE_PLUGIN_URL = 'https://github.com/dongwook-chan/cloudcli-plugin-codex-usage';
 
 type PluginRecommendation = {
   id: string;
@@ -126,6 +127,14 @@ const UNOFFICIAL_PLUGIN_RECOMMENDATIONS: PluginRecommendation[] = [
     translationKey: 'claudeUsagePlugin',
     repoUrl: CLAUDE_USAGE_PLUGIN_URL,
     installedNames: ['claude-usage'],
+    icon: BarChart3,
+    source: 'unofficial',
+  },
+  {
+    id: 'codex-usage',
+    translationKey: 'codexUsagePlugin',
+    repoUrl: CODEX_USAGE_PLUGIN_URL,
+    installedNames: ['codex-usage'],
     icon: BarChart3,
     source: 'unofficial',
   },

--- a/src/i18n/locales/en/settings.json
+++ b/src/i18n/locales/en/settings.json
@@ -568,6 +568,12 @@
       "description": "Track live Claude Code plan limits and explore 30-day token and cost history.",
       "install": "Install"
     },
+    "codexUsagePlugin": {
+      "name": "Codex Usage",
+      "badge": "unofficial",
+      "description": "Track live Codex plan limits, reset timing, and 30-day account token activity.",
+      "install": "Install"
+    },
     "morePlugins": "More",
     "enable": "Enable",
     "disable": "Disable",


### PR DESCRIPTION
Related to #1003.

## What changed

- Add the public `Codex Usage` plugin to the unofficial recommendations in **Settings → Plugins**.
- Match installed plugins by both the `codex-usage` manifest name and repository URL.
- Add the English recommendation name and description used by the install card.

## Why

Issue #1003 asked for proactive quota visibility, and the existing resolution points users to the Claude Usage plugin. Codex users now have a corresponding plugin, but there was no discoverable install path in CloudCLI.

The standalone implementation lives at [dongwook-chan/cloudcli-plugin-codex-usage](https://github.com/dongwook-chan/cloudcli-plugin-codex-usage). It displays live Codex plan limits, reset timing and available resets, plus 30-day account token activity. It uses the official `codex app-server` account methods and does not read or store authentication tokens.

This PR stays deliberately narrow: it only adds recommendation metadata to CloudCLI. The plugin remains independently installable and reviewable, matching the existing Claude Usage integration pattern.

## Screenshot

![Codex Usage enabled and running in Settings → Plugins](https://raw.githubusercontent.com/dongwook-chan/cloudcli-plugin-codex-usage/main/docs/settings-card.png)

## Test plan

- [x] `npm run lint` — 0 errors; existing repository warnings only
- [x] `npm run typecheck`
- [x] `npm run build` — passes with the existing CSS minification and bundle-size warnings
- [x] Installed the plugin from its public Git repository and verified CloudCLI detects it as enabled
- [x] Verified the installed backend against a real Codex account for both rate-limit and 30-day activity responses



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a recommendation for the Codex Usage plugin in plugin settings.
  * Included plugin details such as its name, icon, installation option, repository link, and unofficial status.
  * Added English text describing the plugin and its usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->