### PR TITLE
fix(providers): report Claude auth status from the CLI instead of files

### DIFF
--- a/server/modules/providers/list/claude/claude-auth.provider.ts
+++ b/server/modules/providers/list/claude/claude-auth.provider.ts
@@ -78,6 +78,46 @@ export class ClaudeProviderAuth implements IProviderAuth {
   }
 
   /**
+   * Asks the Claude Code CLI whether it is logged in.
+   *
+   * This is the only authoritative source. The credentials file below is a
+   * cache the CLI is free to bypass: on macOS the OAuth token lives in the
+   * Keychain and `~/.claude/.credentials.json` is left behind as a stale
+   * copy, and even when the file is used its access token expires long
+   * before the session does, because `refreshToken` renews it silently.
+   *
+   * Returns null when the CLI cannot answer (missing, too old, timing out),
+   * so the caller falls back to the previous file-based detection.
+   */
+  private checkCliStatus(): ClaudeCredentialsStatus | null {
+    const cliPath = resolveClaudeCodeExecutablePath(process.env.CLAUDE_CLI_PATH);
+
+    try {
+      const result = spawn.sync(cliPath, ['auth', 'status', '--json'], {
+        encoding: 'utf8',
+        timeout: 10000,
+      });
+
+      if (result.status !== 0 || typeof result.stdout !== 'string') {
+        return null;
+      }
+
+      const status = readObjectRecord(JSON.parse(result.stdout));
+      if (!status || status.loggedIn !== true) {
+        return null;
+      }
+
+      return {
+        authenticated: true,
+        email: readOptionalString(status.email) ?? 'Authenticated',
+        method: 'cli_status',
+      };
+    } catch {
+      return null;
+    }
+  }
+
+  /**
    * Checks Claude credentials in the same priority order used by Claude Code.
    */
   private async checkCredentials(): Promise<ClaudeCredentialsStatus> {
@@ -106,6 +146,11 @@ export class ClaudeProviderAuth implements IProviderAuth {
 
     if (readOptionalString(settingsEnv.CLAUDE_CODE_OAUTH_TOKEN)) {
       return { authenticated: true, email: 'OAuth Token (long-lived)', method: 'environment' };
+    }
+
+    const cliStatus = this.checkCliStatus();
+    if (cliStatus) {
+      return cliStatus;
     }
 
     try {

--- a/server/modules/providers/tests/claude-auth.test.ts
+++ b/server/modules/providers/tests/claude-auth.test.ts
@@ -6,10 +6,11 @@ import test from 'node:test';
 
 import { ClaudeProviderAuth } from '@/modules/providers/list/claude/claude-auth.provider.js';
 
-// checkCredentials() is private, but unlike getStatus() it never shells out to the
-// `claude` CLI — it only reads env vars and ~/.claude files. Calling it directly
-// (TypeScript's `private` has no runtime effect) tests the priority order without
-// depending on `claude` being installed in the test environment.
+// checkCredentials() is private; calling it directly (TypeScript's `private` has
+// no runtime effect) tests the priority order. It asks the `claude` CLI before
+// falling back to env vars and ~/.claude files, so the probe is stubbed here:
+// otherwise every assertion below would depend on whether the machine running
+// the suite happens to have a logged-in CLI.
 type CheckCredentialsResult = {
   authenticated: boolean;
   email: string | null;
@@ -17,8 +18,16 @@ type CheckCredentialsResult = {
   error?: string;
 };
 
-const checkCredentials = (auth: ClaudeProviderAuth): Promise<CheckCredentialsResult> =>
-  (auth as unknown as { checkCredentials: () => Promise<CheckCredentialsResult> }).checkCredentials();
+const checkCredentials = (
+  auth: ClaudeProviderAuth,
+  cliStatus: CheckCredentialsResult | null = null,
+): Promise<CheckCredentialsResult> => {
+  (auth as unknown as { checkCliStatus: () => CheckCredentialsResult | null }).checkCliStatus =
+    () => cliStatus;
+  return (auth as unknown as {
+    checkCredentials: () => Promise<CheckCredentialsResult>;
+  }).checkCredentials();
+};
 
 const ENV_KEYS = ['CLAUDE_CODE_OAUTH_TOKEN', 'ANTHROPIC_API_KEY', 'ANTHROPIC_AUTH_TOKEN'] as const;
 
@@ -146,5 +155,37 @@ test('checkCredentials: ANTHROPIC_API_KEY takes precedence over CLAUDE_CODE_OAUT
         assert.equal(status.method, 'api_key');
       },
     );
+  });
+});
+
+test('checkCredentials: a logged-in CLI is authenticated even when the credentials file is expired', async () => {
+  await withTempHome(async (homeDir) => {
+    await writeCredentialsFile(homeDir, {
+      claudeAiOauth: { accessToken: 'stale-token', expiresAt: 1_000_000_000_000 }, // long expired
+    });
+
+    await withEnv({}, async () => {
+      const status = await checkCredentials(new ClaudeProviderAuth(), {
+        authenticated: true,
+        email: 'someone@example.com',
+        method: 'cli_status',
+      });
+      assert.equal(status.authenticated, true);
+      assert.equal(status.method, 'cli_status');
+      assert.equal(status.email, 'someone@example.com');
+    });
+  });
+});
+
+test('checkCredentials: explicit env credentials still win over the CLI probe', async () => {
+  await withTempHome(async () => {
+    await withEnv({ ANTHROPIC_API_KEY: 'test-api-key' }, async () => {
+      const status = await checkCredentials(new ClaudeProviderAuth(), {
+        authenticated: true,
+        email: 'someone@example.com',
+        method: 'cli_status',
+      });
+      assert.equal(status.method, 'api_key');
+    });
   });
 });


