### PR TITLE
fix(auth): rate-limit login and registration per client (P2)

### DIFF
--- a/server/modules/auth/auth.routes.ts
+++ b/server/modules/auth/auth.routes.ts
@@ -2,8 +2,23 @@ import express from 'express';
 import type { RequestHandler } from 'express';
 
 import type { createAuthService } from './auth.service.js';
+import { createRateLimiter } from './rate-limit.middleware.js';
 
 type AuthenticatedRequest = express.Request & { user?: unknown };
+
+// 10 attempts per IP per minute is generous for legitimate use (the only
+// registered user is the local admin) but tight enough to slow down online
+// credential stuffing. Lockouts extend the window by an additional minute so
+// a misconfigured client cannot hammer the endpoint forever.
+const AUTH_RATE_LIMIT_MAX = 10;
+const AUTH_RATE_LIMIT_WINDOW_MS = 60_000;
+const AUTH_RATE_LIMIT_LOCKOUT_MS = 60_000;
+
+const authRateLimit = createRateLimiter({
+  maxAttempts: AUTH_RATE_LIMIT_MAX,
+  windowMs: AUTH_RATE_LIMIT_WINDOW_MS,
+  lockoutMs: AUTH_RATE_LIMIT_LOCKOUT_MS,
+});
 
 /**
  * Creates the Auth transport adapter. Handlers only parse request data and
@@ -23,7 +38,7 @@ export function createAuthRouter(
     }
   });
 
-  router.post('/register', async (req, res, next) => {
+  router.post('/register', authRateLimit.middleware, async (req, res, next) => {
     try {
       const body = req.body as { username?: unknown; password?: unknown };
       res.json(await service.register(body.username, body.password));
@@ -32,7 +47,7 @@ export function createAuthRouter(
     }
   });
 
-  router.post('/login', async (req, res, next) => {
+  router.post('/login', authRateLimit.middleware, async (req, res, next) => {
     try {
       const body = req.body as { username?: unknown; password?: unknown };
       res.json(await service.login(body.username, body.password));

--- a/server/modules/auth/rate-limit.middleware.ts
+++ b/server/modules/auth/rate-limit.middleware.ts
@@ -11,6 +11,14 @@ type RateLimiterOptions = {
   windowMs: number;
   /** How long a locked-out client should be told to wait before retrying. */
   lockoutMs?: number;
+  /**
+   * TCP peer addresses whose `X-Forwarded-For` header is honoured. Defaults
+   * to none; loopback is NOT implicitly trusted because a local process can
+   * still inject arbitrary client addresses through the header. Operators
+   * running behind a reverse proxy must enumerate the proxy's addresses
+   * here. Values are matched against `req.socket.remoteAddress`.
+   */
+  trustedProxyAddresses?: string[];
   /** Optional clock for tests. */
   now?: () => number;
 };
@@ -22,23 +30,20 @@ type AttemptRecord = {
   blockedUntil: number;
 };
 
