### PR TITLE
fix: install dev deps and rebuild during git-mode self-update

### DIFF
--- a/server/modules/system/system.service.ts
+++ b/server/modules/system/system.service.ts
@@ -32,7 +32,15 @@ export function createSystemUpdateService(dependencies: SystemUpdateDependencies
       const updateCommand = dependencies.isPlatform
         ? 'npm run update:platform'
         : dependencies.installMode === 'git'
-          ? 'git checkout main && git pull && npm install'
+          // --include=dev is required because NODE_ENV=production (set by the
+          // systemd unit) makes npm default to omit=dev, which drops vite and
+          // husky. husky's "prepare" lifecycle script then fails with exit 127
+          // ("husky: not found"), which fails the whole install — and without
+          // vite the subsequent build can't run either. The trailing build
+          // step is required too: git pull only updates the source tree, but
+          // the server runs the compiled dist-server/dist output, so skipping
+          // this step leaves the old build running after a "successful" update.
+          ? 'git checkout main && git pull && npm install --include=dev && npm run build'
           : 'npm install -g @cloudcli-ai/cloudcli@latest';
       const workingDirectory = dependencies.isPlatform || dependencies.installMode === 'git'
         ? dependencies.appRoot

--- a/server/modules/system/tests/system.service.test.ts
+++ b/server/modules/system/tests/system.service.test.ts
@@ -34,7 +34,7 @@ test('git installations update from the application root', async () => {
   const result = await service.updateSystem();
 
   assert.deepEqual(calls, [[
-    'git checkout main && git pull && npm install',
+    'git checkout main && git pull && npm install --include=dev && npm run build',
     '/app/cloudcli',
     dependencies.environment,
   ]]);


### PR DESCRIPTION
## Problem

The git-install self-update workflow runs:
git checkout main && git pull && npm install

On a production install with NODE_ENV=production set (as in the systemd
unit shipped for this project), npm defaults to omit=dev, so devDependencies
such as vite and husky are never installed. husky is invoked unconditionally
by the "prepare" lifecycle script, which then fails with exit code 127
(husky: not found). That failure makes the entire npm install command
return a non-zero exit code, so updateSystem() reports the update as
failed even though git pull itself succeeded.

Separately, the update command never rebuilds the app. git pull only
refreshes the source tree; the server actually runs the compiled
dist-server/dist output. So even on a successful npm install, the
previously built (and now stale) server keeps running until someone
manually runs npm run build and restarts the process.

## Fix

Change the git-mode update command to:
git checkout main && git pull && npm install --include=dev && npm run build

--include=dev overrides the omit=dev default so husky/vite/etc. install
correctly regardless of NODE_ENV, and the trailing npm run build ensures
the compiled output is refreshed as part of the same update step.

## Testing

- All 5 unit tests in system.service.test.ts pass with the updated command.
- tsc --noEmit is clean.
- Reproduced and fixed the failure live on a production instance running
  this exact update path.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Git-based updates now install all required development dependencies.
  * A production build runs automatically after pulling updates, helping ensure changes are ready to use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->