### PR TITLE
fix(agent): read the model catalog's own shape, not a wrapper

### DIFF
--- a/server/modules/agent/agent.routes.ts
+++ b/server/modules/agent/agent.routes.ts
@@ -978,8 +978,8 @@ export function createAgentRouter(dependencies: AgentRouterDependencies): expres
         });
       }
 
-      const codexModels = (await providerModelsService.getProviderModels('codex')).models;
-      const opencodeModels = (await providerModelsService.getProviderModels('opencode')).models;
+      const codexModels = await providerModelsService.getProviderModels('codex');
+      const opencodeModels = await providerModelsService.getProviderModels('opencode');
 
       // Start the appropriate session
       if (provider === 'claude') {

--- a/server/modules/agent/tests/agent.routes.test.ts
+++ b/server/modules/agent/tests/agent.routes.test.ts
@@ -182,7 +182,7 @@ test('Agent route reuses a matching checkout without cloning or deleting it', as
     } as unknown as AgentDependencies['fileSystem'],
     spawnProcess,
     models: {
-      getProviderModels: async () => ({ models: { DEFAULT: 'default-model' } }),
+      getProviderModels: async () => ({ OPTIONS: [], DEFAULT: 'default-model' }),
     } as unknown as AgentDependencies['models'],
     queryClaude: (async () => undefined) as AgentDependencies['queryClaude'],
   }), async (baseUrl) => {
@@ -202,4 +202,36 @@ test('Agent route reuses a matching checkout without cloning or deleting it', as
 
   assert.deepEqual(spawnedArguments, [['config', '--get', 'remote.origin.url']]);
   assert.deepEqual(removedPaths, []);
+});
+
+test('Agent route starts codex on the catalog default when the request names no model', async () => {
+  const codexCalls: { model?: string }[] = [];
+
+  await withAgentServer(createDependencies({
+    fileSystem: {
+      access: async () => undefined,
+    } as unknown as AgentDependencies['fileSystem'],
+    models: {
+      // `getProviderModels` resolves to a `ProviderModelsDefinition` - `OPTIONS`
+      // and `DEFAULT`, with nothing wrapped around it.
+      getProviderModels: async () => ({ OPTIONS: [], DEFAULT: 'catalog-default' }),
+    } as unknown as AgentDependencies['models'],
+    queryCodex: (async (_prompt: string, options: { model?: string }) => {
+      codexCalls.push(options);
+    }) as unknown as AgentDependencies['queryCodex'],
+  }), async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/agent`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        projectPath: '/home/test/project',
+        message: 'Run',
+        provider: 'codex',
+        stream: false,
+      }),
+    });
+    assert.equal(response.status, 200);
+  });
+
+  assert.deepEqual(codexCalls.map((call) => call.model), ['catalog-default']);
 });


### PR DESCRIPTION
Fixes a live `TypeError` in the agent route: an agent run that names no model crashes before the provider is started, and the failure surfaces as a 500.

## The bug

`server/modules/agent/agent.routes.ts` reads `.models` off the result of `providerModelsService.getProviderModels(...)`:

```js
const codexModels = (await providerModelsService.getProviderModels('codex')).models;
```

`getProviderModels` resolves to a `ProviderModelsDefinition` — `OPTIONS` and `DEFAULT` — with no `models` wrapper, so both catalog handles come back `undefined`. The next line dereferences `codexModels.DEFAULT`, which throws.

Reproduction: start an agent run with `provider: 'codex'` (or `'opencode'`) and no `model`. The route throws before spawning anything, and the client sees a 500 rather than a run.

## Why the suite was green over it

The route's own test mock encoded the same imaginary wrapper:

```js
getProviderModels: async () => ({ models: { OPTIONS: [...], DEFAULT: '...' } })
```

so the tests exercised the fiction, not the service contract.

## The change

- `agent.routes.ts`: read `OPTIONS`/`DEFAULT` off the definition directly.
- `tests/agent.routes.test.ts`: mock now returns the real `ProviderModelsDefinition` shape, plus a new test that drives the codex path with no model and asserts the catalog default reaches the runtime.

Two files, no behavior change for runs that do name a model.

## Verification

`npx tsx --tsconfig server/tsconfig.json --test server/modules/agent/tests/agent.routes.test.ts` — 6/6 pass. Typecheck, lint and build clean.

Independent of my other open PRs (#1141, #1143); it touches only `server/modules/agent/`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved default model selection for Codex and OpenCode requests.
  * Requests without an explicitly selected model now correctly use the provider’s configured default.

* **Tests**
  * Added coverage to verify default model behavior.
  * Updated model catalog test data to reflect the current provider format.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->