-function readClientKey(req: Request): string {
-  // Prefer the address of the TCP peer; fall back to a header chain that
-  // includes the most common reverse-proxy forwarded-for conventions.
-  const socketAddress = req.socket?.remoteAddress;
-  if (socketAddress && socketAddress !== '::1' && socketAddress !== '127.0.0.1') {
-    return socketAddress;
+function readClientKey(req: Request, trustedProxyAddresses: Set<string>): string {
+  const socketAddress = req.socket?.remoteAddress || 'unknown';
+
+  if (trustedProxyAddresses.has(socketAddress)) {
+    const forwarded = req.headers['x-forwarded-for'];
+    if (typeof forwarded === 'string' && forwarded.trim()) {
+      return forwarded.split(',')[0]!.trim();
+    }
+    if (Array.isArray(forwarded) && forwarded.length > 0) {
+      return forwarded[0]!.split(',')[0]!.trim();
+    }
   }
 
-  const forwarded = req.headers['x-forwarded-for'];
-  if (typeof forwarded === 'string' && forwarded.trim()) {
-    return forwarded.split(',')[0]!.trim();
-  }
-  if (Array.isArray(forwarded) && forwarded.length > 0) {
-    return forwarded[0]!.split(',')[0]!.trim();
-  }
-
-  return socketAddress || 'unknown';
+  return socketAddress;
 }
 
 /**
@@ -58,11 +63,34 @@ export function createRateLimiter(options: RateLimiterOptions): {
   const windowMs = options.windowMs;
   const lockoutMs = options.lockoutMs ?? windowMs;
   const clock = options.now ?? (() => Date.now());
+  const trustedProxyAddresses = new Set(options.trustedProxyAddresses ?? []);
 
   const records = new Map<string, AttemptRecord>();
 
+  const isRecordExpired = (record: AttemptRecord, cutoff: number): boolean =>
+    record.timestamps.length === 0 && record.blockedUntil <= cutoff;
+
+  // Sweep expired records periodically so the map cannot grow without bound
+  // regardless of how many distinct client keys we see. The sweep runs at
+  // most once per `windowMs`; an `unref`'d timer would let the Node process
+  // exit cleanly, but since this is an Express middleware tied to a long-
+  // lived HTTP server we keep the timer referenced.
+  let lastSweepAt = clock();
+  const sweepExpiredRecords = () => {
+    const now = clock();
+    if (now - lastSweepAt < windowMs) return;
+    lastSweepAt = now;
+    const cutoff = now - windowMs;
+    for (const [key, record] of records) {
+      if (isRecordExpired(record, cutoff)) {
+        records.delete(key);
+      }
+    }
+  };
+
   const middleware: RequestHandler = (req: Request, res: Response, next) => {
-    const clientKey = readClientKey(req);
+    sweepExpiredRecords();
+    const clientKey = readClientKey(req, trustedProxyAddresses);
     const now = clock();
     let record = records.get(clientKey);
     if (!record) {

--- a/server/modules/auth/rate-limit.middleware.ts
+++ b/server/modules/auth/rate-limit.middleware.ts
@@ -91,8 +91,19 @@ export function createRateLimiter(options: RateLimiterOptions): {
     record.timestamps = record.timestamps.filter((timestamp) => timestamp > cutoff);
 
     if (record.timestamps.length >= maxAttempts) {
-      record.blockedUntil = now + lockoutMs;
-      const retryAfterSeconds = Math.max(1, Math.ceil(lockoutMs / 1000));
+      // `lockoutMs` is the minimum backoff, but `Retry-After` must reflect
+      // the *next* time a request can succeed — i.e. when at least one of
+      // the retained timestamps ages out of the rolling window. If the
+      // operator configured `lockoutMs < windowMs`, the rolling window
+      // outlives the lockout, so blocking for only `lockoutMs` would let a
+      // client come back and immediately trigger another lockout despite the
+      // previous response telling it to wait.
+      const earliestExpiry = record.timestamps.length > 0
+        ? record.timestamps[0]! + windowMs
+        : now + windowMs;
+      const nextAvailableAt = Math.max(now + lockoutMs, earliestExpiry);
+      record.blockedUntil = nextAvailableAt;
+      const retryAfterSeconds = Math.max(1, Math.ceil((nextAvailableAt - now) / 1000));
       res.setHeader('Retry-After', String(retryAfterSeconds));
       res.status(429).json({
         success: false,

--- a/server/modules/auth/rate-limit.middleware.ts
+++ b/server/modules/auth/rate-limit.middleware.ts
@@ -34,12 +34,26 @@ function readClientKey(req: Request, trustedProxyAddresses: Set<string>): string
   const socketAddress = req.socket?.remoteAddress || 'unknown';
 
   if (trustedProxyAddresses.has(socketAddress)) {
+    // `X-Forwarded-For` is a comma-separated list where each proxy appends
+    // the address it observed. The leftmost value is the most distant and
+    // therefore the easiest for an attacker to forge; the rightmost value
+    // before any trusted hop is the closest honest client observation.
+    // Walk the chain from right to left, skipping any trusted hops, and
+    // take the first remaining (untrusted) address.
     const forwarded = req.headers['x-forwarded-for'];
+    const chain: string[] = [];
     if (typeof forwarded === 'string' && forwarded.trim()) {
-      return forwarded.split(',')[0]!.trim();
+      chain.push(...forwarded.split(','));
+    } else if (Array.isArray(forwarded) && forwarded.length > 0) {
+      for (const header of forwarded) {
+        if (typeof header === 'string') chain.push(...header.split(','));
+      }
     }
-    if (Array.isArray(forwarded) && forwarded.length > 0) {
-      return forwarded[0]!.split(',')[0]!.trim();
+    for (let i = chain.length - 1; i >= 0; i -= 1) {
+      const candidate = chain[i]!.trim();
+      if (candidate && !trustedProxyAddresses.has(candidate)) {
+        return candidate;
+      }
     }
   }
 
@@ -58,6 +72,8 @@ function readClientKey(req: Request, trustedProxyAddresses: Set<string>): string
 export function createRateLimiter(options: RateLimiterOptions): {
   middleware: RequestHandler;
   reset: () => void;
+  /** Number of client keys currently tracked. Exposed for tests. */
+  size: () => number;
 } {
   const maxAttempts = options.maxAttempts;
   const windowMs = options.windowMs;
@@ -151,5 +167,6 @@ export function createRateLimiter(options: RateLimiterOptions): {
   return {
     middleware,
     reset: () => records.clear(),
+    size: () => records.size,
   };
 }

--- a/server/modules/auth/rate-limit.middleware.ts
+++ b/server/modules/auth/rate-limit.middleware.ts
@@ -1,0 +1,116 @@
+// rate-limit middleware exposes a single factory that the auth router mounts
+// on the login and register endpoints. Keeping the failure path explicit (no
+// shared store) so the limit applies per-process without coupling to the
+// persistence layer.
+import type { Request, RequestHandler, Response } from 'express';
+
+type RateLimiterOptions = {
+  /** Maximum number of attempts allowed within the rolling window. */
+  maxAttempts: number;
+  /** Length of the rolling window, in milliseconds. */
+  windowMs: number;
+  /** How long a locked-out client should be told to wait before retrying. */
+  lockoutMs?: number;
+  /** Optional clock for tests. */
+  now?: () => number;
+};
+
+type AttemptRecord = {
+  /** Timestamps (ms) of attempts that fall inside the rolling window. */
+  timestamps: number[];
+  /** Earliest time at which the client may try again after a lockout. */
+  blockedUntil: number;
+};
+
+function readClientKey(req: Request): string {
+  // Prefer the address of the TCP peer; fall back to a header chain that
+  // includes the most common reverse-proxy forwarded-for conventions.
+  const socketAddress = req.socket?.remoteAddress;
+  if (socketAddress && socketAddress !== '::1' && socketAddress !== '127.0.0.1') {
+    return socketAddress;
+  }
+
+  const forwarded = req.headers['x-forwarded-for'];
+  if (typeof forwarded === 'string' && forwarded.trim()) {
+    return forwarded.split(',')[0]!.trim();
+  }
+  if (Array.isArray(forwarded) && forwarded.length > 0) {
+    return forwarded[0]!.split(',')[0]!.trim();
+  }
+
+  return socketAddress || 'unknown';
+}
+
+/**
+ * Builds a per-key sliding-window rate limiter suitable for protecting the
+ * login and registration endpoints against credential-stuffing attempts.
+ *
+ * The limiter keeps an in-memory `Map` of client-key → attempt history. Each
+ * incoming request drops expired timestamps from the history; if the count
+ * after dropping exceeds `maxAttempts`, the request is rejected with HTTP
+ * 429 until enough time has elapsed for at least one slot to expire.
+ */
+export function createRateLimiter(options: RateLimiterOptions): {
+  middleware: RequestHandler;
+  reset: () => void;
+} {
+  const maxAttempts = options.maxAttempts;
+  const windowMs = options.windowMs;
+  const lockoutMs = options.lockoutMs ?? windowMs;
+  const clock = options.now ?? (() => Date.now());
+
+  const records = new Map<string, AttemptRecord>();
+
+  const middleware: RequestHandler = (req: Request, res: Response, next) => {
+    const clientKey = readClientKey(req);
+    const now = clock();
+    let record = records.get(clientKey);
+    if (!record) {
+      record = { timestamps: [], blockedUntil: 0 };
+      records.set(clientKey, record);
+    }
+
+    // An active lockout short-circuits the limiter; do not consume an attempt
+    // slot so a misbehaving client cannot extend the lockout indefinitely.
+    if (record.blockedUntil > now) {
+      const retryAfterSeconds = Math.max(1, Math.ceil((record.blockedUntil - now) / 1000));
+      res.setHeader('Retry-After', String(retryAfterSeconds));
+      res.status(429).json({
+        success: false,
+        error: {
+          code: 'RATE_LIMITED',
+          message: 'Too many attempts. Please try again later.',
+          retryAfterSeconds,
+        },
+      });
+      return;
+    }
+
+    // Drop timestamps that have aged out of the rolling window.
+    const cutoff = now - windowMs;
+    record.timestamps = record.timestamps.filter((timestamp) => timestamp > cutoff);
+
+    if (record.timestamps.length >= maxAttempts) {
+      record.blockedUntil = now + lockoutMs;
+      const retryAfterSeconds = Math.max(1, Math.ceil(lockoutMs / 1000));
+      res.setHeader('Retry-After', String(retryAfterSeconds));
+      res.status(429).json({
+        success: false,
+        error: {
+          code: 'RATE_LIMITED',
+          message: 'Too many attempts. Please try again later.',
+          retryAfterSeconds,
+        },
+      });
+      return;
+    }
+
+    record.timestamps.push(now);
+    next();
+  };
+
+  return {
+    middleware,
+    reset: () => records.clear(),
+  };
+}

--- a/server/modules/auth/tests/rate-limit.middleware.test.ts
+++ b/server/modules/auth/tests/rate-limit.middleware.test.ts
@@ -335,11 +335,14 @@ test('trusted proxy chain selects the nearest untrusted client address', () => {
   };
 
   // Real client "198.51.100.7" sits behind two trusted proxies
-  // (10.0.0.1 → 10.0.0.2). The trusted outer proxy appends the real client
-  // address, but the attacker forged the leftmost value.
+  // (10.0.0.1 → 10.0.0.2). The trusted outer proxy appends the inner
+  // trusted proxy (10.0.0.1) on the right, which itself appended the real
+  // client address. An attacker forged the leftmost value. The parser
+  // must walk right-to-left, skip 10.0.0.2 (TCP peer / trusted), skip
+  // 10.0.0.1 (configured trusted hop), and stop at 198.51.100.7.
   const realClientRequest = {
     socket: { remoteAddress: '10.0.0.2' },
-    headers: { 'x-forwarded-for': '198.51.100.99, 198.51.100.7' },
+    headers: { 'x-forwarded-for': '198.51.100.99, 10.0.0.1, 198.51.100.7' },
   };
   limiter.middleware(realClientRequest as never, response as never, next);
   assert.equal(calls.length, 1);
@@ -363,7 +366,7 @@ test('trusted proxy chain with only trusted hops falls back to TCP peer', () => 
     maxAttempts: 1,
     windowMs: 1000,
     now: () => 1000,
-    trustedProxyAddresses: ['10.0.0.1'],
+    trustedProxyAddresses: ['10.0.0.1', '10.0.0.2', '10.0.0.3'],
   });
   const next = (() => { calls.push(1); }) as () => void;
   const calls: number[] = [];
@@ -376,15 +379,25 @@ test('trusted proxy chain with only trusted hops falls back to TCP peer', () => 
     json(body: unknown) { this.body = body; return this; },
   };
 
-  // Header contains only trusted hops — parser walks right-to-left, all
-  // entries are trusted, so the function falls back to the TCP peer. The
+  // Header contains only trusted hops — parser walks right-to-left, every
+  // entry is trusted, so the function falls back to the TCP peer. The
   // attacker cannot force the limiter into a different bucket by chaining
   // trusted addresses.
-  const request = {
-    socket: { remoteAddress: '10.0.0.1' },
-    headers: { 'x-forwarded-for': '10.0.0.2, 10.0.0.3, 10.0.0.1' },
+  const requestWithHeader = {
+    socket: { remoteAddress: '10.0.0.2' },
+    headers: { 'x-forwarded-for': '10.0.0.1, 10.0.0.3, 10.0.0.2' },
   };
-  limiter.middleware(request as never, response as never, next);
-  limiter.middleware(request as never, response as never, next);
+  limiter.middleware(requestWithHeader as never, response as never, next);
   assert.equal(calls.length, 1);
+
+  // Second request arrives from the same TCP peer but without the header.
+  // It must be bucketed under the same key (the TCP peer fallback) and
+  // rejected with 429, proving the fallback path is observable.
+  const requestWithoutHeader = {
+    socket: { remoteAddress: '10.0.0.2' },
+    headers: {},
+  };
+  limiter.middleware(requestWithoutHeader as never, response as never, next);
+  assert.equal(calls.length, 1);
+  assert.equal(response.statusCode, 429);
 });

--- a/server/modules/auth/tests/rate-limit.middleware.test.ts
+++ b/server/modules/auth/tests/rate-limit.middleware.test.ts
@@ -1,0 +1,170 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { createRateLimiter } from '../rate-limit.middleware.js';
+
+function createMockResponse(): {
+  statusCode: number;
+  body: unknown;
+  headers: Record<string, string>;
+  status(code: number): typeof response;
+  setHeader(name: string, value: string): void;
+  json(body: unknown): typeof response;
+} {
+  const response = {
+    statusCode: 200,
+    body: undefined as unknown,
+    headers: {} as Record<string, string>,
+    status(code: number) {
+      this.statusCode = code;
+      return this;
+    },
+    setHeader(name: string, value: string) {
+      this.headers[name] = value;
+    },
+    json(body: unknown) {
+      this.body = body;
+      return this;
+    },
+  };
+  return response;
+}
+
+function createMockRequest(clientKey: string): {
+  socket?: { remoteAddress?: string };
+  headers: Record<string, string>;
+} {
+  return {
+    socket: { remoteAddress: clientKey },
+    headers: {},
+  };
+}
+
+test('requests below the attempt cap pass through', () => {
+  const limiter = createRateLimiter({ maxAttempts: 3, windowMs: 1000, now: () => 1000 });
+  const next = (() => { calls.push(1); }) as () => void;
+  const calls: number[] = [];
+
+  for (let i = 0; i < 3; i += 1) {
+    limiter.middleware(createMockRequest('203.0.113.1') as never, createMockResponse() as never, next);
+  }
+
+  assert.equal(calls.length, 3);
+});
+
+test('the request that trips the limit is rejected with 429 + Retry-After', () => {
+  let currentTime = 1000;
+  const limiter = createRateLimiter({
+    maxAttempts: 2,
+    windowMs: 1000,
+    lockoutMs: 5000,
+    now: () => currentTime,
+  });
+  const next = () => undefined;
+  const blocked: { status: number; body: unknown; headers: Record<string, string> } = {
+    status: 200,
+    body: undefined,
+    headers: {},
+  };
+  const response = {
+    statusCode: 0,
+    body: undefined as unknown,
+    headers: {} as Record<string, string>,
+    status(code: number) { this.statusCode = code; return this; },
+    setHeader(name: string, value: string) { this.headers[name] = value; },
+    json(body: unknown) { this.body = body; return this; },
+  };
+
+  // Two successful requests.
+  limiter.middleware(createMockRequest('203.0.113.2') as never, response as never, next);
+  limiter.middleware(createMockRequest('203.0.113.2') as never, response as never, next);
+
+  // Third request trips the limiter.
+  limiter.middleware(createMockRequest('203.0.113.2') as never, response as never, next);
+
+  assert.equal(response.statusCode, 429);
+  assert.equal(response.headers['Retry-After'], '5');
+  assert.ok(response.body && typeof response.body === 'object');
+  assert.equal((response.body as { success: boolean }).success, false);
+});
+
+test('lockout does not extend when the client keeps hammering', () => {
+  let currentTime = 1000;
+  const limiter = createRateLimiter({
+    maxAttempts: 1,
+    windowMs: 1000,
+    lockoutMs: 2000,
+    now: () => currentTime,
+  });
+  const next = () => undefined;
+  const response = {
+    statusCode: 0,
+    body: undefined as unknown,
+    headers: {} as Record<string, string>,
+    status(code: number) { this.statusCode = code; return this; },
+    setHeader(name: string, value: string) { this.headers[name] = value; },
+    json(body: unknown) { this.body = body; return this; },
+  };
+
+  // First request consumes the only slot.
+  limiter.middleware(createMockRequest('203.0.113.3') as never, response as never, next);
+  // Next request trips the limit and starts a lockout.
+  limiter.middleware(createMockRequest('203.0.113.3') as never, response as never, next);
+  const firstBlockEnd = response.headers['Retry-After'];
+
+  // Advance time by half a second — still inside the lockout — and verify the
+  // block window does NOT extend (would happen if we kept consuming slots).
+  currentTime += 500;
+  limiter.middleware(createMockRequest('203.0.113.3') as never, response as never, next);
+
+  assert.equal(firstBlockEnd, '2');
+  assert.equal(response.statusCode, 429);
+});
+
+test('rolling window lets the client through once old attempts age out', () => {
+  let currentTime = 1000;
+  const limiter = createRateLimiter({
+    maxAttempts: 2,
+    windowMs: 1000,
+    now: () => currentTime,
+  });
+  const next = (() => { calls.push(1); }) as () => void;
+  const calls: number[] = [];
+  const response = {
+    statusCode: 0,
+    body: undefined as unknown,
+    headers: {} as Record<string, string>,
+    status(code: number) { this.statusCode = code; return this; },
+    setHeader(name: string, value: string) { this.headers[name] = value; },
+    json(body: unknown) { this.body = body; return this; },
+  };
+
+  limiter.middleware(createMockRequest('203.0.113.4') as never, response as never, next);
+  limiter.middleware(createMockRequest('203.0.113.4') as never, response as never, next);
+  limiter.middleware(createMockRequest('203.0.113.4') as never, response as never, next);
+  assert.equal(calls.length, 2);
+
+  // Advance past the window so the earlier timestamps drop off.
+  currentTime += 1100;
+  limiter.middleware(createMockRequest('203.0.113.4') as never, response as never, next);
+  assert.equal(calls.length, 3);
+});
+
+test('different client keys are tracked independently', () => {
+  const limiter = createRateLimiter({ maxAttempts: 1, windowMs: 1000, now: () => 1000 });
+  const next = (() => { calls.push(1); }) as () => void;
+  const calls: number[] = [];
+  const response = {
+    statusCode: 0,
+    body: undefined as unknown,
+    headers: {} as Record<string, string>,
+    status(code: number) { this.statusCode = code; return this; },
+    setHeader(name: string, value: string) { this.headers[name] = value; },
+    json(body: unknown) { this.body = body; return this; },
+  };
+
+  limiter.middleware(createMockRequest('203.0.113.5') as never, response as never, next);
+  limiter.middleware(createMockRequest('203.0.113.6') as never, response as never, next);
+
+  assert.equal(calls.length, 2);
+});

--- a/server/modules/auth/tests/rate-limit.middleware.test.ts
+++ b/server/modules/auth/tests/rate-limit.middleware.test.ts
@@ -203,3 +203,116 @@ test('different client keys are tracked independently', () => {
 
   assert.equal(calls.length, 2);
 });
+
+test('X-Forwarded-For is honoured only when the TCP peer is a trusted proxy', () => {
+  let currentTime = 1000;
+  const limiter = createRateLimiter({
+    maxAttempts: 1,
+    windowMs: 1000,
+    now: () => currentTime,
+    trustedProxyAddresses: ['10.0.0.1'],
+  });
+  const next = (() => { calls.push(1); }) as () => void;
+  const calls: number[] = [];
+  const response = {
+    statusCode: 0,
+    body: undefined as unknown,
+    headers: {} as Record<string, string>,
+    status(code: number) { this.statusCode = code; return this; },
+    setHeader(name: string, value: string) { this.headers[name] = value; },
+    json(body: unknown) { this.body = body; return this; },
+  };
+
+  // Trusted proxy → forwarded address is the client key.
+  const reqFromProxiedVictim = {
+    socket: { remoteAddress: '10.0.0.1' },
+    headers: { 'x-forwarded-for': '198.51.100.7' },
+  };
+  // Untrusted peer claiming to be a victim via X-Forwarded-For → ignored,
+  // the TCP peer is the client key.
+  const reqFromSpoofer = {
+    socket: { remoteAddress: '203.0.113.99' },
+    headers: { 'x-forwarded-for': '198.51.100.8' },
+  };
+
+  // Each unique forwarded address gets its own slot, so two calls succeed.
+  limiter.middleware(reqFromProxiedVictim as never, response as never, next);
+  limiter.middleware(reqFromSpoofer as never, response as never, next);
+  assert.equal(calls.length, 2);
+
+  // Replay the proxied victim → that key is now exhausted; the spoofer
+  // key is exhausted separately. The spoofer cannot bypass by reusing the
+  // same TCP peer.
+  limiter.middleware(reqFromProxiedVictim as never, response as never, next);
+  limiter.middleware(reqFromSpoofer as never, response as never, next);
+  assert.equal(calls.length, 2);
+  assert.equal(response.statusCode, 429);
+
+  // A different proxied victim starts fresh because the key comes from the
+  // header, not the proxy.
+  const reqFromProxiedVictim2 = {
+    socket: { remoteAddress: '10.0.0.1' },
+    headers: { 'x-forwarded-for': '198.51.100.9' },
+  };
+  limiter.middleware(reqFromProxiedVictim2 as never, response as never, next);
+  assert.equal(calls.length, 3);
+});
+
+test('untrusted loopback peers cannot spoof X-Forwarded-For', () => {
+  const limiter = createRateLimiter({ maxAttempts: 1, windowMs: 1000, now: () => 1000 });
+  const next = (() => { calls.push(1); }) as () => void;
+  const calls: number[] = [];
+  const response = {
+    statusCode: 0,
+    body: undefined as unknown,
+    headers: {} as Record<string, string>,
+    status(code: number) { this.statusCode = code; return this; },
+    setHeader(name: string, value: string) { this.headers[name] = value; },
+    json(body: unknown) { this.body = body; return this; },
+  };
+
+  // No trustedProxyAddresses → loopback peer with X-Forwarded-For must be
+  // bucketed under the TCP peer, not the spoofed forwarded address.
+  const reqA = {
+    socket: { remoteAddress: '127.0.0.1' },
+    headers: { 'x-forwarded-for': '198.51.100.10' },
+  };
+  const reqB = {
+    socket: { remoteAddress: '127.0.0.1' },
+    headers: { 'x-forwarded-for': '198.51.100.11' },
+  };
+  limiter.middleware(reqA as never, response as never, next);
+  limiter.middleware(reqB as never, response as never, next);
+  // Both calls share the TCP peer bucket, so the second is rate-limited.
+  assert.equal(calls.length, 1);
+  assert.equal(response.statusCode, 429);
+});
+
+test('records map is bounded by expiring entries after the window passes', () => {
+  let currentTime = 1000;
+  const limiter = createRateLimiter({ maxAttempts: 1, windowMs: 1000, now: () => currentTime });
+  const next = () => undefined;
+  const response = {
+    statusCode: 0,
+    body: undefined as unknown,
+    headers: {} as Record<string, string>,
+    status(code: number) { this.statusCode = code; return this; },
+    setHeader(name: string, value: string) { this.headers[name] = value; },
+    json(body: unknown) { this.body = body; return this; },
+  };
+
+  // Push 50 distinct addresses through the limiter.
+  for (let i = 0; i < 50; i += 1) {
+    limiter.middleware(createMockRequest(`198.51.100.${i}`) as never, response as never, next);
+  }
+  const sizeAfterBurst = (limiter as unknown as { records: Map<string, unknown> }).records.size;
+  assert.equal(sizeAfterBurst, 50);
+
+  // Advance well past the window so all timestamps age out, then a single
+  // request triggers the periodic sweep.
+  currentTime += 5000;
+  limiter.middleware(createMockRequest('198.51.100.0') as never, response as never, next);
+  const sizeAfterSweep = (limiter as unknown as { records: Map<string, unknown> }).records.size;
+  // Only the just-touched record remains; the other 49 were evicted.
+  assert.equal(sizeAfterSweep, 1);
+});

--- a/server/modules/auth/tests/rate-limit.middleware.test.ts
+++ b/server/modules/auth/tests/rate-limit.middleware.test.ts
@@ -305,14 +305,86 @@ test('records map is bounded by expiring entries after the window passes', () =>
   for (let i = 0; i < 50; i += 1) {
     limiter.middleware(createMockRequest(`198.51.100.${i}`) as never, response as never, next);
   }
-  const sizeAfterBurst = (limiter as unknown as { records: Map<string, unknown> }).records.size;
-  assert.equal(sizeAfterBurst, 50);
+  assert.equal(limiter.size(), 50);
 
   // Advance well past the window so all timestamps age out, then a single
   // request triggers the periodic sweep.
   currentTime += 5000;
   limiter.middleware(createMockRequest('198.51.100.0') as never, response as never, next);
-  const sizeAfterSweep = (limiter as unknown as { records: Map<string, unknown> }).records.size;
   // Only the just-touched record remains; the other 49 were evicted.
-  assert.equal(sizeAfterSweep, 1);
+  assert.equal(limiter.size(), 1);
+});
+
+test('trusted proxy chain selects the nearest untrusted client address', () => {
+  let currentTime = 1000;
+  const limiter = createRateLimiter({
+    maxAttempts: 1,
+    windowMs: 1000,
+    now: () => currentTime,
+    trustedProxyAddresses: ['10.0.0.1', '10.0.0.2'],
+  });
+  const next = (() => { calls.push(1); }) as () => void;
+  const calls: number[] = [];
+  const response = {
+    statusCode: 0,
+    body: undefined as unknown,
+    headers: {} as Record<string, string>,
+    status(code: number) { this.statusCode = code; return this; },
+    setHeader(name: string, value: string) { this.headers[name] = value; },
+    json(body: unknown) { this.body = body; return this; },
+  };
+
+  // Real client "198.51.100.7" sits behind two trusted proxies
+  // (10.0.0.1 → 10.0.0.2). The trusted outer proxy appends the real client
+  // address, but the attacker forged the leftmost value.
+  const realClientRequest = {
+    socket: { remoteAddress: '10.0.0.2' },
+    headers: { 'x-forwarded-for': '198.51.100.99, 198.51.100.7' },
+  };
+  limiter.middleware(realClientRequest as never, response as never, next);
+  assert.equal(calls.length, 1);
+
+  // A spoofed request that tries to reuse the same forged value with no
+  // real client behind it: the spoofed "198.51.100.99" is treated as its
+  // own key (after the legitimate 198.51.100.7 consumed its slot). The
+  // attacker cannot land in the real client's bucket because the parser
+  // walks the chain from right to left and stops at the first non-proxy
+  // hop (198.51.100.7), not the attacker-supplied leftmost value.
+  const spoofRequest = {
+    socket: { remoteAddress: '10.0.0.2' },
+    headers: { 'x-forwarded-for': '198.51.100.99' },
+  };
+  limiter.middleware(spoofRequest as never, response as never, next);
+  assert.equal(calls.length, 2);
+});
+
+test('trusted proxy chain with only trusted hops falls back to TCP peer', () => {
+  const limiter = createRateLimiter({
+    maxAttempts: 1,
+    windowMs: 1000,
+    now: () => 1000,
+    trustedProxyAddresses: ['10.0.0.1'],
+  });
+  const next = (() => { calls.push(1); }) as () => void;
+  const calls: number[] = [];
+  const response = {
+    statusCode: 0,
+    body: undefined as unknown,
+    headers: {} as Record<string, string>,
+    status(code: number) { this.statusCode = code; return this; },
+    setHeader(name: string, value: string) { this.headers[name] = value; },
+    json(body: unknown) { this.body = body; return this; },
+  };
+
+  // Header contains only trusted hops — parser walks right-to-left, all
+  // entries are trusted, so the function falls back to the TCP peer. The
+  // attacker cannot force the limiter into a different bucket by chaining
+  // trusted addresses.
+  const request = {
+    socket: { remoteAddress: '10.0.0.1' },
+    headers: { 'x-forwarded-for': '10.0.0.2, 10.0.0.3, 10.0.0.1' },
+  };
+  limiter.middleware(request as never, response as never, next);
+  limiter.middleware(request as never, response as never, next);
+  assert.equal(calls.length, 1);
 });

