### PR TITLE
fix(auth): keep the session when auth cannot be verified

### DIFF
--- a/src/modules/auth/AuthUnavailableScreen.tsx
+++ b/src/modules/auth/AuthUnavailableScreen.tsx
@@ -1,0 +1,25 @@
+import AuthScreenLayout from '@/modules/auth/AuthScreenLayout';
+
+type AuthUnavailableScreenProps = {
+  onRetry: () => void;
+};
+
+export default function AuthUnavailableScreen({ onRetry }: AuthUnavailableScreenProps) {
+  return (
+    <AuthScreenLayout
+      title="CloudCLI"
+      description="Cannot reach the server. You are still signed in, and CloudCLI will reconnect on its own."
+      footerText="Your stored session has been kept."
+    >
+      <div role="status" aria-live="polite">
+        <button
+          type="button"
+          onClick={onRetry}
+          className="flex w-full items-center justify-center rounded-xl bg-primary px-4 py-2.5 font-medium text-primary-foreground shadow-lg shadow-primary/25 transition-all duration-200 hover:shadow-primary/30 hover:brightness-110 focus:outline-none focus:ring-2 focus:ring-primary/40 focus:ring-offset-2 focus:ring-offset-card active:scale-[0.99]"
+        >
+          Try again
+        </button>
+      </div>
+    </AuthScreenLayout>
+  );
+}

--- a/src/modules/auth/ProtectedRoute.tsx
+++ b/src/modules/auth/ProtectedRoute.tsx
@@ -4,6 +4,7 @@ import { IS_PLATFORM } from '@/shared/utils';
 import { useAuth } from '@/modules/auth/context/AuthContext';
 import { Onboarding } from '@/modules/onboarding';
 import AuthLoadingScreen from '@/modules/auth/AuthLoadingScreen';
+import AuthUnavailableScreen from '@/modules/auth/AuthUnavailableScreen';
 import LoginForm from '@/modules/auth/LoginForm';
 import SetupForm from '@/modules/auth/SetupForm';
 
@@ -11,33 +12,73 @@ type ProtectedRouteProps = {
   children: ReactNode;
 };
 
