### PR TITLE
feat(chat): show README summary on the new-conversation empty state

### DIFF
--- a/src/components/chat/view/subcomponents/ChatMessagesPane.tsx
+++ b/src/components/chat/view/subcomponents/ChatMessagesPane.tsx
@@ -185,6 +185,7 @@ function ChatMessagesPane({
         </div>
       ) : chatMessages.length === 0 ? (
         <ProviderSelectionEmptyState
+          selectedProject={selectedProject}
           selectedSession={selectedSession}
           currentSessionId={currentSessionId}
           provider={provider}

--- a/src/components/chat/view/subcomponents/ProviderSelectionEmptyState.tsx
+++ b/src/components/chat/view/subcomponents/ProviderSelectionEmptyState.tsx
@@ -1,14 +1,16 @@
-import React, { useCallback, useMemo, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { Check, ChevronDown, Plus } from "lucide-react";
 import { Trans, useTranslation } from "react-i18next";
 
 import type {
+  Project,
   ProjectSession,
   LLMProvider,
   ProviderModelActions,
   ProviderModelOption,
   ProviderModelsDefinition,
 } from "../../../../types/app";
+import { api } from "../../../../utils/api";
 import SessionProviderLogo from "../../../llm-logo-provider/SessionProviderLogo";
 import { NextTaskBanner } from "../../../task-master";
 import {
@@ -28,6 +30,7 @@ import {
 } from "../../../../shared/view/ui";
 
 import ModelLibraryPanel from "./ModelLibraryPanel";
+import { parseReadmeSummary, type ReadmeSummary } from "./readmeSummary";
 
 const PROVIDER_META: { id: LLMProvider; name: string }[] = [
   { id: "claude", name: "Anthropic" },
@@ -51,6 +54,7 @@ function modelSearchFilter(value: string, search: string): number {
 }
 
 type ProviderSelectionEmptyStateProps = {
+  selectedProject: Project | null;
   selectedSession: ProjectSession | null;
   currentSessionId: string | null;
   provider: LLMProvider;
@@ -109,6 +113,7 @@ function getProviderDisplayName(p: LLMProvider) {
 }
 
 export default function ProviderSelectionEmptyState({
+  selectedProject,
   selectedSession,
   currentSessionId,
   provider,
@@ -133,6 +138,48 @@ export default function ProviderSelectionEmptyState({
   const { t } = useTranslation("chat");
   const [dialogOpen, setDialogOpen] = useState(false);
   const [modelLibraryOpen, setModelLibraryOpen] = useState(false);
+
+  // Summary of the current project's README.md (first title + first paragraph),
+  // shown only on the brand-new-conversation empty state as lightweight context.
+  // `"missing"` means the project has no usable README — the pane then nudges
+  // the user to add one; `null` means "unknown yet / render nothing".
+  const [readmeState, setReadmeState] = useState<ReadmeSummary | "missing" | null>(null);
+  const [creatingReadme, setCreatingReadme] = useState(false);
+  const isNewConversation = !selectedSession && !currentSessionId;
+  const projectId = selectedProject?.projectId ?? null;
+
+  useEffect(() => {
+    if (!isNewConversation || !projectId) {
+      setReadmeState(null);
+      return;
+    }
+
+    let cancelled = false;
+    setReadmeState(null);
+
+    (async () => {
+      try {
+        const response = await api.readFile(projectId, "README.md");
+        if (cancelled) return;
+        if (!response.ok) {
+          // 404 = no README to read; other errors are transient, show nothing.
+          setReadmeState(response.status === 404 ? "missing" : null);
+          return;
+        }
+        const { content } = await response.json();
+        if (cancelled) return;
+        const summary = parseReadmeSummary(content ?? "");
+        setReadmeState(summary.title || summary.paragraph ? summary : "missing");
+      } catch {
+        // Offline / unexpected error: don't claim the README is missing.
+        if (!cancelled) setReadmeState(null);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [isNewConversation, projectId]);
 
   const visibleProviderGroups = useMemo<ProviderGroup[]>(() => {
     return PROVIDER_META.map((p) => ({
@@ -202,10 +249,55 @@ export default function ProviderSelectionEmptyState({
     setDialogOpen(true);
   };
 
+  // Seed a starter README.md (titled with the project name) and swap the
+  // "add" prompt for the freshly parsed summary on success.
+  const handleAddReadme = useCallback(async () => {
+    if (!projectId || creatingReadme) return;
+    const heading = selectedProject?.displayName?.trim() || "Project";
+    const content = `# ${heading}\n\n`;
+    setCreatingReadme(true);
+    try {
+      const response = await api.saveFile(projectId, "README.md", content);
+      if (response.ok) setReadmeState(parseReadmeSummary(content));
+    } catch {
+      // Leave the prompt in place so the user can retry.
+    } finally {
+      setCreatingReadme(false);
+    }
+  }, [projectId, creatingReadme, selectedProject]);
+
   if (!selectedSession && !currentSessionId) {
     return (
       <div className="flex h-full items-center justify-center px-4">
         <div className="w-full max-w-[34.25rem]">
+          {readmeState === "missing" ? (
+            <div className="mb-6 text-center">
+              <button
+                type="button"
+                onClick={handleAddReadme}
+                disabled={creatingReadme}
+                className="text-lg font-semibold tracking-tight text-muted-foreground/50 underline-offset-4 transition-colors hover:text-muted-foreground hover:underline disabled:opacity-60 sm:text-xl"
+              >
+                {t("providerSelection.addReadme", {
+                  defaultValue: "Add README.md to project",
+                })}
+              </button>
+            </div>
+          ) : readmeState ? (
+            <div className="mb-6 text-center">
+              {readmeState.title && (
+                <h2 className="text-lg font-semibold tracking-tight text-foreground sm:text-xl">
+                  {readmeState.title}
+                </h2>
+              )}
+              {readmeState.paragraph && (
+                <p className="mt-1 line-clamp-4 text-[13px] text-muted-foreground">
+                  {readmeState.paragraph}
+                </p>
+              )}
+            </div>
+          ) : null}
+
           <div className="mb-8 text-center">
             <h2 className="text-lg font-semibold tracking-tight text-foreground sm:text-xl">
               {t("providerSelection.title")}

--- a/src/components/chat/view/subcomponents/readmeSummary.ts
+++ b/src/components/chat/view/subcomponents/readmeSummary.ts
@@ -1,0 +1,125 @@
+// Extracts a short, human-readable summary from a project's README.md for
+// display in the New Conversation pane: the first title (heading) and the first
+// real paragraph of prose. READMEs commonly open with an HTML block — a
+// centered logo, an <h1>, a tagline <p>, then rows of shields.io badges — so the
+// parser understands both Markdown (`# Title`, prose paragraphs) and the HTML
+// equivalents (`<h1>`, `<p>`), and skips badge/image/link-only decoration so the
+// paragraph is actual descriptive text.
+
+export type ReadmeSummary = {
+  title: string | null;
+  paragraph: string | null;
+};
+
+// First ATX heading on its own line: `# Title` … `###### Title`.
+const ATX_HEADING_RE = /^[ \t]*#{1,6}[ \t]+(.+?)[ \t]*#*[ \t]*$/m;
+// First HTML heading, possibly spanning lines: <h1 ...>Title</h1>.
+const HTML_HEADING_RE = /<h[1-6][^>]*>([\s\S]*?)<\/h[1-6]>/i;
+// HTML paragraph blocks.
+const HTML_P_RE = /<p[^>]*>([\s\S]*?)<\/p>/gi;
+const HR_RE = /^([-*_])\1{2,}$/;
+
+// Reduce a line/fragment to plain text so it can be judged prose-vs-decoration
+// and rendered directly. Tags and images collapse to a space (so adjacent words
+// and <br>-separated sentences don't fuse); links keep their visible label.
+function stripInline(text: string): string {
+  return text
+    .replace(/!\[[^\]]*\]\([^)]*\)/g, " ") // ![alt](src) images
+    .replace(/\[([^\]]*)\]\([^)]*\)/g, "$1") // [label](href) -> label
+    .replace(/<[^>]+>/g, " ") // html tags -> space
+    .replace(/[*_~`]+/g, "") // emphasis / inline-code markers
+    .replace(/\s+([,.;:!?])/g, "$1") // tidy stray space before punctuation
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function wordCount(text: string): number {
+  return text ? text.split(/\s+/).filter(Boolean).length : 0;
+}
+
+// Enough words to look like a sentence rather than a badge row or a single-word
+// caption. Keeps taglines; link-only nav bars are excluded by position instead.
+function isProse(text: string): boolean {
+  return wordCount(text) >= 3;
+}
+
+function findTitle(markdown: string): { text: string | null; end: number } {
+  const atx = ATX_HEADING_RE.exec(markdown);
+  const html = HTML_HEADING_RE.exec(markdown);
+  const atxIdx = atx ? atx.index : Infinity;
+  const htmlIdx = html ? html.index : Infinity;
+
+  if (atx && atxIdx <= htmlIdx) {
+    return { text: stripInline(atx[1]) || null, end: atxIdx + atx[0].length };
+  }
+  if (html) {
+    return { text: stripInline(html[1]) || null, end: htmlIdx + html[0].length };
+  }
+  return { text: null, end: 0 };
+}
+
+// First qualifying <p>…</p> in the region, with its offset so it can be ranked
+// against a Markdown paragraph by document position.
+function findHtmlParagraph(region: string): { index: number; text: string } | null {
+  HTML_P_RE.lastIndex = 0;
+  let match: RegExpExecArray | null;
+  while ((match = HTML_P_RE.exec(region)) !== null) {
+    const text = stripInline(match[1]);
+    if (isProse(text)) return { index: match.index, text };
+  }
+  return null;
+}
+
+// First run of plain Markdown prose lines in the region (skips blank lines,
+// horizontal rules, headings, and HTML/badge/image-only lines).
+function findMarkdownParagraph(region: string): { index: number; text: string } | null {
+  const lines = region.split(/\r?\n/);
+  let offset = 0;
+  for (let i = 0; i < lines.length; i += 1) {
+    const trimmed = lines[i].trim();
+    const skip =
+      !trimmed ||
+      HR_RE.test(trimmed) ||
+      /^#{1,6}\s/.test(trimmed) ||
+      trimmed.startsWith("<") ||
+      !stripInline(trimmed);
+
+    if (skip) {
+      offset += lines[i].length + 1;
+      continue;
+    }
+
+    const collected: string[] = [];
+    for (let j = i; j < lines.length; j += 1) {
+      const next = lines[j].trim();
+      if (!next || HR_RE.test(next) || /^#{1,6}\s/.test(next) || next.startsWith("<")) break;
+      const prose = stripInline(next);
+      if (prose) collected.push(prose);
+    }
+    return { index: offset, text: collected.join(" ") };
+  }
+  return null;
+}
+
+/**
+ * Parse the first heading and first prose paragraph out of README markdown.
+ * Handles both Markdown and HTML-headed READMEs. Returns nulls when nothing
+ * suitable is found; callers can fall back to the project name.
+ */
+export function parseReadmeSummary(markdown: string): ReadmeSummary {
+  if (!markdown) return { title: null, paragraph: null };
+
+  // Drop HTML comments (may span lines) before parsing.
+  const cleaned = markdown.replace(/<!--[\s\S]*?-->/g, "");
+
+  const { text: title, end } = findTitle(cleaned);
+  const region = cleaned.slice(end);
+
+  // Pick whichever paragraph — HTML <p> or Markdown prose — comes first after
+  // the title, so the tagline directly under an <h1> wins over later badge rows.
+  const candidates = [findHtmlParagraph(region), findMarkdownParagraph(region)]
+    .filter((c): c is { index: number; text: string } => c !== null && isProse(c.text))
+    .sort((a, b) => a.index - b.index);
+
+  return { title, paragraph: candidates[0]?.text ?? null };
+}

--- a/src/i18n/locales/en/chat.json
+++ b/src/i18n/locales/en/chat.json
@@ -163,7 +163,8 @@
       "opencode": "Ready to use OpenCode with {{model}}. Start typing your message below.",
       "default": "Select a provider above to begin"
     },
-    "pressToSearch": "Press <kbd>{{shortcut}}</kbd> to search sessions, files, and commits"
+    "pressToSearch": "Press <kbd>{{shortcut}}</kbd> to search sessions, files, and commits",
+    "addReadme": "Add README.md to project"
   },
   "session": {
     "continue": {


### PR DESCRIPTION
Shows the current project’s `README.md` — its first heading and first prose paragraph — above the provider picker on the new-conversation empty state, so an empty chat says something about the project you just opened instead of nothing.

When a project has no usable README, the pane shows an "Add README.md to project" action that seeds a starter file titled with the project name.

## Why

The empty state is currently the least informative screen in the app, and it is the one you land on every time you start a conversation. With several projects open, the README summary is a cheap, familiar way to confirm at a glance which project the new chat is attached to.

## How it works

`readmeSummary.ts` is a small self-contained parser. READMEs commonly open with an HTML block — a centered logo, an `<h1>`, a tagline `<p>`, then rows of shields.io badges — so it understands both Markdown (`# Title`, prose paragraphs) and the HTML equivalents (`<h1>`, `<p>`), strips inline decoration, and skips badge/image/link-only lines so the paragraph it picks is actual descriptive prose. Whichever of the HTML or Markdown candidates appears first after the title wins.

Rendering is deliberately conservative:

- Only on the brand-new-conversation empty state (`!selectedSession && !currentSessionId`).
- A `404` means "no README" and shows the add prompt; any other error renders nothing rather than falsely claiming the README is missing.
- The fetch is cancelled on unmount / project switch.
- Falls back to rendering nothing when no title or paragraph can be extracted.

## Notes

- Uses the existing `api.readFile` / `api.saveFile` endpoints — no server changes.
- Frontend only; one new `addReadme` key in `en/chat.json`, matching the convention in recent feature PRs of leaving other locales to dedicated translation PRs.

## Testing

- `npm run typecheck` — pass
- `npm run lint` — pass
- `npm run build` — pass
- `npm test` — 262/262 pass

Screenshots to follow shortly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * New conversations now display relevant project context from the project’s README.
  * Added support for showing the README title and introductory summary in the conversation view.
  * Projects without a README can now add a starter README directly from the empty state.
  * Added feedback for loading, cancellation, and temporary errors while creating the README.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->