### PR TITLE
feat(sidebar): allow multiple projects to be open at the same time

### DIFF
--- a/src/components/sidebar/hooks/useSidebarController.ts
+++ b/src/components/sidebar/hooks/useSidebarController.ts
@@ -524,8 +524,10 @@ export function useSidebarController({
   // `projectId` as their identifier after the migration.
   const toggleProject = useCallback((projectId: string) => {
     setExpandedProjects((prev) => {
-      const next = new Set<string>();
-      if (!prev.has(projectId)) {
+      const next = new Set(prev);
+      if (next.has(projectId)) {
+        next.delete(projectId);
+      } else {
         next.add(projectId);
       }
       return next;

--- a/src/components/sidebar/view/subcomponents/SidebarProjectItem.tsx
+++ b/src/components/sidebar/view/subcomponents/SidebarProjectItem.tsx
@@ -137,11 +137,14 @@ export default function SidebarProjectItem({
   };
 
   const selectAndToggleProject = () => {
+    // Selecting a different project expands it (via the auto-expand effect) while
+    // leaving other expanded projects open. Only toggle when it's already the
+    // selected one, so a second click collapses it.
     if (selectedProject?.projectId !== project.projectId) {
       onProjectSelect(project);
+    } else {
+      toggleProject();
     }
-
-    toggleProject();
   };
 
   return (


### PR DESCRIPTION
For my workflows, I like to be able to have multiple projects open at once, so I can see at-a-glance how sessions from different projects are doing without having to click through each project. This changes the sidebar from accordion to multi-open. Click to open, click again to close. Been working great for me for a few weeks. Feel free to close if you don't want this change, I can just keep applying it from my patch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved project selection and expansion behavior in the sidebar.
  * Selecting a different project now selects it without unexpectedly expanding or collapsing it.
  * Clicking the currently selected project reliably toggles its expanded state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->