### PR TITLE
fix(auth): stop a cached API response from restoring an expired token

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -25,6 +25,7 @@ import {
     authenticateWebSocket,
     authRoutes,
     validateApiKey,
+    preventApiResponseCaching,
 } from './modules/auth/index.js';
 import { taskmasterRoutes } from './modules/taskmaster/index.js';
 import { commandsRoutes } from './modules/commands/index.js';
@@ -143,6 +144,8 @@ app.get('/health', (req, res) => {
         version: RUNNING_VERSION
     });
 });
+
+app.use('/api', preventApiResponseCaching);
 
 // Optional API key validation (if configured)
 app.use('/api', validateApiKey);

--- a/server/modules/auth/auth.middleware.ts
+++ b/server/modules/auth/auth.middleware.ts
@@ -8,6 +8,12 @@ import { userDb, appConfigDb } from '../database/index.js';
 // Use env var if set, otherwise auto-generate a unique secret per installation
 const JWT_SECRET = process.env.JWT_SECRET || appConfigDb.getOrCreateJwtSecret();
 
+/** Used by the server entrypoint so API responses carrying auth state never enter HTTP caches. */
+export const preventApiResponseCaching = (_req, res, next) => {
+  res.setHeader('Cache-Control', 'no-store');
+  next();
+};
+
 // Optional API key middleware
 const validateApiKey = (req, res, next) => {
   // Skip API key validation if not configured

--- a/server/modules/auth/index.ts
+++ b/server/modules/auth/index.ts
@@ -7,3 +7,5 @@ export { authenticateToken } from './auth.middleware.js';
 export { authenticateWebSocket } from './auth.middleware.js';
 // validateApiKey: used by the server entrypoint for optional API-wide key validation.
 export { validateApiKey } from './auth.middleware.js';
+// preventApiResponseCaching: used by the server entrypoint before API routes can emit auth state.
+export { preventApiResponseCaching } from './auth.middleware.js';

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -32,6 +32,8 @@ export const authenticatedFetch = (
 
   return fetch(url, {
     ...options,
+    // Auth responses carry session headers, so callers cannot opt back into caching.
+    cache: 'no-store',
     headers: {
       ...defaultHeaders,
       ...options.headers,

--- a/src/shared/authToken.ts
+++ b/src/shared/authToken.ts
@@ -92,6 +92,23 @@ export const storeAuthToken = (token: unknown): boolean => {
     return false;
   }
 
+  const claims = readTokenClaims(token);
+  if (!claims) {
+    return false;
+  }
+
+  // Issue time is the ordering key, even when the newer response arrives already expired.
+  // Different tokens minted in the same second have no safe ordering, so keep the stored one.
+  const storedToken = localStorage.getItem('auth-token');
+  const storedClaims = readTokenClaims(storedToken);
+  if (
+    storedClaims &&
+    (claims.issuedAt < storedClaims.issuedAt ||
+      (claims.issuedAt === storedClaims.issuedAt && token !== storedToken))
+  ) {
+    return false;
+  }
+
   localStorage.setItem('auth-token', token);
   if (typeof window !== 'undefined') {
     window.dispatchEvent(new CustomEvent(AUTH_TOKEN_REFRESHED_EVENT, { detail: token }));

--- a/src/shared/tests/authToken.test.ts
+++ b/src/shared/tests/authToken.test.ts
@@ -84,6 +84,50 @@ test('storeAuthToken: a non-token value is rejected and does not overwrite the s
   assert.equal(localStorage.getItem('auth-token'), 'existing');
 });
 
+test('storeAuthToken: an older refresh cannot replace a newer stored token', () => {
+  localStorage.clear();
+  const now = Math.floor(Date.now() / 1000);
+  const newer = makeToken({ iat: now - 60, exp: now + 600 });
+  const older = makeToken({ iat: now - 600, exp: now + 300 });
+  localStorage.setItem('auth-token', newer);
+
+  assert.equal(storeAuthToken(older), false);
+  assert.equal(localStorage.getItem('auth-token'), newer);
+});
+
+test('storeAuthToken: equal issue times accept only the token already stored', () => {
+  localStorage.clear();
+  const now = Math.floor(Date.now() / 1000);
+  const stored = makeToken({ sub: 'current', iat: now, exp: now + 600 });
+  const different = makeToken({ sub: 'late-response', iat: now, exp: now + 600 });
+  localStorage.setItem('auth-token', stored);
+
+  assert.equal(storeAuthToken(stored), true);
+  assert.equal(storeAuthToken(different), false);
+  assert.equal(localStorage.getItem('auth-token'), stored);
+});
+
+test('storeAuthToken: a newer token is accepted even when it is already expired', () => {
+  localStorage.clear();
+  const now = Math.floor(Date.now() / 1000);
+  const older = makeToken({ iat: now - 600, exp: now + 600 });
+  const newerButExpired = makeToken({ iat: now - 120, exp: now - 60 });
+  localStorage.setItem('auth-token', older);
+
+  assert.equal(storeAuthToken(newerButExpired), true);
+  assert.equal(localStorage.getItem('auth-token'), newerButExpired);
+});
+
+test('storeAuthToken: unreadable claims cannot replace the stored token', () => {
+  localStorage.clear();
+  const now = Math.floor(Date.now() / 1000);
+  const stored = makeToken({ iat: now, exp: now + 600 });
+  localStorage.setItem('auth-token', stored);
+
+  assert.equal(storeAuthToken(makeToken({ sub: 'missing-timestamps' })), false);
+  assert.equal(localStorage.getItem('auth-token'), stored);
+});
+
 test('getStoredAuthToken: an expired token is dropped and the expiry is announced once', () => {
   localStorage.clear();
   const now = Math.floor(Date.now() / 1000);

--- a/src/shared/tests/authenticatedFetch.test.ts
+++ b/src/shared/tests/authenticatedFetch.test.ts
@@ -107,6 +107,14 @@ test('no token means no Authorization header at all', async () => {
   assert.equal('Authorization' in sentHeaders(), false);
 });
 
+test('authenticated responses always bypass the HTTP cache', async () => {
+  respondWith();
+
+  await (await loadFetch(false))('/api/projects', { cache: 'force-cache' });
+
+  assert.equal(lastInit?.cache, 'no-store');
+});
+
 test('a JSON body is labelled as JSON', async () => {
   respondWith();
 
@@ -138,8 +146,9 @@ test('a caller header wins over the default', async () => {
 });
 
 test('a refreshed token on the response replaces the stored one', async () => {
-  localStorage.setItem('auth-token', liveToken());
-  const rotated = liveToken().replace('signature', 'rotated');
+  const now = Math.floor(Date.now() / 1000);
+  localStorage.setItem('auth-token', makeToken({ iat: now - 60, exp: now + 540 }));
+  const rotated = makeToken({ iat: now, exp: now + 600 });
   let announced: string | null = null;
   const onRefresh = (event: Event) => {
     announced = (event as CustomEvent<string>).detail;
@@ -152,6 +161,37 @@ test('a refreshed token on the response replaces the stored one', async () => {
   window.removeEventListener(AUTH_TOKEN_REFRESHED_EVENT, onRefresh);
   assert.equal(localStorage.getItem('auth-token'), rotated);
   assert.equal(announced, rotated);
+});
+
+test('a slower older refresh response cannot replace a newer token', async () => {
+  const now = Math.floor(Date.now() / 1000);
+  const older = makeToken({ iat: now - 600, exp: now + 300 });
+  const newer = makeToken({ iat: now - 60, exp: now + 600 });
+  let releaseSlowResponse: (() => void) | undefined;
+  const slowResponse = new Promise<void>((resolve) => {
+    releaseSlowResponse = resolve;
+  });
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (url: string) => {
+      const isSlow = url.endsWith('/slow');
+      if (isSlow) {
+        await slowResponse;
+      }
+      return new Response('{}', {
+        headers: { 'X-Refreshed-Token': isSlow ? older : newer },
+      });
+    }),
+  );
+  const fetch = await loadFetch(false);
+
+  const slowRequest = fetch('/api/slow');
+  await fetch('/api/fast');
+  assert.ok(releaseSlowResponse);
+  releaseSlowResponse();
+  await slowRequest;
+
+  assert.equal(localStorage.getItem('auth-token'), newer);
 });
 
 test('an auth error on the response ends the session', async () => {


### PR DESCRIPTION
## Problem

An installed PWA is logged out on almost every cold start, with "Your session expired", while a long-lived browser tab on the same server never is.

The cause is HTTP caching of `/api` responses:

- Express sends an `ETag` on JSON responses but no `Cache-Control`, so `/api/auth/user` is cacheable and ETag-revalidated.
- `authenticateToken()` only attaches `X-Refreshed-Token` when the token is past half-life, so a revalidated `304` usually carries no such header.
- The browser then merges the `304` onto the **cached** response, and JS reads the `X-Refreshed-Token` stored with it, which can be days old.
- `storeAuthToken()` validated only that the value was JWT-shaped, so it persisted that stale token over the live one.
- The next `getStoredAuthToken()` read it as expired, wiped the session and dispatched `auth-session-expired`.

Measured against a running server:

```
request 1 : 200 | etag: W/"6b-..." | cache-control: null | X-Refreshed-Token: present
request 2 : 304 |                                        | X-Refreshed-Token: ABSENT
```

A cold start replays those requests against a warm cache. A tab that stays open avoids that cold-start check, but token changes can also re-run authentication checks in an already-open tab.

Instrumenting the shipped bundle on the affected device confirmed the sequence within a single launch: boot with a token valid for 7 more days, then a write of a token that had expired 4 days earlier, then the wipe.

[TadMSTR independently reproduced the cached-header condition](https://github.com/siteboon/claudecodeui/pull/1174#issuecomment-5343245708) and reported that alternating old and new tokens also triggered a WebSocket reconnect storm. Their comparison with the token-ordering guard stopped the alternation. They opened #1177 to address the token-dependent auth-check loop that amplifies it.

## Fix

- Serve `/api` with `Cache-Control: no-store`, so per-session headers are not stored in HTTP caches.
- Force `cache: 'no-store'` in `authenticatedFetch`, even if a caller requests caching. This also bypasses caches already holding a poisoned entry.
- `storeAuthToken()` requires readable, finite `iat` and `exp` claims. It rejects an older `iat`, and rejects a different token with the same `iat` as the stored token. The identical stored token remains acceptable.
- Expiry is not a storage rejection criterion: a newer token is accepted even if already expired. `getStoredAuthToken()` retains responsibility for local expiry handling.

## Tests

`src/shared/tests/authToken.test.ts` adds coverage for older tokens, conflicting equal-`iat` tokens, identical tokens, a newer-but-expired token, and unreadable claims. `src/shared/tests/authenticatedFetch.test.ts` covers forced cache bypass and a slower older refresh response arriving after a newer one.

The current diff does not change the client test glob or `import.meta.env` handling. Those changes and the old `src/utils/api.test.js` path belonged to the original version of this PR.

The original submission reported clean typecheck, lint with no new findings, 270 server tests and 56 client tests. Those results predate the current posted diff and are not current-head verification.
