### PR TITLE
fix(codex): parse cmd from exec command history

### DIFF
--- a/server/modules/providers/list/codex/codex-sessions.provider.ts
+++ b/server/modules/providers/list/codex/codex-sessions.provider.ts
@@ -143,7 +143,7 @@ function decodeJavaScriptStringLiteral(literal: string): string {
 
 function extractNestedCodexCommands(source: string): string[] {
   const commands: string[] = [];
-  const commandPattern = /(?:["']command["']|\bcommand)\s*:\s*("(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|`(?:\\.|[^`\\])*`)/gs;
+  const commandPattern = /(?:["'](?:command|cmd)["']|\b(?:command|cmd))\s*:\s*("(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|`(?:\\.|[^`\\])*`)/gs;
   for (const match of source.matchAll(commandPattern)) {
     commands.push(decodeJavaScriptStringLiteral(match[1]));
   }

--- a/server/modules/providers/tests/codex-sessions.test.ts
+++ b/server/modules/providers/tests/codex-sessions.test.ts
@@ -180,6 +180,12 @@ test('Codex history preserves wrapped exec tool calls and results', { concurrenc
         expectedToolName: 'Bash',
         expectedToolInput: JSON.stringify({ command: 'echo current' }),
       },
+      {
+        callId: 'exec-command-cmd-1',
+        input: 'await tools.exec_command({"cmd":"git diff --check","workdir":"/workspace"});',
+        expectedToolName: 'Bash',
+        expectedToolInput: JSON.stringify({ command: 'git diff --check' }),
+      },
       { callId: 'apply-patch-1', input: 'await tools.apply_patch("*** Begin Patch\\n*** End Patch");' },
       { callId: 'web-run-1', input: 'await tools.web__run({ search_query: [{ q: "Codex" }] });' },
       { callId: 'update-plan-1', input: 'await tools.update_plan({ plan: [] });' },


### PR DESCRIPTION
## Summary

- recognize the `cmd` key emitted by current Codex `tools.exec_command` rollout records
- keep those history entries normalized as `Bash` instead of falling back to generic `exec`
- add a regression fixture using the observed `{"cmd":"git diff --check","workdir":"/workspace"}` payload

## Context

This is a focused follow-up to #1095 and the regression reported in #1089.

The parent PR recognizes the `tools.exec_command` wrapper, but its command extractor only accepts `command`. Current Codex rollouts use `cmd`, so the tool/result pair is preserved but displayed as generic `exec`. Supporting both keys restores the intended Bash rendering while retaining the parent's generic fallback for other wrappers.

## Verification

- `npx tsx --tsconfig server/tsconfig.json --test server/modules/providers/tests/codex-sessions.test.ts` — 4 passed
- `npm test` — 260 passed
- `npm run build`
- `npm run typecheck`
- `npm run lint` — 0 errors (existing branch warnings only)
