### PR TITLE
fix(claude): keep the account connected when the access token is refreshable

### DIFF
--- a/server/modules/providers/list/claude/claude-auth.provider.ts
+++ b/server/modules/providers/list/claude/claude-auth.provider.ts
@@ -79,6 +79,9 @@ export class ClaudeProviderAuth implements IProviderAuth {
 
   /**
    * Checks Claude credentials in the same priority order used by Claude Code.
+   *
+   * An expired access token still counts as logged in while a refresh token is present:
+   * it lives ~12 hours and the CLI refreshes it the next time it runs.
    */
   private async checkCredentials(): Promise<ClaudeCredentialsStatus> {
     const missingCredentialsError = 'Claude CLI is not authenticated. Run claude /login or configure ANTHROPIC_API_KEY.';
@@ -118,7 +121,8 @@ export class ClaudeProviderAuth implements IProviderAuth {
       if (accessToken) {
         const expiresAt = typeof oauth?.expiresAt === 'number' ? oauth.expiresAt : undefined;
         const email = readOptionalString(creds.email) ?? readOptionalString(creds.user) ?? null;
-        if (!expiresAt || Date.now() < expiresAt) {
+        const refreshable = Boolean(readOptionalString(oauth?.refreshToken));
+        if (!expiresAt || Date.now() < expiresAt || refreshable) {
           return {
             authenticated: true,
             email,


### PR DESCRIPTION
Fixes #1209.

`checkCredentials()` treated an expired access token as a lost login. The token lives
~12 hours and the CLI refreshes it with the refresh token the next time it runs, so a
session left idle overnight reported as disconnected while the login was intact.

A present `refreshToken` now counts as still logged in.

**To reproduce:** log in with `claude /login`, leave the CLI unused until
`claudeAiOauth.expiresAt` passes, then open Settings → Agents → Claude → Account.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Claude credential-file authentication by allowing expired access tokens with valid refresh tokens to remain authenticated.
  * The CLI can now refresh expired Claude access tokens instead of incorrectly reporting them as expired.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->