### PR TITLE
fix(codex): hide memory citation metadata

### DIFF
--- a/server/modules/providers/list/codex/codex-sessions.provider.ts
+++ b/server/modules/providers/list/codex/codex-sessions.provider.ts
@@ -5,7 +5,13 @@ import { sessionsDb } from '@/modules/database/index.js';
 import { parseFilesInputTag, toImageAttachments } from '@/shared/image-attachments.js';
 import type { IProviderSessions } from '@/shared/interfaces.js';
 import type { AnyRecord, FetchHistoryOptions, FetchHistoryResult, NormalizedMessage } from '@/shared/types.js';
-import { createNormalizedMessage, generateMessageId, readObjectRecord, sliceTailPage } from '@/shared/utils.js';
+import {
+  createNormalizedMessage,
+  generateMessageId,
+  readObjectRecord,
+  sliceTailPage,
+  stripCodexMemoryCitation,
+} from '@/shared/utils.js';
 
 const PROVIDER = 'codex';
 
@@ -675,7 +681,7 @@ export class CodexSessionsProvider implements IProviderSessions {
     }
 
     if (raw.message?.role === 'assistant') {
-      const content = typeof raw.message.content === 'string'
+      const rawContent = typeof raw.message.content === 'string'
         ? raw.message.content
         : Array.isArray(raw.message.content)
           ? raw.message.content
@@ -683,6 +689,7 @@ export class CodexSessionsProvider implements IProviderSessions {
               .filter(Boolean)
               .join('\n')
           : '';
+      const content = stripCodexMemoryCitation(rawContent);
       if (!content.trim()) {
         return [];
       }
@@ -744,7 +751,13 @@ export class CodexSessionsProvider implements IProviderSessions {
 
     if (raw.type === 'item') {
       switch (raw.itemType) {
-        case 'agent_message':
+        case 'agent_message': {
+          const content = stripCodexMemoryCitation(
+            typeof raw.message?.content === 'string' ? raw.message.content : '',
+          );
+          if (!content.trim()) {
+            return [];
+          }
           return [createNormalizedMessage({
             id: baseId,
             sessionId,
@@ -752,8 +765,9 @@ export class CodexSessionsProvider implements IProviderSessions {
             provider: PROVIDER,
             kind: 'text',
             role: 'assistant',
-            content: raw.message?.content || '',
+            content,
           })];
+        }
         case 'reasoning':
           return [createNormalizedMessage({
             id: baseId,

--- a/server/modules/providers/services/session-conversations-search.service.ts
+++ b/server/modules/providers/services/session-conversations-search.service.ts
@@ -6,6 +6,7 @@ import { spawn } from 'cross-spawn';
 import { rgPath } from '@vscode/ripgrep';
 
 import { projectsDb, sessionsDb } from '@/modules/database/index.js';
+import { stripCodexMemoryCitation } from '@/shared/utils.js';
 
 type AnyRecord = Record<string, any>;
 type SearchableProvider = 'claude' | 'codex';
@@ -988,7 +989,7 @@ async function parseCodexSessionMatches(
           text = extractCodexText(payload.content);
           role = 'user';
         } else if (payload.role === 'assistant') {
-          text = extractCodexText(payload.content);
+          text = stripCodexMemoryCitation(extractCodexText(payload.content));
           role = 'assistant';
         }
       } else if (entry.type === 'response_item' && entry.payload?.type === 'reasoning') {

--- a/server/modules/providers/tests/codex-sessions.test.ts
+++ b/server/modules/providers/tests/codex-sessions.test.ts
@@ -7,6 +7,17 @@ import test from 'node:test';
 import { closeConnection, initializeDatabase, sessionsDb } from '@/modules/database/index.js';
 import { CodexSessionSynchronizer } from '@/modules/providers/list/codex/codex-session-synchronizer.provider.js';
 import { CodexSessionsProvider } from '@/modules/providers/list/codex/codex-sessions.provider.js';
+import { searchConversations } from '@/modules/providers/services/session-conversations-search.service.js';
+import { stripCodexMemoryCitation } from '@/shared/utils.js';
+
+const MEMORY_CITATION_BLOCK = `<oai-mem-citation>
+<citation_entries>
+MEMORY.md:1-2|note=[internal source]
+</citation_entries>
+<rollout_ids>
+memoryonlytoken
+</rollout_ids>
+</oai-mem-citation>`;
 
 const patchHomeDir = (nextHomeDir: string) => {
   const original = os.homedir;
@@ -63,6 +74,42 @@ const writeCodexTranscript = async (
   await writeFile(filePath, `${lines.join('\n')}\n`, 'utf8');
   return filePath;
 };
+
+test('Codex memory citations are removed only from canonical trailing metadata', () => {
+  assert.equal(
+    stripCodexMemoryCitation(`Visible answer\n\n${MEMORY_CITATION_BLOCK}\n`),
+    'Visible answer',
+  );
+  assert.equal(stripCodexMemoryCitation(MEMORY_CITATION_BLOCK), '');
+  assert.equal(
+    stripCodexMemoryCitation('<oai-mem-citation> <citation_entries>source</citation_entries> <rollout_ids>id</rollout_ids> </oai-mem-citation>'),
+    '',
+  );
+
+  const inlineExample = `Example: ${MEMORY_CITATION_BLOCK}`;
+  assert.equal(stripCodexMemoryCitation(inlineExample), inlineExample);
+
+  const incomplete = 'Visible answer\n<oai-mem-citation>\n<citation_entries>';
+  assert.equal(stripCodexMemoryCitation(incomplete), incomplete);
+
+  const ordinary = 'Ordinary assistant text\n';
+  assert.equal(stripCodexMemoryCitation(ordinary), ordinary);
+
+  const provider = new CodexSessionsProvider();
+  const liveMessages = provider.normalizeMessage({
+    type: 'item',
+    itemType: 'agent_message',
+    message: { role: 'assistant', content: `Visible live answer\n\n${MEMORY_CITATION_BLOCK}` },
+  }, 'live-session');
+  assert.equal(liveMessages[0]?.content, 'Visible live answer');
+
+  const metadataOnly = provider.normalizeMessage({
+    type: 'item',
+    itemType: 'agent_message',
+    message: { role: 'assistant', content: MEMORY_CITATION_BLOCK },
+  }, 'live-session');
+  assert.deepEqual(metadataOnly, []);
+});
 
 test('Codex synchronizer titles app-created sessions from the first user message', { concurrency: false }, async () => {
   const tempRoot = await mkdtemp(path.join(os.tmpdir(), 'codex-session-sync-app-'));
@@ -184,6 +231,81 @@ test('Codex history renders Promise.all shell wrappers as Bash activity', { conc
       assert.equal(toolUses[0].toolName, 'Bash');
       assert.equal(toolUses[0].toolInput, JSON.stringify({ command: 'echo one\necho two' }));
       assert.equal(toolResults.some((message) => message.toolCallId === 'plan-1'), false);
+    });
+  } finally {
+    restoreHomeDir();
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test('Codex history hides trailing memory citation metadata', { concurrency: false }, async () => {
+  const tempRoot = await mkdtemp(path.join(os.tmpdir(), 'codex-memory-citation-history-'));
+  const workspacePath = path.join(tempRoot, 'workspace');
+  await mkdir(workspacePath, { recursive: true });
+  const restoreHomeDir = patchHomeDir(tempRoot);
+
+  try {
+    const providerSessionId = 'codex-memory-history-1';
+    const transcriptPath = await writeCodexTranscript(tempRoot, providerSessionId, workspacePath);
+    await writeFile(transcriptPath, [
+      JSON.stringify({ type: 'session_meta', payload: { id: providerSessionId, cwd: workspacePath } }),
+      JSON.stringify({
+        type: 'response_item',
+        payload: {
+          type: 'message',
+          role: 'assistant',
+          content: [{ type: 'output_text', text: `Visible history answer\n\n${MEMORY_CITATION_BLOCK}` }],
+        },
+      }),
+    ].join('\n') + '\n', 'utf8');
+
+    await withIsolatedDatabase(async () => {
+      sessionsDb.createAppSession('app-memory-history-1', 'codex', workspacePath);
+      sessionsDb.assignProviderSessionId('app-memory-history-1', providerSessionId);
+      await new CodexSessionSynchronizer().synchronize();
+
+      const history = await new CodexSessionsProvider().fetchHistory('app-memory-history-1');
+      const assistant = history.messages.find((message) => message.role === 'assistant' && message.kind === 'text');
+      assert.equal(assistant?.content, 'Visible history answer');
+    });
+  } finally {
+    restoreHomeDir();
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test('Codex conversation search excludes memory citation metadata', { concurrency: false }, async () => {
+  const tempRoot = await mkdtemp(path.join(os.tmpdir(), 'codex-memory-citation-search-'));
+  const workspacePath = path.join(tempRoot, 'workspace');
+  await mkdir(workspacePath, { recursive: true });
+  const restoreHomeDir = patchHomeDir(tempRoot);
+
+  try {
+    const providerSessionId = 'codex-memory-search-1';
+    const transcriptPath = await writeCodexTranscript(tempRoot, providerSessionId, workspacePath);
+    await writeFile(transcriptPath, [
+      JSON.stringify({ type: 'session_meta', payload: { id: providerSessionId, cwd: workspacePath } }),
+      JSON.stringify({
+        type: 'response_item',
+        payload: {
+          type: 'message',
+          role: 'assistant',
+          content: [{ type: 'output_text', text: `Visible searchable answer\n\n${MEMORY_CITATION_BLOCK}` }],
+        },
+      }),
+    ].join('\n') + '\n', 'utf8');
+
+    await withIsolatedDatabase(async () => {
+      sessionsDb.createAppSession('app-memory-search-1', 'codex', workspacePath);
+      sessionsDb.assignProviderSessionId('app-memory-search-1', providerSessionId);
+      await new CodexSessionSynchronizer().synchronize();
+
+      const visible = await searchConversations('searchable');
+      assert.equal(visible.totalMatches, 1);
+      assert.equal(visible.results[0]?.sessions[0]?.matches[0]?.snippet.includes('memoryonlytoken'), false);
+
+      const hidden = await searchConversations('memoryonlytoken');
+      assert.equal(hidden.totalMatches, 0);
     });
   } finally {
     restoreHomeDir();

--- a/server/modules/providers/tests/codex-sessions.test.ts
+++ b/server/modules/providers/tests/codex-sessions.test.ts
@@ -80,6 +80,10 @@ test('Codex memory citations are removed only from canonical trailing metadata',
     stripCodexMemoryCitation(`Visible answer\n\n${MEMORY_CITATION_BLOCK}\n`),
     'Visible answer',
   );
+  assert.equal(
+    stripCodexMemoryCitation(`Visible answer\n\n${MEMORY_CITATION_BLOCK}\n   `),
+    'Visible answer',
+  );
   assert.equal(stripCodexMemoryCitation(MEMORY_CITATION_BLOCK), '');
   assert.equal(
     stripCodexMemoryCitation('<oai-mem-citation> <citation_entries>source</citation_entries> <rollout_ids>id</rollout_ids> </oai-mem-citation>'),

--- a/server/shared/utils.ts
+++ b/server/shared/utils.ts
@@ -48,6 +48,28 @@ type NormalizedMessageInput =
   } & Record<string, unknown>;
 
 // ---------------------------
+//----------------- CODEX OUTPUT UTILITIES ------------
+/**
+ * Removes the internal memory-citation envelope that Codex can append to an
+ * assistant response. The providers module uses this at both the normalized
+ * message boundary and the conversation-search boundary so internal source
+ * metadata never becomes user-facing content.
+ *
+ * Only a complete, canonical block on its own trailing lines is removed. An
+ * inline example, an incomplete tag, or otherwise ordinary text is preserved.
+ */
+export function stripCodexMemoryCitation(content: string): string {
+  const trailingCitation = /(?:^|(?:\r?\n[ \t]*)+)<oai-mem-citation>\s*<citation_entries>[\s\S]*?<\/citation_entries>\s*<rollout_ids>[\s\S]*?<\/rollout_ids>\s*<\/oai-mem-citation>[ \t]*(?:\r?\n)*$/;
+  const match = trailingCitation.exec(content);
+
+  if (!match) {
+    return content;
+  }
+
+  return content.slice(0, match.index).trimEnd();
+}
+
+// ---------------------------
 //----------------- HTTP HANDLER UTILITIES ------------
 /**
  * Wraps arbitrary data in the standard API success envelope.

--- a/server/shared/utils.ts
+++ b/server/shared/utils.ts
@@ -59,7 +59,7 @@ type NormalizedMessageInput =
  * inline example, an incomplete tag, or otherwise ordinary text is preserved.
  */
 export function stripCodexMemoryCitation(content: string): string {
-  const trailingCitation = /(?:^|(?:\r?\n[ \t]*)+)<oai-mem-citation>\s*<citation_entries>[\s\S]*?<\/citation_entries>\s*<rollout_ids>[\s\S]*?<\/rollout_ids>\s*<\/oai-mem-citation>[ \t]*(?:\r?\n)*$/;
+  const trailingCitation = /(?:^|(?:\r?\n[ \t]*)+)<oai-mem-citation>\s*<citation_entries>[\s\S]*?<\/citation_entries>\s*<rollout_ids>[\s\S]*?<\/rollout_ids>\s*<\/oai-mem-citation>\s*$/;
   const match = trailingCitation.exec(content);
 
   if (!match) {


### PR DESCRIPTION
## Summary

- remove canonical trailing `<oai-mem-citation>` metadata from Codex assistant messages
- apply the same normalization to live messages, persisted history, and conversation search
- suppress metadata-only assistant messages while preserving inline or incomplete tag examples

## Why

Codex can append an internal memory-citation envelope to an otherwise normal assistant response. CloudCLI currently renders the raw XML-like block and indexes it as searchable conversation text because the Codex SDK exposes the response as plain text.

## Reproduction

1. Run a Codex session that emits a memory-backed final response.
2. Wait for the assistant response to finish.
3. Observe the raw `<oai-mem-citation>` block at the end of the CloudCLI message and in restored history.

## Implementation

A shared server utility removes only a complete canonical citation block at the end of an assistant response. It requires both `citation_entries` and `rollout_ids`, accepts whitespace folded by transport or rendering, and leaves ordinary text, inline examples, and incomplete tags untouched.

The sanitizer runs at the Codex normalization boundary for live and persisted messages and in Codex conversation search. If a response contains only internal citation metadata, no empty assistant message is emitted.

## Tests

- `npm test` — 256 tests passed
- `npm run typecheck` — passed
- `npm run lint` — passed with 0 errors
- `npm run build` — passed

Regression coverage includes live normalization, metadata-only responses, persisted JSONL history, conversation search, compact whitespace, malformed blocks, and literal inline examples.

## Upstream context

- OpenAI Codex issue tracking missing structured citation data in exec/SDK output: https://github.com/openai/codex/issues/30190
- OpenAI Codex app-server support for structured memory citations: https://github.com/openai/codex/pull/14821

This compatibility fix can remain until the exec/SDK path exposes structured `memoryCitation` data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Removed trailing Codex memory-citation metadata from assistant responses.
  - Applied cleanup consistently to conversation history, live responses, search results, snippets, and summaries.
  - Omitted messages that contain no visible content after citation removal.
  - Preserved ordinary inline or incomplete citation-like text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->