### PR TITLE
fix(chat): resolve the subagent tool under both Task and Agent

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "postbuild:server": "node scripts/promote-dist-server.mjs",
     "preview": "vite preview",
     "typecheck": "tsc --noEmit -p tsconfig.json && tsc --noEmit -p server/tsconfig.json",
-    "test": "tsx --tsconfig server/tsconfig.json --test \"server/**/*.test.ts\" \"server/**/*.test.js\"",
+    "test": "tsx --tsconfig server/tsconfig.json --test \"server/**/*.test.ts\" \"server/**/*.test.js\" \"src/**/*.test.ts\" \"src/**/*.test.tsx\"",
     "lint": "eslint src/ server/",
     "lint:fix": "eslint src/ server/ --fix",
     "start": "npm run build && npm run server",

--- a/src/components/chat/hooks/useChatMessages.ts
+++ b/src/components/chat/hooks/useChatMessages.ts
@@ -5,6 +5,7 @@
 
 import type { NormalizedMessage } from '../../../stores/useSessionStore';
 import type { ChatMessage, SubagentChildTool } from '../types/types';
+import { isSubagentTool } from '../tools/toolAliases';
 import { decodeHtmlEntities, unescapeWithMathProtection, formatUsageLimitText } from '../utils/chatFormatting';
 
 function formatToolResultContent(content: unknown): string {
@@ -145,7 +146,10 @@ export function normalizedToChatMessages(messages: NormalizedMessage[]): ChatMes
 
       case 'tool_use': {
         const tr = msg.toolResult || (msg.toolId ? toolResultMap.get(msg.toolId) : null);
-        const isSubagentContainer = msg.toolName === 'Task';
+        // Alias-aware: the subagent tool is 'Agent' in current Claude Code and
+        // 'Task' in older transcripts. Missing this is what made a spawned
+        // agent render as a raw parameter dump instead of a tidy container.
+        const isSubagentContainer = isSubagentTool(msg.toolName);
 
         // Build child tools from subagentTools
         const childTools: SubagentChildTool[] = [];

--- a/src/components/chat/tools/ToolRenderer.tsx
+++ b/src/components/chat/tools/ToolRenderer.tsx
@@ -4,6 +4,7 @@ import type { Project } from '../../../types/app';
 import type { SubagentChildTool } from '../types/types';
 
 import { getToolConfig } from './configs/toolConfigs';
+import { isSubagentTool } from './toolAliases';
 import { OneLineDisplay, BashCommandDisplay, CollapsibleDisplay, ToolDiffViewer, MarkdownContent, FileListContent, TodoListContent, TaskListContent, TextContent, QuestionAnswerContent, SubagentContainer } from './components';
 import { PlanDisplay } from './components/PlanDisplay';
 import { ToolStatusBadge } from './components/ToolStatusBadge';
@@ -40,7 +41,7 @@ function getToolCategory(toolName: string): string {
   if (toolName === 'Bash') return 'bash';
   if (['TodoWrite', 'TodoRead'].includes(toolName)) return 'todo';
   if (['TaskCreate', 'TaskUpdate', 'TaskList', 'TaskGet'].includes(toolName)) return 'task';
-  if (toolName === 'Task') return 'agent';
+  if (isSubagentTool(toolName)) return 'agent';
   if (toolName === 'exit_plan_mode' || toolName === 'ExitPlanMode') return 'plan';
   if (toolName === 'AskUserQuestion') return 'question';
   return 'default';

--- a/src/components/chat/tools/components/SubagentContainer.tsx
+++ b/src/components/chat/tools/components/SubagentContainer.tsx
@@ -1,7 +1,10 @@
 import React from 'react';
+
 import type { SubagentChildTool } from '../../types/types';
-import { CollapsibleSection } from './CollapsibleSection';
+import { canonicalToolName } from '../toolAliases';
 import { Collapsible, CollapsibleTrigger, CollapsibleContent } from '../../../../shared/view/ui';
+
+import { CollapsibleSection } from './CollapsibleSection';
 
 interface SubagentContainerProps {
   toolInput: unknown;
@@ -18,7 +21,10 @@ const getCompactToolDisplay = (toolName: string, toolInput: unknown): string => 
     try { return JSON.parse(toolInput); } catch { return {}; }
   })() : (toolInput || {});
 
-  switch (toolName) {
+  // Child tools carry the same rename risk as the parent, so the compact
+  // one-liner is matched on the canonical name too — otherwise a nested
+  // subagent shows a blank label instead of its description.
+  switch (canonicalToolName(toolName)) {
     case 'Read':
     case 'Write':
     case 'Edit':

--- a/src/components/chat/tools/configs/toolConfigs.ts
+++ b/src/components/chat/tools/configs/toolConfigs.ts
@@ -1,7 +1,9 @@
 /**
  * Centralized tool configuration registry
- * Defines display behavior for all tool types 
+ * Defines display behavior for all tool types
  */
+
+import { canonicalToolName } from '../toolAliases';
 
 export interface ToolDisplayConfig {
   input: {
@@ -585,7 +587,9 @@ export const TOOL_CONFIGS: Record<string, ToolDisplayConfig> = {
  * Get configuration for a tool, with fallback to default
  */
 export function getToolConfig(toolName: string): ToolDisplayConfig {
-  return TOOL_CONFIGS[toolName] || TOOL_CONFIGS.Default;
+  // Resolved through the alias map so a renamed tool keeps its rich rendering
+  // instead of silently degrading to Default's raw JSON dump.
+  return TOOL_CONFIGS[canonicalToolName(toolName)] || TOOL_CONFIGS.Default;
 }
 
 /**

--- a/src/components/chat/tools/toolAliases.test.ts
+++ b/src/components/chat/tools/toolAliases.test.ts
@@ -1,0 +1,63 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { getToolConfig } from './configs/toolConfigs';
+import { canonicalToolName, isSubagentTool } from './toolAliases';
+
+/**
+ * Regression guard: spawning a subagent rendered the entire prompt inline as a
+ * wall of text that looked like a message the user had typed. Cause was a
+ * silent rename — Claude Code's subagent tool went from `Task` to `Agent`, no
+ * config matched, and it fell through to `Default`, which titles the block
+ * "Parameters" and dumps the raw input as JSON.
+ *
+ * The failure mode is what makes these tests worth having: a missing config is
+ * not an error, it degrades. Nothing throws, nothing logs, the UI just gets
+ * worse. So the assertions below check the tool resolves to the RICH config,
+ * not merely that it resolves to something.
+ */
+
+test('the subagent tool resolves to the same config under both its names', () => {
+  const viaOldName = getToolConfig('Task');
+  const viaNewName = getToolConfig('Agent');
+  assert.equal(viaNewName, viaOldName, 'Agent must share Task config, not fall through to Default');
+});
+
+test('the subagent tool does NOT fall through to the Default parameter dump', () => {
+  const agent = getToolConfig('Agent');
+  const fallback = getToolConfig('a-tool-that-does-not-exist');
+  assert.notEqual(agent, fallback, 'Agent is resolving to Default — the rename regressed');
+  // Default titles the block a literal 'Parameters'; the subagent config
+  // builds a "Subagent / <type>: <description>" title from the input instead.
+  assert.equal(typeof agent.input?.title, 'function', 'expected a computed subagent title');
+});
+
+test('the computed title describes the subagent rather than dumping input', () => {
+  const agent = getToolConfig('Agent');
+  const title = typeof agent.input?.title === 'function'
+    ? agent.input.title({ subagent_type: 'code-reviewer', description: 'Review the diff' })
+    : String(agent.input?.title);
+  assert.match(title, /code-reviewer/);
+  assert.match(title, /Review the diff/);
+});
+
+test('the subagent config shows the prompt alone when nothing else is set', () => {
+  const agent = getToolConfig('Agent');
+  const props = agent.input?.getContentProps?.({ prompt: 'do the thing' });
+  // The prompt is rendered on its own, not as a JSON blob of every field.
+  assert.equal(props?.content, 'do the thing');
+});
+
+test('both names are recognised as the subagent tool', () => {
+  assert.equal(isSubagentTool('Agent'), true);
+  assert.equal(isSubagentTool('Task'), true, 'older transcripts still say Task');
+  assert.equal(isSubagentTool('Bash'), false);
+  assert.equal(isSubagentTool(null), false);
+  assert.equal(isSubagentTool(undefined), false);
+});
+
+test('unknown tool names pass through untouched', () => {
+  assert.equal(canonicalToolName('Bash'), 'Bash');
+  assert.equal(canonicalToolName('mcp__whatever__thing'), 'mcp__whatever__thing');
+  assert.equal(canonicalToolName(''), '');
+});

--- a/src/components/chat/tools/toolAliases.ts
+++ b/src/components/chat/tools/toolAliases.ts
@@ -1,0 +1,38 @@
+/**
+ * Canonical tool names.
+ *
+ * Claude Code renames tools occasionally, and every rename silently degrades
+ * this UI: a tool with no config falls through to `Default`, which titles the
+ * block "Parameters" and dumps the whole input as JSON. For most tools that is
+ * merely ugly. For the subagent tool it is a wall of text — the entire prompt
+ * sent to the subagent, rendered inline — which is what made spawning an agent
+ * look like a huge message the user had typed themselves.
+ *
+ * The subagent tool was `Task` and is now `Agent`. Six separate places keyed
+ * off the literal 'Task' (config lookup, subagent-container detection, icon
+ * category, the container's own switch), so the rename broke all six
+ * independently and each would have needed spotting on its own.
+ *
+ * Hence one map, applied at every name-based decision, rather than an
+ * `|| 'Agent'` sprinkled per site: the next rename is a one-line change here
+ * instead of another scavenger hunt.
+ */
+const TOOL_NAME_ALIASES: Record<string, string> = {
+  // Subagent spawning. Keep BOTH directions working: a transcript recorded
+  // before the rename still says 'Task', and one recorded after says 'Agent'.
+  Agent: 'Task',
+};
+
+/**
+ * Resolves a tool name to the one this UI has config and behaviour for.
+ * Unknown names pass through untouched.
+ */
+export function canonicalToolName(toolName: string | null | undefined): string {
+  if (!toolName) return '';
+  return TOOL_NAME_ALIASES[toolName] ?? toolName;
+}
+
+/** True when this tool spawns a subagent, under any of its historical names. */
+export function isSubagentTool(toolName: string | null | undefined): boolean {
+  return canonicalToolName(toolName) === 'Task';
+}


### PR DESCRIPTION
## The problem

Claude Code renamed its subagent tool from `Task` to `Agent`. Six places in this
codebase key off the literal string `'Task'`:

- `getToolConfig` lookup in `toolConfigs.ts`
- subagent-container detection in `useChatMessages.ts`
- the icon category in `ToolRenderer.tsx`
- the container's own switch in `SubagentContainer.tsx`

With no config matching `'Agent'`, the tool falls through to the `Default`
renderer — which titles the block **"Parameters"** and dumps the raw input as
JSON. For the subagent tool that input is *the entire prompt sent to the
subagent*, rendered inline, so spawning an agent looks like an enormous message
the user typed themselves.

The failure mode is what makes this easy to miss: **a missing tool config is not
an error.** Nothing throws, nothing logs. The UI just silently gets worse, and
each of the six sites regressed independently.

## The fix

One alias map, applied at every name-based decision, rather than an
`|| 'Agent'` sprinkled per call site — so the next rename is a one-line change
in one file instead of another hunt through six.

**Both names keep working.** A transcript recorded before the rename still says
`Task`; one recorded after says `Agent`. Old conversations must keep rendering.

## What's included

| File | Change |
|---|---|
| `tools/toolAliases.ts` | New. The alias map, `canonicalToolName`, `isSubagentTool` |
| `tools/toolAliases.test.ts` | New. Regression test |
| `tools/configs/toolConfigs.ts` | Resolve through the alias map |
| `tools/ToolRenderer.tsx` | Icon category via `isSubagentTool` |
| `tools/components/SubagentContainer.tsx` | Alias-aware switch |
| `hooks/useChatMessages.ts` | Container detection via `isSubagentTool` |
| `package.json` | One line: add `src/**` test globs so the new test runs |

+123/−7.

## About the test

It asserts the tool resolves to the **rich** config, not merely that it resolves
to something — because "falls through to Default" is exactly the bug, and a test
that only checked for a non-null result would have passed throughout.

`package.json` currently globs only `server/**` for tests, so the client test
would not run without the added `src/**` globs. Happy to drop that hunk and the
test file if you would rather keep the test scope as it is.

## Cross-provider impact — one open question for you

This repo supports four providers, so I checked what the alias map does to each
rather than only to Claude. **`grep` for tools literally named `Task` or `Agent`
outside the Claude provider:**

| Provider | Emits | Effect of this PR |
|---|---|---|
| Claude | `Agent` (was `Task`) | **Fixed** — the point of the PR |
| Codex | `Task` (`codex-sessions.provider.ts:356,403`) | **None.** `Task` is the canonical name, so it maps to itself and keeps rendering exactly as today |
| Cursor | neither | None |
| OpenCode | **`Agent`** (`opencode-sessions.provider.ts:491`) | **Behaviour changes — please sanity-check this one** |

**The OpenCode case.** It emits `toolName: partType === 'patch' ? 'Patch' :
'Agent'`. Today that `Agent` matches no config and falls through to `Default`,
so OpenCode users see the raw JSON dump. With this PR it resolves to the
subagent container instead.

That is probably an improvement — it is an agent invocation, and the container
is the right shape for one. But I have not verified OpenCode's semantics, and
**`SubagentContainer` was written against Claude's `Task` input shape**
(`prompt`, `subagent_type`, …). If OpenCode's `partData` carries a different
shape, the container could render thin where the JSON dump at least showed
everything. You will know immediately whether that is a win or a regression.

If it is unwelcome, the fix is one line — make `isSubagentTool` provider-aware,
or narrow the alias to the Claude provider only. Happy to make that change.

## Notes

Verified on a clean checkout of `main`, not on my own tree:

- `npm run build` passes.
- The new test passes 6/6 — and **fails 4/6 with the `toolConfigs` change
  reverted**, so it guards the regression rather than its own scaffolding.

Running in a downstream fork.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chat rendering for subagent tools using either the current or legacy tool name.
  * Preserved specialized tool displays and meaningful subagent titles for aliased tools.
  * Prevented aliased tools from falling back to generic parameter-only displays.

* **Tests**
  * Added regression coverage for subagent aliases, rendering, titles, and unknown tool handling.
  * Expanded the test command to discover client-side TypeScript test files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->