### PR TITLE
fix(database): never rotate persisted secrets on a failed read

### DIFF
--- a/server/modules/auth/auth.middleware.ts
+++ b/server/modules/auth/auth.middleware.ts
@@ -22,6 +22,15 @@ const validateApiKey = (req, res, next) => {
   next();
 };
 
+// A log line is one line: a newline, a control character or a quote coming
+// from the request would let a caller forge entries or break the `ua="..."`
+// field. Everything interpolated below goes through this first.
+const forLogLine = (value: unknown, maxLength: number): string =>
+  String(value ?? '')
+    .replace(/[\u0000-\u001F\u007F]/g, ' ')
+    .replace(/"/g, "'")
+    .slice(0, maxLength);
+
 /**
  * Records why a request was rejected with 401.
  *
@@ -34,15 +43,16 @@ const logAuthRejection = (req, reason: string, detail = ''): void => {
   // `baseUrl + path` deliberately, never `originalUrl`: SSE endpoints pass the
   // JWT as a `?token=` query parameter, which would put bearer credentials in
   // the log. `path` alone is router-relative, so it loses the endpoint.
-  const target = `${req.method} ${req.baseUrl || ''}${req.path}`;
+  const target = forLogLine(`${req.method} ${req.baseUrl || ''}${req.path}`, 200);
 
   // Every client reaches this server through the same loopback proxy, so the
   // remote address cannot tell one device from another. The user agent can,
   // which is what makes a rejection attributable to a specific browser.
-  const userAgent = String(req.headers['user-agent'] ?? 'unknown').slice(0, 120);
+  const userAgent = forLogLine(req.headers['user-agent'] ?? 'unknown', 120);
+  const safeDetail = forLogLine(detail, 200);
 
   console.warn(
-    `[Auth] 401 ${reason} ${target}${detail ? ` ${detail}` : ''} ua="${userAgent}"`
+    `[Auth] 401 ${reason} ${target}${safeDetail ? ` ${safeDetail}` : ''} ua="${userAgent}"`
   );
 };
 

--- a/server/modules/auth/auth.middleware.ts
+++ b/server/modules/auth/auth.middleware.ts
@@ -22,6 +22,30 @@ const validateApiKey = (req, res, next) => {
   next();
 };
 
+/**
+ * Records why a request was rejected with 401.
+ *
+ * Every rejection branch below used to be silent apart from a bad signature,
+ * so the server logs could not distinguish "the client sent no token" from
+ * "the token expired" from "the signing secret changed" - all three of which
+ * surface identically in the UI as an expired session.
+ */
+const logAuthRejection = (req, reason: string, detail = ''): void => {
+  // `baseUrl + path` deliberately, never `originalUrl`: SSE endpoints pass the
+  // JWT as a `?token=` query parameter, which would put bearer credentials in
+  // the log. `path` alone is router-relative, so it loses the endpoint.
+  const target = `${req.method} ${req.baseUrl || ''}${req.path}`;
+
+  // Every client reaches this server through the same loopback proxy, so the
+  // remote address cannot tell one device from another. The user agent can,
+  // which is what makes a rejection attributable to a specific browser.
+  const userAgent = String(req.headers['user-agent'] ?? 'unknown').slice(0, 120);
+
+  console.warn(
+    `[Auth] 401 ${reason} ${target}${detail ? ` ${detail}` : ''} ua="${userAgent}"`
+  );
+};
+
 // JWT authentication middleware
 const authenticateToken = async (req, res, next) => {
   // Platform mode:  use single database user
@@ -49,6 +73,7 @@ const authenticateToken = async (req, res, next) => {
   }
 
   if (!token) {
+    logAuthRejection(req, 'no-token');
     res.setHeader('X-Auth-Error', 'invalid-token');
     return res.status(401).json({
       error: 'Access denied. No token provided.',
@@ -62,6 +87,7 @@ const authenticateToken = async (req, res, next) => {
     // Verify user still exists and is active
     const user = userDb.getUserById(decoded.userId);
     if (!user) {
+      logAuthRejection(req, 'user-not-found', `userId=${decoded.userId}`);
       res.setHeader('X-Auth-Error', 'invalid-token');
       return res.status(401).json({
         error: 'Invalid token. User not found.',
@@ -83,6 +109,19 @@ const authenticateToken = async (req, res, next) => {
     next();
   } catch (error) {
     if (error instanceof jwt.TokenExpiredError) {
+      // `issued` shows how old the token was: a full lifetime means the client
+      // never picked up an X-Refreshed-Token, which is a refresh bug rather
+      // than a user who simply stayed away past the expiry window.
+      const claims = jwt.decode(token);
+      const issued =
+        claims && typeof claims === 'object' && typeof claims.iat === 'number'
+          ? new Date(claims.iat * 1000).toISOString()
+          : 'unknown';
+      logAuthRejection(
+        req,
+        'session-expired',
+        `issued=${issued} expired=${error.expiredAt?.toISOString() ?? 'unknown'}`,
+      );
       res.setHeader('X-Auth-Error', 'session-expired');
       return res.status(401).json({
         error: 'Session expired. Please log in again.',
@@ -90,8 +129,9 @@ const authenticateToken = async (req, res, next) => {
       });
     }
 
-    console.warn(
-      'Token verification failed:',
+    logAuthRejection(
+      req,
+      'invalid-token',
       error instanceof Error ? error.message : String(error),
     );
     res.setHeader('X-Auth-Error', 'invalid-token');

--- a/server/modules/auth/tests/auth.middleware.test.ts
+++ b/server/modules/auth/tests/auth.middleware.test.ts
@@ -18,11 +18,13 @@ async function withMiddleware(
   // Dynamic on purpose: both modules open the database at import time, so the
   // disposable DATABASE_PATH above has to be in place before they load.
   const { closeConnection, initializeDatabase } = await import('@/modules/database/index.js');
-  await initializeDatabase();
-
-  const { authenticateToken } = await import('@/modules/auth/index.js');
 
   try {
+    // Inside the try: a failed init or import must still restore
+    // DATABASE_PATH and remove the temporary directory.
+    await initializeDatabase();
+
+    const { authenticateToken } = await import('@/modules/auth/index.js');
     await runTest(authenticateToken);
   } finally {
     closeConnection();

--- a/server/modules/auth/tests/auth.middleware.test.ts
+++ b/server/modules/auth/tests/auth.middleware.test.ts
@@ -1,0 +1,98 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+
+/**
+ * The middleware reads the JWT secret at module load, so the database has to
+ * exist and point somewhere disposable before the import happens.
+ */
+async function withMiddleware(
+  runTest: (authenticateToken: (req: unknown, res: unknown, next: () => void) => Promise<void>) => Promise<void>
+): Promise<void> {
+  const previousDatabasePath = process.env.DATABASE_PATH;
+  const tempDirectory = await mkdtemp(path.join(tmpdir(), 'auth-middleware-'));
+  process.env.DATABASE_PATH = path.join(tempDirectory, 'auth.db');
+
+  // Dynamic on purpose: both modules open the database at import time, so the
+  // disposable DATABASE_PATH above has to be in place before they load.
+  const { closeConnection, initializeDatabase } = await import('@/modules/database/index.js');
+  await initializeDatabase();
+
+  const { authenticateToken } = await import('@/modules/auth/index.js');
+
+  try {
+    await runTest(authenticateToken);
+  } finally {
+    closeConnection();
+    if (previousDatabasePath === undefined) {
+      delete process.env.DATABASE_PATH;
+    } else {
+      process.env.DATABASE_PATH = previousDatabasePath;
+    }
+    await rm(tempDirectory, { recursive: true, force: true });
+  }
+}
+
+function captureWarnings(): { lines: string[]; restore: () => void } {
+  const lines: string[] = [];
+  const original = console.warn;
+  console.warn = (...args: unknown[]) => {
+    lines.push(args.map((arg) => String(arg)).join(' '));
+  };
+  return { lines, restore: () => { console.warn = original; } };
+}
+
+test('a rejection logs a single line even when the request forges one', async () => {
+  await withMiddleware(async (authenticateToken) => {
+    const capture = captureWarnings();
+    let nextCalled = false;
+    const responseHeaders: Record<string, string> = {};
+    let statusCode = 0;
+
+    const req = {
+      method: 'GET',
+      baseUrl: '/api',
+      path: '/projects',
+      query: {},
+      headers: {
+        // A user agent is attacker-supplied: the newline would otherwise append
+        // a second, invented log entry and the quote would close the ua field.
+        'user-agent': 'Evil/1.0"\n[Auth] 401 forged GET /api/admin ua="innocent',
+      },
+    };
+    const res = {
+      setHeader(name: string, value: string) {
+        responseHeaders[name] = value;
+      },
+      status(code: number) {
+        statusCode = code;
+        return this;
+      },
+      json() {
+        return this;
+      },
+    };
+
+    try {
+      await authenticateToken(req, res, () => {
+        nextCalled = true;
+      });
+    } finally {
+      capture.restore();
+    }
+
+    assert.equal(nextCalled, false);
+    assert.equal(statusCode, 401);
+    assert.equal(responseHeaders['X-Auth-Error'], 'invalid-token');
+
+    assert.equal(capture.lines.length, 1);
+    const [line] = capture.lines;
+    assert.equal(line.includes('\n'), false);
+    assert.equal(line.includes('forged'), true, 'the text survives, only its framing is neutralised');
+    assert.match(line, /^\[Auth\] 401 no-token GET \/api\/projects ua="Evil\/1\.0'/);
+    // Exactly one ua field, so the injected one did not become a field of its own.
+    assert.equal(line.split('ua="').length - 1, 1);
+  });
+});

--- a/server/modules/browser-use/browser-use.service.ts
+++ b/server/modules/browser-use/browser-use.service.ts
@@ -113,13 +113,11 @@ function writeSettings(settings: BrowserUseSettings): BrowserUseSettings {
 }
 
 function getOrCreateMcpToken(): string {
-  const existing = appConfigDb.get(BROWSER_USE_MCP_TOKEN_KEY);
-  if (existing) {
-    return existing;
-  }
-  const token = randomBytes(32).toString('hex');
-  appConfigDb.set(BROWSER_USE_MCP_TOKEN_KEY, token);
-  return token;
+  // Must not mint a replacement on a failed read: the token authenticates the
+  // already-registered MCP server entry, which a silent rotation would break.
+  return appConfigDb.getOrCreateSecret(BROWSER_USE_MCP_TOKEN_KEY, () =>
+    randomBytes(32).toString('hex')
+  );
 }
 
 function getSetupMessage(settings: BrowserUseSettings, readiness: RuntimeReadiness): string {

--- a/server/modules/database/connection.ts
+++ b/server/modules/database/connection.ts
@@ -118,10 +118,19 @@ export function getConnection(): Database.Database {
 
   try {
     // Several processes can hold this file open at once (server, CLI, dev
-    // watcher). WAL keeps readers from blocking the writer, and the busy
-    // timeout makes a contended statement wait rather than fail immediately.
-    connection.pragma('journal_mode = WAL');
+    // watcher). The busy timeout comes first so the journal-mode switch, which
+    // needs a brief exclusive lock, waits for a contended file instead of
+    // failing outright; WAL then keeps readers from blocking the writer.
     connection.pragma('busy_timeout = 5000');
+    const journalMode = connection.pragma('journal_mode = WAL', { simple: true });
+
+    // SQLite answers with the mode actually in force, so a file on a mount
+    // that cannot do WAL (NFS, some container volumes) silently stays on
+    // rollback journaling. That is slower under concurrency but still correct,
+    // so it belongs in the log rather than in a refusal to start.
+    if (journalMode !== 'wal') {
+      console.warn(`[Database] WAL unavailable for ${dbPath}; journal mode is '${journalMode}'`);
+    }
 
     // app_config must exist immediately — the auth middleware reads
     // the JWT secret at module-load time, before initializeDatabase() runs.

--- a/server/modules/database/connection.ts
+++ b/server/modules/database/connection.ts
@@ -102,9 +102,9 @@ let instance: Database.Database | null = null;
  *   1. Resolves the target database path
  *   2. Ensures the parent directory exists
  *   3. Migrates from the legacy install-directory path if needed
- *   4. Opens the SQLite connection
+ *   4. Opens the SQLite connection and applies concurrency pragmas
  *   5. Eagerly creates the app_config table (auth reads JWT secret at import time)
- *   6. Logs the database location
+ *   6. Publishes the singleton only once the above succeeded
  */
 export function getConnection(): Database.Database {
   if (instance) return instance;
@@ -114,12 +114,27 @@ export function getConnection(): Database.Database {
   ensureDatabaseDirectory(dbPath);
   migrateLegacyDatabase(dbPath);
 
-  instance = new Database(dbPath);
+  const connection = new Database(dbPath);
 
-  // app_config must exist immediately — the auth middleware reads
-  // the JWT secret at module-load time, before initializeDatabase() runs.
-  instance.exec(APP_CONFIG_TABLE_SCHEMA_SQL);
+  try {
+    // Several processes can hold this file open at once (server, CLI, dev
+    // watcher). WAL keeps readers from blocking the writer, and the busy
+    // timeout makes a contended statement wait rather than fail immediately.
+    connection.pragma('journal_mode = WAL');
+    connection.pragma('busy_timeout = 5000');
 
+    // app_config must exist immediately — the auth middleware reads
+    // the JWT secret at module-load time, before initializeDatabase() runs.
+    connection.exec(APP_CONFIG_TABLE_SCHEMA_SQL);
+  } catch (error) {
+    // Never publish a half-initialised handle: callers would go on to write
+    // through a connection whose schema setup had failed. Discard it so the
+    // next call retries from scratch.
+    connection.close();
+    throw error;
+  }
+
+  instance = connection;
   return instance;
 }
 

--- a/server/modules/database/repositories/app-config.ts
+++ b/server/modules/database/repositories/app-config.ts
@@ -15,18 +15,20 @@ import { getConnection } from '@/modules/database/connection.js';
 // ---------------------------------------------------------------------------
 
 export const appConfigDb = {
-  /** Returns the stored value for a config key, or null if missing. */
+  /**
+   * Returns the stored value for a config key, or null when the key is absent.
+   *
+   * Read failures propagate. Callers must never be able to confuse "this key
+   * has no row" with "this read did not complete": secret bootstrap treats the
+   * former as permission to mint a replacement, so swallowing the latter
+   * silently rotated the JWT secret out from under every issued token.
+   */
   get(key: string): string | null {
-    try {
-      const db = getConnection();
-      const row = db
-        .prepare('SELECT value FROM app_config WHERE key = ?')
-        .get(key) as { value: string } | undefined;
-      return row?.value ?? null;
-    } catch {
-      // Swallow errors so early-startup reads (e.g. JWT secret) do not crash.
-      return null;
-    }
+    const db = getConnection();
+    const row = db
+      .prepare('SELECT value FROM app_config WHERE key = ?')
+      .get(key) as { value: string } | undefined;
+    return row?.value ?? null;
   },
 
   /** Inserts or updates a config key (upsert). */
@@ -38,16 +40,43 @@ export const appConfigDb = {
   },
 
   /**
-   * Returns the JWT signing secret, generating and persisting one
-   * if it does not already exist. This ensures the secret survives
-   * server restarts while being created automatically on first boot.
+   * Returns the persisted secret for `key`, generating one only when the row
+   * is genuinely absent. Used by auth (JWT signing secret) and browser-use
+   * (MCP token) — values whose replacement invalidates live credentials.
+   *
+   * The write is INSERT OR IGNORE rather than an upsert, so a racing writer
+   * that inserted first keeps its value, and the value returned is always the
+   * one now in the table rather than the local candidate. A row that is still
+   * unreadable afterwards throws: refusing to start is safer than signing with
+   * a secret that does not match the tokens already issued.
+   */
+  getOrCreateSecret(key: string, generateSecret: () => string): string {
+    const existing = appConfigDb.get(key);
+    if (existing) {
+      return existing;
+    }
+
+    const db = getConnection();
+    db.prepare('INSERT OR IGNORE INTO app_config (key, value) VALUES (?, ?)').run(
+      key,
+      generateSecret()
+    );
+
+    const stored = appConfigDb.get(key);
+    if (!stored) {
+      throw new Error(`Failed to persist app_config secret '${key}'`);
+    }
+    return stored;
+  },
+
+  /**
+   * Returns the JWT signing secret, generating and persisting one on first
+   * boot. Read by the auth middleware at module load; the secret must survive
+   * every restart or previously issued tokens fail signature verification.
    */
   getOrCreateJwtSecret(): string {
-    let secret = appConfigDb.get('jwt_secret');
-    if (!secret) {
-      secret = crypto.randomBytes(64).toString('hex');
-      appConfigDb.set('jwt_secret', secret);
-    }
-    return secret;
+    return appConfigDb.getOrCreateSecret('jwt_secret', () =>
+      crypto.randomBytes(64).toString('hex')
+    );
   },
 };

--- a/server/modules/database/repositories/app-config.ts
+++ b/server/modules/database/repositories/app-config.ts
@@ -14,6 +14,24 @@ import { getConnection } from '@/modules/database/connection.js';
 // Queries
 // ---------------------------------------------------------------------------
 
+/**
+ * Narrows a secret read to a value that can actually be used for signing.
+ *
+ * `null` means the row is absent; an empty string means the row exists and
+ * holds nothing, which INSERT OR IGNORE cannot replace. Neither may be handed
+ * back: an empty signing secret would reject every token already issued, and
+ * treating one as "missing" would loop over a row that never gets written.
+ */
+const requireUsableSecret = (key: string, value: string | null): string => {
+  if (value === null) {
+    throw new Error(`Failed to persist app_config secret '${key}'`);
+  }
+  if (value === '') {
+    throw new Error(`app_config secret '${key}' exists but is empty`);
+  }
+  return value;
+};
+
 export const appConfigDb = {
   /**
    * Returns the stored value for a config key, or null when the key is absent.
@@ -52,8 +70,8 @@ export const appConfigDb = {
    */
   getOrCreateSecret(key: string, generateSecret: () => string): string {
     const existing = appConfigDb.get(key);
-    if (existing) {
-      return existing;
+    if (existing !== null) {
+      return requireUsableSecret(key, existing);
     }
 
     const db = getConnection();
@@ -62,11 +80,7 @@ export const appConfigDb = {
       generateSecret()
     );
 
-    const stored = appConfigDb.get(key);
-    if (!stored) {
-      throw new Error(`Failed to persist app_config secret '${key}'`);
-    }
-    return stored;
+    return requireUsableSecret(key, appConfigDb.get(key));
   },
 
   /**

--- a/server/modules/database/repositories/app-config.ts
+++ b/server/modules/database/repositories/app-config.ts
@@ -74,11 +74,16 @@ export const appConfigDb = {
       return requireUsableSecret(key, existing);
     }
 
+    const candidate = generateSecret();
+    if (candidate === '') {
+      // Never let an empty candidate reach the table: INSERT OR IGNORE would
+      // preserve that row for good, so every later call would fail on a key
+      // that can no longer be created.
+      throw new Error(`Generated app_config secret '${key}' is empty`);
+    }
+
     const db = getConnection();
-    db.prepare('INSERT OR IGNORE INTO app_config (key, value) VALUES (?, ?)').run(
-      key,
-      generateSecret()
-    );
+    db.prepare('INSERT OR IGNORE INTO app_config (key, value) VALUES (?, ?)').run(key, candidate);
 
     return requireUsableSecret(key, appConfigDb.get(key));
   },

--- a/server/modules/database/tests/app-config.test.ts
+++ b/server/modules/database/tests/app-config.test.ts
@@ -90,3 +90,20 @@ test('a failed read throws instead of reporting the key as absent', async () => 
     assert.equal(original.length, 128);
   });
 });
+
+test('an empty stored secret is refused rather than treated as absent', async () => {
+  await withIsolatedDatabase(() => {
+    getConnection()
+      .prepare('INSERT INTO app_config (key, value) VALUES (?, ?)')
+      .run('test_secret', '');
+
+    // A row holding '' is corruption, not absence: INSERT OR IGNORE cannot
+    // replace it, so calling it absent would return '' on the next read, and
+    // signing with an empty secret rejects every token already issued.
+    assert.throws(
+      () => appConfigDb.getOrCreateSecret('test_secret', () => 'replacement'),
+      /exists but is empty/
+    );
+    assert.equal(appConfigDb.get('test_secret'), '');
+  });
+});

--- a/server/modules/database/tests/app-config.test.ts
+++ b/server/modules/database/tests/app-config.test.ts
@@ -1,0 +1,92 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+
+import Database from 'better-sqlite3';
+
+import { closeConnection, getConnection } from '@/modules/database/connection.js';
+import { initializeDatabase } from '@/modules/database/init-db.js';
+import { appConfigDb } from '@/modules/database/repositories/app-config.js';
+
+async function withIsolatedDatabase(
+  runTest: (databasePath: string) => void | Promise<void>
+): Promise<void> {
+  const previousDatabasePath = process.env.DATABASE_PATH;
+  const tempDirectory = await mkdtemp(path.join(tmpdir(), 'app-config-'));
+  const databasePath = path.join(tempDirectory, 'auth.db');
+
+  closeConnection();
+  process.env.DATABASE_PATH = databasePath;
+  await initializeDatabase();
+
+  try {
+    await runTest(databasePath);
+  } finally {
+    closeConnection();
+    if (previousDatabasePath === undefined) {
+      delete process.env.DATABASE_PATH;
+    } else {
+      process.env.DATABASE_PATH = previousDatabasePath;
+    }
+    await rm(tempDirectory, { recursive: true, force: true });
+  }
+}
+
+test('getOrCreateJwtSecret returns the same secret across a reconnect', async () => {
+  await withIsolatedDatabase(() => {
+    const first = appConfigDb.getOrCreateJwtSecret();
+    assert.equal(first.length, 128);
+
+    // Stands in for a server restart: same file, brand new connection.
+    closeConnection();
+
+    assert.equal(appConfigDb.getOrCreateJwtSecret(), first);
+  });
+});
+
+test('getOrCreateSecret never regenerates once a value is stored', async () => {
+  await withIsolatedDatabase(() => {
+    assert.equal(appConfigDb.getOrCreateSecret('test_secret', () => 'stored'), 'stored');
+
+    const reread = appConfigDb.getOrCreateSecret('test_secret', () => {
+      throw new Error('generator must not run for an existing key');
+    });
+
+    assert.equal(reread, 'stored');
+  });
+});
+
+test('getOrCreateSecret yields to a racing writer instead of overwriting it', async () => {
+  await withIsolatedDatabase((databasePath) => {
+    // The generator body simulates another process winning the insert between
+    // our read and our write — the exact race that used to rotate the secret.
+    const resolved = appConfigDb.getOrCreateSecret('test_secret', () => {
+      const racer = new Database(databasePath);
+      racer
+        .prepare('INSERT INTO app_config (key, value) VALUES (?, ?)')
+        .run('test_secret', 'written-by-racer');
+      racer.close();
+      return 'losing-candidate';
+    });
+
+    assert.equal(resolved, 'written-by-racer');
+    assert.equal(appConfigDb.get('test_secret'), 'written-by-racer');
+  });
+});
+
+test('a failed read throws instead of reporting the key as absent', async () => {
+  await withIsolatedDatabase(() => {
+    const original = appConfigDb.getOrCreateJwtSecret();
+
+    // Any unreadable table stands in for a transient read failure.
+    getConnection().exec('DROP TABLE app_config');
+
+    assert.throws(() => appConfigDb.get('jwt_secret'));
+    // The critical regression: an unreadable secret must never be treated as
+    // an absent one and replaced with a freshly minted value.
+    assert.throws(() => appConfigDb.getOrCreateJwtSecret());
+    assert.equal(original.length, 128);
+  });
+});

--- a/server/modules/database/tests/app-config.test.ts
+++ b/server/modules/database/tests/app-config.test.ts
@@ -19,9 +19,11 @@ async function withIsolatedDatabase(
 
   closeConnection();
   process.env.DATABASE_PATH = databasePath;
-  await initializeDatabase();
 
   try {
+    // Inside the try: a failed init must still restore DATABASE_PATH and
+    // remove the temporary directory.
+    await initializeDatabase();
     await runTest(databasePath);
   } finally {
     closeConnection();

--- a/server/modules/database/tests/app-config.test.ts
+++ b/server/modules/database/tests/app-config.test.ts
@@ -107,3 +107,15 @@ test('an empty stored secret is refused rather than treated as absent', async ()
     assert.equal(appConfigDb.get('test_secret'), '');
   });
 });
+
+test('an empty generated secret never reaches the table', async () => {
+  await withIsolatedDatabase(() => {
+    assert.throws(() => appConfigDb.getOrCreateSecret('test_secret', () => ''), /is empty/);
+
+    // The key has to stay absent. A persisted '' would be permanent, because
+    // INSERT OR IGNORE cannot replace it, so a later call must still be able
+    // to create the secret for real.
+    assert.equal(appConfigDb.get('test_secret'), null);
+    assert.equal(appConfigDb.getOrCreateSecret('test_secret', () => 'recovered'), 'recovered');
+  });
+});


### PR DESCRIPTION
## Problem

`appConfigDb.get()` swallowed every error into `null`:

```ts
try { /* SELECT value FROM app_config WHERE key = ? */ }
catch { return null; }  // "so early-startup reads (e.g. JWT secret) do not crash"
```

`getOrCreateJwtSecret()` therefore could not tell *this key has no row* from *this read did not complete*. A transient read failure could cause it to mint a new secret and upsert it over the good one if the subsequent write succeeded. Every JWT signed with the old secret then fails signature verification, invalidating sessions that used it. The upsert preserves `created_at`, so that timestamp does not reveal the rotation.

Two things widen the window:

- `getConnection()` assigned the module singleton **before** running `exec(APP_CONFIG_TABLE_SCHEMA_SQL)`. Once that DDL failed, the cached half-initialised handle was still handed to the writer, so the read could fail while the write succeeded, which is exactly the ordering that completes a rotation.
- The connection did not explicitly configure `busy_timeout` or request WAL mode for concurrent access by the server, CLI and dev watcher.

`browser-use`'s `getOrCreateMcpToken()` had the identical shape and could silently rotate the token that authenticates the registered MCP server entry.

Reproduced against a copy of a real database, with a write lock held during startup: the stored secret changed while `created_at` stayed frozen, and nothing was logged.

## Fix

- `get()` propagates read errors. Callers that genuinely tolerate absence, such as `browser-use`'s `readSettings`, already have their own `try`/`catch`.
- New `getOrCreateSecret(key, generate)` returns an existing non-empty secret. When the row is absent, it writes with `INSERT OR IGNORE` and then re-reads, so a racing writer keeps its value and the caller gets the persisted value rather than its local candidate. A failed read, a still-absent row, or an empty stored secret throws. An empty generated candidate is rejected before insertion. Both the JWT secret and the MCP token use this helper.
- `getConnection()` publishes the singleton only after the pragmas and schema succeed, and closes the handle on failure so the next call retries cleanly.
- Set `busy_timeout = 5000` before requesting `journal_mode = WAL`. Inspect the returned journal mode; if it is not `wal`, warn and continue in the returned mode rather than refusing startup. A thrown pragma or schema error still closes the connection and propagates.

## Authentication rejection logging

The token-authentication rejection branches now log `no-token`, `user-not-found`, `session-expired`, or `invalid-token`. Expiry logs include the token's `iat` and expiration time to help investigate token age. Those timestamps alone do not prove whether a client missed a refresh or was simply inactive.

The log includes the request method, `req.baseUrl + req.path`, a bounded user agent and rejection details. It deliberately excludes the query string: SSE endpoints accept the JWT as a `?token=` query parameter. Request-derived fields pass through a helper that replaces control characters and double quotes and caps their length, limiting log injection.

## Tests

`server/modules/database/tests/app-config.test.ts` covers a secret surviving a reconnect, avoiding regeneration of an existing value, returning a racing writer's value, propagating failed reads, refusing an empty stored secret, and rejecting an empty generated candidate without persisting it. Database initialization is inside the test helper's `try` block so its cleanup also runs when initialization fails.

`server/modules/auth/tests/auth.middleware.test.ts` covers a forged user agent producing a single sanitized rejection line while retaining the 401 response and `X-Auth-Error` header.

The original submission reported clean typecheck, lint with 0 errors and 271 passing server tests, plus a replay of the rotation reproduction that left the secret intact. Later discussion reported additional test cases and higher counts. These are historical results, not verification of the current posted head.
