### PR TITLE
fix(claude): read the model catalog from the CLI instead of a hardcoded table

### DIFF
--- a/server/modules/providers/list/claude/claude-models.provider.ts
+++ b/server/modules/providers/list/claude/claude-models.provider.ts
@@ -220,14 +220,14 @@ const probeClaudeSupportedModels = async (): Promise<ProviderModelsDefinition> =
 
     if (options.length === 0) {
       console.warn('[Claude models] CLI reported no models; using the built-in catalog');
-      return CLAUDE_FALLBACK_MODELS;
+      return { ...CLAUDE_FALLBACK_MODELS, isFallback: true };
     }
 
     return mergeWithFallbackModels(options);
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     console.warn(`[Claude models] Unable to read the CLI catalog (${message}); using the built-in catalog`);
-    return CLAUDE_FALLBACK_MODELS;
+    return { ...CLAUDE_FALLBACK_MODELS, isFallback: true };
   } finally {
     clearTimeout(timeout);
     try {

--- a/server/modules/providers/list/claude/claude-models.provider.ts
+++ b/server/modules/providers/list/claude/claude-models.provider.ts
@@ -1,6 +1,10 @@
 import { readFile } from 'node:fs/promises';
+import os from 'node:os';
+
+import { query } from '@anthropic-ai/claude-agent-sdk';
 
 import { sessionsDb } from '@/modules/database/index.js';
+import { resolveClaudeCodeExecutablePath } from '@/shared/claude-cli-path.js';
 import type { IProviderModels } from '@/shared/interfaces.js';
 import type {
   ProviderCurrentActiveModel,
@@ -14,7 +18,7 @@ export const CLAUDE_FALLBACK_MODELS: ProviderModelsDefinition = {
     {
       value: 'default',
       label: 'Default (recommended)',
-      description: 'Use the Claude Code default model (currently Sonnet 5)',
+      description: 'Use the Claude Code default model (currently Opus 5 with 1M context)',
       effort: {
         default: 'high',
         values: [
@@ -71,7 +75,7 @@ export const CLAUDE_FALLBACK_MODELS: ProviderModelsDefinition = {
     {
       value: 'opus',
       label: 'Opus',
-      description: 'Opus 4.8 · Best for everyday, complex tasks · ~2× usage vs Sonnet',
+      description: 'Opus 5 · Best for everyday, complex tasks · $5/$25 per Mtok',
       effort: {
         default: 'high',
         values: [
@@ -85,8 +89,8 @@ export const CLAUDE_FALLBACK_MODELS: ProviderModelsDefinition = {
     },
     {
       value: 'opus[1m]',
-      label: 'Opus 4.8 (1M context)',
-      description: 'Opus 4.8 with 1M context · Most capable for complex work · $5/$25 per Mtok',
+      label: 'Opus (1M context)',
+      description: 'Opus 5 with 1M context · Best for everyday, complex tasks · $5/$25 per Mtok',
       effort: {
         default: 'high',
         values: [
@@ -105,6 +109,133 @@ export const CLAUDE_FALLBACK_MODELS: ProviderModelsDefinition = {
     },
   ],
   DEFAULT: 'default',
+};
+
+/**
+ * How long to wait for the CLI to start up and answer the catalog request.
+ * Generous because the probe spawns a process; the fallback table covers the
+ * timeout, so a slow machine degrades to stale labels rather than a stall.
+ */
+const SUPPORTED_MODELS_TIMEOUT_MS = 30_000;
+
+/** Effort level the API applies when a request does not ask for one. */
+const DEFAULT_EFFORT = 'high';
+
+/** One entry of the CLI's own model catalog, as far as this adapter reads it. */
+type ClaudeCliModel = {
+  value?: unknown;
+  displayName?: unknown;
+  description?: unknown;
+  supportsEffort?: unknown;
+  supportedEffortLevels?: unknown;
+};
+
+/** In-flight probe shared by concurrent callers. */
+let supportedModelsProbe: Promise<ProviderModelsDefinition> | null = null;
+
+const toProviderModelOption = (entry: ClaudeCliModel): ProviderModelOption | null => {
+  const value = typeof entry.value === 'string' ? entry.value.trim() : '';
+  if (!value) {
+    return null;
+  }
+
+  const displayName = typeof entry.displayName === 'string' ? entry.displayName.trim() : '';
+  const effortLevels = Array.isArray(entry.supportedEffortLevels)
+    ? entry.supportedEffortLevels.filter((level): level is string => typeof level === 'string' && level.length > 0)
+    : [];
+
+  return {
+    value,
+    label: displayName || value,
+    ...(typeof entry.description === 'string' && entry.description
+      ? { description: entry.description }
+      : {}),
+    ...(entry.supportsEffort === true && effortLevels.length > 0
+      ? {
+        effort: {
+          default: effortLevels.includes(DEFAULT_EFFORT) ? DEFAULT_EFFORT : effortLevels[0],
+          values: effortLevels.map((level) => ({ value: level })),
+        },
+      }
+      : {}),
+  };
+};
+
+/**
+ * Combines the CLI's catalog with the static table.
+ *
+ * Options the CLI reports win outright — they carry the current names,
+ * descriptions and effort levels. Entries only the static table knows are
+ * appended rather than dropped: the CLI stops advertising older aliases well
+ * before it stops accepting them, and dropping one would silently reset the
+ * stored selection of every user who picked it.
+ */
+const mergeWithFallbackModels = (options: ProviderModelOption[]): ProviderModelsDefinition => {
+  const advertised = new Set(options.map((option) => option.value));
+  const retained = CLAUDE_FALLBACK_MODELS.OPTIONS.filter((option) => !advertised.has(option.value));
+
+  return {
+    OPTIONS: [...options, ...retained],
+    DEFAULT: advertised.has(CLAUDE_FALLBACK_MODELS.DEFAULT)
+      ? CLAUDE_FALLBACK_MODELS.DEFAULT
+      : options[0].value,
+  };
+};
+
+/**
+ * Asks the installed Claude CLI which models it supports.
+ *
+ * The query runs with `persistSession: false` and outside any project
+ * directory, so the probe leaves no session transcript behind — the reason
+ * this lookup used to be disabled. The prompt stream ends immediately without
+ * yielding: `supportedModels()` is answered from the CLI's startup handshake,
+ * so no turn is ever started and no tokens are spent.
+ *
+ * The executable is resolved the same way the runtime resolves it. Without
+ * that, the SDK falls back to its own bundled CLI, which is typically older
+ * than the one actually running chats and answers with a stale catalog.
+ */
+const probeClaudeSupportedModels = async (): Promise<ProviderModelsDefinition> => {
+  const abortController = new AbortController();
+  const timeout = setTimeout(() => abortController.abort(), SUPPORTED_MODELS_TIMEOUT_MS);
+  timeout.unref?.();
+
+  let queryInstance: ReturnType<typeof query> | null = null;
+  try {
+    queryInstance = query({
+      prompt: (async function* () {})(),
+      options: {
+        abortController,
+        cwd: os.tmpdir(),
+        settingSources: [],
+        persistSession: false,
+        pathToClaudeCodeExecutable: resolveClaudeCodeExecutablePath(process.env.CLAUDE_CLI_PATH),
+      },
+    });
+
+    const reported = await queryInstance.supportedModels();
+    const options = (Array.isArray(reported) ? reported : [])
+      .map((entry) => toProviderModelOption((entry ?? {}) as ClaudeCliModel))
+      .filter((option): option is ProviderModelOption => option !== null);
+
+    if (options.length === 0) {
+      console.warn('[Claude models] CLI reported no models; using the built-in catalog');
+      return CLAUDE_FALLBACK_MODELS;
+    }
+
+    return mergeWithFallbackModels(options);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.warn(`[Claude models] Unable to read the CLI catalog (${message}); using the built-in catalog`);
+    return CLAUDE_FALLBACK_MODELS;
+  } finally {
+    clearTimeout(timeout);
+    try {
+      await queryInstance?.close();
+    } catch {
+      // The probe is finished either way; a failed close must not surface.
+    }
+  }
 };
 
 export const findClaudeModelOption = (model: string | undefined | null): ProviderModelOption | null => {
@@ -225,24 +356,36 @@ const readClaudeSessionModelFromJsonl = async (
 };
 
 export class ClaudeProviderModels implements IProviderModels {
+  /**
+   * Reads the catalog from the installed Claude CLI, falling back to the
+   * static table when it cannot be reached.
+   *
+   * The CLI is the only thing that knows which aliases it accepts and what
+   * they resolve to today, so hardcoding that list means every model release
+   * leaves the picker showing last release's names. The fallback covers a
+   * missing or outdated CLI and any failure of the probe itself.
+   *
+   * Concurrent callers share one probe: the models service caches the result,
+   * but its cache is cold on the first request after a restart, and several
+   * clients tend to ask at once.
+   */
   async getSupportedModels(): Promise<ProviderModelsDefinition> {
-    // claude creates a new jsonl file as a separate session for this request.
-    // As a result, it lists the workspace where this is invoked when it shouldn't.
-    //
-    // Disabled for now:
-    // const queryInstance = query({
-    //   prompt: 'Get supported models',
-    //   options: buildClaudeQueryOptions(),
-    // });
-    // const supportedModels = await queryInstance.supportedModels();
-    // queryInstance.close();
-    // return buildClaudeModelsDefinition(supportedModels);
-    return CLAUDE_FALLBACK_MODELS;
+    if (!supportedModelsProbe) {
+      supportedModelsProbe = probeClaudeSupportedModels()
+        .finally(() => {
+          supportedModelsProbe = null;
+        });
+    }
+
+    return supportedModelsProbe;
   }
 
   async getCurrentActiveModel(sessionId?: string): Promise<ProviderCurrentActiveModel> {
+    // Deliberately the static default rather than the probed catalog: this is
+    // a fallback on a per-session hot path, and spawning the CLI to learn a
+    // value that has been `default` across every catalog is not worth it.
     if (!sessionId?.trim()) {
-      return buildDefaultProviderCurrentActiveModel(await this.getSupportedModels());
+      return buildDefaultProviderCurrentActiveModel(CLAUDE_FALLBACK_MODELS);
     }
 
     try {
@@ -257,6 +400,6 @@ export class ClaudeProviderModels implements IProviderModels {
       // Fall through to the provider default when the session-backed lookup fails.
     }
 
-    return buildDefaultProviderCurrentActiveModel(await this.getSupportedModels());
+    return buildDefaultProviderCurrentActiveModel(CLAUDE_FALLBACK_MODELS);
   }
 }

--- a/server/modules/providers/services/provider-models.service.ts
+++ b/server/modules/providers/services/provider-models.service.ts
@@ -16,7 +16,6 @@ import type {
 
 export const PROVIDER_MODELS_CACHE_TTL_MS = 3 * 24 * 60 * 60 * 1000;
 const PROVIDER_MODELS_CACHE_VERSION = 2;
-const UNCACHED_PROVIDERS = new Set<LLMProvider>(['claude']);
 
 /** Session-row access the service needs, narrowed so tests can stub it. */
 type ProviderModelsSessionStore = {
@@ -238,42 +237,10 @@ export const createProviderModelsService = (dependencies: ProviderModelsServiceD
     return request;
   };
 
-  const loadDirectModels = (
-    provider: LLMProvider,
-  ): Promise<ProviderModelsResult> => {
-    const request = resolveProvider(provider).models.getSupportedModels()
-      .then((models) => {
-        const currentTime = now();
-        return {
-          models,
-          cache: {
-            updatedAt: new Date(currentTime).toISOString(),
-            expiresAt: new Date(currentTime).toISOString(),
-            source: 'fresh' as const,
-          },
-        };
-      })
-      .finally(() => {
-        pendingRequests.delete(provider);
-      });
-
-    pendingRequests.set(provider, request);
-    return request;
-  };
-
   const getProviderModels = async (
     provider: LLMProvider,
     options: ProviderModelsOptions = {},
   ): Promise<ProviderModelsResult> => {
-    if (UNCACHED_PROVIDERS.has(provider)) {
-      const pendingRequest = pendingRequests.get(provider);
-      if (pendingRequest) {
-        return pendingRequest;
-      }
-
-      return loadDirectModels(provider);
-    }
-
     if (options.bypassCache) {
       const pendingRequest = pendingRequests.get(provider);
       if (pendingRequest) {

--- a/server/modules/providers/services/provider-models.service.ts
+++ b/server/modules/providers/services/provider-models.service.ts
@@ -15,6 +15,13 @@ import type {
 } from '@/shared/types.js';
 
 export const PROVIDER_MODELS_CACHE_TTL_MS = 3 * 24 * 60 * 60 * 1000;
+/**
+ * TTL for a catalog probe that fell back to the static built-in table
+ * (`isFallback: true`) instead of reading the provider. Kept short so a
+ * transient probe failure retries again soon rather than pinning the picker
+ * to the fallback table for the full 3-day TTL of a real result.
+ */
+export const PROVIDER_MODELS_FALLBACK_CACHE_TTL_MS = 60 * 1000;
 const PROVIDER_MODELS_CACHE_VERSION = 2;
 
 /** Session-row access the service needs, narrowed so tests can stub it. */
@@ -120,7 +127,7 @@ const writeProviderModelsCacheFile = async (
   now: number,
 ): Promise<void> => {
   const serializableEntries = Object.fromEntries(
-    [...entries.entries()].filter(([, entry]) => entry.expiresAt > now),
+    [...entries.entries()].filter(([, entry]) => entry.expiresAt > now && !entry.models.isFallback),
   );
   const payload: ProviderModelsCacheFile = {
     version: PROVIDER_MODELS_CACHE_VERSION,
@@ -207,14 +214,19 @@ export const createProviderModelsService = (dependencies: ProviderModelsServiceD
     models: ProviderModelsDefinition,
   ): Promise<ProviderModelsCacheEntry> => {
     const currentTime = now();
+    const ttl = models.isFallback ? PROVIDER_MODELS_FALLBACK_CACHE_TTL_MS : PROVIDER_MODELS_CACHE_TTL_MS;
     const entry: ProviderModelsCacheEntry = {
       updatedAt: currentTime,
-      expiresAt: currentTime + PROVIDER_MODELS_CACHE_TTL_MS,
+      expiresAt: currentTime + ttl,
       models,
     };
 
     memoryCache.set(provider, entry);
-    await persistCache();
+    // Fallback catalogs are memory-only: persisting one would let a
+    // transient probe failure survive a restart and outlive its short TTL.
+    if (!models.isFallback) {
+      await persistCache();
+    }
     return entry;
   };
 

--- a/server/modules/providers/tests/provider-models.service.test.ts
+++ b/server/modules/providers/tests/provider-models.service.test.ts
@@ -7,6 +7,7 @@ import test from 'node:test';
 import {
   createProviderModelsService,
   PROVIDER_MODELS_CACHE_TTL_MS,
+  PROVIDER_MODELS_FALLBACK_CACHE_TTL_MS,
 } from '@/modules/providers/services/provider-models.service.js';
 import type {
   LLMProvider,
@@ -121,6 +122,81 @@ test('provider models are cached for the three-day ttl', async () => {
     const refreshed = await service.getProviderModels('codex');
     assert.equal(loadCount, 2);
     assert.equal(refreshed.models.DEFAULT, 'codex-2');
+  } finally {
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test('a fallback catalog expires on the short fallback ttl, not the three-day ttl', async () => {
+  const tempRoot = await mkdtemp(path.join(os.tmpdir(), 'provider-model-cache-fallback-ttl-'));
+  let currentTime = 1_000;
+  let loadCount = 0;
+
+  try {
+    const service = createProviderModelsService({
+      cachePath: path.join(tempRoot, 'models-cache.json'),
+      now: () => currentTime,
+      resolveProvider: (provider) => ({
+        models: {
+          getSupportedModels: async () => {
+            loadCount += 1;
+            return { ...createModels(`${provider}-${loadCount}`), isFallback: true };
+          },
+          getCurrentActiveModel: async () => createCurrentActiveModel(`${provider}-active`),
+        },
+      }),
+    });
+
+    await service.getProviderModels('claude');
+    assert.equal(loadCount, 1);
+
+    currentTime += PROVIDER_MODELS_FALLBACK_CACHE_TTL_MS - 1;
+    await service.getProviderModels('claude');
+    assert.equal(loadCount, 1);
+
+    currentTime += 2;
+    const refreshed = await service.getProviderModels('claude');
+    assert.equal(loadCount, 2);
+    assert.equal(refreshed.models.DEFAULT, 'claude-2');
+  } finally {
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test('a fallback catalog is not written to the persisted cache', async () => {
+  const tempRoot = await mkdtemp(path.join(os.tmpdir(), 'provider-model-cache-fallback-disk-'));
+  const cachePath = path.join(tempRoot, 'models-cache.json');
+
+  try {
+    const writer = createProviderModelsService({
+      cachePath,
+      resolveProvider: () => ({
+        models: {
+          getSupportedModels: async () => ({ ...createModels('claude-fallback'), isFallback: true }),
+          getCurrentActiveModel: async () => createCurrentActiveModel('claude-active'),
+        },
+      }),
+    });
+    await writer.getProviderModels('claude');
+
+    let readerLoadCount = 0;
+    const reader = createProviderModelsService({
+      cachePath,
+      resolveProvider: () => ({
+        models: {
+          getSupportedModels: async () => {
+            readerLoadCount += 1;
+            return createModels('claude-fresh');
+          },
+          getCurrentActiveModel: async () => createCurrentActiveModel('claude-active'),
+        },
+      }),
+    });
+    const models = await reader.getProviderModels('claude');
+
+    assert.equal(readerLoadCount, 1);
+    assert.equal(models.models.DEFAULT, 'claude-fresh');
+    assert.equal(models.cache.source, 'fresh');
   } finally {
     await rm(tempRoot, { recursive: true, force: true });
   }

--- a/server/modules/providers/tests/provider-models.service.test.ts
+++ b/server/modules/providers/tests/provider-models.service.test.ts
@@ -126,8 +126,12 @@ test('provider models are cached for the three-day ttl', async () => {
   }
 });
 
-test('claude provider models are always loaded directly from the provider', async () => {
-  const tempRoot = await mkdtemp(path.join(os.tmpdir(), 'provider-model-cache-claude-direct-'));
+// Claude used to bypass the cache entirely: its catalog was a hardcoded
+// constant, so re-reading it cost nothing. It is now read from the CLI (a
+// spawned process), which makes it exactly the kind of lookup this cache
+// exists for.
+test('claude provider models are served from cache like every other provider', async () => {
+  const tempRoot = await mkdtemp(path.join(os.tmpdir(), 'provider-model-cache-claude-'));
   let loadCount = 0;
 
   try {
@@ -146,11 +150,13 @@ test('claude provider models are always loaded directly from the provider', asyn
 
     const first = await service.getProviderModels('claude');
     const second = await service.getProviderModels('claude');
+    const refreshed = await service.getProviderModels('claude', { bypassCache: true });
 
     assert.equal(loadCount, 2);
     assert.equal(first.models.DEFAULT, 'claude-1');
-    assert.equal(second.models.DEFAULT, 'claude-2');
-    assert.equal(second.cache.source, 'fresh');
+    assert.equal(second.models.DEFAULT, 'claude-1');
+    assert.equal(second.cache.source, 'memory');
+    assert.equal(refreshed.models.DEFAULT, 'claude-2');
   } finally {
     await rm(tempRoot, { recursive: true, force: true });
   }

--- a/server/shared/types.ts
+++ b/server/shared/types.ts
@@ -90,6 +90,13 @@ export type ProviderModelOption = {
 export type ProviderModelsDefinition = {
   OPTIONS: ProviderModelOption[];
   DEFAULT: string;
+  /**
+   * Set when this catalog is the static built-in table returned because the
+   * provider could not be probed, rather than a catalog read from the
+   * provider itself. Callers that cache catalogs should give a fallback a
+   * much shorter lifetime than a real one.
+   */
+  isFallback?: boolean;
 };
 
 /**


### PR DESCRIPTION
Fixes #1131

## Problem

The Claude model picker's options come from a hardcoded catalog. It falls behind every model release:

- `default` was labeled "currently Sonnet 5" — it actually resolves to `claude-opus-5[1m]` on current CLI builds.
- `opus` / `opus[1m]` were labeled "Opus 4.8" — they resolve to Opus 5.

`getSupportedModels()` had the dynamic lookup written but disabled, with a comment explaining why: calling `supportedModels()` was creating a separate jsonl session file, polluting the workspace's session list.

## Fix

Re-enable the dynamic lookup, addressing the jsonl-pollution concern directly instead of working around it:

- `persistSession: false` on the query — no transcript is written.
- The prompt is a stream that never yields, so `supportedModels()` is answered from the CLI's startup handshake without ever starting a turn (no tokens spent, nothing to persist in the first place).
- `cwd` is a temp directory outside any project, so even the CLI's own state files land somewhere disposable.
- `pathToClaudeCodeExecutable` resolves the same way the runtime resolves it (`resolveClaudeCodeExecutablePath`). Without this the SDK falls back to its own bundled binary, which is typically older than whatever's actually driving chats — I hit this in testing: the bundled 2.1.165 binary reported "Opus 4.8 / Sonnet 4.6", while the installed 2.1.227 binary (what the runtime actually uses) correctly reported Opus 5 / Sonnet 5.

**Fallback behavior:** if the probe fails, times out (30s), or returns nothing, `getSupportedModels()` falls back to the same static table as before — so a missing/very old CLI degrades to the previous (occasionally stale) behavior rather than breaking.

**Alias retention:** CLI-reported entries win (current names, descriptions, effort levels). Options that only the static table knows about — aliases the CLI has stopped advertising but the SDK confirms it still accepts — are appended rather than dropped. This matters because the CLI stops *advertising* an alias well before it stops *accepting* it; dropping one outright would silently reset the stored per-session model selection for anyone who'd picked it.

**Caching:** `claude` is removed from `UNCACHED_PROVIDERS` in the provider-models service. That exemption existed because the old catalog was a free in-memory constant — now that reading it means spawning a process, it's exactly the kind of lookup the existing 3-day disk-persisted cache is for. Concurrent-caller coalescing (`pendingRequests`) also now applies to Claude, so a burst of picker opens right after a cold start only spawns the CLI once.

## Verification

Ran the real `ClaudeProviderModels` class directly (not mocked) against the installed CLI:

- Concurrent calls to `getSupportedModels()` share one in-flight probe.
- Returned catalog has correct current labels (Opus 5, Sonnet 5, etc.) and effort levels straight from the CLI.
- Legacy aliases the CLI no longer lists (`opus`, `sonnet[1m]`, `fable`) are retained from the fallback table.
- `getCurrentActiveModel()` (a per-session hot path) stays at 0ms — it intentionally uses the static default rather than the probed catalog, since spawning a process there isn't worth it for a value that's `default` in every catalog anyway.
- No jsonl file appeared under `~/.claude/projects` for the probe's temp cwd, confirming the pollution the original comment described no longer happens.

On this PR's branch (rebased onto current `main`): `tsc --noEmit` clean, eslint 0 errors, and the provider-models test suite passes (17/17, including an updated test that now exercises Claude going through the same cache path as every other provider instead of asserting it bypasses caching).

## Notes for review

- Timeout is 30s (process spawn + CLI startup); a slow/broken machine degrades to the static table rather than stalling the request.
- I did not touch the static table's *content* beyond what's needed for the merge to make sense — it stays as the fallback and the source of retained legacy aliases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic discovery of installed Claude models through the Claude CLI.
  * Added fallback Claude model options when discovery is unavailable or incomplete.
  * Updated Claude model names and descriptions with current metadata.

* **Bug Fixes**
  * Improved reliability when discovery times out, fails, returns no results, or closes unexpectedly.
  * Ensured current-model selection consistently uses the supported static catalog.

* **Performance**
  * Improved model loading by sharing concurrent discovery requests and consistently using cached results.
  * Added shorter-lived, memory-only caching for fallback model catalogs.
  * Added fresh catalog loading when bypassing the cache.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->