### PR TITLE
fix(database): stop leaking DATABASE_PATH to child processes

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -162,6 +162,8 @@ export default tseslint.config(
             "server/shared/frontmatter.ts",
             "server/shared/claude-cli-path.ts",
             "server/shared/image-attachments.ts",
+            "server/shared/database-path.ts",
+            "server/shared/child-process-env.ts",
           ], // classify shared utility files so modules can depend on them explicitly
           mode: "file",
         },

--- a/server/load-env.ts
+++ b/server/load-env.ts
@@ -1,6 +1,5 @@
 // Load environment variables from .env before other imports execute.
 import fs from 'fs';
-import os from 'os';
 import path from 'path';
 import { fileURLToPath } from 'url';
 
@@ -29,8 +28,24 @@ try {
     const trimmedLine = line.trim();
     if (trimmedLine && !trimmedLine.startsWith('#')) {
       const [key, ...valueParts] = trimmedLine.split('=');
-      if (key && valueParts.length > 0 && !process.env[key]) {
-        process.env[key] = valueParts.join('=').trim();
+      if (key && valueParts.length > 0) {
+        const value = valueParts.join('=').trim();
+
+        // A real environment variable outranks `.env`, but silently ignoring a
+        // DATABASE_PATH the user wrote in `.env` is how a checkout ends up
+        // attached to another instance's database. Say so instead.
+        if (process.env[key] !== undefined) {
+          if (key === 'DATABASE_PATH' && process.env[key] !== value) {
+            console.warn(
+              `[env] Ignoring DATABASE_PATH=${value} from ${envPath}: the inherited ` +
+              `environment already sets DATABASE_PATH=${process.env[key]}, which takes ` +
+              'precedence. Unset it in the parent process to use the .env value.',
+            );
+          }
+          return;
+        }
+
+        process.env[key] = value;
       }
     }
   });
@@ -38,10 +53,8 @@ try {
   console.error('No .env file found or error reading it:', e.message);
 }
 
-// Keep the default database in a stable user-level location so rebuilding dist-server
-// never changes where the backend stores auth.db when DATABASE_PATH is not set explicitly.
-const DEFAULT_DATABASE_PATH = path.join(os.homedir(), '.cloudcli', 'auth.db');
-
-if (!process.env.DATABASE_PATH) {
-  process.env.DATABASE_PATH = DEFAULT_DATABASE_PATH;
-}
+// The default database path is intentionally NOT written back to process.env.
+// It lives in server/shared/database-path.ts and is applied when the connection
+// is opened: writing it here would leak it to every spawned child process, so a
+// dev server launched from an in-app terminal would attach to the running
+// production database.

--- a/server/modules/agent/agent.routes.ts
+++ b/server/modules/agent/agent.routes.ts
@@ -3,6 +3,7 @@ import path from 'path';
 
 import express from 'express';
 
+import { buildChildProcessEnv } from '@/shared/child-process-env.js';
 import type { ProviderRunFunction } from '@/shared/types.js';
 
 import { normalizeProjectPath } from '../../shared/utils.js';
@@ -385,7 +386,7 @@ export function createAgentRouter(dependencies: AgentRouterDependencies): expres
         console.log('📁 Destination:', cloneDir);
 
         // Execute git clone