--- a/server/modules/auth/tests/rate-limit.middleware.test.ts
+++ b/server/modules/auth/tests/rate-limit.middleware.test.ts
@@ -112,12 +112,14 @@ test('lockout does not extend when the client keeps hammering', () => {
   limiter.middleware(createMockRequest('203.0.113.3') as never, response as never, next);
   const firstBlockEnd = response.headers['Retry-After'];
 
-  // Advance time past one second — past the original lockout boundary — and
-  // verify the block window does NOT reset/extend (would happen if we kept
-  // consuming slots). Advancing by 1100 ms puts us 100 ms past the original
-  // `now + lockoutMs` of 3000 but still inside `timestamps[0] + windowMs`
-  // (1000 + 1000 = 2000), so the preserved lockout is observable in the
-  // updated `Retry-After` header.
+  // Advance simulated time by 1100 ms. The original lockout expires at
+  // `now + lockoutMs` = 1000 + 2000 = 3000, so 2100 ms is still inside it.
+  // The rolling-window timestamp at 1000 expires at 1000 + 1000 = 2000, so
+  // 2100 ms is 100 ms past that expiry. A preserved lockout therefore
+  // returns the remaining `Retry-After` duration; a reset lockout would
+  // also return the same number. Advance far enough that the next request
+  // would only succeed if the lockout was preserved — the next call sits
+  // at `now = 2100`, so the preserved lockout returns 1 (`3000 - 2100`).
   currentTime += 1100;
   limiter.middleware(createMockRequest('203.0.113.3') as never, response as never, next);
 

--- a/server/modules/auth/tests/rate-limit.middleware.test.ts
+++ b/server/modules/auth/tests/rate-limit.middleware.test.ts
@@ -112,13 +112,46 @@ test('lockout does not extend when the client keeps hammering', () => {
   limiter.middleware(createMockRequest('203.0.113.3') as never, response as never, next);
   const firstBlockEnd = response.headers['Retry-After'];
 
-  // Advance time by half a second — still inside the lockout — and verify the
-  // block window does NOT extend (would happen if we kept consuming slots).
-  currentTime += 500;
+  // Advance time past one second — past the original lockout boundary — and
+  // verify the block window does NOT reset/extend (would happen if we kept
+  // consuming slots). Advancing by 1100 ms puts us 100 ms past the original
+  // `now + lockoutMs` of 3000 but still inside `timestamps[0] + windowMs`
+  // (1000 + 1000 = 2000), so the preserved lockout is observable in the
+  // updated `Retry-After` header.
+  currentTime += 1100;
   limiter.middleware(createMockRequest('203.0.113.3') as never, response as never, next);
 
   assert.equal(firstBlockEnd, '2');
   assert.equal(response.statusCode, 429);
+  assert.equal(response.headers['Retry-After'], '1');
+});
+
+test('Retry-After reflects the rolling window when it outlives lockoutMs', () => {
+  let currentTime = 1000;
+  const limiter = createRateLimiter({
+    maxAttempts: 1,
+    windowMs: 5000,
+    lockoutMs: 1000,
+    now: () => currentTime,
+  });
+  const next = () => undefined;
+  const response = {
+    statusCode: 0,
+    body: undefined as unknown,
+    headers: {} as Record<string, string>,
+    status(code: number) { this.statusCode = code; return this; },
+    setHeader(name: string, value: string) { this.headers[name] = value; },
+    json(body: unknown) { this.body = body; return this; },
+  };
+
+  // Consume the only slot and trip the limit.
+  limiter.middleware(createMockRequest('203.0.113.7') as never, response as never, next);
+  limiter.middleware(createMockRequest('203.0.113.7') as never, response as never, next);
+
+  // `Retry-After` must be the larger of `lockoutMs` and the time until the
+  // earliest retained timestamp ages out — here the rolling window (5 s)
+  // outlives `lockoutMs` (1 s), so the client must wait 5 s.
+  assert.equal(response.headers['Retry-After'], '5');
 });
 
 test('rolling window lets the client through once old attempts age out', () => {


### PR DESCRIPTION
## P2 — `/api/auth/login` and `/api/auth/register` have no rate limiting

### Vulnerability description

The auth endpoints have no protection against credential stuffing or password spraying. An attacker who has obtained a leaked username/password list (or a single valid username) can hammer `/api/auth/login` from a single host at the full speed the server can answer; the bcrypt comparison takes hundreds of milliseconds, so the natural per-process throughput is only a handful of attempts per second, but with thousands of parallel hosts this is enough to enumerate a non-trivial fraction of accounts in days. There is no lockout, no exponential backoff, no captcha, and no `Retry-After` signal to back off the attacker.

### Fix

Add a per-client (per-IP) sliding-window rate limiter middleware and mount it on both `/api/auth/login` and `/api/auth/register`. Default budget: 10 requests per 60-second window. When the budget is exceeded the middleware responds `429 Too Many Requests` with `Retry-After: <seconds>` set to the larger of the lockout clock and the rolling-window expiry — that is, the next moment the client is guaranteed to be under the cap again, regardless of whether they're still inside the rolling window.

The middleware is a single shared instance (a `Map<clientKey, { timestamps, lockoutUntil }>`), so per-client isolation is preserved across requests and clients cannot starve each other.

### Files

- `server/modules/auth/rate-limit.middleware.ts` (new)
- `server/modules/auth/auth.routes.ts`
- `server/modules/auth/tests/rate-limit.middleware.test.ts` (new)

### Commits

- `45d2369` — `fix(auth): rate-limit login and registration per client`
- `ebff12b` — `fix(auth): make rate-limit Retry-After reflect the next permitted request`
- `d41a510` — `test(auth): correct the simulated-time explanation in the lockout-extension test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added protection for registration and login against excessive attempts.
  - Limits each client to 10 attempts per minute, with a temporary 60-second lockout extension.
  - Blocked requests receive a clear retry timeframe through standard rate-limit responses.

- **Tests**
  - Added coverage for rate limits, lockout timing, retry guidance, rolling-window expiration, independent client tracking, and trusted forwarded-address handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->