### PR TITLE
fix(claude): ignore <synthetic> model placeholder when resolving session model

### DIFF
--- a/server/modules/providers/list/claude/claude-models.provider.ts
+++ b/server/modules/providers/list/claude/claude-models.provider.ts
@@ -207,19 +207,20 @@ const extractClaudeModelFromTextContent = (content: string): string | null => {
   if (localCommandStdout !== null) {
     const cleanedStdout = stripAnsi(localCommandStdout).replace(/\s+/g, ' ').trim();
     const changedModel = /(?:set|changed|switched)\s+model\s+to\s+(.+?)\.?$/i.exec(cleanedStdout);
-    if (changedModel?.[1]?.trim()) {
-      return changedModel[1].trim();
+    const stdoutModel = changedModel?.[1]?.trim();
+    // A placeholder stdout hit must not shadow a real <model> tag further down.
+    if (stdoutModel && !isPlaceholderModel(stdoutModel)) {
+      return stdoutModel;
     }
   }
 
   const modelTag = extractTaggedContent(content, 'model')?.trim();
-  return modelTag || null;
+  return modelTag && !isPlaceholderModel(modelTag) ? modelTag : null;
 };
 
 const extractClaudeModelFromMessageContent = (content: unknown): string | null => {
   if (typeof content === 'string') {
-    const model = extractClaudeModelFromTextContent(content);
-    return model && !isPlaceholderModel(model) ? model : null;
+    return extractClaudeModelFromTextContent(content);
   }
 
   if (!Array.isArray(content)) {
@@ -231,9 +232,10 @@ const extractClaudeModelFromMessageContent = (content: unknown): string | null =
       continue;
     }
 
-    // Skip placeholder hits so a later part can still supply the real model.
+    // extractClaudeModelFromTextContent rejects placeholders, so a placeholder
+    // part yields null here and a later part can still supply the real model.
     const model = extractClaudeModelFromTextContent(part.text);
-    if (model && !isPlaceholderModel(model)) {
+    if (model) {
       return model;
     }
   }

--- a/server/modules/providers/list/claude/claude-models.provider.ts
+++ b/server/modules/providers/list/claude/claude-models.provider.ts
@@ -166,6 +166,13 @@ const ANSI_PATTERN = new RegExp(
   'g',
 );
 
+/**
+ * Claude Code stamps locally-synthesized rows (API-error placeholders and the
+ * like) with `model: "<synthetic>"`. Angle-bracketed values are placeholders,
+ * never real model ids, and must not be surfaced as the session's model.
+ */
+const isPlaceholderModel = (model: string): boolean => model.startsWith('<') && model.endsWith('>');
+
 const extractClaudeEventModel = (event: ClaudeInitEvent, sessionId: string): string | null => {
   const eventSessionId = event.sessionId ?? event.session_id;
   if (eventSessionId && eventSessionId !== sessionId) {
@@ -173,17 +180,17 @@ const extractClaudeEventModel = (event: ClaudeInitEvent, sessionId: string): str
   }
 
   const contentModel = extractClaudeModelFromMessageContent(event.message?.content);
-  if (contentModel) {
+  if (contentModel && !isPlaceholderModel(contentModel)) {
     return contentModel;
   }
 
   const directModel = event.model?.trim();
-  if (directModel) {
+  if (directModel && !isPlaceholderModel(directModel)) {
     return directModel;
   }
 
   const messageModel = event.message?.model?.trim();
-  return messageModel || null;
+  return messageModel && !isPlaceholderModel(messageModel) ? messageModel : null;
 };
 
 const stripAnsi = (value: string): string => value.replace(ANSI_PATTERN, '');

--- a/server/modules/providers/list/claude/claude-models.provider.ts
+++ b/server/modules/providers/list/claude/claude-models.provider.ts
@@ -173,14 +173,15 @@ const ANSI_PATTERN = new RegExp(
  */
 const isPlaceholderModel = (model: string): boolean => model.startsWith('<') && model.endsWith('>');
 
-const extractClaudeEventModel = (event: ClaudeInitEvent, sessionId: string): string | null => {
+/** Exported for tests. */
+export const extractClaudeEventModel = (event: ClaudeInitEvent, sessionId: string): string | null => {
   const eventSessionId = event.sessionId ?? event.session_id;
   if (eventSessionId && eventSessionId !== sessionId) {
     return null;
   }
 
   const contentModel = extractClaudeModelFromMessageContent(event.message?.content);
-  if (contentModel && !isPlaceholderModel(contentModel)) {
+  if (contentModel) {
     return contentModel;
   }
 
@@ -217,7 +218,8 @@ const extractClaudeModelFromTextContent = (content: string): string | null => {
 
 const extractClaudeModelFromMessageContent = (content: unknown): string | null => {
   if (typeof content === 'string') {
-    return extractClaudeModelFromTextContent(content);
+    const model = extractClaudeModelFromTextContent(content);
+    return model && !isPlaceholderModel(model) ? model : null;
   }
 
   if (!Array.isArray(content)) {
@@ -229,8 +231,9 @@ const extractClaudeModelFromMessageContent = (content: unknown): string | null =
       continue;
     }
 
+    // Skip placeholder hits so a later part can still supply the real model.
     const model = extractClaudeModelFromTextContent(part.text);
-    if (model) {
+    if (model && !isPlaceholderModel(model)) {
       return model;
     }
   }

--- a/server/modules/providers/tests/claude-models.test.ts
+++ b/server/modules/providers/tests/claude-models.test.ts
@@ -1,0 +1,68 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { extractClaudeEventModel } from '@/modules/providers/list/claude/claude-models.provider.js';
+
+const SESSION_ID = 'session-1';
+
+test('ignores the <synthetic> placeholder Claude Code stamps on synthesized rows', () => {
+  assert.equal(
+    extractClaudeEventModel(
+      { sessionId: SESSION_ID, message: { model: '<synthetic>' } },
+      SESSION_ID,
+    ),
+    null,
+  );
+  assert.equal(
+    extractClaudeEventModel({ sessionId: SESSION_ID, model: '<synthetic>' }, SESSION_ID),
+    null,
+  );
+});
+
+test('still surfaces real model ids from message and event fields', () => {
+  assert.equal(
+    extractClaudeEventModel(
+      { sessionId: SESSION_ID, message: { model: 'claude-sonnet-5' } },
+      SESSION_ID,
+    ),
+    'claude-sonnet-5',
+  );
+  assert.equal(
+    extractClaudeEventModel({ sessionId: SESSION_ID, model: 'opus' }, SESSION_ID),
+    'opus',
+  );
+});
+
+test('skips a placeholder content part so a later real model tag still wins', () => {
+  assert.equal(
+    extractClaudeEventModel(
+      {
+        sessionId: SESSION_ID,
+        message: {
+          content: [
+            { text: '<model><synthetic></model>' },
+            { text: '<model>claude-sonnet-5</model>' },
+          ],
+        },
+      },
+      SESSION_ID,
+    ),
+    'claude-sonnet-5',
+  );
+});
+
+test('falls back to the message model when every content hit is a placeholder', () => {
+  assert.equal(
+    extractClaudeEventModel(
+      {
+        sessionId: SESSION_ID,
+        message: {
+          content: '<model><synthetic></model>',
+          model: 'claude-sonnet-5',
+        },
+      },
+      SESSION_ID,
+    ),
+    'claude-sonnet-5',
+  );
+});

--- a/server/modules/providers/tests/claude-models.test.ts
+++ b/server/modules/providers/tests/claude-models.test.ts
@@ -51,6 +51,25 @@ test('skips a placeholder content part so a later real model tag still wins', ()
   );
 });
 
+test('a placeholder stdout hit does not shadow a real <model> tag in the same text', () => {
+  const text = '<local-command-stdout>Set model to <synthetic></local-command-stdout>'
+    + '<model>claude-sonnet-5</model>';
+  assert.equal(
+    extractClaudeEventModel(
+      { sessionId: SESSION_ID, message: { content: text } },
+      SESSION_ID,
+    ),
+    'claude-sonnet-5',
+  );
+  assert.equal(
+    extractClaudeEventModel(
+      { sessionId: SESSION_ID, message: { content: [{ text }] } },
+      SESSION_ID,
+    ),
+    'claude-sonnet-5',
+  );
+});
+
 test('falls back to the message model when every content hit is a placeholder', () => {
   assert.equal(
     extractClaudeEventModel(


### PR DESCRIPTION
## Problem

Claude Code stamps locally-synthesized rows in session JSONL files (API-error placeholders and similar) with `model: "<synthetic>"`. This is an internal marker, not a real model id.

`readClaudeSessionModelFromJsonl` (in `server/modules/providers/list/claude/claude-models.provider.ts`) walks the session JSONL backwards and takes the first event carrying a model field as the session's active model. When the last row of a session happens to be such a placeholder (e.g. the previous turn ended with an API error), `<synthetic>` is surfaced as the session's model.

From there it propagates end to end:

1. `resolveSessionModel` returns it (`source: 'provider'`) via `GET /:provider/sessions/:sessionId/active-model`;
2. the composer adopts it as the session's current model;
3. the next send passes it back as `clientOptions.model`, which is recorded via `setSessionModel` and handed to the Agent SDK;
4. the SDK issues a real API request with `model: "<synthetic>"`, which the API rejects with **404 model_not_found**.

For users behind an API gateway this is worse than a single failed request — gateways commonly rate-limit an account after an upstream `model_not_found`, so one poisoned session can block real traffic for a while.

## Fix

Treat angle-bracketed values as placeholders in `extractClaudeEventModel` and skip them, so the scan falls through to an earlier event with a real model id, or ultimately to the provider default. This filters the poison at its single entry point; everything downstream is just faithful propagation.

## Testing

- `npm run typecheck` passes
- `server/modules/providers/tests/provider-models.service.test.ts` passes (16/16)
- Reproduced against a real session JSONL containing `"model":"<synthetic>"` rows: before the fix the active-model endpoint reported `<synthetic>`; after the fix it falls back correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Claude model detection by excluding synthetic placeholder values such as `<synthetic>`.
  * Ensured model information is reported consistently across message and event data.
  * Preserved valid model detection when placeholder values appear alongside real model information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->