### PR TITLE
fix(sidebar): let Running now collapse its project groups

### DIFF
--- a/src/modules/sidebar/Sidebar.tsx
+++ b/src/modules/sidebar/Sidebar.tsx
@@ -80,7 +80,7 @@ function Sidebar({
 
   const {
     isSidebarCollapsed,
-    expandedProjects,
+    isProjectExpanded,
     activeRename,
     showNewProject,
     initialSessionsLoaded,
@@ -191,7 +191,7 @@ function Sidebar({
     selectedSession,
     isLoading,
     loadingProgress,
-    expandedProjects,
+    isProjectExpanded,
     activeRename,
     initialSessionsLoaded,
     currentTime,
@@ -202,7 +202,6 @@ function Sidebar({
     loadingMoreProjects,
     activeSessions,
     attentionSessionIds,
-    forceExpanded: searchMode === 'running',
     isProjectStarred,
     onRenameDraftChange: updateRenameDraft,
     onToggleProject: toggleProject,

--- a/src/modules/sidebar/SidebarProjectItem.tsx
+++ b/src/modules/sidebar/SidebarProjectItem.tsx
@@ -30,9 +30,9 @@ type SidebarProjectItemProps = {
   tasksEnabled: boolean;
   mcpServerStatus: MCPServerStatus;
   onRenameDraftChange: (name: string) => void;
-  onToggleProject: (projectName: string) => void;
+  onToggleProject: (projectId: string) => void;
   onProjectSelect: (project: Project) => void;
-  onToggleStarProject: (projectName: string) => void;
+  onToggleStarProject: (projectId: string) => void;
   onStartEditingProject: (project: Project) => void;
   onCancelEditingProject: () => void;
   onSaveProjectName: (projectId: string, nextName: string) => void;

--- a/src/modules/sidebar/SidebarProjectList.tsx
+++ b/src/modules/sidebar/SidebarProjectList.tsx
@@ -14,7 +14,7 @@ export default function SidebarProjectList({
   selectedSession,
   isLoading,
   loadingProgress,
-  expandedProjects,
+  isProjectExpanded,
   activeRename,
   initialSessionsLoaded,
   currentTime,
@@ -27,7 +27,6 @@ export default function SidebarProjectList({
   loadingMoreProjects,
   activeSessions,
   attentionSessionIds,
-  forceExpanded = false,
   isProjectStarred,
   onRenameDraftChange,
   onToggleProject,
@@ -88,7 +87,7 @@ export default function SidebarProjectList({
                 project={project}
                 selectedProject={selectedProject}
                 selectedSession={selectedSession}
-                isExpanded={forceExpanded || expandedProjects.has(project.projectId)}
+                isExpanded={isProjectExpanded(project.projectId)}
                 isDeleting={deletingProjects.has(project.projectId)}
                 isStarred={isProjectStarred(project.projectId)}
                 isEditing={renamingProject !== null}

--- a/src/modules/sidebar/hooks/useSidebarController.ts
+++ b/src/modules/sidebar/hooks/useSidebarController.ts
@@ -80,6 +80,8 @@ export function useSidebarController({
 }: UseSidebarControllerArgs) {
   const paletteOps = usePaletteOps();
   const [expandedProjects, setExpandedProjects] = useState<Set<string>>(new Set());
+  // Running groups start expanded and remember manual collapses independently of Projects.
+  const [collapsedRunningProjects, setCollapsedRunningProjects] = useState<Set<string>>(new Set());
   // The one rename the sidebar has open, as a single value so a project and a
   // session cannot both be mid-rename. See ActiveSidebarRename.
   const [activeRename, setActiveRename] = useState<ActiveSidebarRename | null>(null);
@@ -490,15 +492,37 @@ export function useSidebarController({
 
   // All sidebar state keys (expanded, starred, loading, etc.) use the DB
   // `projectId` as their identifier after the migration.
-  const toggleProject = useCallback((projectId: string) => {
-    setExpandedProjects((prev) => {
-      const next = new Set<string>();
-      if (!prev.has(projectId)) {
-        next.add(projectId);
+  const toggleProject = useCallback(
+    (projectId: string) => {
+      if (searchMode === 'running') {
+        setCollapsedRunningProjects((prev) => {
+          const next = new Set(prev);
+          if (!next.delete(projectId)) {
+            next.add(projectId);
+          }
+          return next;
+        });
+        return;
       }
-      return next;
-    });
-  }, []);
+
+      setExpandedProjects((prev) => {
+        const next = new Set<string>();
+        if (!prev.has(projectId)) {
+          next.add(projectId);
+        }
+        return next;
+      });
+    },
+    [searchMode],
+  );
+
+  const isProjectExpanded = useCallback(
+    (projectId: string) =>
+      searchMode === 'running'
+        ? !collapsedRunningProjects.has(projectId)
+        : expandedProjects.has(projectId),
+    [collapsedRunningProjects, expandedProjects, searchMode],
+  );
 
   const handleSessionClick = useCallback(
     (session: SessionWithProvider, projectId: string) => {
@@ -1040,7 +1064,7 @@ export function useSidebarController({
 
   return {
     isSidebarCollapsed,
-    expandedProjects,
+    isProjectExpanded,
     activeRename,
     showNewProject,
     initialSessionsLoaded,

--- a/src/modules/sidebar/tests/sidebarRowProps.test.tsx
+++ b/src/modules/sidebar/tests/sidebarRowProps.test.tsx
@@ -67,7 +67,7 @@ const listProps = (activeRename: ActiveSidebarRename | null): SidebarProjectList
   selectedSession: null,
   isLoading: false,
   loadingProgress: null,
-  expandedProjects: new Set(),
+  isProjectExpanded: () => false,
   activeRename,
   initialSessionsLoaded: new Set(),
   currentTime: NOW,
@@ -105,6 +105,34 @@ const changedProps = (before: Record<string, unknown>, after: Record<string, unk
 beforeEach(() => {
   recordedProjectRowProps.length = 0;
   recordedSessionRowProps.length = 0;
+});
+
+test('project expansion is resolved per project without dropping rows', () => {
+  const props = listProps(null);
+  const { rerender } = render(
+    React.createElement(SidebarProjectList, {
+      ...props,
+      isProjectExpanded: (projectId) => projectId === PROJECT_A.projectId,
+    }),
+  );
+
+  assert.deepEqual(
+    recordedProjectRowProps.map(({ isExpanded }) => isExpanded),
+    [true, false],
+  );
+
+  rerender(
+    React.createElement(SidebarProjectList, {
+      ...props,
+      isProjectExpanded: () => true,
+    }),
+  );
+
+  assert.equal(recordedProjectRowProps.length, 4);
+  assert.deepEqual(
+    recordedProjectRowProps.slice(2).map(({ isExpanded }) => isExpanded),
+    [true, true],
+  );
 });
 
 test('renaming a project changes props on that row only', () => {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1261,7 +1261,7 @@ export type SidebarProjectListProps = SessionRowActions & {
   selectedSession: ProjectSession | null;
   isLoading: boolean;
   loadingProgress: LoadingProgress | null;
-  expandedProjects: Set<string>;
+  isProjectExpanded: (projectId: string) => boolean;
   initialSessionsLoaded: Set<string>;
   currentTime: Date;
   deletingProjects: Set<string>;
@@ -1270,11 +1270,10 @@ export type SidebarProjectListProps = SessionRowActions & {
   getProjectSessions: (project: Project) => SessionWithProvider[];
   onLoadMoreSessions: (projectId: string) => void;
   loadingMoreProjects: Set<string>;
-  forceExpanded?: boolean;
-  isProjectStarred: (projectName: string) => boolean;
-  onToggleProject: (projectName: string) => void;
+  isProjectStarred: (projectId: string) => boolean;
+  onToggleProject: (projectId: string) => void;
   onProjectSelect: (project: Project) => void;
-  onToggleStarProject: (projectName: string) => void;
+  onToggleStarProject: (projectId: string) => void;
   onStartEditingProject: (project: Project) => void;
   onCancelEditingProject: () => void;
   onSaveProjectName: (projectId: string, nextName: string) => void;


### PR DESCRIPTION
## Problem

In the sidebar's Running view, every project group is forced open. Clicking its chevron cannot collapse it, but still updates the separate Projects-view accordion state.

## Change

- Keep Running groups expanded by default, while allowing each group to be collapsed and reopened independently.
- Track Running collapses separately so those clicks do not change the Projects-view accordion. Projects retains its existing single-open behavior.
- Replace `expandedProjects` and `forceExpanded` row props with `isProjectExpanded(projectId)`, shared by the chevron and session-list rendering.
- Rename callback parameter labels from `projectName` to `projectId` to match the values already passed. This is a type-documentation correction, not a change to project starring or renaming.

The collapse state is held in memory for the mounted sidebar; this PR adds no persisted preference.

## Verification

Rebased onto upstream `main` at `5e73a49b89` as requested. The PR remains one feature commit, `3695bb33`, changing six files.

Checks passed on that rebased head:

- `npm run typecheck`
- `npx vitest run src/modules/sidebar/tests/sidebarRowProps.test.tsx` — 7 tests passed, including per-project expansion rendering across a rerender.
- `npm run build:client` — passed with CSS-minification and chunk-size warnings.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sidebar project expansion behavior: running projects can be expanded or collapsed independently, while other project views retain their existing behavior.
  * Deleted sessions are now removed from Recent Conversations immediately, with totals updated without requiring a refresh.
  * Renamed sessions now display their updated titles in Recent Conversations immediately.

* **Improvements**
  * Updated project and session actions to use stable project identifiers for more consistent sidebar interactions.
  * Added support for displaying compaction status and summaries in chat messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->