-        const gitEnvironment = githubToken ? {
+        const gitEnvironment = buildChildProcessEnv(githubToken ? {
           ...process.env,
           GIT_CONFIG_COUNT: '2',
           GIT_CONFIG_KEY_0: 'credential.helper',
@@ -394,7 +395,7 @@ export function createAgentRouter(dependencies: AgentRouterDependencies): expres
           GIT_CONFIG_VALUE_1: '!f() { echo username=x-access-token; echo "password=$CLOUDCLI_GITHUB_TOKEN"; }; f',
           CLOUDCLI_GITHUB_TOKEN: githubToken,
           GIT_TERMINAL_PROMPT: '0'
-        } : process.env;
+        } : process.env);
         const gitProcess = spawn('git', ['clone', '--depth', '1', '--', cloneUrl, cloneDir], {
           stdio: ['pipe', 'pipe', 'pipe'],
           env: gitEnvironment

--- a/server/modules/cli/cli.module.ts
+++ b/server/modules/cli/cli.module.ts
@@ -5,6 +5,7 @@ import path from 'node:path';
 
 import spawn from 'cross-spawn';
 
+import { DEFAULT_DATABASE_PATH } from '@/shared/database-path.js';
 import type { CliApplication, CliPackageMetadata } from '@/shared/types.js';
 import { findApplicationRoot, getModuleDirectory } from '@/shared/utils.js';
 
@@ -63,7 +64,7 @@ export function createCliApplication(): CliApplication {
 
   return createCliService({
     applicationRoot,
-    defaultDatabasePath: path.join(homeDirectory, '.cloudcli', 'auth.db'),
+    defaultDatabasePath: DEFAULT_DATABASE_PATH,
     homeDirectory,
     packageMetadata,
     environment: process.env,

--- a/server/modules/database/connection.ts
+++ b/server/modules/database/connection.ts
@@ -16,6 +16,7 @@ import path from 'path';
 import { fileURLToPath } from 'url';
 
 import { APP_CONFIG_TABLE_SCHEMA_SQL } from '@/modules/database/schema.js';
+import { DEFAULT_DATABASE_PATH, readConfiguredDatabasePath } from '@/shared/database-path.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -25,16 +26,21 @@ const __dirname = path.dirname(__filename);
 // ---------------------------------------------------------------------------
 
 /**
- * Resolves the database file path from environment or falls back
- * to the legacy location inside the server/database/ folder.
+ * Resolves the database file path.
  *
  * Priority:
- *   1. DATABASE_PATH environment variable (set by cli.js or load-env-vars.js)
- *   2. Legacy path: server/database/auth.db
+ *   1. DATABASE_PATH, when explicitly set (.env, CLI `--db-path`, or the
+ *      deployment environment)
+ *   2. The default user-level location (~/.cloudcli/auth.db)
+ *
+ * A legacy server/database/auth.db is not selected here — it is copied into the
+ * resolved path by migrateLegacyDatabase() instead.
+ *
+ * The default is applied here rather than written into process.env so it is not
+ * inherited by spawned child processes.
  */
 function resolveDatabasePath(): string {
-    // process.env.DATABASE_PATH is set by load-env-vars.js to either the .env value or a default(~/.cloudcli/auth.db) in the user's home directory. 
-    return process.env.DATABASE_PATH || resolveLegacyDatabasePath();
+  return readConfiguredDatabasePath() ?? DEFAULT_DATABASE_PATH;
 }
 
 /**
@@ -93,6 +99,92 @@ function migrateLegacyDatabase(targetPath: string): void {
 // ---------------------------------------------------------------------------
 
 let instance: Database.Database | null = null;
+let openedPath: string | null = null;
+let lastExistenceCheckAt = 0;
+
+// Checking the file on every getConnection() would add a stat() to every query,
+// so the check is throttled: a deleted database recovers within this window.
+const STALE_CHECK_INTERVAL_MS = 1000;
+
+/**
+ * SQLite error codes that mean the open handle can never succeed again, so the
+ * only recovery is to reopen. DBMOVED is raised once SQLite notices the file it
+ * opened was renamed or unlinked — which latches the connection read-only for
+ * the rest of the process lifetime.
+ */
+const UNRECOVERABLE_SQLITE_CODES = new Set([
+  'SQLITE_READONLY_DBMOVED',
+  'SQLITE_READONLY_DIRECTORY',
+]);
+
+/**
+ * True when an error means the cached handle is permanently unusable.
+ *
+ * Note this cannot be detected by comparing inodes: deleting and recreating a
+ * file in the same directory routinely reuses the inode number *and* reports an
+ * unchanged birthtime, so only the error itself is a reliable signal.
+ */
+export function isDatabaseMovedError(error: unknown): boolean {
+  const code = (error as { code?: unknown } | null)?.code;
+  return typeof code === 'string' && UNRECOVERABLE_SQLITE_CODES.has(code);
+}
+
+function discardConnection(reason: string): void {
+  if (!instance) return;
+
+  console.warn(`[Database] Reopening connection: ${reason}`, { path: openedPath });
+
+  try {
+    instance.close();
+  } catch {
+    // The handle is already unusable; closing is best-effort.
+  }
+
+  instance = null;
+  openedPath = null;
+}
+
+/**
+ * Drops the cached connection when it can no longer serve queries: the handle
+ * was closed, the configured path changed, or the file was deleted outright.
+ * Safe because no repository caches prepared statements across calls.
+ */
+function discardConnectionIfUnusable(): void {
+  if (!instance) return;
+
+  if (!instance.open) {
+    discardConnection('the handle was closed');
+    return;
+  }
+
+  const dbPath = resolveDatabasePath();
+  if (dbPath !== openedPath) {
+    discardConnection(`the configured path changed to ${dbPath}`);
+    return;
+  }
+
+  const now = Date.now();
+  if (now - lastExistenceCheckAt < STALE_CHECK_INTERVAL_MS) return;
+  lastExistenceCheckAt = now;
+
+  if (!fs.existsSync(dbPath)) {
+    discardConnection('the database file no longer exists');
+  }
+}
+
+/**
+ * Reopens the connection when `error` indicates the database file was moved or
+ * deleted. Returns true when a retry is worth attempting.
+ *
+ * Without this a single replaced file leaves every subsequent write failing
+ * until the process restarts.
+ */
+export function recoverFromDatabaseError(error: unknown): boolean {
+  if (!isDatabaseMovedError(error)) return false;
+
+  discardConnection('a query reported the database file was moved or deleted');
+  return true;
+}
 
 /**
  * Returns the shared database connection, creating it on first call.
@@ -106,7 +198,10 @@ let instance: Database.Database | null = null;
  *   6. Logs the database location
  */
 export function getConnection(): Database.Database {
-  if (instance) return instance;
+  if (instance) {
+    discardConnectionIfUnusable();
+    if (instance) return instance;
+  }
 
   const dbPath = resolveDatabasePath();
 
@@ -118,6 +213,9 @@ export function getConnection(): Database.Database {
   // app_config must exist immediately — the auth middleware reads
   // the JWT secret at module-load time, before initializeDatabase() runs.
   instance.exec(APP_CONFIG_TABLE_SCHEMA_SQL);
+
+  openedPath = dbPath;
+  lastExistenceCheckAt = Date.now();
 
   return instance;
 }
@@ -138,6 +236,8 @@ export function closeConnection(): void {
   if (instance) {
     instance.close();
     instance = null;
+    openedPath = null;
+    lastExistenceCheckAt = 0;
     console.log('Database connection closed');
   }
 }

--- a/server/modules/database/index.ts
+++ b/server/modules/database/index.ts
@@ -1,5 +1,11 @@
 export { initializeDatabase } from '@/modules/database/init-db.js';
-export { closeConnection, getConnection, getDatabasePath } from '@/modules/database/connection.js';
+export {
+  closeConnection,
+  getConnection,
+  getDatabasePath,
+  isDatabaseMovedError,
+  recoverFromDatabaseError,
+} from '@/modules/database/connection.js';
 export { apiKeysDb } from '@/modules/database/repositories/api-keys.js';
 export { appConfigDb } from '@/modules/database/repositories/app-config.js';
 export { credentialsDb } from '@/modules/database/repositories/credentials.js';

--- a/server/modules/database/tests/connection-recovery.test.ts
+++ b/server/modules/database/tests/connection-recovery.test.ts
@@ -1,0 +1,116 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import test, { afterEach } from 'node:test';
+
+import {
+  closeConnection,
+  getConnection,
+  getDatabasePath,
+  isDatabaseMovedError,
+  recoverFromDatabaseError,
+} from '@/modules/database/connection.js';
+
+const previousDatabasePath = process.env.DATABASE_PATH;
+let temporaryDirectory: string | null = null;
+
+afterEach(() => {
+  closeConnection();
+
+  if (previousDatabasePath === undefined) {
+    delete process.env.DATABASE_PATH;
+  } else {
+    process.env.DATABASE_PATH = previousDatabasePath;
+  }
+
+  if (temporaryDirectory) {
+    fs.rmSync(temporaryDirectory, { recursive: true, force: true });
+    temporaryDirectory = null;
+  }
+});
+
+function useTemporaryDatabase(): string {
+  temporaryDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'cloudcli-connection-'));
+  const databasePath = path.join(temporaryDirectory, 'auth.db');
+  process.env.DATABASE_PATH = databasePath;
+  closeConnection();
+  return databasePath;
+}
+
+/** The missing-file check is throttled, so tests must step past the window. */
+const waitPastStaleCheck = () => new Promise((resolve) => setTimeout(resolve, 1050));
+
+test('recovers from a moved-database error so the next query can succeed', () => {
+  useTemporaryDatabase();
+
+  const firstConnection = getConnection();
+  firstConnection.exec('CREATE TABLE IF NOT EXISTS probe (value TEXT)');
+
+  // This is the incident: SQLite latches the handle read-only once it notices
+  // the file it opened was unlinked, and never recovers on its own.
+  const movedError = Object.assign(new Error('attempt to write a readonly database'), {
+    code: 'SQLITE_READONLY_DBMOVED',
+  });
+
+  assert.equal(recoverFromDatabaseError(movedError), true);
+
+  const recovered = getConnection();
+  assert.notEqual(recovered, firstConnection);
+
+  recovered.exec('CREATE TABLE IF NOT EXISTS probe (value TEXT)');
+  recovered.prepare('INSERT INTO probe (value) VALUES (?)').run('after');
+  const rows = recovered.prepare('SELECT value FROM probe').all() as Array<{ value: string }>;
+  assert.deepEqual(rows.map((row) => row.value), ['after']);
+});
+
+test('ignores errors that are not a moved database', () => {
+  useTemporaryDatabase();
+
+  const connection = getConnection();
+  const unrelated = Object.assign(new Error('no such table: probe'), { code: 'SQLITE_ERROR' });
+
+  assert.equal(isDatabaseMovedError(unrelated), false);
+  assert.equal(recoverFromDatabaseError(unrelated), false);
+  assert.equal(getConnection(), connection);
+});
+
+test('reopens when the handle was closed underneath the singleton', () => {
+  useTemporaryDatabase();
+
+  const firstConnection = getConnection();
+  firstConnection.close();
+
+  const recovered = getConnection();
+
+  assert.notEqual(recovered, firstConnection);
+  assert.equal(recovered.open, true);
+});
+
+test('reopens when the database file is deleted', async () => {
+  const databasePath = useTemporaryDatabase();
+
+  const firstConnection = getConnection();
+  fs.rmSync(databasePath);
+
+  await waitPastStaleCheck();
+  const recovered = getConnection();
+
+  assert.notEqual(recovered, firstConnection);
+  assert.equal(fs.existsSync(databasePath), true);
+});
+
+test('keeps returning the same connection while the file is untouched', async () => {
+  useTemporaryDatabase();
+
+  const firstConnection = getConnection();
+  await waitPastStaleCheck();
+
+  assert.equal(getConnection(), firstConnection);
+});
+
+test('resolves an explicitly configured path over the default', () => {
+  const databasePath = useTemporaryDatabase();
+
+  assert.equal(getDatabasePath(), databasePath);
+});

--- a/server/modules/projects/services/project-clone.service.ts
+++ b/server/modules/projects/services/project-clone.service.ts
@@ -6,6 +6,7 @@ import spawn from 'cross-spawn';
 
 import { githubTokensDb } from '@/modules/database/index.js';
 import { createProject } from '@/modules/projects/services/project-management.service.js';
+import { buildChildProcessEnv } from '@/shared/child-process-env.js';
 import type { WorkspacePathValidationResult } from '@/shared/types.js';
 import { AppError, validateWorkspacePath } from '@/shared/utils.js';
 
@@ -129,10 +130,10 @@ const defaultDependencies: CloneProjectDependencies = {
   spawnGitClone: (cloneUrl: string, clonePath: string): GitCloneProcess =>
     spawn('git', ['clone', '--progress', '--', cloneUrl, clonePath], {
       stdio: ['ignore', 'pipe', 'pipe'],
-      env: {
+      env: buildChildProcessEnv({
         ...process.env,
         GIT_TERMINAL_PROMPT: '0',
-      },
+      }),
     }) as unknown as GitCloneProcess,
   registerProject: async (
     projectPath: string,

--- a/server/modules/providers/services/session-synchronizer.service.ts
+++ b/server/modules/providers/services/session-synchronizer.service.ts
@@ -1,4 +1,4 @@
-import { scanStateDb } from '@/modules/database/index.js';
+import { recoverFromDatabaseError, scanStateDb } from '@/modules/database/index.js';
 import { providerRegistry } from '@/modules/providers/provider.registry.js';
 import type { LLMProvider } from '@/shared/types.js';
 
@@ -43,7 +43,21 @@ export const sessionSynchronizerService = {
     }
 
     if (failures.length === 0) {
-      scanStateDb.updateLastScannedAt(scanBoundary);
+      // Advancing the cursor is bookkeeping: callers only read sessions. A
+      // failure here (a read-only or moved database, a locked file) must be
+      // reported like a provider failure rather than thrown, otherwise it takes
+      // down every endpoint that lists projects.
+      try {
+        scanStateDb.updateLastScannedAt(scanBoundary);
+      } catch (error) {
+        const reason = error instanceof Error ? error.message : String(error);
+        console.warn(`[Sessions] Failed to advance scan_state cursor: ${reason}`);
+        failures.push(`scan_state cursor update failed: ${reason}`);
+
+        // If the database file was replaced underneath us the handle is latched
+        // read-only forever; drop it so the next request opens a fresh one.
+        recoverFromDatabaseError(error);
+      }
     } else {
       console.warn(
         `[Sessions] Skipping scan_state cursor advance because ${failures.length} provider sync(s) failed.`,

--- a/server/modules/providers/tests/session-synchronizer.service.test.ts
+++ b/server/modules/providers/tests/session-synchronizer.service.test.ts
@@ -1,0 +1,72 @@
+import assert from 'node:assert/strict';
+import test, { afterEach } from 'node:test';
+
+import { scanStateDb } from '@/modules/database/index.js';
+import { providerRegistry } from '@/modules/providers/provider.registry.js';
+import { sessionSynchronizerService } from '@/modules/providers/services/session-synchronizer.service.js';
+
+const originalListProviders = providerRegistry.listProviders;
+const originalGetLastScannedAt = scanStateDb.getLastScannedAt;
+const originalUpdateLastScannedAt = scanStateDb.updateLastScannedAt;
+
+afterEach(() => {
+  providerRegistry.listProviders = originalListProviders;
+  scanStateDb.getLastScannedAt = originalGetLastScannedAt;
+  scanStateDb.updateLastScannedAt = originalUpdateLastScannedAt;
+});
+
+function stubNoProviders() {
+  providerRegistry.listProviders = () => [];
+  scanStateDb.getLastScannedAt = () => null;
+}
+
+test('reports a failing cursor update instead of throwing', async () => {
+  stubNoProviders();
+  scanStateDb.updateLastScannedAt = () => {
+    throw new Error('attempt to write a readonly database');
+  };
+
+  // A read-only or moved database must not take down callers that only list
+  // projects — GET /api/projects awaits this bare.
+  const result = await sessionSynchronizerService.synchronizeSessions();
+
+  assert.equal(result.failures.length, 1);
+  assert.match(result.failures[0], /scan_state cursor update failed/);
+  assert.match(result.failures[0], /readonly database/);
+});
+
+test('advances the cursor when every provider succeeds', async () => {
+  stubNoProviders();
+  const cursorWrites: Date[] = [];
+  scanStateDb.updateLastScannedAt = (scannedAt: Date) => {
+    cursorWrites.push(scannedAt);
+  };
+
+  const result = await sessionSynchronizerService.synchronizeSessions();
+
+  assert.deepEqual(result.failures, []);
+  assert.equal(cursorWrites.length, 1);
+  assert.ok(cursorWrites[0] instanceof Date);
+});
+
+test('skips the cursor update when a provider fails', async () => {
+  scanStateDb.getLastScannedAt = () => null;
+  providerRegistry.listProviders = () => ([{
+    id: 'claude',
+    sessionSynchronizer: {
+      synchronize: async () => {
+        throw new Error('provider exploded');
+      },
+    },
+  }] as unknown as ReturnType<typeof originalListProviders>);
+
+  let cursorWritten = false;
+  scanStateDb.updateLastScannedAt = () => {
+    cursorWritten = true;
+  };
+
+  const result = await sessionSynchronizerService.synchronizeSessions();
+
+  assert.equal(cursorWritten, false);
+  assert.deepEqual(result.failures, ['provider exploded']);
+});

--- a/server/modules/websocket/services/shell-websocket.service.ts
+++ b/server/modules/websocket/services/shell-websocket.service.ts
@@ -5,6 +5,7 @@ import path from 'node:path';
 import pty, { type IPty } from 'node-pty';
 import { WebSocket, type RawData } from 'ws';
 
+import { buildChildProcessEnv } from '@/shared/child-process-env.js';
 import { parseIncomingJsonObject } from '@/shared/utils.js';
 
 type ShellIncomingMessage = {
@@ -404,13 +405,13 @@ export function handleShellConnection(
           cols: termCols,
           rows: termRows,
           cwd: resolvedProjectPath,
-          env: {
+          env: buildChildProcessEnv({
             ...process.env,
             [prioritizedPath.key]: prioritizedPath.value,
             TERM: 'xterm-256color',
             COLORTERM: 'truecolor',
             FORCE_COLOR: '3',
-          },
+          }),
         });
 
         ptySessionsMap.set(ptySessionKey, {

--- a/server/shared/child-process-env.ts
+++ b/server/shared/child-process-env.ts
@@ -1,0 +1,27 @@
+// Environment scrubbing for spawned child processes.
+
+/**
+ * Variables that configure *this* server instance and must not be inherited by
+ * child processes.
+ *
+ * DATABASE_PATH is the dangerous one: a dev server started from an in-app
+ * terminal inherits it and opens the running production database instead of its
+ * own, so both processes hold the same SQLite file open.
+ */
+const SERVER_ONLY_ENV_KEYS = ['DATABASE_PATH'] as const;
+
+/**
+ * Returns a copy of `environment` without the variables that belong to this
+ * server process. Use for any spawn/pty that runs user or project code.
+ */
+export function buildChildProcessEnv<T extends Record<string, string | undefined>>(
+  environment: T,
+): T {
+  const childEnvironment = { ...environment };
+
+  for (const key of SERVER_ONLY_ENV_KEYS) {
+    delete childEnvironment[key];
+  }
+
+  return childEnvironment;
+}

--- a/server/shared/database-path.ts
+++ b/server/shared/database-path.ts
@@ -1,0 +1,25 @@
+// Single source of truth for the default database location.
+//
+// This is deliberately a plain module constant rather than a `process.env`
+// assignment: anything written to `process.env` is inherited by every child
+// process the app spawns (terminal sessions, git clones, plugin hosts). A dev
+// server started from an in-app terminal would then silently open the running
+// production database instead of its own.
+import os from 'os';
+import path from 'path';
+
+/**
+ * Default database file, kept in a stable user-level location so rebuilding
+ * dist-server never changes where the backend stores auth.db.
+ */
+export const DEFAULT_DATABASE_PATH = path.join(os.homedir(), '.cloudcli', 'auth.db');
+
+/**
+ * Reads an explicitly configured database path (env var or CLI `--db-path`).
+ * Returns undefined when unset or blank so callers fall back to the default.
+ */
+export function readConfiguredDatabasePath(
+  environment: NodeJS.ProcessEnv = process.env,
+): string | undefined {
+  return environment.DATABASE_PATH?.trim() || undefined;
+}

--- a/server/shared/tests/child-process-env.test.ts
+++ b/server/shared/tests/child-process-env.test.ts
@@ -1,0 +1,28 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { buildChildProcessEnv } from '@/shared/child-process-env.js';
+
+test('removes DATABASE_PATH so children do not inherit this server database', () => {
+  const childEnvironment = buildChildProcessEnv({
+    DATABASE_PATH: '/root/.cloudcli/auth.db',
+    PATH: '/usr/bin',
+  });
+
+  assert.equal(childEnvironment.DATABASE_PATH, undefined);
+  assert.equal(childEnvironment.PATH, '/usr/bin');
+});
+
+test('does not mutate the source environment', () => {
+  const sourceEnvironment = { DATABASE_PATH: '/root/.cloudcli/auth.db' };
+
+  buildChildProcessEnv(sourceEnvironment);
+
+  assert.equal(sourceEnvironment.DATABASE_PATH, '/root/.cloudcli/auth.db');
+});
+
+test('is a no-op when DATABASE_PATH is absent', () => {
+  const childEnvironment = buildChildProcessEnv({ HOME: '/root', TERM: 'xterm' });
+
+  assert.deepEqual(childEnvironment, { HOME: '/root', TERM: 'xterm' });
+});


### PR DESCRIPTION
A dev server started from an in-app terminal silently opens the **running production database**: `load-env` writes the default `DATABASE_PATH` into `process.env`, and the pty/git spawns pass `...process.env` to their children. Two processes then hold the same SQLite file, and when one replaces it the other latches read-only (`SQLITE_READONLY_DBMOVED`) until restart.

This happened in practice and cost a database.

## Changes

**1. Stop exporting the default path into the environment (root cause)**

The default is now a module constant in `server/shared/database-path.ts`, applied when the connection opens, instead of being assigned to `process.env`. An explicitly set `DATABASE_PATH` still wins, so `.env`, `--db-path`, tests and deployments are unaffected.

**2. Strip `DATABASE_PATH` from spawned environments**

Via `server/shared/child-process-env.ts`, applied to the terminal pty and both git-clone spawns. Needed as defence in depth because deployments *do* set the variable explicitly, so fixing the source alone would not cover them.

**3. Warn when an inherited value overrides `.env`**

`.env` previously lost to an inherited variable silently, which made the obvious workaround look broken.

**4. Recover from a moved/deleted database**

`getConnection()` reopens on a closed handle, a changed path, or a missing file, and `recoverFromDatabaseError()` reopens on `SQLITE_READONLY_DBMOVED`. Previously only a full restart recovered.

Inode identity is deliberately **not** used: deleting and recreating a file in the same directory reuses the inode number *and* reports an unchanged birthtime, so only the error itself is a reliable signal.

**5. A bookkeeping write no longer 500s a read endpoint**

`scanStateDb.updateLastScannedAt()` was unguarded while provider failures were tolerated, so the less serious problem was fatal. Both call sites in `projects-with-sessions-fetch.service.ts` await it bare, so a failed cursor update took down `GET /api/projects`. It now joins `failures[]` like a provider failure.

Also dedupes the default path, which was defined in both `load-env` and `cli.module`.

## Verification

- 274/274 server tests pass (12 new, covering the env scrubbing, cursor-write tolerance, and connection recovery)
- `npm run typecheck`, `npm run lint` (0 errors) and `npm run build` all clean
- Verified directly that `process.env.DATABASE_PATH` is now `undefined` after `load-env` where it previously held the default

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved database handling when database files are moved, deleted, or become unavailable, allowing connections to recover automatically.
  - Preserved inherited database configuration while warning about conflicting environment settings.
  - Prevented server-only database settings from being passed to launched shells and Git operations.
  - Session synchronization now records cursor-update failures and continues processing instead of stopping unexpectedly.

- **Reliability**
  - Standardized the default database location and handling of explicitly configured paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->