### PR TITLE
fix(chat): close the streamed row at each message boundary

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "build:server": "tsc -p server/tsconfig.json && tsc-alias -p server/tsconfig.json",
     "preview": "vite preview",
     "typecheck": "tsc --noEmit -p tsconfig.json && tsc --noEmit -p server/tsconfig.json",
-    "test": "tsx --tsconfig server/tsconfig.json --test \"server/**/*.test.ts\" \"server/**/*.test.js\"",
+    "test": "tsx --tsconfig server/tsconfig.json --test \"server/**/*.test.ts\" \"server/**/*.test.js\" \"src/**/*.test.ts\"",
     "lint": "eslint src/ server/",
     "lint:fix": "eslint src/ server/ --fix",
     "start": "npm run build && npm run server",

--- a/src/components/chat/hooks/streamBuffers.test.ts
+++ b/src/components/chat/hooks/streamBuffers.test.ts
@@ -1,0 +1,234 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import type { StreamBuffers, StreamFlushScheduler, StreamRowSink } from './streamBuffers';
+import {
+  appendStreamDelta,
+  closeStreamBuffer,
+  dropStreamBuffers,
+  isStreamBoundaryKind,
+} from './streamBuffers';
+
+type Write = { call: 'update' | 'finalize'; sessionId: string; text?: string };
+
+/** Records store writes in order, so tests can assert on row lifecycle. */
+const createSink = (writes: Write[]): StreamRowSink => ({
+  update: (sessionId, text) => writes.push({ call: 'update', sessionId, text }),
+  finalize: (sessionId) => writes.push({ call: 'finalize', sessionId }),
+});
+
+/** Scheduler whose pending flushes only run when a test says so. */
+const createScheduler = () => {
+  const pending = new Map<number, () => void>();
+  let nextTimer = 1;
+  const scheduler: StreamFlushScheduler = {
+    schedule: (flush) => {
+      const timer = nextTimer++;
+      pending.set(timer, flush);
+      return timer;
+    },
+    cancel: (timer) => {
+      pending.delete(timer);
+    },
+  };
+  return {
+    scheduler,
+    flushAll: () => {
+      const due = [...pending.values()];
+      pending.clear();
+      for (const flush of due) flush();
+    },
+    pendingCount: () => pending.size,
+  };
+};
+
+test('boundary kinds are the frames that carry a row of their own', () => {
+  for (const kind of ['text', 'thinking', 'tool_use', 'tool_result']) {
+    assert.equal(isStreamBoundaryKind(kind), true, kind);
+  }
+  for (const kind of ['stream_delta', 'status', 'complete', 'error', undefined]) {
+    assert.equal(isStreamBoundaryKind(kind), false, String(kind));
+  }
+});
+
+test('deltas are coalesced into one write per flush', () => {
+  const writes: Write[] = [];
+  const buffers: StreamBuffers = new Map();
+  const { scheduler, flushAll, pendingCount } = createScheduler();
+
+  appendStreamDelta(buffers, 's1', 'Hel', createSink(writes), scheduler);
+  appendStreamDelta(buffers, 's1', 'lo ', createSink(writes), scheduler);
+  appendStreamDelta(buffers, 's1', 'there', createSink(writes), scheduler);
+
+  assert.equal(pendingCount(), 1);
+  assert.deepEqual(writes, []);
+
+  flushAll();
+  assert.deepEqual(writes, [{ call: 'update', sessionId: 's1', text: 'Hello there' }]);
+});
+
+test('a boundary finalizes the row so the next message does not replace it', () => {
+  const writes: Write[] = [];
+  const sink = createSink(writes);
+  const buffers: StreamBuffers = new Map();
+  const { scheduler, flushAll } = createScheduler();
+
+  appendStreamDelta(buffers, 's1', 'first message', sink, scheduler);
+  flushAll();
+
+  closeStreamBuffer(buffers, 's1', sink, scheduler);
+
+  appendStreamDelta(buffers, 's1', 'second message', sink, scheduler);
+  flushAll();
+  closeStreamBuffer(buffers, 's1', sink, scheduler);
+
+  assert.deepEqual(writes, [
+    { call: 'update', sessionId: 's1', text: 'first message' },
+    { call: 'finalize', sessionId: 's1' },
+    { call: 'update', sessionId: 's1', text: 'second message' },
+    { call: 'finalize', sessionId: 's1' },
+  ]);
+});
+
+test('closing flushes deltas that never reached a scheduled flush', () => {
+  const writes: Write[] = [];
+  const sink = createSink(writes);
+  const buffers: StreamBuffers = new Map();
+  const { scheduler, flushAll, pendingCount } = createScheduler();
+
+  appendStreamDelta(buffers, 's1', 'tail text', sink, scheduler);
+  closeStreamBuffer(buffers, 's1', sink, scheduler);
+
+  assert.deepEqual(writes, [
+    { call: 'update', sessionId: 's1', text: 'tail text' },
+    { call: 'finalize', sessionId: 's1' },
+  ]);
+
+  // The cancelled flush must not fire afterwards and re-open the closed row.
+  assert.equal(pendingCount(), 0);
+  flushAll();
+  assert.equal(writes.length, 2);
+});
+
+test('closing with no open buffer still frees a row left parked by an earlier switch', () => {
+  const writes: Write[] = [];
+  const buffers: StreamBuffers = new Map();
+  const { scheduler } = createScheduler();
+
+  closeStreamBuffer(buffers, 's1', createSink(writes), scheduler);
+
+  assert.deepEqual(writes, [{ call: 'finalize', sessionId: 's1' }]);
+});
+
+test('closing does not repeat a write the row already holds', () => {
+  const writes: Write[] = [];
+  const sink = createSink(writes);
+  const buffers: StreamBuffers = new Map();
+  const { scheduler, flushAll } = createScheduler();
+
+  appendStreamDelta(buffers, 's1', 'complete message', sink, scheduler);
+  flushAll();
+  closeStreamBuffer(buffers, 's1', sink, scheduler);
+
+  assert.deepEqual(writes, [
+    { call: 'update', sessionId: 's1', text: 'complete message' },
+    { call: 'finalize', sessionId: 's1' },
+  ]);
+});
+
+test('concurrent sessions keep separate text', () => {
+  const writes: Write[] = [];
+  const sink = createSink(writes);
+  const buffers: StreamBuffers = new Map();
+  const { scheduler, flushAll } = createScheduler();
+
+  appendStreamDelta(buffers, 's1', 'from one', sink, scheduler);
+  appendStreamDelta(buffers, 's2', 'from two', sink, scheduler);
+  flushAll();
+
+  assert.deepEqual(writes, [
+    { call: 'update', sessionId: 's1', text: 'from one' },
+    { call: 'update', sessionId: 's2', text: 'from two' },
+  ]);
+});
+
+test('closing one session leaves another session mid-stream untouched', () => {
+  const writes: Write[] = [];
+  const sink = createSink(writes);
+  const buffers: StreamBuffers = new Map();
+  const { scheduler, flushAll } = createScheduler();
+
+  appendStreamDelta(buffers, 's1', 'viewed', sink, scheduler);
+  appendStreamDelta(buffers, 's2', 'background', sink, scheduler);
+
+  closeStreamBuffer(buffers, 's1', sink, scheduler);
+  flushAll();
+
+  assert.deepEqual(writes, [
+    { call: 'update', sessionId: 's1', text: 'viewed' },
+    { call: 'finalize', sessionId: 's1' },
+    { call: 'update', sessionId: 's2', text: 'background' },
+  ]);
+});
+
+test('dropping one session keeps the other pending flush alive', () => {
+  const writes: Write[] = [];
+  const sink = createSink(writes);
+  const buffers: StreamBuffers = new Map();
+  const { scheduler, flushAll } = createScheduler();
+
+  appendStreamDelta(buffers, 's1', 'abandoned', sink, scheduler);
+  appendStreamDelta(buffers, 's2', 'still running', sink, scheduler);
+
+  dropStreamBuffers(buffers, scheduler, 's1');
+  flushAll();
+
+  assert.deepEqual(writes, [{ call: 'update', sessionId: 's2', text: 'still running' }]);
+  assert.equal(buffers.has('s1'), false);
+});
+
+test('dropping without a session id abandons every buffer silently', () => {
+  const writes: Write[] = [];
+  const sink = createSink(writes);
+  const buffers: StreamBuffers = new Map();
+  const { scheduler, flushAll, pendingCount } = createScheduler();
+
+  appendStreamDelta(buffers, 's1', 'one', sink, scheduler);
+  appendStreamDelta(buffers, 's2', 'two', sink, scheduler);
+
+  dropStreamBuffers(buffers, scheduler);
+  flushAll();
+
+  assert.deepEqual(writes, []);
+  assert.equal(buffers.size, 0);
+  assert.equal(pendingCount(), 0);
+});
+
+test('a turn that interleaves deltas with a tool call produces one row per message', () => {
+  const writes: Write[] = [];
+  const sink = createSink(writes);
+  const buffers: StreamBuffers = new Map();
+  const { scheduler, flushAll } = createScheduler();
+
+  // The OpenCode live sequence: text deltas, a tool_use mid-turn, more deltas,
+  // then step_finish. Only the frames that touch the buffer appear here.
+  for (const part of ['Reading ', 'the helper.']) {
+    appendStreamDelta(buffers, 's1', part, sink, scheduler);
+  }
+  flushAll();
+
+  closeStreamBuffer(buffers, 's1', sink, scheduler); // tool_use boundary
+
+  for (const part of ['Renamed ', 'it.']) {
+    appendStreamDelta(buffers, 's1', part, sink, scheduler);
+  }
+  flushAll();
+
+  closeStreamBuffer(buffers, 's1', sink, scheduler); // stream_end
+
+  const finalized = writes
+    .filter((write, index) => write.call === 'update' && writes[index + 1]?.call === 'finalize')
+    .map((write) => write.text);
+
+  assert.deepEqual(finalized, ['Reading the helper.', 'Renamed it.']);
+});

