### PR TITLE
fix(claude): normalize queue-operation remove records as user-role text

### DIFF
--- a/server/modules/providers/list/claude/claude-sessions.provider.ts
+++ b/server/modules/providers/list/claude/claude-sessions.provider.ts
@@ -546,6 +546,28 @@ export class ClaudeSessionsProvider implements IProviderSessions {
       return messages;
     }
 
+    // When a background sub-agent finishes while the parent turn is still
+    // active, the Claude Code harness removes the notification from its queue
+    // rather than dequeuing it into a user message. The removal record carries
+    // the full `<task-notification>` payload in `content`. Normalize it as a
+    // user-role text message — identical to a deferred dequeue — so the daemon
+    // and every downstream consumer see it instead of silently losing it.
+    if (raw.type === 'queue-operation' && raw.operation === 'remove') {
+      const content = typeof raw.content === 'string' ? raw.content : '';
+      if (content.startsWith('<task-notification>')) {
+        messages.push(createNormalizedMessage({
+          id: baseId,
+          sessionId,
+          timestamp: ts,
+          provider: PROVIDER,
+          kind: 'text',
+          role: 'user',
+          content,
+        }));
+      }
+      return messages;
+    }
+
     if (raw.message?.role === 'assistant' && raw.message?.content) {
       if (Array.isArray(raw.message.content)) {
         let partIndex = 0;

--- a/server/modules/providers/tests/claude-sessions.test.ts
+++ b/server/modules/providers/tests/claude-sessions.test.ts
@@ -59,3 +59,97 @@ test('claude: the Skill tool result itself still reaches the UI', () => {
   assert.equal(messages[0].kind, 'tool_result');
   assert.equal(messages[0].toolId, 'toolu_1');
 });
+
+test('claude: queue-operation remove with task-notification emits user-role text', () => {
+  const provider = new ClaudeSessionsProvider();
+
+  const notifications = provider.normalizeMessage(
+    {
+      uuid: 'qop-remove-1',
+      timestamp: '2026-08-25T10:00:00.000Z',
+      type: 'queue-operation',
+      operation: 'remove',
+      content: '<task-notification>\n<task-id>abc123</task-id>\n<status>completed</status>\n<summary>Agent finished</summary>\n</task-notification>',
+    },
+    SESSION_ID,
+  );
+
+  assert.equal(notifications.length, 1);
+  assert.equal(notifications[0]?.kind, 'text');
+  assert.equal(notifications[0]?.role, 'user');
+  assert.equal(notifications[0]?.id, 'qop-remove-1');
+  assert.ok(String(notifications[0]?.content ?? '').startsWith('<task-notification>'));
+});
+
+test('claude: queue-operation enqueue is ignored', () => {
+  const provider = new ClaudeSessionsProvider();
+
+  const notifications = provider.normalizeMessage(
+    {
+      uuid: 'qop-enq-1',
+      timestamp: '2026-08-25T10:00:00.000Z',
+      type: 'queue-operation',
+      operation: 'enqueue',
+      content: '<task-notification>\n<task-id>abc123</task-id>\n<status>completed</status>\n</task-notification>',
+    },
+    SESSION_ID,
+  );
+
+  assert.deepEqual(notifications, []);
+});
+
+test('claude: queue-operation dequeue without content is ignored', () => {
+  const provider = new ClaudeSessionsProvider();
+
+  const notifications = provider.normalizeMessage(
+    {
+      uuid: 'qop-deq-1',
+      timestamp: '2026-08-25T10:00:00.000Z',
+      type: 'queue-operation',
+      operation: 'dequeue',
+    },
+    SESSION_ID,
+  );
+
+  assert.deepEqual(notifications, []);
+});
+
+test('claude: queue-operation remove without task-notification prefix is ignored', () => {
+  const provider = new ClaudeSessionsProvider();
+
+  const notifications = provider.normalizeMessage(
+    {
+      uuid: 'qop-other-1',
+      timestamp: '2026-08-25T10:00:00.000Z',
+      type: 'queue-operation',
+      operation: 'remove',
+      content: 'Some other queue content',
+    },
+    SESSION_ID,
+  );
+
+  assert.deepEqual(notifications, []);
+});
+
+test('claude: existing user-role task-notification from dequeue still works', () => {
+  const provider = new ClaudeSessionsProvider();
+
+  const notifications = provider.normalizeMessage(
+    {
+      uuid: 'u-deq-1',
+      timestamp: '2026-08-25T10:00:00.000Z',
+      message: {
+        role: 'user',
+        content: '<task-notification>\n<task-id>xyz789</task-id>\n<status>completed</status>\n<summary>Done</summary>\n</task-notification>',
+      },
+    },
+    SESSION_ID,
+  );
+
+  // Already handled by the existing user-role text branch — just verify no
+  // regression (it doesn't get caught by the queue-operation branch above).
+  assert.equal(notifications.length, 1);
+  assert.equal(notifications[0]?.kind, 'text');
+  assert.equal(notifications[0]?.role, 'user');
+  assert.ok(String(notifications[0]?.content ?? '').startsWith('<task-notification>'));
+});


### PR DESCRIPTION
## Problem

`ClaudeSessionsProvider.normalizeMessage` ignores `queue-operation` records entirely. When a background sub-agent finishes **while the parent turn is still active**, the Claude Code harness consumes its `<task-notification>` completion report inline: it emits a `queue-operation` record with `operation: 'remove'` whose `content` holds the full `<task-notification>` payload, and never writes a user-role turn for it.

Because `normalizeMessage` returns nothing for `queue-operation` records, those completion reports are silently dropped from the normalized stream. Only sub-agents that finish *between* turns — which produce a `dequeue` user turn — are visible, so a large fraction of background sub-agent completion reports are lost.

## Fix

Normalize a `remove` record whose `content` starts with `<task-notification>` into a `kind: 'text', role: 'user'` message — the same shape a deferred `dequeue` already produces — so downstream consumers render it identically instead of losing it. `enqueue`/`dequeue` and non-notification `remove` records are unaffected.

## Tests

Adds 5 tests to `claude-sessions.test.ts`:
- `remove` + `<task-notification>` → one user-role text message
- `enqueue` is ignored
- `dequeue` without content is ignored
- `remove` without a `<task-notification>` prefix is ignored
- existing user-role `<task-notification>` (deferred dequeue) still works — no regression

All server tests pass (`npm test`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved background task completion notifications in Claude session conversations.
  * Ensured task notifications removed from the processing queue remain visible as user messages.
  * Ignored unrelated queue events and content that do not represent task notifications.

* **Tests**
  * Added coverage for queue-based task notifications and existing notification behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->