### PR TITLE
feat(sidebar): add logout action

### DIFF
--- a/src/components/sidebar/view/Sidebar.tsx
+++ b/src/components/sidebar/view/Sidebar.tsx
@@ -8,6 +8,7 @@ import { useSidebarController } from '../hooks/useSidebarController';
 import { useTaskMaster } from '../../../contexts/TaskMasterContext';
 import { usePaletteOps } from '../../../contexts/PaletteOpsContext';
 import { useTasksSettings } from '../../../contexts/TasksSettingsContext';
+import { useAuth } from '../../auth';
 import type { Project, LLMProvider } from '../../../types/app';
 import type { MCPServerStatus, SidebarProps } from '../types/types';
 
@@ -52,6 +53,7 @@ function Sidebar({
   const { sidebarVisible } = preferences;
   const { setCurrentProject, mcpServerStatus } = useTaskMaster() as TaskMasterSidebarContext;
   const { tasksEnabled } = useTasksSettings();
+  const { logout } = useAuth();
   const paletteOps = usePaletteOps();
 
   const {
@@ -233,6 +235,7 @@ function Sidebar({
         <SidebarCollapsed
           onExpand={handleExpandSidebar}
           onShowSettings={onShowSettings}
+          onLogout={logout}
           updateAvailable={updateAvailable}
           restartRequired={restartRequired}
           onShowVersionModal={() => setShowVersionModal(true)}
@@ -321,6 +324,7 @@ function Sidebar({
             currentVersion={currentVersion}
             onShowVersionModal={() => setShowVersionModal(true)}
             onShowSettings={onShowSettings}
+            onLogout={logout}
             projectListProps={projectListProps}
             t={t}
           />

--- a/src/components/sidebar/view/subcomponents/SidebarCollapsed.tsx
+++ b/src/components/sidebar/view/subcomponents/SidebarCollapsed.tsx
@@ -1,5 +1,6 @@
-import { Settings, Sparkles, PanelLeftOpen, Bug, AlertTriangle } from 'lucide-react';
+import { Settings, Sparkles, PanelLeftOpen, Bug, AlertTriangle, LogOut } from 'lucide-react';
 import type { TFunction } from 'i18next';
+import { IS_PLATFORM } from '../../../../constants/config';
 
 const DISCORD_INVITE_URL = 'https://discord.gg/buxwujPNRE';
 const GITHUB_ISSUES_URL = 'https://github.com/siteboon/claudecodeui/issues/new';
@@ -15,6 +16,7 @@ function DiscordIcon({ className }: { className?: string }) {
 type SidebarCollapsedProps = {
   onExpand: () => void;
   onShowSettings: () => void;
+  onLogout: () => void;
   updateAvailable: boolean;
   restartRequired: boolean;
   onShowVersionModal: () => void;
@@ -24,6 +26,7 @@ type SidebarCollapsedProps = {
 export default function SidebarCollapsed({
   onExpand,
   onShowSettings,
+  onLogout,
   updateAvailable,
   restartRequired,
   onShowVersionModal,
@@ -52,6 +55,17 @@ export default function SidebarCollapsed({
       >
         <Settings className="h-4 w-4 text-muted-foreground transition-colors group-hover:text-foreground" />
       </button>
+
+      {!IS_PLATFORM && (
+        <button
+          onClick={onLogout}
+          className="group flex h-8 w-8 items-center justify-center rounded-lg transition-colors hover:bg-destructive/10"
+          aria-label={t('common:navigation.logout')}
+          title={t('common:navigation.logout')}
+        >
+          <LogOut className="h-4 w-4 text-muted-foreground transition-colors group-hover:text-destructive" />
+        </button>
+      )}
 
       {/* Report Issue */}
       <a

--- a/src/components/sidebar/view/subcomponents/SidebarContent.tsx
+++ b/src/components/sidebar/view/subcomponents/SidebarContent.tsx
@@ -130,6 +130,7 @@ type SidebarContentProps = {
   currentVersion: string;
   onShowVersionModal: () => void;
   onShowSettings: () => void;
+  onLogout: () => void;
   projectListProps: SidebarProjectListProps;
   t: TFunction;
 };
@@ -176,6 +177,7 @@ export default function SidebarContent({
   currentVersion,
   onShowVersionModal,
   onShowSettings,
+  onLogout,
   projectListProps,
   t,
 }: SidebarContentProps) {
@@ -627,6 +629,7 @@ export default function SidebarContent({
           currentVersion={currentVersion}
           onShowVersionModal={onShowVersionModal}
           onShowSettings={onShowSettings}
+          onLogout={onLogout}
           t={t}
         />
       )}

--- a/src/components/sidebar/view/subcomponents/SidebarFooter.tsx
+++ b/src/components/sidebar/view/subcomponents/SidebarFooter.tsx
@@ -187,7 +187,7 @@ export default function SidebarFooter({
       </div>
 
       {/* Mobile Discord */}
-      <div className="px-3 pt-2 md:hidden">
+      <div className={IS_PLATFORM ? 'px-3 pb-3 pt-2 md:hidden' : 'px-3 pt-2 md:hidden'}>
         <a
           href={DISCORD_INVITE_URL}
           target="_blank"

--- a/src/components/sidebar/view/subcomponents/SidebarFooter.tsx
+++ b/src/components/sidebar/view/subcomponents/SidebarFooter.tsx
@@ -1,4 +1,4 @@
-import { Settings, ArrowUpCircle, Bug, AlertTriangle } from 'lucide-react';
+import { Settings, ArrowUpCircle, Bug, AlertTriangle, LogOut } from 'lucide-react';
 import type { TFunction } from 'i18next';
 import { IS_PLATFORM } from '../../../../constants/config';
 import type { ReleaseInfo } from '../../../../types/sharedTypes';
@@ -24,6 +24,7 @@ type SidebarFooterProps = {
   currentVersion: string;
   onShowVersionModal: () => void;
   onShowSettings: () => void;
+  onLogout: () => void;
   t: TFunction;
 };
 
@@ -35,6 +36,7 @@ export default function SidebarFooter({
   currentVersion,
   onShowVersionModal,
   onShowSettings,
+  onLogout,
   t,
 }: SidebarFooterProps) {
   return (
@@ -143,6 +145,18 @@ export default function SidebarFooter({
         </button>
       </div>
 
+      {!IS_PLATFORM && (
+        <div className="hidden px-2 pb-1.5 md:block">
+          <button
+            className="flex w-full items-center gap-2 rounded-lg px-2.5 py-1.5 text-muted-foreground transition-colors hover:bg-destructive/10 hover:text-destructive"
+            onClick={onLogout}
+          >
+            <LogOut className="h-3.5 w-3.5" />
+            <span className="text-sm">{t('common:navigation.logout')}</span>
+          </button>
+        </div>
+      )}
+
       {/* Desktop version brand line (OSS mode only) */}
       {!IS_PLATFORM && (
         <div className="hidden px-3 py-2 text-center md:block">
@@ -188,7 +202,7 @@ export default function SidebarFooter({
       </div>
 
       {/* Mobile settings */}
-      <div className="px-3 pb-3 pt-2 md:hidden">
+      <div className="px-3 pt-2 md:hidden">
         <button
           className="flex h-10 w-full items-center gap-3 rounded-xl bg-muted/40 px-3.5 transition-all hover:bg-muted/60 active:scale-[0.98]"
           onClick={onShowSettings}
@@ -199,6 +213,20 @@ export default function SidebarFooter({
           <span className="text-sm font-normal text-foreground">{t('actions.settings')}</span>
         </button>
       </div>
+
+      {!IS_PLATFORM && (
+        <div className="px-3 pb-3 pt-2 md:hidden">
+          <button
+            className="flex h-10 w-full items-center gap-3 rounded-xl bg-muted/40 px-3.5 transition-all hover:bg-destructive/10 active:scale-[0.98]"
+            onClick={onLogout}
+          >
+            <div className="flex h-7 w-7 items-center justify-center rounded-lg bg-background/80">
+              <LogOut className="h-4 w-4 text-muted-foreground" />
+            </div>
+            <span className="text-sm font-normal text-foreground">{t('common:navigation.logout')}</span>
+          </button>
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- add a localized logout action to the expanded desktop and mobile sidebars
- expose the same action in the collapsed sidebar
- reuse AuthContext logout so the local token and session are cleared
- hide the action in hosted platform mode, where local authentication is bypassed

Closes #1122

## Validation

- npm run typecheck
- npm run lint — 0 errors; existing repository warnings remain
- npm run build — passed; existing CSS minifier and chunk-size warnings remain
- git diff --check

## Screenshots

Not included yet; this is a draft PR and the new action follows the existing sidebar action styles.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added logout controls to expanded and collapsed sidebar views.
  * Added logout access in desktop and mobile sidebar footers.
  * Logout controls appear only when applicable and include localized accessibility labels.
  * Added visual styling to clearly indicate the logout action.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->