+export type AuthView = 'loading' | 'setup' | 'unavailable' | 'login' | 'onboarding' | 'app';
+
+export type AuthViewState = {
+  isLoading: boolean;
+  isPlatform: boolean;
+  needsSetup: boolean;
+  hasToken: boolean;
+  hasUser: boolean;
+  authUnavailable: boolean;
+  hasCompletedOnboarding: boolean;
+};
+
+export function resolveAuthView(state: AuthViewState): AuthView {
+  if (state.isLoading) {
+    return 'loading';
+  }
+  if (state.isPlatform) {
+    return state.hasCompletedOnboarding ? 'app' : 'onboarding';
+  }
+  if (state.needsSetup) {
+    return 'setup';
+  }
+  if (!state.hasUser) {
+    return state.hasToken && state.authUnavailable ? 'unavailable' : 'login';
+  }
+  return state.hasCompletedOnboarding ? 'app' : 'onboarding';
+}
+
 /** Used by App to gate the routed application behind setup, login and onboarding. */
 export default function ProtectedRoute({ children }: ProtectedRouteProps) {
-  const { user, isLoading, needsSetup, hasCompletedOnboarding, refreshOnboardingStatus } = useAuth();
+  const {
+    user,
+    token,
+    isLoading,
+    needsSetup,
+    hasCompletedOnboarding,
+    refreshOnboardingStatus,
+    authUnavailable,
+    retryAuthCheck,
+  } = useAuth();
 
-  if (isLoading) {
-    return <AuthLoadingScreen />;
-  }
+  const view = resolveAuthView({
+    isLoading,
+    isPlatform: IS_PLATFORM,
+    needsSetup,
+    hasToken: Boolean(token),
+    hasUser: Boolean(user),
+    authUnavailable,
+    hasCompletedOnboarding,
+  });
 
-  if (IS_PLATFORM) {
-    if (!hasCompletedOnboarding) {
+  switch (view) {
+    case 'loading':
+      return <AuthLoadingScreen />;
+    case 'setup':
+      return <SetupForm />;
+    case 'unavailable':
+      return <AuthUnavailableScreen onRetry={retryAuthCheck} />;
+    case 'login':
+      return <LoginForm />;
+    case 'onboarding':
       return <Onboarding onComplete={refreshOnboardingStatus} />;
+    case 'app':
+      return <>{children}</>;
+    default: {
+      const unhandled: never = view;
+      throw new Error(`Unhandled auth view: ${String(unhandled)}`);
     }
-
-    return <>{children}</>;
   }
-
-  if (needsSetup) {
-    return <SetupForm />;
-  }
-
-  if (!user) {
-    return <LoginForm />;
-  }
-
-  if (!hasCompletedOnboarding) {
-    return <Onboarding onComplete={refreshOnboardingStatus} />;
-  }
-
-  return <>{children}</>;
 }

--- a/src/modules/auth/context/AuthContext.tsx
+++ b/src/modules/auth/context/AuthContext.tsx
@@ -1,4 +1,4 @@
-import { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
 import type { ReactNode } from 'react';
 
 import { IS_PLATFORM } from '@/shared/utils';
@@ -7,7 +7,7 @@ import { AUTH_SESSION_EXPIRED_EVENT, AUTH_TOKEN_REFRESHED_EVENT, getAuthTokenRef
 import { hydrateChatDrafts, resetChatDrafts } from '@/shared/chatDrafts';
 import { hydrateUserPreferences, resetUserPreferences } from '@/shared/userSettings';
 /** The signed-in account held by AuthContext - a required `username` plus an optional id and any additional fields the auth API returns - and should be read through `useAuth()` rather than re-derived from raw auth responses. */
-type AuthUser = {
+export type AuthUser = {
   id?: number | string;
   username: string;
   [key: string]: unknown;
@@ -16,12 +16,14 @@ type AuthUser = {
 const AUTH_TOKEN_STORAGE_KEY = 'auth-token';
 
 const AUTH_ERROR_MESSAGES = {
-  authStatusCheckFailed: 'Failed to check authentication status',
   loginFailed: 'Login failed',
   registrationFailed: 'Registration failed',
   networkError: 'Network error. Please try again.',
   sessionExpired: 'Your session expired. Please log in again.',
+  authUnavailable: 'Cannot reach the server. Your session is kept while CloudCLI retries.',
 } as const;
+
+const AUTH_RETRY_INTERVAL_MS = 5000;
 
 type AuthActionResult = { success: true } | { success: false; error: string };
 
@@ -49,17 +51,19 @@ type ApiErrorPayload = {
   message?: string;
 };
 
-type AuthContextValue = {
+export type AuthContextValue = {
   user: AuthUser | null;
   token: string | null;
   isLoading: boolean;
   needsSetup: boolean;
   hasCompletedOnboarding: boolean;
   error: string | null;
+  authUnavailable: boolean;
   login: (username: string, password: string) => Promise<AuthActionResult>;
   register: (username: string, password: string) => Promise<AuthActionResult>;
   logout: () => void;
   refreshOnboardingStatus: () => Promise<void>;
+  retryAuthCheck: () => Promise<void>;
 };
 
 type AuthProviderProps = {
@@ -80,6 +84,23 @@ function resolveApiErrorMessage(payload: ApiErrorPayload | null, fallback: strin
   }
 
   return payload.error ?? payload.message ?? fallback;
+}
+
+export type AuthProbeResult = 'authenticated' | 'rejected' | 'unavailable';
+
+export function classifyAuthProbe(response: Response): AuthProbeResult {
+  if (response.ok) {
+    return 'authenticated';
+  }
+
+  return response.headers.get('X-Auth-Error') ? 'rejected' : 'unavailable';
+}
+
+export function rejectionEndsSession(
+  sentToken: string | null,
+  storedToken: string | null,
+): boolean {
+  return sentToken !== null && sentToken === storedToken;
 }
 
 const AuthContext = createContext<AuthContextValue | null>(null);
@@ -111,16 +132,25 @@ export function AuthProvider({ children }: AuthProviderProps) {
   const [needsSetup, setNeedsSetup] = useState(false);
   const [hasCompletedOnboarding, setHasCompletedOnboarding] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [authUnavailable, setAuthUnavailable] = useState(false);
+  const authProbeId = useRef(0);
+  const retryInFlight = useRef<Promise<void> | null>(null);
 
   const setSession = useCallback((nextUser: AuthUser, nextToken: string) => {
+    authProbeId.current += 1;
+    retryInFlight.current = null;
     setUser(nextUser);
     setToken(nextToken);
+    setAuthUnavailable(false);
     persistToken(nextToken);
   }, []);
 
   const clearSession = useCallback(() => {
+    authProbeId.current += 1;
     setUser(null);
+    retryInFlight.current = null;
     setToken(null);
+    setAuthUnavailable(false);
     clearStoredToken();
     // Otherwise the next person to sign in on this device would start out
     // looking at the previous user's theme, language, permissions and drafts.
@@ -187,6 +217,8 @@ export function AuthProvider({ children }: AuthProviderProps) {
     const handleTokenRefreshed = (event: Event) => {
       const nextToken = (event as CustomEvent<unknown>).detail;
       if (isValidRefreshedToken(nextToken)) {
+        authProbeId.current += 1;
+        retryInFlight.current = null;
         setToken(nextToken);
       }
     };
@@ -203,44 +235,97 @@ export function AuthProvider({ children }: AuthProviderProps) {
     };
   }, [clearSession]);
 
-  const checkAuthStatus = useCallback(async () => {
+  const checkAuthStatus = useCallback(async (options?: { silent?: boolean }) => {
+    const silent = options?.silent ?? false;
+    const probeId = (authProbeId.current += 1);
+    const superseded = () => authProbeId.current !== probeId;
+
     try {
-      setIsLoading(true);
+      if (!silent) {
+        setIsLoading(true);
+      }
       setError(null);
 
       const statusResponse = await api.auth.status();
       const statusPayload = await parseJsonSafely<AuthStatusPayload>(statusResponse);
 
-      if (statusPayload?.needsSetup) {
+      if (superseded()) {
+        return;
+      }
+
+      if (statusResponse.ok && statusPayload?.needsSetup) {
         setNeedsSetup(true);
+        setAuthUnavailable(false);
+        return;
+      }
+
+      if (!statusResponse.ok) {
+        if (token) {
+          setAuthUnavailable(true);
+          setError(AUTH_ERROR_MESSAGES.authUnavailable);
+        } else {
+          setError(AUTH_ERROR_MESSAGES.networkError);
+        }
         return;
       }
 
       setNeedsSetup(false);
 
       if (!token) {
+        setAuthUnavailable(false);
         return;
       }
 
+      const sentToken = token;
       const userResponse = await api.auth.user();
-      if (!userResponse.ok) {
-        clearSession();
+      const probe = classifyAuthProbe(userResponse);
+
+      if (superseded()) {
         return;
       }
 
-      const userPayload = await parseJsonSafely<AuthUserPayload>(userResponse);
+      if (probe === 'rejected') {
+        if (rejectionEndsSession(sentToken, readStoredToken())) {
+          clearSession();
+          setError(AUTH_ERROR_MESSAGES.sessionExpired);
+        }
+        return;
+      }
+
+      const userPayload = probe === 'authenticated'
+        ? await parseJsonSafely<AuthUserPayload>(userResponse)
+        : null;
+
+      if (superseded()) {
+        return;
+      }
+
       if (!userPayload?.user) {
-        clearSession();
+        setAuthUnavailable(true);
+        setError(AUTH_ERROR_MESSAGES.authUnavailable);
         return;
       }
 
       setUser(userPayload.user);
+      setAuthUnavailable(false);
       await checkOnboardingStatus();
     } catch (caughtError) {
-      console.error('[Auth] Auth status check failed:', caughtError);
-      setError(AUTH_ERROR_MESSAGES.authStatusCheckFailed);
+      console.warn('[Auth] Auth status check could not complete:', caughtError);
+
+      if (superseded()) {
+        return;
+      }
+
+      if (token) {
+        setAuthUnavailable(true);
+        setError(AUTH_ERROR_MESSAGES.authUnavailable);
+      } else {
+        setError(AUTH_ERROR_MESSAGES.networkError);
+      }
     } finally {
-      setIsLoading(false);
+      if (!superseded()) {
+        setIsLoading(false);
+      }
     }
   }, [checkOnboardingStatus, clearSession, token]);
 
@@ -256,6 +341,43 @@ export function AuthProvider({ children }: AuthProviderProps) {
 
     void checkAuthStatus();
   }, [checkAuthStatus, checkOnboardingStatus]);
+
+  const retryAuthCheck = useCallback((): Promise<void> => {
+    if (retryInFlight.current) {
+      return retryInFlight.current;
+    }
+
+    const retry = checkAuthStatus({ silent: true }).finally(() => {
+      if (retryInFlight.current === retry) {
+        retryInFlight.current = null;
+      }
+    });
+    retryInFlight.current = retry;
+    return retry;
+  }, [checkAuthStatus]);
+
+  useEffect(() => {
+    if (IS_PLATFORM || !authUnavailable || !token || user) {
+      return undefined;
+    }
+
+    const retry = () => void retryAuthCheck();
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === 'visible') {
+        retry();
+      }
+    };
+
+    const retryTimer = window.setInterval(retry, AUTH_RETRY_INTERVAL_MS);
+    window.addEventListener('online', retry);
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+
+    return () => {
+      window.clearInterval(retryTimer);
+      window.removeEventListener('online', retry);
+      document.removeEventListener('visibilitychange', handleVisibilityChange);
+    };
+  }, [authUnavailable, retryAuthCheck, token, user]);
 
   useEffect(() => {
     if (IS_PLATFORM || !token || !user) {
@@ -357,12 +479,15 @@ export function AuthProvider({ children }: AuthProviderProps) {
       needsSetup,
       hasCompletedOnboarding,
       error,
+      authUnavailable,
       login,
       register,
       logout,
       refreshOnboardingStatus,
+      retryAuthCheck,
     }),
     [
+      authUnavailable,
       error,
       hasCompletedOnboarding,
       isLoading,
@@ -371,6 +496,7 @@ export function AuthProvider({ children }: AuthProviderProps) {
       needsSetup,
       refreshOnboardingStatus,
       register,
+      retryAuthCheck,
       token,
       user,
     ],

--- a/src/modules/auth/tests/authState.test.tsx
+++ b/src/modules/auth/tests/authState.test.tsx
@@ -1,0 +1,255 @@
+import assert from 'node:assert/strict';
+
+import { act, cleanup, renderHook, waitFor } from '@testing-library/react';
+import React from 'react';
+import { afterEach, beforeEach, test, vi } from 'vitest';
+
+import {
+  AuthProvider,
+  classifyAuthProbe,
+  rejectionEndsSession,
+  useAuth,
+} from '@/modules/auth/context/AuthContext';
+import type { AuthViewState } from '@/modules/auth/ProtectedRoute';
+import { resolveAuthView } from '@/modules/auth/ProtectedRoute';
+
+const mocks = vi.hoisted(() => ({
+  authStatus: vi.fn(),
+  authUser: vi.fn(),
+  onboardingStatus: vi.fn(),
+  resetPreferences: vi.fn(),
+  resetDrafts: vi.fn(),
+}));
+
+vi.mock('@/shared/utils', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  IS_PLATFORM: false,
+}));
+
+vi.mock('@/shared/api', () => ({
+  api: {
+    auth: {
+      status: (...args: unknown[]) => mocks.authStatus(...args),
+      user: (...args: unknown[]) => mocks.authUser(...args),
+      refresh: vi.fn(),
+      login: vi.fn(),
+      register: vi.fn(),
+    },
+    user: {
+      onboardingStatus: (...args: unknown[]) => mocks.onboardingStatus(...args),
+    },
+  },
+}));
+
+vi.mock('@/shared/userSettings', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  hydrateUserPreferences: vi.fn(),
+  resetUserPreferences: () => mocks.resetPreferences(),
+}));
+
+vi.mock('@/shared/chatDrafts', () => ({
+  hydrateChatDrafts: vi.fn(),
+  resetChatDrafts: () => mocks.resetDrafts(),
+}));
+
+const jsonResponse = (body: unknown, status = 200, headers: Record<string, string> = {}) =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json', ...headers },
+  });
+
+function AuthWrapper({ children }: { children: React.ReactNode }) {
+  return <AuthProvider>{children}</AuthProvider>;
+}
+
+const renderAuth = () => renderHook(() => useAuth(), { wrapper: AuthWrapper });
+
+const flushAuth = async () => {
+  await act(async () => {
+    for (let index = 0; index < 8; index += 1) {
+      await Promise.resolve();
+    }
+  });
+};
+
+beforeEach(() => {
+  localStorage.clear();
+  vi.clearAllMocks();
+  mocks.authStatus.mockResolvedValue(jsonResponse({ needsSetup: false }));
+  mocks.authUser.mockResolvedValue(jsonResponse({ user: { username: 'mate' } }));
+  mocks.onboardingStatus.mockResolvedValue(jsonResponse({ hasCompletedOnboarding: true }));
+});
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+});
+
+test('only an auth rejection header rejects the stored session', () => {
+  assert.equal(classifyAuthProbe(new Response(null, { status: 200 })), 'authenticated');
+  assert.equal(classifyAuthProbe(new Response(null, { status: 401 })), 'unavailable');
+  assert.equal(classifyAuthProbe(new Response(null, { status: 503 })), 'unavailable');
+  assert.equal(
+    classifyAuthProbe(new Response(null, {
+      status: 401,
+      headers: { 'X-Auth-Error': 'invalid-token' },
+    })),
+    'rejected',
+  );
+});
+
+test('a rejection only ends the session for the token it checked', () => {
+  assert.equal(rejectionEndsSession('token-a', 'token-a'), true);
+  assert.equal(rejectionEndsSession('token-old', 'token-new'), false);
+  assert.equal(rejectionEndsSession('token-a', null), false);
+  assert.equal(rejectionEndsSession(null, null), false);
+});
+
+const viewState = (overrides: Partial<AuthViewState> = {}): AuthViewState => ({
+  isLoading: false,
+  isPlatform: false,
+  needsSetup: false,
+  hasToken: true,
+  hasUser: true,
+  authUnavailable: false,
+  hasCompletedOnboarding: true,
+  ...overrides,
+});
+
+test('an unavailable held session has its own route state', () => {
+  assert.equal(resolveAuthView(viewState()), 'app');
+  assert.equal(resolveAuthView(viewState({ hasUser: false, authUnavailable: true })), 'unavailable');
+  assert.equal(
+    resolveAuthView(viewState({ hasToken: false, hasUser: false, authUnavailable: true })),
+    'login',
+  );
+  assert.equal(resolveAuthView(viewState({ hasToken: false, hasUser: false })), 'login');
+  assert.equal(resolveAuthView(viewState({ isLoading: true, hasUser: false })), 'loading');
+  assert.equal(resolveAuthView(viewState({ needsSetup: true, hasUser: false })), 'setup');
+});
+
+test('network failure keeps the token, preferences, and drafts', async () => {
+  localStorage.setItem('auth-token', 'stored-token');
+  mocks.authStatus.mockRejectedValue(new TypeError('offline'));
+
+  const { result } = renderAuth();
+
+  await waitFor(() => assert.equal(result.current.authUnavailable, true));
+  assert.equal(result.current.user, null);
+  assert.equal(result.current.token, 'stored-token');
+  assert.equal(localStorage.getItem('auth-token'), 'stored-token');
+  assert.equal(mocks.resetPreferences.mock.calls.length, 0);
+  assert.equal(mocks.resetDrafts.mock.calls.length, 0);
+});
+
+test('a verified rejection clears the session data', async () => {
+  localStorage.setItem('auth-token', 'rejected-token');
+  mocks.authUser.mockResolvedValue(jsonResponse(
+    {},
+    401,
+    { 'X-Auth-Error': 'invalid-token' },
+  ));
+
+  const { result } = renderAuth();
+
+  await waitFor(() => assert.equal(result.current.token, null));
+  assert.equal(result.current.authUnavailable, false);
+  assert.equal(localStorage.getItem('auth-token'), null);
+  assert.equal(mocks.resetPreferences.mock.calls.length, 1);
+  assert.equal(mocks.resetDrafts.mock.calls.length, 1);
+});
+
+test('a superseded response cannot overwrite a newer authenticated result', async () => {
+  localStorage.setItem('auth-token', 'stored-token');
+  const olderResponse: { resolve?: (response: Response) => void } = {};
+  mocks.authUser
+    .mockImplementationOnce(() => new Promise<Response>((resolve) => {
+      olderResponse.resolve = resolve;
+    }))
+    .mockResolvedValueOnce(jsonResponse({ user: { username: 'newer-user' } }));
+
+  const { result } = renderAuth();
+  await waitFor(() => assert.equal(mocks.authUser.mock.calls.length, 1));
+
+  await act(async () => {
+    await result.current.retryAuthCheck();
+  });
+  assert.equal(result.current.user?.username, 'newer-user');
+
+  assert.ok(olderResponse.resolve);
+  olderResponse.resolve(jsonResponse(
+    {},
+    401,
+    { 'X-Auth-Error': 'invalid-token' },
+  ));
+  await flushAuth();
+
+  assert.equal(result.current.user?.username, 'newer-user');
+  assert.equal(result.current.token, 'stored-token');
+  assert.equal(mocks.resetPreferences.mock.calls.length, 0);
+});
+
+test('unavailable auth retries on online, visibility, and timer changes', async () => {
+  vi.useFakeTimers();
+  localStorage.setItem('auth-token', 'stored-token');
+  mocks.authUser.mockResolvedValue(jsonResponse({}, 503));
+
+  const { result } = renderAuth();
+  await flushAuth();
+  assert.equal(result.current.authUnavailable, true);
+  assert.equal(mocks.authUser.mock.calls.length, 1);
+
+  window.dispatchEvent(new Event('online'));
+  await flushAuth();
+  assert.equal(mocks.authUser.mock.calls.length, 2);
+
+  document.dispatchEvent(new Event('visibilitychange'));
+  await flushAuth();
+  assert.equal(mocks.authUser.mock.calls.length, 3);
+
+  await act(async () => {
+    vi.advanceTimersByTime(5000);
+    await Promise.resolve();
+  });
+  await flushAuth();
+  assert.equal(mocks.authUser.mock.calls.length, 4);
+});
+
+test('slow retries settle before another trigger starts a new probe', async () => {
+  vi.useFakeTimers();
+  localStorage.setItem('auth-token', 'stored-token');
+  mocks.authUser.mockResolvedValue(jsonResponse({}, 503));
+
+  const { result } = renderAuth();
+  await flushAuth();
+  assert.equal(result.current.authUnavailable, true);
+  assert.equal(mocks.authUser.mock.calls.length, 1);
+
+  const slowResponse: { resolve?: (response: Response) => void } = {};
+  mocks.authUser.mockImplementationOnce(() => new Promise<Response>((resolve) => {
+    slowResponse.resolve = resolve;
+  }));
+
+  window.dispatchEvent(new Event('online'));
+  await flushAuth();
+  assert.equal(mocks.authUser.mock.calls.length, 2);
+
+  document.dispatchEvent(new Event('visibilitychange'));
+  vi.advanceTimersByTime(15_000);
+  void result.current.retryAuthCheck();
+  await flushAuth();
+  assert.equal(mocks.authUser.mock.calls.length, 2);
+
+  assert.ok(slowResponse.resolve);
+  slowResponse.resolve(jsonResponse({}, 503));
+  await flushAuth();
+
+  await act(async () => {
+    await result.current.retryAuthCheck();
+  });
+  assert.equal(mocks.authUser.mock.calls.length, 3);
+
+  vi.advanceTimersByTime(5000);
+  await flushAuth();
+  assert.equal(mocks.authUser.mock.calls.length, 4);
+});

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -24,6 +24,13 @@ const rejectionStillApplies = (requestSequence: number, sentToken: string | null
   return sentToken ? storedToken === sentToken : storedToken === null;
 };
 
+// Reads the token out of an `Authorization` header value, or null when the
+// header carries a credential this client does not own.
+const bearerCredential = (header: string): string | null => {
+  const match = /^Bearer (.+)$/.exec(header);
+  return match ? match[1] : null;
+};
+
 // Utility function for authenticated API calls
 export const authenticatedFetch = (
   url: string,
@@ -43,19 +50,22 @@ export const authenticatedFetch = (
     defaultHeaders['Authorization'] = `Bearer ${token}`;
   }
 
-  return fetch(url, {
-    ...options,
-    headers: {
-      ...defaultHeaders,
-      ...options.headers,
-    },
-  }).then((response) => {
+  const headers = { ...defaultHeaders, ...options.headers };
+
+  // A rejection belongs to the credential the request actually carried, so a
+  // caller that overrides `Authorization` cannot end the session held in
+  // storage. With no such header at all - platform builds authenticate by
+  // cookie - the stored token is still what the rejection ends.
+  const authorization = headers.Authorization ?? headers.authorization;
+  const sentToken = authorization === undefined ? token : bearerCredential(authorization);
+
+  return fetch(url, { ...options, headers }).then((response) => {
     const refreshedToken = response.headers.get('X-Refreshed-Token');
     if (refreshedToken) {
       storeAuthToken(refreshedToken);
     }
     if (response.headers.get('X-Auth-Error')) {
-      if (rejectionStillApplies(requestSequence, token)) {
+      if (rejectionStillApplies(requestSequence, sentToken)) {
         expireAuthSession();
       }
     } else if (response.ok && requestSequence > lastAuthorizedRequest) {

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -12,12 +12,25 @@ export type ApiRequestOptions = Omit<RequestInit, 'headers'> & {
   headers?: Record<string, string>;
 };
 
+let authRequestSequence = 0;
+let lastAuthorizedRequest = 0;
+
+const rejectionStillApplies = (requestSequence: number, sentToken: string | null): boolean => {
+  if (requestSequence < lastAuthorizedRequest) {
+    return false;
+  }
+
+  const storedToken = localStorage.getItem('auth-token');
+  return sentToken ? storedToken === sentToken : storedToken === null;
+};
+
 // Utility function for authenticated API calls
 export const authenticatedFetch = (
   url: string,
   options: ApiRequestOptions = {},
 ): Promise<Response> => {
   const token = getStoredAuthToken();
+  const requestSequence = (authRequestSequence += 1);
 
   const defaultHeaders: Record<string, string> = {};
 
@@ -42,7 +55,11 @@ export const authenticatedFetch = (
       storeAuthToken(refreshedToken);
     }
     if (response.headers.get('X-Auth-Error')) {
-      expireAuthSession();
+      if (rejectionStillApplies(requestSequence, token)) {
+        expireAuthSession();
+      }
+    } else if (response.ok && requestSequence > lastAuthorizedRequest) {
+      lastAuthorizedRequest = requestSequence;
     }
     return response;
   });

--- a/src/shared/tests/authenticatedFetch.test.ts
+++ b/src/shared/tests/authenticatedFetch.test.ts
@@ -170,6 +170,42 @@ test('an auth error on the response ends the session', async () => {
   assert.equal(localStorage.getItem('auth-token'), null);
 });
 
+test('a late rejection cannot expire a session a newer request authorized', async () => {
+  const token = liveToken();
+  localStorage.setItem('auth-token', token);
+  const firstResponse: { resolve?: (response: Response) => void } = {};
+  let requestCount = 0;
+  vi.stubGlobal('fetch', vi.fn(() => {
+    requestCount += 1;
+    if (requestCount === 1) {
+      return new Promise<Response>((resolve) => {
+        firstResponse.resolve = resolve;
+      });
+    }
+    return Promise.resolve(new Response('{}', { status: 200 }));
+  }));
+
+  let expiries = 0;
+  const onExpired = () => {
+    expiries += 1;
+  };
+  window.addEventListener(AUTH_SESSION_EXPIRED_EVENT, onExpired);
+
+  const authenticatedFetch = await loadFetch(false);
+  const olderRequest = authenticatedFetch('/api/auth/user');
+  await authenticatedFetch('/api/projects');
+  assert.ok(firstResponse.resolve);
+  firstResponse.resolve(new Response('{}', {
+    status: 401,
+    headers: { 'X-Auth-Error': 'invalid-token' },
+  }));
+  await olderRequest;
+
+  window.removeEventListener(AUTH_SESSION_EXPIRED_EVENT, onExpired);
+  assert.equal(expiries, 0);
+  assert.equal(localStorage.getItem('auth-token'), token);
+});
+
 test('an ordinary response leaves the stored token alone', async () => {
   const token = liveToken();
   localStorage.setItem('auth-token', token);

--- a/src/shared/tests/authenticatedFetch.test.ts
+++ b/src/shared/tests/authenticatedFetch.test.ts
@@ -215,3 +215,23 @@ test('an ordinary response leaves the stored token alone', async () => {
 
   assert.equal(localStorage.getItem('auth-token'), token);
 });
+
+test('a caller Authorization header cannot end the stored session', async () => {
+  const token = liveToken();
+  const otherToken = liveToken().replace('signature', 'other');
+  localStorage.setItem('auth-token', token);
+  let expiries = 0;
+  const onExpired = () => {
+    expiries += 1;
+  };
+  window.addEventListener(AUTH_SESSION_EXPIRED_EVENT, onExpired);
+  respondWith({ 'X-Auth-Error': 'invalid-token' });
+
+  await (await loadFetch(false))('/api/projects', {
+    headers: { Authorization: `Bearer ${otherToken}` },
+  });
+
+  window.removeEventListener(AUTH_SESSION_EXPIRED_EVENT, onExpired);
+  assert.equal(expiries, 0);
+  assert.equal(localStorage.getItem('auth-token'), token);
+});


### PR DESCRIPTION
## Problem

`checkAuthStatus()` runs on mount and again when its callback dependencies change, including the token. It previously ended the session on **any** non-2xx response from `/api/auth/user`:

```js
const userResponse = await api.auth.user();
if (!userResponse.ok) { clearSession(); return; }
```

`!ok` is true for a `502`, a `503` and a raw `304`, not just a real rejection. An installed PWA executes the check on every cold start, so reopening the app during a server restart can delete a perfectly valid token. A warm tab can also re-run the check when its token changes.

Measured through a reverse proxy in front of the server, the restart window returns `502` about 500 ms in, which is exactly the interval a PWA launch can land in.

A thrown request was mishandled in the other direction: the catch left `user` null with loading finished, and `ProtectedRoute` renders `LoginForm` for any `!user`, so an offline resume *looked* signed out even though the token was intact. Neither failure path scheduled its own retry, so restoring the network alone did not recover the cold-start check.

By contrast `refreshSession()` already tolerates failure, with the comment "A transient network failure must not sign the user out". This brings the initial check in line with it.

## Fix

- `classifyAuthProbe()` distinguishes `authenticated` / `rejected` / `unavailable`. A successful HTTP response is classified as authenticated; a non-success response is rejected only when it carries `X-Auth-Error`.
- `X-Auth-Error` is the rejection discriminator, not the status code. A bare `401`/`403` without it does not establish that this application's token check rejected the session, so the probe treats it as unavailable rather than deleting the token.
- Non-success responses without `X-Auth-Error`, an unreadable or missing user payload, and thrown requests preserve the held token. On a cold start with no loaded user, `authUnavailable` selects a "still signed in, reconnecting" screen instead of the login form. Local token expiry and explicit authentication rejection still end a session.
- While a token is held, auth is unavailable, and no user has loaded, silent retries run every 5 s, on `online`, and when the document becomes visible. The screen also has a manual retry button. Retry triggers share an in-flight promise, so another trigger waits for that retry to settle. An already-loaded user remains in the app or onboarding flow and does not arm this unavailable-auth retry loop.
- Probe IDs discard superseded results, and the rejection branch compares the probed token with the stored token before clearing. `authenticatedFetch` also checks token ownership and whether a later-started request has already succeeded before expiring a session. It derives the bearer token from the merged `Authorization` header rather than assuming every request uses the stored credential.
- `resolveAuthView()` makes screen precedence a single pure function rather than nested JSX conditionals.

## Tests

`src/modules/auth/tests/authState.test.tsx` covers classification, view precedence, token-matched rejection, preserving tokens/preferences/drafts on network failure, clearing them on rejection, superseded probes, retry triggers, and sharing a slow in-flight retry. `src/shared/tests/authenticatedFetch.test.ts` adds cases for a late rejection after a newer successful request and a caller's `Authorization` override carrying a different token.

The original submission reported browser verification against the production bundle with `/api/*` synthesised via request interception on a throwaway origin: a `502` cold start and an outright network failure kept the token and showed the offline screen; recovery happened unprompted 5 s later; a `401` authentication rejection still cleared the session. These are historical results, not verification of the current posted head.

The original submission also reported clean typecheck, lint with no new findings, 270 server tests and 59 client tests. Those counts predate the current posted diff.
