### PR TITLE
perf(sessions): bound the session-title scan to the transcript's tail

### DIFF
--- a/server/modules/providers/list/claude/claude-session-synchronizer.provider.ts
+++ b/server/modules/providers/list/claude/claude-session-synchronizer.provider.ts
@@ -8,9 +8,21 @@ import {
   extractFirstValidJsonlData,
   findFilesRecursivelyCreatedAfter,
   normalizeSessionName,
+  readFileTail,
   readFileTimestamps,
 } from '@/shared/utils.js';
 import type { IProviderSessionSynchronizer } from '@/shared/interfaces.js';
+
+/**
+ * How much of a transcript's tail to scan for a title marker.
+ *
+ * Markers are appended as the session runs, so the newest sits within the last
+ * few hundred bytes: on a 6.1 MB transcript measured here the final marker began
+ * 342 bytes from EOF. 64 KiB is ~190x that, and still covers files whose last
+ * records are unusually large, while a miss only costs the full read that this
+ * function already performed unconditionally.
+ */
+const SESSION_TITLE_TAIL_BYTES = 64 * 1024;
 
 type ParsedSession = {
   sessionId: string;
@@ -162,40 +174,65 @@ export class ClaudeSessionSynchronizer implements IProviderSessionSynchronizer {
     filePath: string,
     sessionId: string
   ): Promise<string | undefined> {
+    // Title markers are appended as the session progresses, so the newest one
+    // sits at the very end of the transcript. Scan a bounded tail first and only
+    // fall back to the whole file if that window holds no marker at all.
+    const tail = await readFileTail(filePath, SESSION_TITLE_TAIL_BYTES);
+    if (tail) {
+      const fromTail = this.findLastSessionTitle(tail.content, sessionId);
+      if (fromTail !== undefined) {
+        return fromTail;
+      }
+
+      if (!tail.truncated) {
+        // The window already covered the whole file; a wider read cannot help.
+        return undefined;
+      }
+    }
+
     try {
       const content = await readFile(filePath, 'utf8');
-      const lines = content.split(/\r?\n/);
-
-      for (let index = lines.length - 1; index >= 0; index -= 1) {
-        const line = lines[index]?.trim();
-        if (!line) {
-          continue;
-        }
-
-        let parsed: unknown;
-        try {
-          parsed = JSON.parse(line);
-        } catch {
-          continue;
-        }
-
-        const data = parsed as Record<string, unknown>;
-        const eventType = typeof data.type === 'string' ? data.type : undefined;
-        const eventSessionId = typeof data.sessionId === 'string' ? data.sessionId : undefined;
-        const aiTitle = typeof data.aiTitle === 'string' ? data.aiTitle : undefined;
-        const lastPrompt = typeof data.lastPrompt === 'string' ? data.lastPrompt : undefined;
-        const claudeRenamedTitle = typeof data.customTitle === 'string' ? data.customTitle : undefined;
-
-        if (
-          (eventType === 'ai-title' && eventSessionId === sessionId && aiTitle?.trim()) ||
-          (eventType === 'last-prompt' && eventSessionId === sessionId && lastPrompt?.trim()) ||
-          (eventType === "custom-title" && eventSessionId === sessionId && claudeRenamedTitle?.trim())
-        ) {
-          return aiTitle || lastPrompt || claudeRenamedTitle;
-        }
-      }
+      return this.findLastSessionTitle(content, sessionId);
     } catch {
       // Ignore missing/unreadable files so sync can continue.
+      return undefined;
+    }
+  }
+
+  /**
+   * Returns the last title marker for `sessionId` in a run of JSONL text, or
+   * `undefined` if it holds none.
+   */
+  private findLastSessionTitle(content: string, sessionId: string): string | undefined {
+    const lines = content.split(/\r?\n/);
+
+    for (let index = lines.length - 1; index >= 0; index -= 1) {
+      const line = lines[index]?.trim();
+      if (!line) {
+        continue;
+      }
+
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(line);
+      } catch {
+        continue;
+      }
+
+      const data = parsed as Record<string, unknown>;
+      const eventType = typeof data.type === 'string' ? data.type : undefined;
+      const eventSessionId = typeof data.sessionId === 'string' ? data.sessionId : undefined;
+      const aiTitle = typeof data.aiTitle === 'string' ? data.aiTitle : undefined;
+      const lastPrompt = typeof data.lastPrompt === 'string' ? data.lastPrompt : undefined;
+      const claudeRenamedTitle = typeof data.customTitle === 'string' ? data.customTitle : undefined;
+
+      if (
+        (eventType === 'ai-title' && eventSessionId === sessionId && aiTitle?.trim()) ||
+        (eventType === 'last-prompt' && eventSessionId === sessionId && lastPrompt?.trim()) ||
+        (eventType === "custom-title" && eventSessionId === sessionId && claudeRenamedTitle?.trim())
+      ) {
+        return aiTitle || lastPrompt || claudeRenamedTitle;
+      }
     }
 
     return undefined;

--- a/server/modules/providers/tests/claude-session-title-tail.test.ts
+++ b/server/modules/providers/tests/claude-session-title-tail.test.ts
@@ -1,0 +1,208 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, readFile, rm, stat, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import test, { after, before } from 'node:test';
+
+import { ClaudeSessionSynchronizer } from '@/modules/providers/list/claude/claude-session-synchronizer.provider.js';
+import { readFileTail } from '@/shared/utils.js';
+
+/**
+ * `extractSessionAiTitleFromEnd` used to `readFile()` the entire transcript on
+ * every add/change event, for any session without a settled title. Title markers
+ * are appended as the session runs, so the answer is always within the last few
+ * hundred bytes — on a 6.1 MB transcript measured in the field the final marker
+ * began 342 bytes from EOF, so the whole cost was the read and decode, not the
+ * backward parse loop.
+ *
+ * These tests assert the read is now bounded, and that bounding it did not change
+ * which title comes back.
+ */
+
+const SESSION_ID = '11111111-2222-3333-4444-555555555555';
+const TAIL_WINDOW = 64 * 1024;
+
+let workDir: string;
+
+/** Builds a JSONL transcript of at least `minBytes`, with `trailing` appended. */
+const writeTranscript = async (
+  name: string,
+  minBytes: number,
+  trailing: string[],
+): Promise<string> => {
+  const filler = `${JSON.stringify({
+    type: 'assistant',
+    sessionId: SESSION_ID,
+    text: 'x'.repeat(512),
+  })}\n`;
+  const rows = Math.ceil(minBytes / filler.length);
+  const body = filler.repeat(rows) + trailing.map((line) => `${line}\n`).join('');
+  const filePath = path.join(workDir, name);
+  await writeFile(filePath, body, 'utf8');
+  return filePath;
+};
+
+/** Bytes this process has received from read syscalls (Linux `rchar`). */
+const readProcessReadChars = async (): Promise<number> => {
+  const io = await readFile('/proc/self/io', 'utf8');
+  const match = /^rchar:\s*(\d+)$/m.exec(io);
+  if (!match) {
+    throw new Error('rchar not reported');
+  }
+  return Number(match[1]);
+};
+
+const titleMarker = (title: string) =>
+  JSON.stringify({ type: 'ai-title', sessionId: SESSION_ID, aiTitle: title });
+
+/** Invokes the private extractor directly; it has no public entry point. */
+const extractTitle = (filePath: string): Promise<string | undefined> => {
+  const synchronizer = new ClaudeSessionSynchronizer();
+  return (
+    synchronizer as unknown as {
+      extractSessionAiTitleFromEnd: (f: string, s: string) => Promise<string | undefined>;
+    }
+  ).extractSessionAiTitleFromEnd(filePath, SESSION_ID);
+};
+
+before(async () => {
+  workDir = await mkdtemp(path.join(os.tmpdir(), 'claude-session-title-'));
+});
+
+after(async () => {
+  await rm(workDir, { recursive: true, force: true });
+});
+
+test('readFileTail reads only the window, not the whole file', async () => {
+  const filePath = await writeTranscript('large.jsonl', 2 * 1024 * 1024, [
+    titleMarker('Latest title'),
+  ]);
+  const { size } = await stat(filePath);
+  assert.ok(size > TAIL_WINDOW * 4, 'fixture must be much larger than the window');
+
+  const tail = await readFileTail(filePath, TAIL_WINDOW);
+  assert.ok(tail);
+  assert.equal(tail.bytesRead, TAIL_WINDOW, 'must read exactly the window, not the file');
+  assert.equal(tail.fileSize, size);
+  assert.equal(tail.truncated, true);
+  assert.ok(tail.bytesRead < size / 30, 'the read must be a small fraction of the file');
+});
+
+test('readFileTail never returns a partial first line', async () => {
+  const filePath = await writeTranscript('partial.jsonl', 256 * 1024, [
+    titleMarker('Trailing title'),
+  ]);
+
+  // A window whose start almost certainly lands mid-line.
+  const tail = await readFileTail(filePath, 3_333);
+  assert.ok(tail);
+  assert.equal(tail.truncated, true);
+
+  for (const line of tail.content.split('\n').filter(Boolean)) {
+    assert.doesNotThrow(
+      () => JSON.parse(line),
+      `every returned line must be whole and parseable, got: ${line.slice(0, 40)}`,
+    );
+  }
+});
+
+test('readFileTail on a file smaller than the window returns all of it, untruncated', async () => {
+  const filePath = path.join(workDir, 'small.jsonl');
+  const body = `${titleMarker('Small file title')}\n`;
+  await writeFile(filePath, body, 'utf8');
+
+  const tail = await readFileTail(filePath, TAIL_WINDOW);
+  assert.ok(tail);
+  assert.equal(tail.truncated, false);
+  assert.equal(tail.bytesRead, Buffer.byteLength(body));
+  assert.equal(tail.content, body);
+});
+
+test('readFileTail returns null for a missing file', async () => {
+  assert.equal(await readFileTail(path.join(workDir, 'nope.jsonl'), TAIL_WINDOW), null);
+});
+
+/**
+ * The equivalence tests below deliberately cannot tell a bounded read from a full
+ * one — the whole point of the change is that the answer is unchanged. This one
+ * asserts the bound itself, by measuring bytes actually returned to userspace, so
+ * that reverting the caller to `readFile()` fails here rather than passing
+ * silently. `rchar` counts bytes delivered by read syscalls whether or not the
+ * page cache served them; it is Linux-only, so elsewhere this skips.
+ */
+test('extracting a title does not read the whole transcript', async (t) => {
+  try {
+    await readProcessReadChars();
+  } catch {
+    return t.skip('no /proc/self/io on this platform');
+  }
+
+  const filePath = await writeTranscript('bounded.jsonl', 8 * 1024 * 1024, [
+    titleMarker('Bounded read title'),
+  ]);
+  const { size } = await stat(filePath);
+
+  const before = await readProcessReadChars();
+  assert.equal(await extractTitle(filePath), 'Bounded read title');
+  const consumed = (await readProcessReadChars()) - before;
+
+  assert.ok(
+    consumed < size / 4,
+    `expected a bounded read, but ${consumed} bytes were read from a ${size}-byte file`,
+  );
+});
+
+test('resolves the newest title from a large transcript', async () => {
+  const filePath = await writeTranscript('titled.jsonl', 2 * 1024 * 1024, [
+    titleMarker('An earlier title'),
+    JSON.stringify({ type: 'assistant', sessionId: SESSION_ID, text: 'after' }),
+    titleMarker('The newest title'),
+  ]);
+
+  assert.equal(await extractTitle(filePath), 'The newest title');
+});
+
+test('a title outside the window is still found, via the full-read fallback', async () => {
+  // Marker first, then more than a window of filler after it: the bounded read
+  // cannot see it, so this asserts the fallback rather than a silent miss.
+  const filler = `${JSON.stringify({
+    type: 'assistant',
+    sessionId: SESSION_ID,
+    text: 'y'.repeat(512),
+  })}\n`;
+  const filePath = path.join(workDir, 'far-title.jsonl');
+  await writeFile(
+    filePath,
+    `${titleMarker('Far from the end')}\n${filler.repeat(Math.ceil((TAIL_WINDOW * 2) / filler.length))}`,
+    'utf8',
+  );
+
+  const tail = await readFileTail(filePath, TAIL_WINDOW);
+  assert.ok(tail && !tail.content.includes('Far from the end'), 'window must not hold the marker');
+
+  assert.equal(await extractTitle(filePath), 'Far from the end');
+});
+
+test('a transcript with no title marker resolves to undefined', async () => {
+  const filePath = await writeTranscript('untitled.jsonl', 128 * 1024, []);
+  assert.equal(await extractTitle(filePath), undefined);
+});
+
+test('a title for a different session is ignored', async () => {
+  const filePath = await writeTranscript('other-session.jsonl', 128 * 1024, [
+    JSON.stringify({ type: 'ai-title', sessionId: 'someone-else', aiTitle: 'Not mine' }),
+  ]);
+  assert.equal(await extractTitle(filePath), undefined);
+});
+
+test('last-prompt and custom-title markers still resolve', async () => {
+  const lastPrompt = await writeTranscript('last-prompt.jsonl', 128 * 1024, [
+    JSON.stringify({ type: 'last-prompt', sessionId: SESSION_ID, lastPrompt: 'A prompt' }),
+  ]);
+  assert.equal(await extractTitle(lastPrompt), 'A prompt');
+
+  const custom = await writeTranscript('custom-title.jsonl', 128 * 1024, [
+    JSON.stringify({ type: 'custom-title', sessionId: SESSION_ID, customTitle: 'Renamed' }),
+  ]);
+  assert.equal(await extractTitle(custom), 'Renamed');
+});

--- a/server/shared/utils.ts
+++ b/server/shared/utils.ts
@@ -4,6 +4,7 @@ import {
   access,
   lstat,
   mkdir,
+  open,
   readFile,
   readdir,
   readlink,
@@ -11,6 +12,7 @@ import {
   stat,
   writeFile,
 } from 'node:fs/promises';
+import type { FileHandle } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 import readline from 'node:readline';
@@ -1102,6 +1104,58 @@ export async function extractFirstValidJsonlData<T>(
   }
 
   return null;
+}
+
+export type FileTail = {
+  /** Text decoded from the window. Never starts mid-line — see `truncated`. */
+  content: string;
+  /** Bytes actually read, which is `min(maxBytes, fileSize)`. */
+  bytesRead: number;
+  /** File size in bytes, so callers can tell whether the window covered it. */
+  fileSize: number;
+  /** True when the window started past the beginning of the file. */
+  truncated: boolean;
+};
+
+/**
+ * Reads at most the last `maxBytes` of a file.
+ *
+ * For append-only artifacts (JSONL transcripts) the interesting records are at
+ * the end, so a bounded tail avoids paying for the whole file on every event.
+ *
+ * A byte-offset window almost always starts mid-line. When it does, the leading
+ * partial line is dropped and `truncated` is set, so `content` is always a run
+ * of whole lines and a caller can tell that earlier lines exist.
+ */
+export async function readFileTail(filePath: string, maxBytes: number): Promise<FileTail | null> {
+  let handle: FileHandle | undefined;
+
+  try {
+    handle = await open(filePath, 'r');
+    const { size } = await handle.stat();
+    const bytesRead = Math.min(maxBytes, size);
+    const start = size - bytesRead;
+
+    const buffer = Buffer.alloc(bytesRead);
+    await handle.read(buffer, 0, bytesRead, start);
+
+    let content = buffer.toString('utf8');
+    const truncated = start > 0;
+    if (truncated) {
+      // Drop everything up to the first newline: that fragment is the tail of a
+      // line whose start lies outside the window, and a multi-byte character may
+      // also have been split at the boundary.
+      const firstBreak = content.indexOf('\n');
+      content = firstBreak === -1 ? '' : content.slice(firstBreak + 1);
+    }
+
+    return { content, bytesRead, fileSize: size, truncated };
+  } catch {
+    // Ignore missing/unreadable files so callers can fall back or skip.
+    return null;
+  } finally {
+    await handle?.close().catch(() => undefined);
+  }
 }
 
 // ---------------------------


### PR DESCRIPTION
## Problem

`extractSessionAiTitleFromEnd` (`claude-session-synchronizer.provider.ts`) does:

```ts
const content = await readFile(filePath, 'utf8');
const lines = content.split(/\r?\n/);
```

on the **entire** `.jsonl` transcript, then scans backward for a title marker.
`synchronizeProviderFile()` calls it on every `add`/`change` event for any session
without a settled title — i.e. every session that is currently being written to.

The backward parse loop is not the expensive part, which is worth stating because
it is the intuitive suspect. Title markers are appended as the session runs, so the
newest one is at the very end. Measured on a 6.1 MB transcript here:

- file size **6,133,834 bytes**, 1,705 lines
- the last `ai-title` / `last-prompt` / `custom-title` marker began at byte
  **6,133,492** — **342 bytes from EOF**

So the loop exits on essentially the first non-empty line it looks at. The entire
cost is the multi-megabyte read, the UTF-8 decode, and splitting into an array of
strings — paid in full, per event, per active session.

For scale, the corpus that surfaced this was 22 project directories / 446 session
files / 430 MB, with several multi-MB transcripts being appended to concurrently.

## Fix

Read at most the last 64 KiB and only fall back to the full file if that window
contains no marker at all.

The resolved title is unchanged by construction: the window ends at EOF, so the
newest marker within it is the newest marker in the file. The fallback preserves
the old answer in the one case the window cannot serve — including when a marker
is truncated at the window boundary, since a truncated line fails `JSON.parse`,
leaves the window with no match, and triggers the full read.

64 KiB is ~190x the measured 342-byte distance, and still covers transcripts whose
trailing records are unusually large. A miss costs only the full read the function
already performed unconditionally.

`readFileTail` is added to `server/shared/utils.ts` alongside the other file
readers. A byte-offset window almost always starts mid-line, so it drops the
leading partial line and reports whether it did — which also avoids decoding a
multi-byte character split across the boundary.

## Tests

`server/modules/providers/tests/claude-session-title-tail.test.ts` (10 tests).

Most of them are equivalence tests — newest-of-several markers, a marker outside
the window reached via the fallback, no marker, another session's marker,
`last-prompt` and `custom-title` — and by design **none of them can tell a bounded
read from a full one**, because the answer is meant to be identical.

So there is also a test that asserts the bound itself, by measuring bytes actually
delivered to the process (`rchar` from `/proc/self/io`, skipped where unavailable)
rather than wall-clock, which would flake. Reverting the caller to `readFile()`
fails it with:

```
expected a bounded read, but 8389478 bytes were read from a 8389164-byte file
```

while all nine equivalence tests still pass — which is the intended split: the
equivalence tests guard the semantics, that one guards the performance property.

`npm test` (280 pass), `npm run typecheck` and `npm run lint` (0 errors, warning
count unchanged) all clean.

## Relationship to #1156

Complementary. #1156 reports that `WATCHER_IGNORED_PATTERNS` are glob strings and
chokidar v4 dropped glob support for `ignored`, so all provider roots are fully
walked and polled — which inflates the number of events reaching this function.
That issue's author has offered a PR for the glob/depth side; this one only makes
each resulting event cheaper, and does not touch the watcher.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Claude session title detection for large transcripts by checking the most recent content first.
  * Preserved support for AI-generated, prompt-based, and custom titles.
  * Added fallback handling when titles are not found near the end of a transcript.
  * Continued to safely ignore malformed entries and unreadable transcripts.

* **Tests**
  * Added coverage for title selection, partial transcript reads, fallback behavior, and missing files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->