### PR TITLE
feat(claude): add ultracode effort option for xhigh-capable models

### DIFF
--- a/server/modules/providers/list/claude/claude-models.provider.ts
+++ b/server/modules/providers/list/claude/claude-models.provider.ts
@@ -37,6 +37,10 @@ export const CLAUDE_FALLBACK_MODELS: ProviderModelsDefinition = {
           { value: 'high' },
           { value: 'xhigh' },
           { value: 'max' },
+          {
+            value: 'ultracode',
+            description: 'xhigh reasoning + multi-agent workflow orchestration · Uses significantly more tokens',
+          },
         ],
       },
     },
@@ -80,6 +84,10 @@ export const CLAUDE_FALLBACK_MODELS: ProviderModelsDefinition = {
           { value: 'high' },
           { value: 'xhigh' },
           { value: 'max' },
+          {
+            value: 'ultracode',
+            description: 'xhigh reasoning + multi-agent workflow orchestration · Uses significantly more tokens',
+          },
         ],
       },
     },
@@ -95,6 +103,10 @@ export const CLAUDE_FALLBACK_MODELS: ProviderModelsDefinition = {
           { value: 'high' },
           { value: 'xhigh' },
           { value: 'max' },
+          {
+            value: 'ultracode',
+            description: 'xhigh reasoning + multi-agent workflow orchestration · Uses significantly more tokens',
+          },
         ],
       },
     },

--- a/server/modules/providers/list/claude/claude-runtime.provider.js
+++ b/server/modules/providers/list/claude/claude-runtime.provider.js
@@ -158,7 +158,8 @@ function matchesToolPermission(entry, toolName, input) {
   return false;
 }
 