--- a/src/components/chat/hooks/streamBuffers.ts
+++ b/src/components/chat/hooks/streamBuffers.ts
@@ -1,0 +1,143 @@
+/**
+ * Per-session buffering for live `stream_delta` frames.
+ *
+ * Deltas are coalesced into one store write per flush interval, and the row
+ * they write to is closed at every assistant-message boundary. Both concerns
+ * live here, free of React, so they can be tested directly.
+ */
+
+/** One session's open streaming row: the deltas so far plus its pending flush. */
+type StreamBuffer = {
+  text: string;
+  /** What the row already holds, so closing does not repeat the last write. */
+  flushedText: string;
+  timer: number | null;
+};
+
+/** Open streaming rows, keyed by app session id. */
+export type StreamBuffers = Map<string, StreamBuffer>;
+
+/**
+ * Store writes a buffer needs. `finalize` must re-id the row away from the
+ * well-known streaming id, otherwise the next message's first delta replaces
+ * the row this one just closed.
+ */
+export type StreamRowSink = {
+  update: (sessionId: string, text: string) => void;
+  finalize: (sessionId: string) => void;
+};
+
+/** Timer plumbing, injected so tests can drive flushes deterministically. */
+export type StreamFlushScheduler = {
+  schedule: (flush: () => void) => number;
+  cancel: (timer: number) => void;
+};
+
+/** Coalescing window for delta writes. Long enough to spare React a render per token. */
+const STREAM_FLUSH_INTERVAL_MS = 100;
+
+const STREAM_BOUNDARY_KINDS = new Set(['text', 'thinking', 'tool_use', 'tool_result']);
+
+/**
+ * Whether a frame ends the assistant message currently being streamed.
+ *
+ * Providers are not required to emit `stream_end` per message — Cursor never
+ * emits it, and OpenCode only emits it at `step_finish` — so the boundary is
+ * derived from the frame kinds that carry a row of their own instead.
+ */
+export function isStreamBoundaryKind(kind: string | undefined): boolean {
+  return typeof kind === 'string' && STREAM_BOUNDARY_KINDS.has(kind);
+}
+
+/**
+ * Accumulate one delta and make sure a flush is pending for its session.
+ */
+export function appendStreamDelta(
+  buffers: StreamBuffers,
+  sessionId: string,
+  text: string,
+  sink: StreamRowSink,
+  scheduler: StreamFlushScheduler,
+): void {
+  const buffer = buffers.get(sessionId) ?? { text: '', flushedText: '', timer: null };
+  buffer.text += text;
+  buffers.set(sessionId, buffer);
+
+  if (buffer.timer !== null) {
+    return;
+  }
+
+  buffer.timer = scheduler.schedule(() => {
+    // The buffer can be closed or dropped between scheduling and firing.
+    const pending = buffers.get(sessionId);
+    if (pending !== buffer) {
+      return;
+    }
+    pending.timer = null;
+    pending.flushedText = pending.text;
+    sink.update(sessionId, pending.text);
+  });
+}
+
+/**
+ * Close one session's streamed row: flush every delta into it, then finalize it
+ * so the next assistant message starts a row of its own.
+ *
+ * `finalize` runs even with no buffer open, because a row can outlive its
+ * buffer — switching away from a streaming session drops the buffer and leaves
+ * the row parked at the well-known id. Finalizing frees that id; the store call
+ * is a no-op when no such row exists.
+ */
+export function closeStreamBuffer(
+  buffers: StreamBuffers,
+  sessionId: string,
+  sink: StreamRowSink,
+  scheduler: StreamFlushScheduler,
+): void {
+  const buffer = buffers.get(sessionId);
+
+  if (buffer) {
+    if (buffer.timer !== null) {
+      scheduler.cancel(buffer.timer);
+    }
+    buffers.delete(sessionId);
+
+    if (buffer.text && buffer.text !== buffer.flushedText) {
+      sink.update(sessionId, buffer.text);
+    }
+  }
+
+  sink.finalize(sessionId);
+}
+
+/**
+ * Abandon buffers without writing them to the store: one session's when the
+ * view moves off it, or every session's when the chat unmounts. Passing a
+ * session id leaves other sessions' pending flushes alone.
+ */
+export function dropStreamBuffers(
+  buffers: StreamBuffers,
+  scheduler: StreamFlushScheduler,
+  sessionId?: string,
+): void {
+  const doomed = sessionId === undefined
+    ? [...buffers.keys()]
+    : [sessionId];
+
+  for (const id of doomed) {
+    const buffer = buffers.get(id);
+    if (!buffer) {
+      continue;
+    }
+    if (buffer.timer !== null) {
+      scheduler.cancel(buffer.timer);
+    }
+    buffers.delete(id);
+  }
+}
+
+/** Scheduler backed by the browser timer queue. */
+export const windowStreamFlushScheduler: StreamFlushScheduler = {
+  schedule: (flush) => window.setTimeout(flush, STREAM_FLUSH_INTERVAL_MS),
+  cancel: (timer) => clearTimeout(timer),
+};

