### PR TITLE
feat: add CLOUDCLI_DISABLE_UPDATE_CHECK to disable update checks

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -42,4 +42,12 @@ HOST=0.0.0.0
 VITE_CONTEXT_WINDOW=160000
 CONTEXT_WINDOW=160000
 
+# =============================================================================
+# UPDATES
+# =============================================================================
 
+# Disable automatic update checks (the sidebar "Update available" banner and the
+# [UPDATE] notice on 'cloudcli start'). Accepts true or 1; any other value warns.
+# The ecosystem-standard NO_UPDATE_NOTIFIER also disables them (any non-empty value).
+# 'cloudcli update' still works when this is set.
+# CLOUDCLI_DISABLE_UPDATE_CHECK=true

--- a/server/index.ts
+++ b/server/index.ts
@@ -9,7 +9,7 @@ import http from 'http';
 import express, { type NextFunction, type Request, type Response } from 'express';
 import cors from 'cors';
 
-import { AppError, findApplicationRoot, getModuleDirectory, IS_PLATFORM, terminalTextStyles } from '@/shared/utils.js';
+import { AppError, findApplicationRoot, getModuleDirectory, getUpdateCheckOptOutVariable, IS_PLATFORM, terminalTextStyles } from '@/shared/utils.js';
 import {
     closeSessionsWatcher,
     initializeSessionsWatcher,
@@ -69,6 +69,13 @@ const RUNNING_VERSION = (() => {
         return null;
     }
 })();
+// Operator opt-out for automatic update checks. Read once at startup like the
+// values above and published on `/health` so the prebuilt frontend bundle can
+// honor it at runtime (a build-time VITE_ variable cannot reach an npm install).
+// The winning variable is kept so the startup banner can name it: a correct
+// opt-out and a mistyped one otherwise look identical (both silent).
+const updateCheckOptOutVariable = getUpdateCheckOptOutVariable(process.env);
+const updateCheckDisabled = updateCheckOptOutVariable !== null;
 const systemRoutes = createSystemModule({
     appRoot: APP_ROOT,
     installMode,
@@ -138,7 +145,8 @@ app.get('/health', (req, res) => {
         status: 'ok',
         timestamp: new Date().toISOString(),
         installMode,
-        version: RUNNING_VERSION
+        version: RUNNING_VERSION,
+        updateCheckDisabled
     });
 });
 
