### PR TITLE
fix(codex): preserve successful terminal status

### DIFF
--- a/server/modules/providers/list/codex/codex-sessions.provider.ts
+++ b/server/modules/providers/list/codex/codex-sessions.provider.ts
@@ -850,13 +850,11 @@ export class CodexSessionsProvider implements IProviderSessions {
     }
 
     if (raw.type === 'turn_complete') {
-      return [createNormalizedMessage({
-        id: baseId,
-        sessionId,
-        timestamp: ts,
-        provider: PROVIDER,
-        kind: 'complete',
-      })];
+      // The runtime emits one authoritative createCompleteMessage after the
+      // SDK stream closes, including success and exitCode. Emitting this
+      // intermediate transform would win terminal deduplication without those
+      // fields and make a successful turn appear failed to clients.
+      return [];
     }
     if (raw.type === 'turn_failed') {
       return [createNormalizedMessage({

--- a/server/modules/providers/tests/codex-sessions.test.ts
+++ b/server/modules/providers/tests/codex-sessions.test.ts
@@ -152,6 +152,17 @@ test('Codex synchronizer leaves indexed sessions untitled when no name is availa
   }
 });
 
+test('Codex live turn completion is emitted only by the runtime terminal message', () => {
+  const provider = new CodexSessionsProvider();
+
+  const normalized = provider.normalizeMessage(
+    { type: 'turn_complete', timestamp: '2026-08-11T02:50:33.960Z' },
+    'codex-session-1',
+  );
+
+  assert.deepEqual(normalized, []);
+});
+
 test('Codex history preserves wrapped exec tool calls and results', { concurrency: false }, async () => {
   const tempRoot = await mkdtemp(path.join(os.tmpdir(), 'codex-exec-history-'));
   const workspacePath = path.join(tempRoot, 'workspace');


### PR DESCRIPTION
## Summary

- skip the intermediate Codex `turn_complete` normalization
- let the runtime terminal message remain authoritative for `success` and `exitCode`
- add a regression test for the duplicate terminal event

## Problem

Codex emits a `turn_complete` stream event before the runtime emits its final normalized completion. The intermediate event lacks `success` and `exitCode`, but wins terminal-event deduplication, so clients can interpret a successful turn as failed.

## Testing

- `npm test`: 256 passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved live session completion handling to prevent duplicate completion messages.
  * Completion status is now reported only once, using the authoritative final event.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->