### PR TITLE
fix(claude): stop dropping an explicitly requested permission mode

### DIFF
--- a/server/modules/providers/list/claude/claude-permission-mode.ts
+++ b/server/modules/providers/list/claude/claude-permission-mode.ts
@@ -1,0 +1,26 @@
+import type { PermissionMode } from '@anthropic-ai/claude-agent-sdk';
+
+
+/**
+ * Decides which `permissionMode` reaches the Claude Agent SDK.
+ *
+ * The distinction that matters is *explicitly requested* vs *omitted*, not which
+ * mode was named:
+ *
+ * - An explicit mode is forwarded verbatim, including `'default'`. Forwarding
+ *   `'default'` is what keeps a caller's choice authoritative: when it is
+ *   omitted instead, the SDK falls back to the user's own `defaultMode` in their
+ *   Claude Code settings, which can silently replace the structural approval
+ *   flow the caller asked for.
+ * - An omitted mode preserves the existing Web-session behaviour, where the
+ *   global `skipPermissions` setting decides.
+ */
+export function resolveClaudePermissionMode(
+  requestedMode: string | undefined,
+  skipPermissions: boolean,
+): PermissionMode | undefined {
+  if (requestedMode !== undefined) {
+    return requestedMode as PermissionMode;
+  }
+  return skipPermissions ? 'bypassPermissions' : undefined;
+}

--- a/server/modules/providers/list/claude/claude-runtime.provider.js
+++ b/server/modules/providers/list/claude/claude-runtime.provider.js
@@ -25,6 +25,7 @@ import {
   normalizeImageDescriptors
 } from '@/shared/image-attachments.js';
 import { CLAUDE_PREDEFINED_MODELS } from '@/modules/providers/list/claude/claude-models.provider.js';
+import { resolveClaudePermissionMode } from '@/modules/providers/list/claude/claude-permission-mode.js';
 import { resolveClaudeCodeExecutablePath } from '@/shared/claude-cli-path.js';
 import {
   createNotificationEvent,
@@ -178,18 +179,18 @@ function mapCliOptionsToSDK(options = {}) {
     sdkOptions.cwd = cwd;
   }
 
-  if (permissionMode && permissionMode !== 'default') {
-    sdkOptions.permissionMode = permissionMode;
-  }
-
   const settings = toolsSettings || {
     allowedTools: [],
     disallowedTools: [],
     skipPermissions: false
   };
 
-  if (settings.skipPermissions && permissionMode !== 'plan') {
-    sdkOptions.permissionMode = 'bypassPermissions';
+  const resolvedPermissionMode = resolveClaudePermissionMode(
+    permissionMode,
+    Boolean(settings.skipPermissions),
+  );
+  if (resolvedPermissionMode) {
+    sdkOptions.permissionMode = resolvedPermissionMode;
   }
 
   let allowedTools = [...(settings.allowedTools || [])];

--- a/server/modules/providers/tests/claude-permission-mode.test.ts
+++ b/server/modules/providers/tests/claude-permission-mode.test.ts
@@ -1,0 +1,30 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { resolveClaudePermissionMode } from '../list/claude/claude-permission-mode.js';
+
+
+test('an explicit default is forwarded rather than dropped', () => {
+  // Dropping it lets the user's own settings.json defaultMode decide instead.
+  assert.equal(resolveClaudePermissionMode('default', false), 'default');
+});
+
+
+test('an explicit mode outranks the global skipPermissions setting', () => {
+  assert.equal(resolveClaudePermissionMode('default', true), 'default');
+  assert.equal(resolveClaudePermissionMode('acceptEdits', true), 'acceptEdits');
+  assert.equal(resolveClaudePermissionMode('plan', true), 'plan');
+});
+
+
+test('an omitted mode keeps the existing Web-session behaviour', () => {
+  assert.equal(resolveClaudePermissionMode(undefined, true), 'bypassPermissions');
+  assert.equal(resolveClaudePermissionMode(undefined, false), undefined);
+});
+
+
+test('modes the SDK gained later pass through without a code change', () => {
+  // The union comes from the SDK, so 'dontAsk' and 'auto' need no local edit.
+  assert.equal(resolveClaudePermissionMode('dontAsk', true), 'dontAsk');
+  assert.equal(resolveClaudePermissionMode('auto', false), 'auto');
+});


### PR DESCRIPTION
## The bug

`mapCliOptionsToSDK` in `server/modules/providers/list/claude/claude-runtime.provider.js`
loses a caller's explicitly requested `permissionMode` in two separate ways:

```js
if (permissionMode && permissionMode !== 'default') {
  sdkOptions.permissionMode = permissionMode;
}
// ...
if (settings.skipPermissions && permissionMode !== 'plan') {
  sdkOptions.permissionMode = 'bypassPermissions';
}
```

1. **`'default'` is dropped.** With `permissionMode` absent from `sdkOptions`, the
   SDK falls back to the user's own `defaultMode` in their Claude Code settings. A
   caller that explicitly asks for the standard approval flow can silently get
   `acceptEdits` or `bypassPermissions` instead — the opposite of what it asked for.
2. **`skipPermissions` exempts only `'plan'`.** An explicit `'default'` or
   `'acceptEdits'` is overwritten with `'bypassPermissions'`, so a global setting
   outranks a per-request choice.

Both cases are invisible in the local Web UI, where the mode picker and
`skipPermissions` belong to the same person and the fallback usually agrees with
the request. They matter as soon as a programmatic caller sets the mode per
session and the server it talks to has its own settings file.

## The change

The distinction that matters is *explicitly requested* vs *omitted*, not which mode
was named. `resolveClaudePermissionMode()` states that in one place:

- an explicit mode is forwarded verbatim, `'default'` included;
- `skipPermissions` decides only when no mode was requested.

Web sessions that send no mode keep their current behaviour exactly.

The return type is the SDK's own `PermissionMode`, imported from
`@anthropic-ai/claude-agent-sdk`, rather than a locally written union. Modes the
SDK adds later — `dontAsk` and `auto` are already there — need no edit here.

## Testing

`npm test` — 266 pass, 0 fail (262 before this change, plus the 4 new ones).
`tsc -p server/tsconfig.json --noEmit` is clean.

The new tests cover the `'default'` case, the generalized precedence over
`skipPermissions`, the omitted-mode path in both `skipPermissions` states, and
pass-through of modes the union gained from the SDK.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Claude permission-mode handling.
  * Explicitly selected permission modes, including the default, are now honored.
  * Automatic permission bypass is applied only when no mode is selected and bypassing is enabled.
  * Supports newer Claude SDK permission modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->