@@ -357,6 +365,9 @@ async function startServer() {
             console.log('');
             console.log(`${terminalTextStyles.info('[INFO]')} Server URL:  ${terminalTextStyles.bright('http://' + DISPLAY_HOST + ':' + SERVER_PORT)}`);
             console.log(`${terminalTextStyles.info('[INFO]')} Installed at: ${terminalTextStyles.dim(appInstallPath)}`);
+            if (updateCheckOptOutVariable) {
+                console.log(`${terminalTextStyles.info('[INFO]')} Automatic update checks disabled (${terminalTextStyles.dim(updateCheckOptOutVariable)})`);
+            }
             console.log(`${terminalTextStyles.tip('[TIP]')}  Run "cloudcli status" for full configuration details`);
             console.log('');
 

--- a/server/load-env.ts
+++ b/server/load-env.ts
@@ -18,6 +18,26 @@ function getBootstrapApplicationRoot(importMetaUrl: string) {
   return path.basename(parent) === 'dist-server' ? path.dirname(parent) : parent;
 }
 
+/**
+ * Parses one `.env` line into a key/value pair, or `null` for blank lines,
+ * comments and lines with no `=`. Exported for tests: the module body below runs
+ * on import, so this is the only way to exercise the parsing rules directly.
+ */
+export function parseEnvironmentFileLine(line: string): { key: string; value: string } | null {
+  const trimmedLine = line.trim();
+  if (!trimmedLine || trimmedLine.startsWith('#')) return null;
+  const separatorIndex = trimmedLine.indexOf('=');
+  if (separatorIndex === -1) return null;
+  // Trim the key and strip one matched pair of surrounding quotes. Both are
+  // dotenv idioms, and without this `KEY = value` produced a key with a trailing
+  // space (so the variable looked unset) while KEY="value" kept the quote
+  // characters inside the value.
+  const key = trimmedLine.slice(0, separatorIndex).trim();
+  if (!key) return null;
+  const value = trimmedLine.slice(separatorIndex + 1).trim();
+  return { key, value: /^"[\s\S]*"$|^'[\s\S]*'$/.test(value) ? value.slice(1, -1) : value };
+}
+
 // Resolve the repo/app root via the nearest /server folder so this file keeps finding the
 // same top-level .env file from both /server/load-env.ts and /dist-server/server/load-env.js.
 const APP_ROOT = getBootstrapApplicationRoot(import.meta.url);
@@ -26,12 +46,9 @@ try {
   const envPath = path.join(APP_ROOT, '.env');
   const envFile = fs.readFileSync(envPath, 'utf8');
   envFile.split('\n').forEach(line => {
-    const trimmedLine = line.trim();
-    if (trimmedLine && !trimmedLine.startsWith('#')) {
-      const [key, ...valueParts] = trimmedLine.split('=');
-      if (key && valueParts.length > 0 && !process.env[key]) {
-        process.env[key] = valueParts.join('=').trim();
-      }
+    const parsed = parseEnvironmentFileLine(line);
+    if (parsed && !process.env[parsed.key]) {
+      process.env[parsed.key] = parsed.value;
     }
   });
 } catch (e: any) {

--- a/server/modules/cli/cli.service.ts
+++ b/server/modules/cli/cli.service.ts
@@ -8,7 +8,7 @@ import type {
   CliPackageMetadata,
   SandboxCommandService,
 } from '@/shared/types.js';
-import { terminalTextStyles } from '@/shared/utils.js';
+import { isUpdateCheckDisabled, terminalTextStyles } from '@/shared/utils.js';
 
 type CliServiceDependencies = {
   applicationRoot: string;
@@ -106,6 +106,8 @@ function showStatus(dependencies: CliServiceDependencies): void {
   output.log(`       DATABASE_PATH: ${terminalTextStyles.dim(environment.DATABASE_PATH || '(using default location)')}`);
   output.log(`       CLAUDE_CLI_PATH: ${terminalTextStyles.dim(environment.CLAUDE_CLI_PATH || 'claude (default)')}`);
   output.log(`       CONTEXT_WINDOW: ${terminalTextStyles.dim(environment.CONTEXT_WINDOW || '160000 (default)')}`);
+  output.log(`       CLOUDCLI_DISABLE_UPDATE_CHECK: ${terminalTextStyles.dim(environment.CLOUDCLI_DISABLE_UPDATE_CHECK || '(not set)')}`);
+  output.log(`       NO_UPDATE_NOTIFIER: ${terminalTextStyles.dim(environment.NO_UPDATE_NOTIFIER || '(not set)')}`);
   output.log(`\n${terminalTextStyles.info('[INFO]')} Claude Projects Folder:`);
   output.log(`       ${terminalTextStyles.dim(claudeProjectsPath)}`);
   output.log(`       Status: ${fileSystem.pathExists(claudeProjectsPath)
@@ -161,6 +163,8 @@ Environment Variables:
   DATABASE_PATH       Set custom database location
   CLAUDE_CLI_PATH     Set custom Claude CLI path
   CONTEXT_WINDOW      Set context window size (default: 160000)
+  CLOUDCLI_DISABLE_UPDATE_CHECK  Disable automatic update checks (true/1)
+  NO_UPDATE_NOTIFIER  Also disables update checks (any non-empty value)
 
 Documentation:
   ${dependencies.packageMetadata.homepage || 'https://github.com/siteboon/claudecodeui'}
@@ -230,7 +234,9 @@ export function createCliService(dependencies: CliServiceDependencies): CliAppli
 
       switch (parsedArguments.command) {
         case 'start':
-          void checkForUpdates(true);
+          // Explicit `cloudcli update` intentionally still checks; only the
+          // implicit start-up check honors the operator opt-out.
+          if (!isUpdateCheckDisabled(dependencies.environment)) void checkForUpdates(true);
           await dependencies.startServer();
           return 0;
         case 'sandbox':

--- a/server/modules/cli/tests/cli.service.test.ts
+++ b/server/modules/cli/tests/cli.service.test.ts
@@ -15,6 +15,7 @@ function createHarness() {
   };
   let serverStarts = 0;
   let sandboxArguments: string[] = [];
+  let latestVersionRequests = 0;
   const service = createCliService({
     applicationRoot: '/application',
     defaultDatabasePath: '/home/user/.cloudcli/auth.db',
@@ -36,7 +37,10 @@ function createHarness() {
         return 7;
       },
     },
-    getLatestPackageVersion: async () => '1.2.3',
+    getLatestPackageVersion: async () => {
+      latestVersionRequests += 1;
+      return '1.2.3';
+    },
     updateGlobalPackage: () => undefined,
     startServer: async () => {
       serverStarts += 1;
@@ -51,6 +55,7 @@ function createHarness() {
     errorMessages,
     getServerStarts: () => serverStarts,
     getSandboxArguments: () => sandboxArguments,
+    getLatestVersionRequests: () => latestVersionRequests,
   };
 }
 
@@ -85,4 +90,35 @@ test('returns a failure code for an unknown command without exiting the process'
 
   assert.equal(exitCode, 1);
   assert.match(harness.errorMessages[0], /Unknown command: unknown/);
+});
+
+test('skips the start-up update check when CLOUDCLI_DISABLE_UPDATE_CHECK is set', async () => {
+  const harness = createHarness();
+  harness.environment.CLOUDCLI_DISABLE_UPDATE_CHECK = 'true';
+
+  const exitCode = await harness.service.run(['start']);
+
+  assert.equal(exitCode, 0);
+  assert.equal(harness.getLatestVersionRequests(), 0);
+  assert.equal(harness.getServerStarts(), 1);
+});
+
+test('checks for updates on start when CLOUDCLI_DISABLE_UPDATE_CHECK is unset', async () => {
+  const harness = createHarness();
+
+  const exitCode = await harness.service.run(['start']);
+
+  assert.equal(exitCode, 0);
+  assert.equal(harness.getLatestVersionRequests(), 1);
+  assert.equal(harness.getServerStarts(), 1);
+});
+
+test('still checks for updates on an explicit update command when the flag is set', async () => {
+  const harness = createHarness();
+  harness.environment.CLOUDCLI_DISABLE_UPDATE_CHECK = 'true';
+
+  const exitCode = await harness.service.run(['update']);
+
+  assert.equal(exitCode, 0);
+  assert.equal(harness.getLatestVersionRequests(), 1);
 });

--- a/server/shared/tests/load-env.test.ts
+++ b/server/shared/tests/load-env.test.ts
@@ -1,0 +1,35 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+// Importing load-env runs its bootstrap body, so this file logs one "No .env
+// file found" line when the repo has no .env. Harmless: only the exported pure
+// parser is under test here.
+import { parseEnvironmentFileLine } from '../../load-env.js';
+
+type Case = {
+  label: string;
+  line: string;
+  expected: { key: string; value: string } | null;
+};
+
+const cases: Case[] = [
+  { label: 'plain assignment', line: 'CONTEXT_WINDOW=160000', expected: { key: 'CONTEXT_WINDOW', value: '160000' } },
+  { label: 'double-quoted value', line: 'CLOUDCLI_DISABLE_UPDATE_CHECK="true"', expected: { key: 'CLOUDCLI_DISABLE_UPDATE_CHECK', value: 'true' } },
+  { label: 'single-quoted value', line: "CLOUDCLI_DISABLE_UPDATE_CHECK='true'", expected: { key: 'CLOUDCLI_DISABLE_UPDATE_CHECK', value: 'true' } },
+  { label: 'spaces around the separator', line: 'CLOUDCLI_DISABLE_UPDATE_CHECK = true', expected: { key: 'CLOUDCLI_DISABLE_UPDATE_CHECK', value: 'true' } },
+  { label: 'empty double-quoted value is empty, not two quote characters', line: 'NO_UPDATE_NOTIFIER=""', expected: { key: 'NO_UPDATE_NOTIFIER', value: '' } },
+  { label: 'unquoted empty value', line: 'NO_UPDATE_NOTIFIER=', expected: { key: 'NO_UPDATE_NOTIFIER', value: '' } },
+  { label: 'value containing an equals sign is kept whole', line: 'TOKEN=abc=def==', expected: { key: 'TOKEN', value: 'abc=def==' } },
+  { label: 'unmatched leading quote is left alone', line: 'TOKEN="abc', expected: { key: 'TOKEN', value: '"abc' } },
+  { label: 'inner quotes are left alone', line: 'JSON={"a":1}', expected: { key: 'JSON', value: '{"a":1}' } },
+  { label: 'comment line', line: '# CLOUDCLI_DISABLE_UPDATE_CHECK=true', expected: null },
+  { label: 'blank line', line: '   ', expected: null },
+  { label: 'line with no separator', line: 'CLOUDCLI_DISABLE_UPDATE_CHECK', expected: null },
+  { label: 'line with no key', line: '=true', expected: null },
+];
+
+for (const testCase of cases) {
+  test(`parseEnvironmentFileLine: ${testCase.label}`, () => {
+    assert.deepEqual(parseEnvironmentFileLine(testCase.line), testCase.expected);
+  });
+}

--- a/server/shared/tests/update-check-disabled.test.ts
+++ b/server/shared/tests/update-check-disabled.test.ts
@@ -1,0 +1,53 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { getUpdateCheckOptOutVariable, isUpdateCheckDisabled } from '@/shared/utils.js';
+
+type Case = {
+  label: string;
+  environment: NodeJS.ProcessEnv;
+  /** The variable expected to win, or null when update checks stay enabled. */
+  source: string | null;
+  warns: boolean;
+};
+
+const cases: Case[] = [
+  { label: 'no variables set', environment: {}, source: null, warns: false },
+  { label: 'CLOUDCLI_DISABLE_UPDATE_CHECK=true', environment: { CLOUDCLI_DISABLE_UPDATE_CHECK: 'true' }, source: 'CLOUDCLI_DISABLE_UPDATE_CHECK', warns: false },
+  { label: 'CLOUDCLI_DISABLE_UPDATE_CHECK=1', environment: { CLOUDCLI_DISABLE_UPDATE_CHECK: '1' }, source: 'CLOUDCLI_DISABLE_UPDATE_CHECK', warns: false },
+  { label: 'CLOUDCLI_DISABLE_UPDATE_CHECK=" TRUE "', environment: { CLOUDCLI_DISABLE_UPDATE_CHECK: ' TRUE ' }, source: 'CLOUDCLI_DISABLE_UPDATE_CHECK', warns: false },
+  { label: 'CLOUDCLI_DISABLE_UPDATE_CHECK empty', environment: { CLOUDCLI_DISABLE_UPDATE_CHECK: '' }, source: null, warns: false },
+  { label: 'CLOUDCLI_DISABLE_UPDATE_CHECK whitespace only', environment: { CLOUDCLI_DISABLE_UPDATE_CHECK: '   ' }, source: null, warns: false },
+  { label: 'CLOUDCLI_DISABLE_UPDATE_CHECK=false', environment: { CLOUDCLI_DISABLE_UPDATE_CHECK: 'false' }, source: null, warns: true },
+  { label: 'CLOUDCLI_DISABLE_UPDATE_CHECK=0', environment: { CLOUDCLI_DISABLE_UPDATE_CHECK: '0' }, source: null, warns: true },
+  { label: 'CLOUDCLI_DISABLE_UPDATE_CHECK=yes', environment: { CLOUDCLI_DISABLE_UPDATE_CHECK: 'yes' }, source: null, warns: true },
+  { label: 'NO_UPDATE_NOTIFIER=1', environment: { NO_UPDATE_NOTIFIER: '1' }, source: 'NO_UPDATE_NOTIFIER', warns: false },
+  { label: 'NO_UPDATE_NOTIFIER=anything', environment: { NO_UPDATE_NOTIFIER: 'anything' }, source: 'NO_UPDATE_NOTIFIER', warns: false },
+  { label: 'NO_UPDATE_NOTIFIER=false still disables', environment: { NO_UPDATE_NOTIFIER: 'false' }, source: 'NO_UPDATE_NOTIFIER', warns: false },
+  { label: 'NO_UPDATE_NOTIFIER empty', environment: { NO_UPDATE_NOTIFIER: '' }, source: null, warns: false },
+  { label: 'NO_UPDATE_NOTIFIER whitespace only', environment: { NO_UPDATE_NOTIFIER: '   ' }, source: null, warns: false },
+  { label: 'NO_UPDATE_NOTIFIER wins over an unrecognized CloudCLI value', environment: { NO_UPDATE_NOTIFIER: '1', CLOUDCLI_DISABLE_UPDATE_CHECK: 'yes' }, source: 'NO_UPDATE_NOTIFIER', warns: false },
+  { label: 'NO_UPDATE_NOTIFIER wins over a recognized CloudCLI value', environment: { NO_UPDATE_NOTIFIER: '1', CLOUDCLI_DISABLE_UPDATE_CHECK: 'true' }, source: 'NO_UPDATE_NOTIFIER', warns: false },
+];
+
+for (const testCase of cases) {
+  test(`update-check opt-out: ${testCase.label}`, () => {
+    const originalWarn = console.warn;
+    const warnings: string[] = [];
+    console.warn = (message?: unknown) => {
+      warnings.push(String(message));
+    };
+
+    try {
+      assert.equal(getUpdateCheckOptOutVariable(testCase.environment), testCase.source);
+      assert.equal(warnings.length, testCase.warns ? 1 : 0);
+      if (testCase.warns) {
+        assert.match(warnings[0], /Ignoring CLOUDCLI_DISABLE_UPDATE_CHECK/);
+      }
+      // Kept inside the swap so its warning does not leak into test output.
+      assert.equal(isUpdateCheckDisabled(testCase.environment), testCase.source !== null);
+    } finally {
+      console.warn = originalWarn;
+    }
+  });
+}

--- a/server/shared/utils.ts
+++ b/server/shared/utils.ts
@@ -39,6 +39,43 @@ import type {
  */
 export const IS_PLATFORM = process.env.VITE_IS_PLATFORM === 'true';
 
+/**
+ * Names the environment variable that disabled automatic update checking for
+ * this deployment, or `null` when update checks are enabled.
+ *
+ * Consumers: `server/index.ts` (publishes the decision on `GET /health` so the
+ * web UI skips its GitHub release poll, and reports the winning variable in the
+ * startup banner) and `server/modules/cli/cli.service.ts` (skips the
+ * npm-registry check on `cloudcli start`). An explicit `cloudcli update`
+ * intentionally ignores this opt-out.
+ *
+ * The two variables have deliberately different truth tables:
+ * `CLOUDCLI_DISABLE_UPDATE_CHECK` accepts `true` or `1` (case-insensitive and
+ * whitespace-tolerant) and warns on any other non-empty value so a typo is
+ * never a silent no-op. `NO_UPDATE_NOTIFIER` follows the npm/update-notifier
+ * convention instead: any non-empty value disables, whatever the value. It is
+ * checked first, so it wins when both are set.
+ */
+export function getUpdateCheckOptOutVariable(environment: NodeJS.ProcessEnv): string | null {
+  if ((environment.NO_UPDATE_NOTIFIER ?? '').trim() !== '') return 'NO_UPDATE_NOTIFIER';
+  const raw = environment.CLOUDCLI_DISABLE_UPDATE_CHECK?.trim() ?? '';
+  if (raw === '') return null;
+  const value = raw.toLowerCase();
+  if (value === 'true' || value === '1') return 'CLOUDCLI_DISABLE_UPDATE_CHECK';
+  console.warn(
+    `[WARN] Ignoring CLOUDCLI_DISABLE_UPDATE_CHECK="${raw}": expected "true" or "1". Update checks stay enabled.`,
+  );
+  return null;
+}
+
+/**
+ * Reports whether automatic update checking is disabled, for the call sites that
+ * only need the decision and not which variable produced it.
+ */
+export function isUpdateCheckDisabled(environment: NodeJS.ProcessEnv): boolean {
+  return getUpdateCheckOptOutVariable(environment) !== null;
+}
+
 // ---------------------------
 //----------------- NORMALIZED MESSAGE HELPER INPUT TYPES ------------
 /**

--- a/src/hooks/useVersionCheck.ts
+++ b/src/hooks/useVersionCheck.ts
@@ -2,6 +2,27 @@ import { useState, useEffect } from 'react';
 import { version } from '../../package.json';
 import { ReleaseInfo } from '../shared/types';
 
+// Three version sources feed two independent banners:
+//
+//   package.json `version`  ──┐ (baked into this bundle at build time)
+//                             ├── differ? ──→ restartRequired  "restart the server"
+//   GET /health .version    ──┘ (what the server process actually runs)
+//
+//   GET /health .updateCheckDisabled ──→ gate ──┐
+//                                               ├── latest > current? ──→ updateAvailable
+//   api.github.com releases/latest .tag_name ───┘                        "Update available"
+//
+// The gate only suppresses the GitHub poll (CLOUDCLI_DISABLE_UPDATE_CHECK /
+// NO_UPDATE_NOTIFIER on the server). `restartRequired` makes no network call and
+// is never suppressed. If `/health` fails or times out we fail open into the
+// pre-flag behavior rather than muting update checks forever.
+
+// Generous on purpose: this only has to break a connection a proxy is holding
+// open. A tighter budget makes a cold or slow-but-healthy server look dead, and
+// the bare catch below would then leave installMode at its 'git' default, which
+// is what decides the upgrade command shown to the user.
+const HEALTH_REQUEST_TIMEOUT_MS = 15000;
+
 /**
  * Compare two semantic version strings
  * Works only with numeric versions separated by dots (e.g. "1.2.3")
@@ -30,11 +51,13 @@ export const useVersionCheck = (owner: string, repo: string) => {
   const [installMode, setInstallMode] = useState<InstallMode>('git');
   const [runningVersion, setRunningVersion] = useState<string | null>(null);
   const [restartRequired, setRestartRequired] = useState(false);
+  const [healthChecked, setHealthChecked] = useState(false);
+  const [updateCheckDisabled, setUpdateCheckDisabled] = useState(false);
 
   useEffect(() => {
     const fetchHealth = async () => {
       try {
-        const response = await fetch('/health');
+        const response = await fetch('/health', { signal: AbortSignal.timeout(HEALTH_REQUEST_TIMEOUT_MS) });
         const data = await response.json();
         if (data.installMode === 'npm' || data.installMode === 'git') {
           setInstallMode(data.installMode);
@@ -48,14 +71,21 @@ export const useVersionCheck = (owner: string, repo: string) => {
           setRunningVersion(data.version);
           setRestartRequired(data.version !== version);
         }
+        setUpdateCheckDisabled(data.updateCheckDisabled === true);
       } catch {
         // Default to git / no restart hint on error
+      } finally {
+        // Set on both paths: a broken or hung /health must fail open into the
+        // pre-flag behavior, never silently mute update checks forever.
+        setHealthChecked(true);
       }
     };
     fetchHealth();
   }, []);
 
   useEffect(() => {
+    if (!healthChecked || updateCheckDisabled) return;
+
     const checkVersion = async () => {
       try {
         const response = await fetch(`https://api.github.com/repos/${owner}/${repo}/releases/latest`);
@@ -93,7 +123,7 @@ export const useVersionCheck = (owner: string, repo: string) => {
     checkVersion();
     const interval = setInterval(checkVersion, 5 * 60 * 1000); // Check every 5 minutes
     return () => clearInterval(interval);
-  }, [owner, repo]);
+  }, [owner, repo, healthChecked, updateCheckDisabled]);
 
   return { updateAvailable, latestVersion, currentVersion: version, releaseInfo, installMode, runningVersion, restartRequired };
 };

--- a/vite.config.js
+++ b/vite.config.js
@@ -30,6 +30,9 @@ export default defineConfig(({ mode }) => {
       port: parseInt(env.VITE_PORT) || 5173,
       proxy: {
         '/api': `http://${proxyHost}:${serverPort}`,
+        // The version checker reads installMode / version / updateCheckDisabled
+        // from /health, so it has to reach the backend in dev too.
+        '/health': `http://${proxyHost}:${serverPort}`,
         '/ws': {
           target: `ws://${proxyHost}:${serverPort}`,
           ws: true


### PR DESCRIPTION
Closes #1187.

## Why

Update checking is unconditional in two places today:

- the web UI polls `api.github.com/repos/siteboon/claudecodeui/releases/latest` every 5 minutes and shows the "Update available" banner;
- `cloudcli start` shells out to `npm show @cloudcli-ai/cloudcli version` and prints `[UPDATE] New version available`.

For a fleet that deliberately pins a version, both are noise with no off switch. This adds one runtime environment variable that silences both. **With nothing set, behavior is unchanged.**

```bash
CLOUDCLI_DISABLE_UPDATE_CHECK=true    # accepts true or 1
NO_UPDATE_NOTIFIER=1                  # ecosystem standard, any non-empty value
```

## How the flag reaches the frontend

Through the existing public `GET /health`, not a `VITE_` variable. The npm package ships a prebuilt `dist/`, so `import.meta.env` is frozen at publish time and cannot carry an operator setting. `useVersionCheck` already fetched `/health` on mount for `installMode` and the restart hint, so this adds no request, no new endpoint and no new auth surface — one additive boolean next to the `installMode` and `version` fields already there.

## Deliberate boundaries

| Decision | Reason |
|---|---|
| `cloudcli update` still checks | An explicitly typed command wins over an environment variable |
| The "restart the server" banner is untouched | Derived locally from `/health` vs the bundled version; makes no network request |
| A set-but-unrecognized value warns | The two variables have different truth tables (`true`/`1` vs any non-empty), so a typo must not be a silent no-op |
| `/health` unreachable fails **open** | Failing closed would mute updates for everyone during a health-check outage, not just for people who opted out |
| `CI=true` is not honored | It would silently change behavior for people already running in containers with `CI` set |

The startup banner now names the variable that won, so a correct opt-out and a mistyped key no longer produce identical silence:

```
[INFO] Automatic update checks disabled (CLOUDCLI_DISABLE_UPDATE_CHECK)
```

`cloudcli status` and `cloudcli help` both list the variables too.

## Not in scope, worth stating explicitly

`src/hooks/useGitHubStars.ts:41` still calls `https://api.github.com/repos/siteboon/claudecodeui` unconditionally for the star badge. It is not an update check, it already has a user-facing dismiss and a 1h cache, and #1187 asks about update prompts rather than egress — but anyone auditing outbound traffic after setting this flag should not be surprised to still see GitHub requests. Say the word if you want it gated by the same variable.

## About the second commit

`fix(env): strip quotes and trim keys when parsing .env` touches the shared `.env` parser, so it is worth a separate look. It is here because without it the flag does not work from a `.env` file at all, which is the Ansible-managed case the issue is about. The parser split on the first `=` without normalizing either side:

| `.env` line | before | after |
|---|---|---|
| `CLOUDCLI_DISABLE_UPDATE_CHECK=true` | disabled | disabled |
| `CLOUDCLI_DISABLE_UPDATE_CHECK="true"` | **checks stay on**, confusing warning | disabled |
| `CLOUDCLI_DISABLE_UPDATE_CHECK='true'` | **checks stay on**, confusing warning | disabled |
| `CLOUDCLI_DISABLE_UPDATE_CHECK = true` | **silently ignored** (key kept a trailing space) | disabled |
| `NO_UPDATE_NOTIFIER=""` | **silently disabled** (value was two quote characters) | enabled |

The same bug affected every quoted variable — `DATABASE_PATH="/srv/auth.db"` became a path with literal quotes in it, `CONTEXT_WINDOW="160000"` became `NaN`. It is a separate commit so it can be reviewed and reverted on its own; happy to pull it into its own PR if you would rather land it first.

Still unsupported, unchanged: `export KEY=value` and a trailing `# comment` on an unquoted value.

## Commits

1. `fix(env)` — trim keys, strip one matched quote pair; extracts `parseEnvironmentFileLine` so the rules are testable
2. `fix(dev)` — add `/health` to the Vite dev proxy; it only forwarded `/api`, `/ws`, `/shell`, `/plugin-ws`, so `installMode`, the running version and the restart hint were all dead under `npm run dev`
3. `feat` — the flag itself

## Verification

- `npm run typecheck` clean, `npm run lint` no new problems, `npm run build` clean
- `npm test` **302 pass / 0 fail**, `npm run test:client` 45/45
- 28 new test cases: the opt-out truth table including the warning path and the `NO_UPDATE_NOTIFIER`-wins precedence, the `.env` line parser, and three CLI tests pinning that `start` skips the check while `update` still performs it
- Checked against a real built server (`node dist-server/server/index.js`) with a temp `.env`: every row of the table above, plus `/health` reporting `false` when nothing is set and the `[WARN]` line on `=yes`
- No UI screenshots since the visible change is an absence: with the flag set, DevTools shows no request to `releases/latest` and no banner in the sidebar footer, the collapsed rail, or Settings → About

## Follow-ups filed separately

- #1199 — `useVersionCheck` is mounted twice, so each client runs two 5-minute GitHub polls against a shared 60 req/h limit
- #1200 — both semver comparators produce `NaN` comparisons on a pre-release tag
- #1201 — `VersionInfoSection.tsx` is never imported

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added options to disable automatic update checks using `CLOUDCLI_DISABLE_UPDATE_CHECK` or `NO_UPDATE_NOTIFIER`.
  - The CLI now displays update-check status and identifies the setting that disabled checks.
  - Manual `cloudcli update` commands continue to work when automatic checks are disabled.
  - The interface now respects the server’s update-check preference and avoids unnecessary version polling.

- **Bug Fixes**
  - Improved environment-file parsing for quoted values, whitespace, comments, and empty entries.
  - Added timeout and fallback handling for unavailable health checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->