### PR TITLE
fix(codex): stream reasoning summaries

### DIFF
--- a/server/modules/providers/list/codex/codex-runtime.provider.js
+++ b/server/modules/providers/list/codex/codex-runtime.provider.js
@@ -25,6 +25,16 @@ import { createCompleteMessage, createNormalizedMessage } from '@/shared/utils.j
 
 const activeCodexSessions = new Map();
 
+export function getCodexClientOptions() {
+  return {
+    config: {
+      // `codex exec` does not request summaries by default, unlike the TUI.
+      // Detailed summaries expose useful progress without revealing raw chain of thought.
+      model_reasoning_summary: 'detailed',
+    },
+  };
+}
+
 function readUsageNumber(value) {
   const parsed = Number(value);
   return Number.isFinite(parsed) ? parsed : 0;
@@ -264,7 +274,7 @@ export async function queryCodex(command, options = {}, ws, context) {
   const sessionKey = () => sessionId || capturedSessionId || null;
 
   try {
-    codex = new Codex();
+    codex = new Codex(getCodexClientOptions());
 
     const threadOptions = {
       workingDirectory,

--- a/server/modules/providers/list/codex/codex-runtime.provider.test.js
+++ b/server/modules/providers/list/codex/codex-runtime.provider.test.js
@@ -1,0 +1,13 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { getCodexClientOptions } from './codex-runtime.provider.js';
+
+
+test('Codex exec requests reasoning summaries for streamed chat turns', () => {
+  assert.deepEqual(getCodexClientOptions(), {
+    config: {
+      model_reasoning_summary: 'detailed',
+    },
+  });
+});


### PR DESCRIPTION
Codex exec does not request reasoning summaries by default, so CloudCLI receives empty reasoning entries even though the provider emits encrypted reasoning.

Configure the SDK client with model_reasoning_summary=detailed. This exposes concise provider-authored summaries without enabling raw chain-of-thought.

Tests:
- npm run typecheck
- npm test (267 passed on the pinned Nacho fork)
- focused test on current upstream main

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Codex-powered responses now include more detailed reasoning summaries when available.

* **Tests**
  * Added coverage to verify that detailed reasoning summaries are requested.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->