-function mapCliOptionsToSDK(options = {}) {
+// Exported for server/modules/providers/tests/claude-ultracode.test.ts.
+export function mapCliOptionsToSDK(options = {}) {
   const { providerSessionId, cwd, toolsSettings, permissionMode, effort } = options;
 
   const sdkOptions = {};
@@ -216,7 +217,13 @@ function mapCliOptionsToSDK(options = {}) {
     effort,
     options.effortModels || CLAUDE_FALLBACK_MODELS,
   );
-  if (resolvedEffort) {
+  if (resolvedEffort === 'ultracode') {
+    // Ultracode is xhigh reasoning plus standing dynamic-workflow orchestration.
+    // The SDK's EffortLevel union has no 'ultracode' member; the mode is enabled
+    // through the session-scoped `ultracode` settings key instead.
+    sdkOptions.effort = 'xhigh';
+    sdkOptions.settings = { ultracode: true };
+  } else if (resolvedEffort) {
     sdkOptions.effort = resolvedEffort;
   }
 

--- a/server/modules/providers/tests/claude-ultracode.test.ts
+++ b/server/modules/providers/tests/claude-ultracode.test.ts
@@ -1,0 +1,44 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { CLAUDE_FALLBACK_MODELS } from '@/modules/providers/list/claude/claude-models.provider.js';
+import { mapCliOptionsToSDK } from '@/modules/providers/list/claude/claude-runtime.provider.js';
+
+const effortValuesFor = (model: string): string[] => {
+  const option = CLAUDE_FALLBACK_MODELS.OPTIONS.find((candidate) => candidate.value === model);
+  return option?.effort?.values.map((value) => value.value) ?? [];
+};
+
+test('ultracode effort is offered exactly on xhigh-capable Claude models', () => {
+  for (const option of CLAUDE_FALLBACK_MODELS.OPTIONS) {
+    const efforts = effortValuesFor(option.value);
+    assert.equal(
+      efforts.includes('ultracode'),
+      efforts.includes('xhigh'),
+      `model "${option.value}" should offer ultracode exactly when it offers xhigh`,
+    );
+  }
+});
+
+test('ultracode effort maps to xhigh plus the session-scoped ultracode settings key', () => {
+  const sdkOptions = mapCliOptionsToSDK({ model: 'fable', effort: 'ultracode' });
+
+  assert.equal(sdkOptions.effort, 'xhigh');
+  assert.deepEqual(sdkOptions.settings, { ultracode: true });
+});
+
+test('plain effort levels do not enable ultracode', () => {
+  const sdkOptions = mapCliOptionsToSDK({ model: 'fable', effort: 'xhigh' });
+
+  assert.equal(sdkOptions.effort, 'xhigh');
+  assert.equal(sdkOptions.settings, undefined);
+});
+
+test('ultracode effort is dropped for models that do not offer it', () => {
+  for (const model of ['sonnet', 'haiku']) {
+    const sdkOptions = mapCliOptionsToSDK({ model, effort: 'ultracode' });
+
+    assert.equal(sdkOptions.effort, undefined, `model "${model}" should not receive an effort`);
+    assert.equal(sdkOptions.settings, undefined, `model "${model}" should not receive settings`);
+  }
+});

--- a/src/components/chat/constants/providerEffort.ts
+++ b/src/components/chat/constants/providerEffort.ts
@@ -3,7 +3,7 @@ import type { LLMProvider, ProviderModelOption } from '../../../types/app';
 export const DEFAULT_EFFORT_VALUE = 'default';
 
 export const FALLBACK_PROVIDER_EFFORT_VALUES: Partial<Record<LLMProvider, readonly string[]>> = {
-  claude: ['low', 'medium', 'high', 'xhigh', 'max'],
+  claude: ['low', 'medium', 'high', 'xhigh', 'max', 'ultracode'],
   codex: ['low', 'medium', 'high', 'xhigh'],
   opencode: ['none', 'low', 'medium', 'high', 'xhigh', 'max'],
 };

--- a/src/components/chat/view/subcomponents/ComposerMenuPrimitives.tsx
+++ b/src/components/chat/view/subcomponents/ComposerMenuPrimitives.tsx
@@ -83,7 +83,7 @@ export function ComposerMenuItem({
       <span className="min-w-0 flex-1">
         <span className="block truncate leading-5">{label}</span>
         {description && (
-          <span className="mt-0.5 block text-xs leading-4 text-muted-foreground">{description}</span>
+          <span className="mt-0.5 block text-xs normal-case leading-4 text-muted-foreground">{description}</span>
         )}
       </span>
       <span className="mt-0.5 flex h-4 w-4 shrink-0 items-center justify-center">


### PR DESCRIPTION
## What

Adds **ultracode** — Claude Code's dynamic-workflows mode (xhigh reasoning + standing multi-agent workflow orchestration) — as a selectable option in the composer's Reasoning menu for the Claude provider. It is offered on exactly the models that support xhigh (`fable`, `opus`, `opus[1m]`), matching Claude Code's own gating for the mode.

## How

The bundled `@anthropic-ai/claude-agent-sdk` (0.3.165) types `EffortLevel` without `'ultracode'`, but exposes the mode through the session-scoped `ultracode?: boolean` settings key ("xhigh effort plus standing dynamic-workflow orchestration" per `sdk.d.ts`), and `Options.settings` accepts an inline `Settings` object. So:

- `claude-models.provider.ts`: adds `{ value: 'ultracode', description: ... }` to `effort.values` of the three xhigh-capable model entries. The existing effort plumbing (catalog → Reasoning menu → `chat.send` options → `resolveClaudeEffort`) carries it end to end with no new wiring.
- `claude-runtime.provider.js`: `mapCliOptionsToSDK` translates a resolved `'ultracode'` effort into `effort: 'xhigh'` + `settings: { ultracode: true }`. Models that don't list ultracode keep dropping it via the existing `resolveClaudeEffort` validation. Nothing else in the repo writes `sdkOptions.settings`, and the flag-settings layer is disjoint from `settingSources`.
- `providerEffort.ts`: adds `'ultracode'` to the claude fallback effort list so a persisted selection survives page reload (the mount-time reconcile runs before the models catalog fetch resolves and would otherwise reset it to Default).
- `ComposerMenuPrimitives.tsx`: adds `normal-case` to the menu-item description span. Ultracode is the first effort option to carry a description, and the effort items apply `capitalize` to the whole button, which would otherwise title-case the description text.

If the user's environment has workflows disabled (`disableWorkflows`, plan gating, or an older CLI), the settings key is ignored gracefully and the turn simply runs at xhigh.

## Tests

New `server/modules/providers/tests/claude-ultracode.test.ts` (idiomatic `node:test`, picked up by the existing `npm test` glob):
- ultracode is offered exactly on the models that offer xhigh
- `effort: 'ultracode'` maps to `effort: 'xhigh'` + `settings: { ultracode: true }`
- plain effort levels don't enable ultracode
- ultracode is dropped for models that don't offer it (`sonnet`, `haiku`)

`npm run lint` (0 errors), `npm run typecheck`, `npm test` (257 pass), and `npm run build` all pass.

## UI change

One new row in the existing Reasoning dropdown (visible when Fable/Opus is selected): label **Ultracode** with description *"xhigh reasoning + multi-agent workflow orchestration · Uses significantly more tokens"*.

## Known pre-existing limitation (not introduced here)

The effort reconcile effect in `useChatProviderState.ts` validates the stored effort against the per-provider stored model rather than the open session's model, so a session pinned to Fable can't hold an ultracode (or, today, xhigh) selection while the provider-stored model is e.g. Sonnet. Happy to address that in a follow-up if you'd like.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the **Ultracode** effort option for supported Claude models.
  * Ultracode enables enhanced xhigh reasoning and multi-agent workflows.
  * Unsupported models and standard effort levels continue using their existing options.

* **Style**
  * Improved composer menu descriptions by preserving normal capitalization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->