### PR TITLE
fix(claude): remove dead CLAUDE_CODE_STREAM_CLOSE_TIMEOUT workaround

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,6 +28,12 @@ HOST=0.0.0.0
 # Uncomment the following line if you have a custom claude cli path other than the default "claude"
 # CLAUDE_CLI_PATH=claude
 
+# How long the Claude CLI waits for still-running background agents after a turn ends before
+# killing them (default: 600000 ms / 10 minutes; 0 = wait indefinitely). Raise it if long-running
+# background agents are cut short and later report "No completion record was found".
+# The server's environment is forwarded to every spawned CLI, so setting it here is enough.
+# CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS=600000
+
 # =============================================================================
 # DATABASE CONFIGURATION
 # =============================================================================

--- a/server/modules/providers/list/claude/claude-runtime.provider.js
+++ b/server/modules/providers/list/claude/claude-runtime.provider.js
@@ -165,6 +165,9 @@ function mapCliOptionsToSDK(options = {}) {
 
   // Forward all host env vars (e.g. ANTHROPIC_BASE_URL) to the subprocess.
   // Since SDK 0.2.113, options.env replaces process.env instead of overlaying it.
+  // This snapshot is also how CLI-side knobs reach the child: e.g. how long the CLI waits for
+  // still-running background agents after a turn ends is set by CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS
+  // (default 600000 ms; 0 = wait indefinitely) on this server's own environment.
   sdkOptions.env = { ...process.env };
 
   // Resolve the executable eagerly on Windows because the SDK uses raw child_process.spawn,
@@ -610,10 +613,6 @@ async function queryClaudeSDK(command, options = {}, ws, context) {
       return { behavior: 'deny', message: decision.message ?? 'User denied tool use' };
     };
 
-    // Query constructor reads this synchronously.
-    const prevStreamTimeout = process.env.CLAUDE_CODE_STREAM_CLOSE_TIMEOUT;
-    process.env.CLAUDE_CODE_STREAM_CLOSE_TIMEOUT = '300000';
-
     let queryInstance;
     try {
       queryInstance = query({
@@ -629,13 +628,6 @@ async function queryClaudeSDK(command, options = {}, ws, context) {
         prompt: await createPrompt(),
         options: sdkOptions
       });
-    }
-
-    // Restore immediately — Query constructor already captured the value
-    if (prevStreamTimeout !== undefined) {
-      process.env.CLAUDE_CODE_STREAM_CLOSE_TIMEOUT = prevStreamTimeout;
-    } else {
-      delete process.env.CLAUDE_CODE_STREAM_CLOSE_TIMEOUT;
     }
 
     // Track the query instance for abort capability


### PR DESCRIPTION
## Problem

Background agents still running 10 minutes after a turn ends are silently killed; the next message in that session surfaces Claude Code's orphan notice: *"No completion record was found for background agent…"*

`claude-runtime.provider.js` appears to guard against this by bumping a timeout around `query()`:

```js
// Query constructor reads this synchronously.
process.env.CLAUDE_CODE_STREAM_CLOSE_TIMEOUT = '300000';
```

## Root cause

The block is dead twice over:

1. **The value never reaches the spawned CLI.** The child's env is snapshotted earlier, in
   `mapCliOptionsToSDK()` (`sdkOptions.env = { ...process.env }`), and since SDK 0.2.113
   `options.env` *replaces* the child's environment rather than overlaying it. Mutating
   `process.env` after the snapshot can't affect it.
2. **The variable doesn't exist.** A byte-level string search of the `claude` v2.1.223 binary has zero hits for `CLAUDE_CODE_STREAM_CLOSE_TIMEOUT`, and the CLI's env-var manifest never declares it.

## Fix

Remove the set/restore block. Nothing replaces it in code, because the real knob already works: `CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS` controls how long the CLI (stream-json/print mode) waits for still-running background agents after a turn ends before killing them — default `600000` (the 10 minutes users are hitting), `0` = wait indefinitely. The env snapshot already forwards the server's environment to every spawned CLI, so operators can set it today with no code change.

This PR therefore just documents it: a comment at the env snapshot naming the variable, and a
commented-out entry in `.env.example` next to `CLAUDE_CLI_PATH`.

**No behavior change** — dead-code removal plus documentation.

## Testing

Self-attested (no CI in this repo), on a branch off `main`:

- `npm run build` — pass (client + server tsc)
- `npm run typecheck` — pass
- `npm run lint` — 0 errors (214 pre-existing warnings, none in the touched file)
- `npm test` — 253/253 pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added configuration guidance for controlling how long the Claude CLI waits for background agents after a turn ends.
  * Documented that host environment variables can be forwarded to the Claude SDK.
* **Bug Fixes**
  * Removed temporary environment handling that could affect stream-close timeout behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->