### PR DESCRIPTION
Closes #1209.

## The problem

`ClaudeProviderAuth.checkCredentials()` infers whether the user is logged in by reading `~/.claude/.credentials.json`. That file is a cache the CLI is free to bypass, so `GET /api/providers/claude/auth/status` reports a disconnected account for sessions that are perfectly valid.

Two ways it goes wrong:

- **macOS Keychain.** Claude Code stores its OAuth token in the Keychain and leaves `~/.claude/.credentials.json` behind as a stale copy. On my machine that file is dated a month ago and a successful `claude /login` never rewrites it — so the "Login" button in Settings → Agents → Claude cannot fix the state it reports. This is the Claude twin of #1008.
- **Refreshable token.** Even when the file is authoritative, `accessToken` expires ~12 h before the session does, because `refreshToken` renews it silently. That is #1209 as filed.

In both cases chat sessions keep working — the provider spawns the `claude` binary, which reads its own credentials. Only the status endpoint is wrong, which makes the UI actively misleading.

## The fix

Ask the CLI instead of guessing:

```
$ claude auth status --json
{ "loggedIn": true, "authMethod": "claude.ai", "email": "...", "subscriptionType": "max" }
```

`checkCliStatus()` runs that and, on `loggedIn: true`, reports the account as connected along with the real email.

**Placement.** The probe sits *after* the explicit environment and `settings.json` checks, so a hand-configured `ANTHROPIC_API_KEY` / `CLAUDE_CODE_OAUTH_TOKEN` still wins, and *before* the credentials-file read, which is the branch that is wrong. No existing precedence changes.

**Fails open.** A missing, older or slow CLI returns `null` and the previous file-based detection runs untouched. `spawn.sync` is already used by `checkInstalled()` in the same class, and the call is bounded by a 10 s timeout.

## Tests

The probe is stubbed in `claude-auth.test.ts`, which also restores the "never shells out" property the test file documents — before that, the existing assertions silently depended on whether the machine running the suite happened to have a logged-in CLI, and each one spawned a real process (~640 ms → <1 ms).

Two cases added: a logged-in CLI wins over an expired credentials file, and explicit env credentials still win over the probe.

Verified locally: `tsc --noEmit -p server/tsconfig.json`, `eslint` on the touched files, `npm run build:server`, and `npm test` (`claude-auth.test.ts` 7/7).

One note in case CI is red: `server/modules/agent/tests/agent.routes.test.ts` is flaky on my machine (Node 26, `.nvmrc` asks for 22) — it fails with `Unable to deserialize cloned data` on roughly one run in three, with and without this change. Happy to look into it separately if it is not already known.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Authentication now recognizes active sign-ins reported by the Claude CLI.
  - Active CLI authentication can remain valid even when stored credentials are expired.
  - Explicitly configured environment credentials continue to take priority.

- **Bug Fixes**
  - Improved authentication checks when credential files are unavailable, expired, or unsupported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->