### PR TITLE
fix(chat): stop a fresh session slot from clobbering the live token budget

### DIFF
--- a/src/stores/sessionSlot.test.ts
+++ b/src/stores/sessionSlot.test.ts
@@ -1,0 +1,14 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { createEmptySlot } from './sessionSlot';
+
+// Chat state syncs the token counter with `if (slot.tokenUsage !== undefined)`.
+// Providers whose history endpoint reports no usage (Claude) deliver the budget
+// over the websocket instead. A `null` default makes that guard always pass, so
+// the first history refresh after a turn resets a correct counter to 0.
+test('a fresh slot reports no token usage until the server sends some', () => {
+  const slot = createEmptySlot();
+
+  assert.equal(slot.tokenUsage, undefined);
+});

--- a/src/stores/sessionSlot.ts
+++ b/src/stores/sessionSlot.ts
@@ -1,0 +1,20 @@
+import type { NormalizedMessage, SessionSlot } from './useSessionStore';
+
+const EMPTY: NormalizedMessage[] = [];
+
+export function createEmptySlot(): SessionSlot {
+  return {
+    serverMessages: EMPTY,
+    realtimeMessages: EMPTY,
+    merged: EMPTY,
+    _lastServerRef: EMPTY,
+    _lastRealtimeRef: EMPTY,
+    status: 'idle',
+    fetchedAt: 0,
+    total: 0,
+    hasMore: false,
+    offset: 0,
+    tokenUsage: undefined,
+    _historyMutationQueue: Promise.resolve(),
+  };
+}

--- a/src/stores/useSessionStore.ts
+++ b/src/stores/useSessionStore.ts
@@ -12,6 +12,7 @@ import { useCallback, useMemo, useRef, useState } from 'react';
 import { authenticatedFetch } from '../utils/api';
 import type { LLMProvider } from '../types/app';
 
+import { createEmptySlot } from './sessionSlot';
 import { removeOptimisticUserEchoes } from './sessionMessageReconciliation';
 import {
   buildSessionMessagesUrl,
@@ -120,28 +121,16 @@ export interface SessionSlot {
   total: number;
   hasMore: boolean;
   offset: number;
+  /**
+   * Usage reported by the session history endpoint, or `undefined` when the
+   * provider does not report any. Callers gate on `!== undefined` before
+   * syncing UI state, so this must NOT default to `null` — that would read as
+   * "server says zero" and wipe a budget delivered over the websocket.
+   */
   tokenUsage: unknown;
 }
 
-const EMPTY: NormalizedMessage[] = [];
 const SESSION_HISTORY_REQUEST_TIMEOUT_MS = 30_000;
-
-function createEmptySlot(): SessionSlot {
-  return {
-    serverMessages: EMPTY,
-    realtimeMessages: EMPTY,
-    merged: EMPTY,
-    _lastServerRef: EMPTY,
-    _lastRealtimeRef: EMPTY,
-    status: 'idle',
-    fetchedAt: 0,
-    total: 0,
-    hasMore: false,
-    offset: 0,
-    tokenUsage: null,
-    _historyMutationQueue: Promise.resolve(),
-  };
-}
 
 type SessionHistoryPage = {
   messages: NormalizedMessage[];


### PR DESCRIPTION
Fixes #1182 — this is option **(b)** from that issue.

## The bug

Regression in v1.37.2 (from #1153). In a Claude session the token pill counts up live during a turn, then drops to `0` the moment the turn completes. Next message it counts again, then zeroes again.

## Root cause

`createEmptySlot()` initialized the slot with `tokenUsage: null`, but every consumer gates on "did the server report anything?" with `!== undefined`:

```ts
// src/components/chat/hooks/useChatSessionState.ts — 3 identical sites
if (slot.tokenUsage !== undefined) {
  setTokenBudget((slot.tokenUsage as Record<string, unknown> | null) ?? null);
}
```

`null !== undefined` is `true`, so the guard always passed and the first history refresh after a turn pushed `null` into the budget → `TokenUsageSummary` renders `0`.

Claude is the provider that actually breaks: `claude-sessions.provider.ts` `fetchHistory` never returns `tokenUsage`, so the slot keeps its initial value forever and the budget only ever arrives over the websocket (`kind: 'status', text: 'token_budget'`). Codex and OpenCode attach a real snapshot to their history response, which overwrites the bad default before anyone reads it — hence "Codex is fine".

## The fix

One value: initialize `tokenUsage` as `undefined`, so "the provider reported nothing" and "the server reported zero" stay distinguishable at the single point all three consumers route through. No consumer code changes.

An explicit `null` from a provider still overwrites it — `hasEquivalentTokenUsage(null, undefined)` is `false` (`Object.is` fails, `JSON.stringify(null) === "null" !== undefined`), so a real server-reported empty usage is applied as before.

`createEmptySlot` moves to `src/stores/sessionSlot.ts` so the invariant is reachable from `node --test`: importing `useSessionStore` transitively pulls in `import.meta.env`, which is undefined under `tsx --test`. The type-only import back into `useSessionStore` is erased at compile time, so there is no runtime cycle. This matches the directory's existing convention (`sessionMessagePagination.ts`, `sessionMessageReconciliation.ts`).

## Verification

- Regression test `src/stores/sessionSlot.test.ts` — fails on `main`, passes with the fix.
- `npm run test:client` → 46 pass, 0 fail.
- `npx tsc --noEmit -p tsconfig.json` → clean. `npx eslint src/` → clean.
- Manually against a running dev server with a real Claude session: without the fix, a 30 ms sampler catches the pill at `64,851` for ~90 ms before it snaps to `0`; with the fix it reaches `64,793` and holds — including across a forced staleness refresh (leave the chat > 30 s, come back, `GET .../messages?limit=20&offset=0` fires) and across a following turn (`64,851 → 64,909`, no `0`).

## Not included

Option **(a)** from #1182 — returning a usage snapshot from the Claude `fetchHistory` — is complementary and still worth doing: it would also populate the pill on a cold session open, which this PR does not address (with no websocket event yet, there is nothing to show). Happy to add it here or in a follow-up if you'd prefer them together.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved token usage information when server-reported usage is unavailable.
  * Ensured newly created session slots correctly represent unknown usage until data is received.

* **Refactor**
  * Improved session slot initialization for consistent empty-state behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->