### PR TITLE
fix(chat): stop escape-unescaping from shredding LaTeX and currency

### DIFF
--- a/src/modules/chat/tests/chatFormatting.test.ts
+++ b/src/modules/chat/tests/chatFormatting.test.ts
@@ -1,8 +1,13 @@
+import React from 'react';
+
+import { render } from '@testing-library/react';
 import assert from 'node:assert/strict';
 
 import { test } from 'vitest';
 
 import { stripProposedPlanEnvelope } from '@/modules/chat/utils/chatFormatting';
+import { Markdown } from '@/modules/chat/transcript/Markdown';
+import StreamingMarkdown from '@/modules/chat/transcript/StreamingMarkdown';
 
 test('stripProposedPlanEnvelope removes a complete outer plan envelope', () => {
   assert.equal(
@@ -26,4 +31,55 @@ test('stripProposedPlanEnvelope preserves tags that are not the outer envelope',
 test('stripProposedPlanEnvelope preserves an unmatched terminal closing tag', () => {
   const content = 'Ordinary text that mentions a terminal tag.\n</proposed_plan>';
   assert.equal(stripProposedPlanEnvelope(content), content);
+});
+
+const renderMarkdown = (content: string) =>
+  render(React.createElement(Markdown, { children: content }));
+
+test('Markdown renders bracket and parenthesis LaTeX without corrupting commands', () => {
+  const content =
+    String.raw`\[ \text{fixed net} = \text{fixed gross} \]` +
+    '\n\n' +
+    String.raw`rate \( \rho \times 2 \) done`;
+  const { container } = renderMarkdown(content);
+
+  assert.equal(container.querySelectorAll('.katex').length, 2);
+  assert.equal(container.textContent?.includes('\t'), false, String.raw`\text must not become a tab`);
+});
+
+test('Markdown leaves currency prose outside math', () => {
+  const content = 'Tiered fees for $200k exposure, and the fixed-$100k stats use it.';
+  const { container } = renderMarkdown(content);
+
+  assert.equal(container.querySelector('.katex'), null);
+  assert.equal(container.textContent, content);
+});
+
+test('Markdown keeps LaTeX-looking delimiters inside fenced and inline code literal', () => {
+  const fenced = String.raw`\[ \theta \]`;
+  const inline = String.raw`\( \rho \)`;
+  const { container } = renderMarkdown(`\`\`\`\n${fenced}\n\`\`\`\n\nUse \`${inline}\` literally.`);
+  const code = Array.from(container.querySelectorAll('code'), (element) => element.textContent);
+
+  assert.equal(container.querySelector('.katex'), null);
+  assert.ok(code.some((value) => value?.includes(fenced)));
+  assert.ok(code.some((value) => value?.includes(inline)));
+});
+
+test('completed replies render normalized LaTeX through MarkdownBody', () => {
+  const content = String.raw`\[ \theta_{t+1} = \theta_t \times 2 \]`;
+  const { container } = render(
+    React.createElement(StreamingMarkdown, { content, isStreaming: false }),
+  );
+
+  assert.equal(container.querySelectorAll('.katex').length, 1);
+});
+
+test('streaming replies render normalized LaTeX through MarkdownBody', () => {
+  const content = 'Before.\n\n' + String.raw`\( \rho \times 2 \)`;
+  const { container } = render(
+    React.createElement(StreamingMarkdown, { content, isStreaming: true }),
+  );
+
+  assert.equal(container.querySelectorAll('.katex').length, 1);
 });

--- a/src/modules/chat/tests/chatFormatting.test.ts
+++ b/src/modules/chat/tests/chatFormatting.test.ts
@@ -102,3 +102,12 @@ test('streaming replies render normalized LaTeX through MarkdownBody', () => {
 
   assert.equal(container.querySelectorAll('.katex').length, 1);
 });
+
+test('Markdown keeps escaped LaTeX delimiters out of math', () => {
+  const escapedPair = String.raw`\\[ \theta \\]`;
+  const escapedCloser = String.raw`\[ \rho \\]`;
+  const { container } = renderMarkdown(`${escapedPair}\n\n${escapedCloser}`);
+
+  assert.equal(container.querySelector('.katex'), null);
+  assert.equal(container.textContent?.includes('$$'), false, 'delimiters must not become math');
+});

--- a/src/modules/chat/tests/chatFormatting.test.ts
+++ b/src/modules/chat/tests/chatFormatting.test.ts
@@ -58,12 +58,31 @@ test('Markdown leaves currency prose outside math', () => {
 test('Markdown keeps LaTeX-looking delimiters inside fenced and inline code literal', () => {
   const fenced = String.raw`\[ \theta \]`;
   const inline = String.raw`\( \rho \)`;
-  const { container } = renderMarkdown(`\`\`\`\n${fenced}\n\`\`\`\n\nUse \`${inline}\` literally.`);
+  const tildeFenced = String.raw`\[ \times \]`;
+  const unfinishedFenced = String.raw`\( \sigma \)`;
+  const content = [
+    '````',
+    '```',
+    fenced,
+    '```',
+    '````',
+    '',
+    `Use \`\`${inline}\`\` literally.`,
+    '',
+    '~~~',
+    tildeFenced,
+    '~~~~',
+    '',
+    '`````',
+    unfinishedFenced,
+  ].join('\n');
+  const { container } = renderMarkdown(content);
   const code = Array.from(container.querySelectorAll('code'), (element) => element.textContent);
 
   assert.equal(container.querySelector('.katex'), null);
-  assert.ok(code.some((value) => value?.includes(fenced)));
-  assert.ok(code.some((value) => value?.includes(inline)));
+  for (const literal of [fenced, inline, tildeFenced, unfinishedFenced]) {
+    assert.ok(code.some((value) => value?.includes(literal)), `${literal} must stay literal`);
+  }
 });
 
 test('completed replies render normalized LaTeX through MarkdownBody', () => {

--- a/src/modules/chat/transcript/Markdown.tsx
+++ b/src/modules/chat/transcript/Markdown.tsx
@@ -62,8 +62,10 @@ const MATH_DELIMITER = /\$\$/;
 
 // Match code before LaTeX so delimiter-like text in code stays literal. The fence
 // branch also covers an unfinished streamed fence by consuming through the end.
+// Both LaTeX delimiters require an unescaped backslash on each side, so text
+// that spells out `\\[ ... \\]` stays prose instead of turning into math.
 const CODE_OR_LATEX_MATH =
-  /^ {0,3}((`|~)\2{2,})(?!\2)[^\r\n]*(?:\r?\n|$)[\s\S]*?(?:^ {0,3}\1\2*[ \t]*(?=\r?$)|$(?![\s\S]))|(?<!`)(`+)(?!`)[\s\S]*?(?<!`)\3(?!`)|\$\$[\s\S]*?\$\$|\\\[([\s\S]*?)\\\]|\\\(([\s\S]*?)\\\)/gm;
+  /^ {0,3}((`|~)\2{2,})(?!\2)[^\r\n]*(?:\r?\n|$)[\s\S]*?(?:^ {0,3}\1\2*[ \t]*(?=\r?$)|$(?![\s\S]))|(?<!`)(`+)(?!`)[\s\S]*?(?<!`)\3(?!`)|\$\$[\s\S]*?\$\$|(?<!\\)\\\[([\s\S]*?)(?<!\\)\\\]|(?<!\\)\\\(([\s\S]*?)(?<!\\)\\\)/gm;
 
 const normalizeLatexDelimiters = (text: string): string =>
   text.replace(

--- a/src/modules/chat/transcript/Markdown.tsx
+++ b/src/modules/chat/transcript/Markdown.tsx
@@ -63,12 +63,12 @@ const MATH_DELIMITER = /\$\$/;
 // Match code before LaTeX so delimiter-like text in code stays literal. The fence
 // branch also covers an unfinished streamed fence by consuming through the end.
 const CODE_OR_LATEX_MATH =
-  /^ {0,3}([`~])\1{2,}[^\r\n]*(?:\r?\n|$)[\s\S]*?(?:^ {0,3}\1{2,}[ \t]*(?=\r?$)|$(?![\s\S]))|(`+)[\s\S]*?\2|\$\$[\s\S]*?\$\$|\\\[([\s\S]*?)\\\]|\\\(([\s\S]*?)\\\)/gm;
+  /^ {0,3}((`|~)\2{2,})(?!\2)[^\r\n]*(?:\r?\n|$)[\s\S]*?(?:^ {0,3}\1\2*[ \t]*(?=\r?$)|$(?![\s\S]))|(?<!`)(`+)(?!`)[\s\S]*?(?<!`)\3(?!`)|\$\$[\s\S]*?\$\$|\\\[([\s\S]*?)\\\]|\\\(([\s\S]*?)\\\)/gm;
 
 const normalizeLatexDelimiters = (text: string): string =>
   text.replace(
     CODE_OR_LATEX_MATH,
-    (match, _fenceMarker, _codeDelimiter, blockMath, inlineMath) => {
+    (match, _fence, _fenceMarker, _codeDelimiter, blockMath, inlineMath) => {
       if (blockMath !== undefined) return `$$${blockMath}$$`;
       if (inlineMath !== undefined) return `$$${inlineMath}$$`;
       return match;

--- a/src/modules/chat/transcript/Markdown.tsx
+++ b/src/modules/chat/transcript/Markdown.tsx
@@ -57,8 +57,23 @@ const childrenToText = (children: React.ReactNode): string => {
   return '';
 };
 
-// The delimiters `remark-math` recognizes with `singleDollarTextMath` off.
-const MATH_DELIMITER = /\$\$|\\\(|\\\[/;
+// With single-dollar math disabled, remark-math only parses double-dollar delimiters.
+const MATH_DELIMITER = /\$\$/;
+
+// Match code before LaTeX so delimiter-like text in code stays literal. The fence
+// branch also covers an unfinished streamed fence by consuming through the end.
+const CODE_OR_LATEX_MATH =
+  /^ {0,3}([`~])\1{2,}[^\r\n]*(?:\r?\n|$)[\s\S]*?(?:^ {0,3}\1{2,}[ \t]*(?=\r?$)|$(?![\s\S]))|(`+)[\s\S]*?\2|\$\$[\s\S]*?\$\$|\\\[([\s\S]*?)\\\]|\\\(([\s\S]*?)\\\)/gm;
+
+const normalizeLatexDelimiters = (text: string): string =>
+  text.replace(
+    CODE_OR_LATEX_MATH,
+    (match, _fenceMarker, _codeDelimiter, blockMath, inlineMath) => {
+      if (blockMath !== undefined) return `$$${blockMath}$$`;
+      if (inlineMath !== undefined) return `$$${inlineMath}$$`;
+      return match;
+    },
+  );
 
 const EMPTY_PLUGINS: never[] = [];
 
@@ -245,7 +260,7 @@ const markdownComponents = {
  */
 function MarkdownBodyRenderer({ children, breaks = false }: Omit<MarkdownProps, 'className'>) {
   const content = useMemo(
-    () => normalizeInlineCodeFences(String(children ?? '')),
+    () => normalizeLatexDelimiters(normalizeInlineCodeFences(String(children ?? ''))),
     [children],
   );
   // Math support costs a remark tree pass plus a full KaTeX walk on every


### PR DESCRIPTION
The escape pass rewrote `\t`, `\n` and friends across the whole message, so a
`\text{…}`, `\theta` or `\rho` inside an equation became a tab, a newline or a
carriage return. Its math guard only protected `$$…$$` and single-`$` spans, and
the single-`$` rule did the opposite damage: `$200k … $100k` in prose was
swallowed as one equation, hiding the text between two amounts.

Protect code spans and real math regions instead — fenced and inline code,
`$$…$$`, `\[…\]` and `\(…\)` — and rewrite the LaTeX delimiters to dollars,
since remark-math only understands those. Single `$` is no longer a math
delimiter, so `singleDollarTextMath` is disabled in the Markdown renderer to
match. Placeholders are NUL-prefixed and widened on collision, so a message
containing the placeholder text cannot have its own words replaced.

Covered by chatFormatting.test.ts: LaTeX survival, currency prose, code-block
escapes, and the placeholder-collision case.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved LaTeX rendering in chat messages, including bracket and parenthesis formats.
  * Prevented currency values and LaTeX-like text in code blocks from being misinterpreted as math.
  * Kept escaped LaTeX delimiters as literal text.
  * Ensured completed and streaming responses render mathematical notation consistently.

* **Tests**
  * Added coverage for LaTeX normalization, currency text, code blocks, escaped delimiters, and streaming content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->