--- a/src/components/chat/hooks/useChatRealtimeHandlers.ts
+++ b/src/components/chat/hooks/useChatRealtimeHandlers.ts
@@ -9,6 +9,14 @@ import type { PendingPermissionRequest } from '../types/types';
 import type { ProjectSession, LLMProvider } from '../../../types/app';
 import type { SessionStore, NormalizedMessage } from '../../../stores/useSessionStore';
 
+import type { StreamBuffers, StreamRowSink } from './streamBuffers';
+import {
+  appendStreamDelta,
+  closeStreamBuffer,
+  isStreamBoundaryKind,
+  windowStreamFlushScheduler,
+} from './streamBuffers';
+
 const isActionablePermissionRequest = (request: { toolName?: unknown } | null | undefined): boolean => {
   return request?.toolName !== 'ExitPlanMode' && request?.toolName !== 'exit_plan_mode';
 };
@@ -25,8 +33,13 @@ interface UseChatRealtimeHandlersArgs {
   setTokenBudget: (budget: Record<string, unknown> | null) => void;
   pendingPermissionRequests: PendingPermissionRequest[];
   setPendingPermissionRequests: Dispatch<SetStateAction<PendingPermissionRequest[]>>;
-  streamTimerRef: MutableRefObject<number | null>;
-  accumulatedStreamRef: MutableRefObject<string>;
+  /**
+   * Open streaming rows, keyed by app session id. Keyed per session because the
+   * row each buffer writes to already is (`__streaming_${sessionId}`): a single
+   * accumulator flushed a background session's text into whichever session the
+   * current frame named.
+   */
+  streamBuffersRef: MutableRefObject<StreamBuffers>;
   /**
    * Highest live `seq` observed per session. Essential for reconnect catch-up:
    * `chat.subscribe` sends this value as `lastSeq` so the server replays only
@@ -63,8 +76,7 @@ export function useChatRealtimeHandlers({
   setTokenBudget,
   pendingPermissionRequests,
   setPendingPermissionRequests,
-  streamTimerRef,
-  accumulatedStreamRef,
+  streamBuffersRef,
   lastSeqRef,
   statusCheckSentAtRef,
   onSessionProcessing,
@@ -89,6 +101,11 @@ export function useChatRealtimeHandlers({
   }, [pendingPermissionRequests]);
 
   useEffect(() => {
+    const streamRowSink: StreamRowSink = {
+      update: (sessionId, text) => sessionStore.updateStreaming(sessionId, text, provider),
+      finalize: (sessionId) => sessionStore.finalizeStreaming(sessionId),
+    };
+
     const handleEvent = (msg: ServerEvent) => {
       if (!msg.kind) {
         return;
@@ -176,14 +193,8 @@ export function useChatRealtimeHandlers({
       if (msg.kind === 'stream_delta') {
         const text = (msg.content as string) || '';
         if (!text) return;
-        accumulatedStreamRef.current += text;
-        if (!streamTimerRef.current) {
-          streamTimerRef.current = window.setTimeout(() => {
-            streamTimerRef.current = null;
-            if (sid) {
-              sessionStore.updateStreaming(sid, accumulatedStreamRef.current, provider);
-            }
-          }, 100);
+        if (sid) {
+          appendStreamDelta(streamBuffersRef.current, sid, text, streamRowSink, windowStreamFlushScheduler);
         }
         // Also route to store for non-active sessions
         if (sid && sid !== activeViewSessionId) {
@@ -193,18 +204,18 @@ export function useChatRealtimeHandlers({
       }
 
       if (msg.kind === 'stream_end') {
-        if (streamTimerRef.current) {
-          clearTimeout(streamTimerRef.current);
-          streamTimerRef.current = null;
-        }
         if (sid) {
-          if (accumulatedStreamRef.current) {
-            sessionStore.updateStreaming(sid, accumulatedStreamRef.current, provider);
-          }
-          sessionStore.finalizeStreaming(sid);
+          closeStreamBuffer(streamBuffersRef.current, sid, streamRowSink, windowStreamFlushScheduler);
         }
-        accumulatedStreamRef.current = '';
         return;
+      }
+
+      // A frame that carries a row of its own ends the message being streamed.
+      // Closing before the row is appended keeps the finalized text ahead of it:
+      // `updateStreaming` re-stamps `timestamp` on every write, so an unclosed
+      // row outlives and sorts past the tool rows it was interleaved with.
+      if (sid && isStreamBoundaryKind(msg.kind)) {
+        closeStreamBuffer(streamBuffersRef.current, sid, streamRowSink, windowStreamFlushScheduler);
       }
 
       // --- All other messages: route to store ---
@@ -222,15 +233,9 @@ export function useChatRealtimeHandlers({
       switch (msg.kind) {
         case 'complete': {
           // Flush any remaining streaming state
-          if (streamTimerRef.current) {
-            clearTimeout(streamTimerRef.current);
-            streamTimerRef.current = null;
+          if (sid) {
+            closeStreamBuffer(streamBuffersRef.current, sid, streamRowSink, windowStreamFlushScheduler);
           }
-          if (sid && accumulatedStreamRef.current) {
-            sessionStore.updateStreaming(sid, accumulatedStreamRef.current, provider);
-            sessionStore.finalizeStreaming(sid);
-          }
-          accumulatedStreamRef.current = '';
 
           // `complete` is the unified terminal event — every provider run ends
           // with exactly one, regardless of success, failure, or abort. The
@@ -336,8 +341,7 @@ export function useChatRealtimeHandlers({
     setTokenBudget,
     pendingPermissionRequests,
     setPendingPermissionRequests,
-    streamTimerRef,
-    accumulatedStreamRef,
+    streamBuffersRef,
     lastSeqRef,
     statusCheckSentAtRef,
     onSessionProcessing,

--- a/src/components/chat/hooks/useChatSessionState.ts
+++ b/src/components/chat/hooks/useChatSessionState.ts
@@ -22,7 +22,8 @@ interface UseChatSessionStateArgs {
   newSessionTrigger?: number;
   processingSessions?: SessionActivityMap;
   onSessionIdle?: MarkSessionIdle;
-  resetStreamingState: () => void;
+  /** Drops buffered deltas for one session, or for every session when called without an id. */
+  resetStreamingState: (sessionId?: string) => void;
   /** When each session's `chat.subscribe` was last sent; guards stale idle acks. */
   statusCheckSentAtRef: MutableRefObject<Map<string, number>>;
   /** Highest live seq observed per session; sent as `lastSeq` on subscribe. */
@@ -109,6 +110,10 @@ export function useChatSessionState({
   sessionStore,
 }: UseChatSessionStateArgs) {
   const [currentSessionId, setCurrentSessionId] = useState<string | null>(selectedSession?.id || null);
+  // Read by the New Session effect, which must not depend on `currentSessionId`:
+  // it has to run once per trigger, not again whenever the session id changes.
+  const currentSessionIdRef = useRef(currentSessionId);
+  currentSessionIdRef.current = currentSessionId;
   const [isLoadingSessionMessages, setIsLoadingSessionMessages] = useState(false);
   const [isLoadingMoreMessages, setIsLoadingMoreMessages] = useState(false);
   const [hasMoreMessages, setHasMoreMessages] = useState(false);
@@ -172,7 +177,9 @@ export function useChatSessionState({
      * - No dependence on route/tab/session-object identity changes.
      * - No coupling to unrelated external update signals.
      */
-    resetStreamingState();
+    if (currentSessionIdRef.current) {
+      resetStreamingState(currentSessionIdRef.current);
+    }
     setCurrentSessionId(null);
     setPendingUserMessage(null);
     messagesOffsetRef.current = 0;
@@ -486,7 +493,9 @@ export function useChatSessionState({
         return;
       }
 
-      resetStreamingState();
+      if (currentSessionId) {
+        resetStreamingState(currentSessionId);
+      }
       setCurrentSessionId(null);
       messagesOffsetRef.current = 0;
       setHasMoreMessages(false);
@@ -522,7 +531,7 @@ export function useChatSessionState({
 
     const sessionChanged = currentSessionId !== null && currentSessionId !== selectedSessionId;
     if (sessionChanged) {
-      resetStreamingState();
+      resetStreamingState(currentSessionId);
     }
 
     // Reset pagination/scroll state

--- a/src/components/chat/view/ChatInterface.tsx
+++ b/src/components/chat/view/ChatInterface.tsx
@@ -9,6 +9,8 @@ import type { ChatInterfaceProps, PermissionMode, Provider  } from '../types/typ
 import { useChatProviderState } from '../hooks/useChatProviderState';
 import { useChatSessionState } from '../hooks/useChatSessionState';
 import { useChatRealtimeHandlers } from '../hooks/useChatRealtimeHandlers';
+import type { StreamBuffers } from '../hooks/streamBuffers';
+import { dropStreamBuffers, windowStreamFlushScheduler } from '../hooks/streamBuffers';
 import { useChatComposerState } from '../hooks/useChatComposerState';
 import { useSessionStore } from '../../../stores/useSessionStore';
 
@@ -41,8 +43,7 @@ function ChatInterface({
   const { t } = useTranslation('chat');
 
   const sessionStore = useSessionStore();
-  const streamTimerRef = useRef<number | null>(null);
-  const accumulatedStreamRef = useRef('');
+  const streamBuffersRef = useRef<StreamBuffers>(new Map());
   // When each session's `chat.subscribe` was last sent; idle acks older than
   // a later local request are discarded as stale.
   const statusCheckSentAtRef = useRef(new Map<string, number>());
@@ -51,12 +52,12 @@ function ChatInterface({
   // server replays only the events this client actually missed.
   const lastSeqRef = useRef(new Map<string, number>());
 
-  const resetStreamingState = useCallback(() => {
-    if (streamTimerRef.current) {
-      clearTimeout(streamTimerRef.current);
-      streamTimerRef.current = null;
-    }
-    accumulatedStreamRef.current = '';
+  /**
+   * Abandons buffered deltas. Pass the session being torn down so a live
+   * background run keeps its pending flush; omit it to drop every buffer.
+   */
+  const resetStreamingState = useCallback((sessionId?: string) => {
+    dropStreamBuffers(streamBuffersRef.current, windowStreamFlushScheduler, sessionId);
   }, []);
 
   const {
@@ -244,8 +245,7 @@ function ChatInterface({
     setTokenBudget,
     pendingPermissionRequests,
     setPendingPermissionRequests,
-    streamTimerRef,
-    accumulatedStreamRef,
+    streamBuffersRef,
     lastSeqRef,
     statusCheckSentAtRef,
     onSessionProcessing,


### PR DESCRIPTION
## Summary

Assistant messages inside one turn were merged into a single chat row, and that row sorted after the tool rows it was interleaved with. The streaming buffer had no notion of a message boundary, so it stayed open for the whole turn unless a provider happened to emit `stream_end` per message.

## Context

Fixes #1136.

`useChatRealtimeHandlers.ts` accumulated every `stream_delta` into one buffer and wrote it to a row keyed by the well-known id `__streaming_${sessionId}`. Nothing closed that buffer when an ordinary frame arrived, only `stream_end` or the terminal `complete`.

OpenCode reproduces it. Its live `normalizeMessage` maps `text` to `stream_delta`, `tool_use` to `tool_use`, and emits `stream_end` only at `step_finish`. A turn that calls a tool therefore streams text, appends the tool row, streams more text, and ends with one row holding both halves concatenated. `updateStreaming` re-stamps `timestamp` on every write, so the open row also outlived and sorted past the tool row.

Claude is unaffected because it emits `stream_end` at `content_block_stop`.

Cursor is listed in the issue as affected. Its live path emits `stream_delta` for every assistant event and nothing else, so no boundary frame ever reaches the frontend and a frontend fix cannot split its messages. That needs provider-side work and is out of scope here.

| Before | After |
| --- | --- |
| <img width="1280" height="900" alt="image" src="https://github.com/user-attachments/assets/7cac153a-e2b7-4301-8d10-897834b23227" /> | <img width="1280" height="900" alt="image" src="https://github.com/user-attachments/assets/4a6f16d9-578a-4dc1-ad55-40759d14c772" /> |


## Changes

- Add `src/components/chat/hooks/streamBuffers.ts`. Holds the buffer mechanics as plain functions over a `Map` keyed by session id, with store writes and timers injected so the logic is testable without React.
- Close the open row on any `text`, `thinking`, `tool_use` or `tool_result` frame, before that frame's own row is appended.
- Close through `finalizeStreaming` rather than only clearing the accumulator. `updateStreaming` replaces by id, so a boundary that left the row parked at `__streaming_${sessionId}` would have the next message overwrite it, giving one row per turn again holding only the last message.
- Call `finalize` on close even when no buffer is open. A row outlives its buffer when the view moves off a streaming session, and finalizing frees the well-known id. The store call is a no-op when no such row exists.
- Key buffers and their flush timers per session, matching the row they already write to. Previously a single accumulator could flush a background session's text into whichever session the current frame named, and the terminal paths cancelled pending flushes belonging to other sessions.
- `resetStreamingState` now takes an optional session id, so tearing down one view drops only that session's buffer. Called with no argument on unmount, where dropping everything is correct.
- Skip the final write when the row already holds the buffered text, so closing right after a flush does not write twice.

No merge-time dedupe was added. `pruneRealtimeSupersededByServer` already drops the superseded partial row on refresh, and `updateStreaming` stamps each row with the time of its last delta, so a finalized row sorts between the tool rows around it.

## Testing

Node 22, matching `.nvmrc`.

```
npm test        282 passing, 0 failing   (12 new)
npm run typecheck   clean
npm run lint    0 errors, 212 warnings   (212 on main, unchanged)
npm run build   exit 0
```

New tests in `src/components/chat/hooks/streamBuffers.test.ts` cover delta coalescing, one row per message across a boundary, closing a buffer whose flush never fired, per-session isolation of both text and timers, and dropping one session's buffer while another stays live. Three mutations were used to confirm the tests bite. Removing the `finalize` call fails 6, sharing one buffer across sessions fails 8, and not cancelling the pending flush on close fails 1.

The wiring in `useChatRealtimeHandlers.ts` is not unit tested. There is no frontend component test runner in the repo, so the handler's decision to close on boundary frames is covered by the before and after captures above rather than by a test.

The first commit adds `src/**/*.test.ts` to the `npm test` glob. The runner globbed `server/**` only, so the existing `src/stores/sessionMessageReconciliation.test.ts` was never executed. It passes. Happy to drop that commit and leave the new test unrun if you would rather keep the glob as it is.

On how the captures were produced. No provider CLI is installed here and OpenCode needs credentials, so instead of driving a live run I replayed OpenCode's frame sequence for one turn over the chat websocket into the real UI, against the real store and render path. Frames used, in order: user `text`, `stream_delta` chunks, `tool_use` with a result, more `stream_delta` chunks, `stream_end`. I also replayed Claude's sequence, deltas then `stream_end` then the assistant `text` row that echoes the same content, and it still renders as one bubble.

## Notes for reviewers

`text` is treated as a boundary regardless of role. A user `text` frame mid-turn is unusual, and closing on it is harmless because there is no open buffer at that point.

`error`, `interactive_prompt` and `task_notification` are deliberately not boundaries. They append rows too, so the same ordering argument could extend to them, but the issue named the four kinds above and widening the set risks splitting a message on an unrelated notification. Easy to add if you would prefer that.

This PR is frontend only, so `AGENTS.md` points the backend module standards at `server/` and none of it applies.

Fixes #1136


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chat streaming reliability by preserving message order and preventing duplicate updates.
  * Added support for concurrent sessions with isolated streaming state.
  * Ensured pending stream content is finalized or safely discarded during session changes and completion.

* **Tests**
  * Expanded automated coverage for streaming boundaries, flushing, cleanup, concurrency, and interleaved tool-call messages.
  * Updated test discovery to include component-level tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->