### PR TITLE
fix(chat): stop scrolled-away messages rendering as tall empty boxes

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -588,20 +588,13 @@
     clip-path: inset(-8px -8px 0 -8px);
   }
 
-  .chat-message {
+  /*
+   * LazyMessageRow owns off-screen sizing through measured placeholders.
+   * Containing its stable wrapper without size containment or content visibility
+   * keeps those placeholder heights and mounted content heights authoritative.
+   */
+  .chat-message-row {
     contain: layout style paint;
-    content-visibility: auto;
-    contain-intrinsic-size: auto 180px;
-  }
-
-  .chat-message.assistant {
-    contain-intrinsic-size: auto 240px;
-  }
-
-  .chat-message.user,
-  .chat-message.tool,
-  .chat-message.error {
-    contain-intrinsic-size: auto 96px;
   }
 
   /* Mobile touch optimization and safe areas */

--- a/src/modules/chat/export/buildTranscriptHtml.tsx
+++ b/src/modules/chat/export/buildTranscriptHtml.tsx
@@ -102,9 +102,6 @@ ${styles}
     border: 1px solid hsl(var(--border)); background: transparent; color: inherit;
     border-radius: 0.5rem; padding: 0.375rem 0.75rem; font-size: 0.75rem; cursor: pointer;
   }
-  /* Off-screen skipping is a scrolling optimisation; in a printed document it
-     leaves blank pages. */
-  .chat-message { content-visibility: visible !important; contain-intrinsic-size: auto !important; }
   @media print {
     .chat-export-theme-toggle { display: none; }
     .chat-export-shell { max-width: none; padding: 0; }

--- a/src/modules/chat/transcript/LazyMessageRow.tsx
+++ b/src/modules/chat/transcript/LazyMessageRow.tsx
@@ -70,6 +70,7 @@ export default function LazyMessageRow({
   return (
     <div
       ref={elementRef}
+      className="chat-message-row"
       data-message-timestamp={timestamp || undefined}
       style={isMounted ? undefined : { height: measuredHeight ?? ESTIMATED_ROW_HEIGHT_PX }}
     >


### PR DESCRIPTION
`content-visibility: auto` sizes an off-screen element by
`contain-intrinsic-size` rather than by its content, and the reserved sizes were
guesses: a collapsed tool row is about 32px and was reserving 240px, so
messages scrolled out of view became tall empty boxes with their text floating
inside them.

The `auto` keyword makes it worse rather than better - the browser then
remembers the last rendered height, so a row expanded once (a diff, a long tool
output) keeps that height forever while skipped. Messages are already
paginated, so the DOM stays small and skipping off-screen work buys little.

Keep the paint/layout isolation, drop the sizing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chat message rendering consistency and reduced blank or incomplete content in transcripts.
  * Improved printed transcript reliability so chat messages render correctly across pages.
  * Preserved efficient lazy loading and layout behavior while improving message display stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->