### PR TITLE
Log Claude run lifecycle transitions, and stop discarding the CLI's stderr

### DIFF
--- a/server/modules/providers/list/claude/claude-runtime.provider.js
+++ b/server/modules/providers/list/claude/claude-runtime.provider.js
@@ -833,6 +833,29 @@ async function queryClaudeSDK(command, options = {}, ws, context) {
   // Hoisted above the try so the catch's cleanup can tell whether this run
   // still owns the activeSessions entry (or was superseded by a newer run).
   let queryInstance = null;
+  // Hoisted so the catch path can still report what was resolved when setup
+  // failed part-way through.
+  let sdkOptions = null;
+  // Guarantees a run_start for every run_end. The record is emitted where its
+  // payload is complete -- but everything above that point can throw, and a
+  // run_end without a matching run_start reads like a run that started before
+  // the log did. That is exactly the confusion this logging exists to remove.
+  let runStartLogged = false;
+  const logRunStart = () => {
+    if (runStartLogged) {
+      return;
+    }
+    runStartLogged = true;
+    logRunLifecycle('run_start', {
+      sessionKey: sessionKey(),
+      providerSessionId: providerSessionId || null,
+      // A run either resumes a known provider session or creates a new one.
+      resumed: Boolean(providerSessionId),
+      userId: ws?.userId || null,
+      model: sdkOptions?.model || null,
+      permissionMode: sdkOptions?.permissionMode || null
+    });
+  };
 
   try {
     const resolvedModel = await context.resolveResumeModel(sessionId, options.model);
@@ -843,7 +866,7 @@ async function queryClaudeSDK(command, options = {}, ws, context) {
       console.warn('[Claude SDK] Unable to load provider models for effort validation:', error);
     }
 
-    const sdkOptions = mapCliOptionsToSDK({
+    sdkOptions = mapCliOptionsToSDK({
       ...options,
       providerSessionId,
       model: resolvedModel || options.model,
@@ -1021,15 +1044,7 @@ async function queryClaudeSDK(command, options = {}, ws, context) {
     }
 
     // Process streaming messages
-    logRunLifecycle('run_start', {
-      sessionKey: sessionKey(),
-      providerSessionId: providerSessionId || null,
-      // A run either resumes a known provider session or creates a new one.
-      resumed: Boolean(providerSessionId),
-      userId: ws?.userId || null,
-      model: sdkOptions.model || null,
-      permissionMode: sdkOptions.permissionMode || null
-    });
+    logRunStart();
     for await (const message of queryInstance) {
       // Capture session ID from first message
       if (message.session_id && !capturedSessionId) {
@@ -1165,6 +1180,9 @@ async function queryClaudeSDK(command, options = {}, ws, context) {
 
   } catch (error) {
     console.error('SDK query error:', error);
+
+    // Setup may have thrown before the run_start above was reached.
+    logRunStart();
 
     // Clean up session on error — only while this run still owns the map entry
     // (a superseding run may have replaced it).

--- a/server/modules/providers/list/claude/claude-runtime.provider.js
+++ b/server/modules/providers/list/claude/claude-runtime.provider.js
@@ -222,6 +222,67 @@ function createCliStderrChunker(emit, maxPending = CLI_STDERR_MAX_PENDING_CHARS)
   };
 }
 
+/**
+ * Rate-limits CLI stderr without letting the redaction state fall behind.
+ *
+ * The throttle and the PEM-block formatter are each correct on their own. The
+ * bug lived at their handover: the formatter used to be called only for lines
+ * that survived the throttle, so a suppressed END marker left `insidePem`
+ * stuck and every later line of the run came out as the placeholder. State
+ * must advance for EVERY line; only the writing is rate-limited.
+ *
+ * Kept as a factory for the same reason as the chunker above: this is state
+ * that is easy to get subtly wrong and impossible to see afterwards in a log
+ * that looks plausible.
+ *
+ * @param {object} deps
+ * @param {(line: string) => string} deps.format - Stateful line formatter.
+ * @param {(text: string) => void} deps.sink - Receives lines that pass.
+ * @param {(dropped: number) => void} deps.throttleNotice - Reports losses.
+ * @param {() => number} [deps.now] - Clock, injectable for tests.
+ * @returns {{push: (line: string) => void, flushDropped: () => void}}
+ */
+function createCliStderrEmitter({ format, sink, throttleNotice, now = Date.now }) {
+  let windowStart = 0;
+  let linesInWindow = 0;
+  let dropped = 0;
+
+  // A throttle that hides its own losses is a log that lies.
+  const flushDropped = () => {
+    if (dropped > 0) {
+      throttleNotice(dropped);
+      dropped = 0;
+    }
+  };
+
+  const push = (rawLine) => {
+    const line = String(rawLine ?? '').trim();
+    if (!line) {
+      return;
+    }
+    // BEFORE the throttle, unconditionally: the formatter carries the PEM
+    // block state across lines. Skipping it for a dropped line would lose the
+    // END marker and silently redact the rest of the run.
+    const formatted = format(line);
+    const stamp = now();
+    if (stamp - windowStart >= CLI_STDERR_WINDOW_MS) {
+      // Report what the previous window swallowed before opening a new one.
+      flushDropped();
+      windowStart = stamp;
+      linesInWindow = 0;
+    }
+    if (linesInWindow >= CLI_STDERR_MAX_LINES_PER_WINDOW) {
+      dropped += 1;
+      return;
+    }
+    linesInWindow += 1;
+    sink(formatted);
+  };
+
+  return { push, flushDropped };
+}
+
+
 function formatCliStderrLine(sessionTag, line) {
   const safe = redactCliStderr(line);
   const capped = safe.length > CLI_STDERR_MAX_LINE_CHARS
@@ -758,17 +819,9 @@ async function queryClaudeSDK(command, options = {}, ws, context) {
   // Short, greppable session tag for the CLI stderr lines below.
   const sessionTag = () => String(sessionKey() || 'unknown').slice(0, 8);
   // Rate-limit state for CLI stderr. Scoped to this run, dies with this run.
-  let stderrWindowStart = 0;
-  let stderrLinesInWindow = 0;
-  let stderrDropped = 0;
-  // Assigned once the SDK options are built; the cleanup path needs it.
+  // Assigned once the SDK options are built; the cleanup path needs both.
   let stderrChunker = null;
-  const flushStderrDropped = () => {
-    if (stderrDropped > 0) {
-      console.error(`[claude-cli-stderr] ${sessionTag()} [throttled ${stderrDropped}]`);
-      stderrDropped = 0;
-    }
-  };
+  let stderrEmitter = null;
   // Wall-clock start of this run, so every run_end can report a duration.
   const runStartedAt = Date.now();
   // Guarantees exactly one terminal lifecycle record per run: the success path
@@ -891,28 +944,15 @@ async function queryClaudeSDK(command, options = {}, ws, context) {
     // One place where a finished line is emitted, used by both the streaming
     // path and the flush during cleanup. Two code paths for the same job are
     // how a redaction rule ends up applied in one of them and not the other.
-    const emitStderrLine = (rawLine) => {
-      const line = rawLine.trim();
-      if (!line) {
-        return;
-      }
-      const now = Date.now();
-      if (now - stderrWindowStart >= CLI_STDERR_WINDOW_MS) {
-        // Report what the previous window swallowed before opening a new one.
-        // A throttle that hides its own losses is a log that lies.
-        flushStderrDropped();
-        stderrWindowStart = now;
-        stderrLinesInWindow = 0;
-      }
-      if (stderrLinesInWindow >= CLI_STDERR_MAX_LINES_PER_WINDOW) {
-        stderrDropped += 1;
-        return;
-      }
-      stderrLinesInWindow += 1;
-      console.error(formatStderrLine(line));
-    };
+    stderrEmitter = createCliStderrEmitter({
+      format: formatStderrLine,
+      sink: (text) => console.error(text),
+      throttleNotice: (dropped) => console.error(
+        `[claude-cli-stderr] ${sessionTag()} [throttled ${dropped}]`,
+      ),
+    });
 
-    stderrChunker = createCliStderrChunker(emitStderrLine);
+    stderrChunker = createCliStderrChunker(stderrEmitter.push);
     sdkOptions.stderr = (data) => stderrChunker.push(data);
 
     sdkOptions.hooks = {
@@ -1259,7 +1299,7 @@ async function queryClaudeSDK(command, options = {}, ws, context) {
     stderrChunker?.flush();
     // A run that ends while its throttle window is still open would otherwise
     // carry the dropped-line count to the grave.
-    flushStderrDropped();
+    stderrEmitter?.flushDropped();
     releasePromptStream();
   }
 }
@@ -1373,6 +1413,7 @@ export const claudeRuntime = {
 // Export public API
 export {
   createCliStderrChunker,
+  createCliStderrEmitter,
   createCliStderrFormatter,
   formatCliStderrLine,
   queryClaudeSDK,

--- a/server/modules/providers/list/claude/claude-runtime.provider.js
+++ b/server/modules/providers/list/claude/claude-runtime.provider.js
@@ -324,6 +324,23 @@ function getAllSessions() {
 }
 
 /**
+ * Emits one greppable line per lifecycle transition of a Claude run.
+ *
+ * The Agent SDK owns the CLI child process, so this provider never holds a
+ * process handle: the *run* is the smallest unit it can observe. These records
+ * therefore report when a run started, which session it belonged to, who owned
+ * it, and how and why it ended.
+ *
+ * @param {string} event - Lifecycle transition: run_start, session_created,
+ *   abort_requested or run_end.
+ * @param {Object} fields - Event payload; serialized as JSON so log processors
+ *   can parse it without a format-specific reader.
+ */
+function logRunLifecycle(event, fields) {
+  console.log(`[Claude SDK] lifecycle ${event}`, JSON.stringify(fields));
+}
+
+/**
  * Transforms SDK messages to WebSocket format expected by frontend
  * @param {Object} sdkMessage - SDK message object
  * @returns {Object} Transformed message ready for WebSocket
@@ -577,6 +594,24 @@ async function queryClaudeSDK(command, options = {}, ws, context) {
   // Process-map key: the app session id when the caller supplied one, else
   // the provider-native id once captured (legacy/direct API callers).
   const sessionKey = () => sessionId || capturedSessionId || null;
+  // Wall-clock start of this run, so every run_end can report a duration.
+  const runStartedAt = Date.now();
+  // Guarantees exactly one terminal lifecycle record per run: the success path
+  // emits run_end before the notification calls, and a throw from one of those
+  // would otherwise reach the catch and log a second, contradicting one.
+  let runEndLogged = false;
+  const logRunEnd = (fields) => {
+    if (runEndLogged) {
+      return;
+    }
+    runEndLogged = true;
+    logRunLifecycle('run_end', {
+      sessionKey: sessionKey(),
+      providerSessionId: capturedSessionId || null,
+      userId: ws?.userId || null,
+      ...fields
+    });
+  };
 
   const emitNotification = (event) => {
     notifyUserIfEnabled({
@@ -779,7 +814,15 @@ async function queryClaudeSDK(command, options = {}, ws, context) {
     }
 
     // Process streaming messages
-    console.log('Starting async generator loop for session:', capturedSessionId || 'NEW');
+    logRunLifecycle('run_start', {
+      sessionKey: sessionKey(),
+      providerSessionId: providerSessionId || null,
+      // A run either resumes a known provider session or creates a new one.
+      resumed: Boolean(providerSessionId),
+      userId: ws?.userId || null,
+      model: sdkOptions.model || null,
+      permissionMode: sdkOptions.permissionMode || null
+    });
     for await (const message of queryInstance) {
       // Capture session ID from first message
       if (message.session_id && !capturedSessionId) {
@@ -795,6 +838,11 @@ async function queryClaudeSDK(command, options = {}, ws, context) {
         // Send session-created event only once for sessions with nothing to resume
         if (!providerSessionId && !sessionCreatedSent) {
           sessionCreatedSent = true;
+          logRunLifecycle('session_created', {
+            sessionKey: sessionKey(),
+            providerSessionId: capturedSessionId,
+            userId: ws?.userId || null
+          });
           ws.send(createNormalizedMessage({ kind: 'session_created', newSessionId: capturedSessionId, sessionId: capturedSessionId, provider: 'claude' }));
         }
       } else {
@@ -895,6 +943,17 @@ async function queryClaudeSDK(command, options = {}, ws, context) {
         stopReason: wasAborted ? 'aborted' : 'completed'
       });
     }
+    // A superseded run skips the block above entirely — it owns none of the
+    // client-facing events. Without a record here it would end as a run_start
+    // with no run_end, which is exactly how such a run becomes invisible at
+    // the moment something unusual happened to it.
+    logRunEnd(superseded
+      ? { reason: 'superseded', exitCode: null, durationMs: Date.now() - runStartedAt }
+      : {
+        reason: wasAborted ? 'aborted' : 'completed',
+        exitCode: wasAborted ? null : 0,
+        durationMs: Date.now() - runStartedAt
+      });
     // Complete
 
   } catch (error) {
@@ -909,6 +968,16 @@ async function queryClaudeSDK(command, options = {}, ws, context) {
     if (supersededInstances.has(queryInstance)) {
       // Interrupted because a newer run took over this session id; that run
       // owns the abort flag and all further client-facing events.
+      //
+      // The run stays silent toward the CLIENT — that is deliberate and
+      // unchanged. It does get a log record, though: this is the path an
+      // interrupted run actually takes, and without a record it vanishes
+      // here without a trace.
+      logRunEnd({
+        reason: 'superseded',
+        exitCode: null,
+        durationMs: Date.now() - runStartedAt
+      });
       return;
     }
 
@@ -916,6 +985,11 @@ async function queryClaudeSDK(command, options = {}, ws, context) {
     if (wasAborted) {
       // The abort already produced the terminal complete; a generator throw
       // caused by interrupt() is expected noise, not a user-facing error.
+      logRunEnd({
+        reason: 'aborted',
+        exitCode: null,
+        durationMs: Date.now() - runStartedAt
+      });
       return;
     }
 
@@ -929,9 +1003,18 @@ async function queryClaudeSDK(command, options = {}, ws, context) {
     // reported completion and then failed during its post-turn hold still
     // surfaces the error, but must not emit a second terminal complete.
     ws.send(createNormalizedMessage({ kind: 'error', content: errorContent, sessionId: capturedSessionId || sessionId || null, provider: 'claude' }));
+    // The logging sits after the guard on purpose: it belongs to the RUN, not
+    // to the client-facing message, and runEndLogged gives it its own
+    // exactly-once guarantee.
     if (!turnCompleteSent) {
       ws.send(createCompleteMessage({ provider: 'claude', sessionId: capturedSessionId || sessionId || null, exitCode: 1 }));
     }
+    logRunEnd({
+      reason: 'error',
+      exitCode: 1,
+      durationMs: Date.now() - runStartedAt,
+      error: error?.message || String(error)
+    });
     notifyRunFailed({
       userId: ws?.userId || null,
       provider: 'claude',
@@ -964,7 +1047,7 @@ async function abortClaudeSDKSession(sessionId) {
   }
 
   try {
-    console.log(`Aborting SDK session: ${sessionId}`);
+    logRunLifecycle('abort_requested', { sessionKey: sessionId });
 
     // Mark before interrupting so the run loop knows not to emit its own
     // terminal complete (the abort handler sends the aborted one).

--- a/server/modules/providers/list/claude/claude-runtime.provider.js
+++ b/server/modules/providers/list/claude/claude-runtime.provider.js
@@ -137,6 +137,43 @@ function redactCliStderr(text) {
  * @param {string} line - One raw stderr line, already trimmed.
  * @returns {string} The line to hand to the logger.
  */
+// A PEM block spans many lines: a header, then base64 body lines that carry
+// the actual key material, then a footer. The single-line pattern above only
+// ever sees the header, so redacting line by line would blank the header and
+// print the key underneath it -- the worst of both worlds, because the log
+// then *looks* redacted.
+const PEM_BEGIN = /-----BEGIN[^-]{0,40}PRIVATE KEY-----/;
+const PEM_END = /-----END[^-]{0,40}PRIVATE KEY-----/;
+const PEM_PLACEHOLDER = '<redacted private key>';
+
+/**
+ * Formats stderr lines, suppressing whole PEM private-key blocks.
+ *
+ * Stateful by necessity: whether a base64 line is key material or ordinary
+ * output cannot be decided from the line itself. The state lives per run and
+ * dies with it.
+ *
+ * @param {() => string} sessionTag - Supplies the current session tag.
+ * @returns {(line: string) => string} Formatter for one stderr line.
+ */
+function createCliStderrFormatter(sessionTag) {
+  let insidePem = false;
+  return (line) => {
+    if (insidePem) {
+      if (PEM_END.test(line)) {
+        insidePem = false;
+      }
+      return formatCliStderrLine(sessionTag(), PEM_PLACEHOLDER);
+    }
+    if (PEM_BEGIN.test(line)) {
+      // A line carrying the whole block at once closes it again immediately.
+      insidePem = !PEM_END.test(line);
+      return formatCliStderrLine(sessionTag(), PEM_PLACEHOLDER);
+    }
+    return formatCliStderrLine(sessionTag(), line);
+  };
+}
+
 /**
  * Reassembles complete lines from raw stderr chunks.
  *
@@ -825,6 +862,9 @@ async function queryClaudeSDK(command, options = {}, ws, context) {
 
     // Forward the CLI child's stderr into the service log; see the limits
     // documented at CLI_STDERR_MAX_LINE_CHARS above.
+    // Per-run PEM state; see createCliStderrFormatter.
+    const formatStderrLine = createCliStderrFormatter(sessionTag);
+
     // One place where a finished line is emitted, used by both the streaming
     // path and the flush during cleanup. Two code paths for the same job are
     // how a redaction rule ends up applied in one of them and not the other.
@@ -846,7 +886,7 @@ async function queryClaudeSDK(command, options = {}, ws, context) {
         return;
       }
       stderrLinesInWindow += 1;
-      console.error(formatCliStderrLine(sessionTag(), line));
+      console.error(formatStderrLine(line));
     };
 
     stderrChunker = createCliStderrChunker(emitStderrLine);
@@ -1315,6 +1355,7 @@ export const claudeRuntime = {
 // Export public API
 export {
   createCliStderrChunker,
+  createCliStderrFormatter,
   formatCliStderrLine,
   queryClaudeSDK,
   abortClaudeSDKSession,

--- a/server/modules/providers/list/claude/claude-runtime.provider.js
+++ b/server/modules/providers/list/claude/claude-runtime.provider.js
@@ -69,6 +69,78 @@ const BG_WAIT_CEILING_MS = 30 * 60 * 1000;
 
 const TOOLS_REQUIRING_INTERACTION = new Set(['AskUserQuestion', 'ExitPlanMode']);
 
+// The SDK forwards the CLI child's stderr through an explicit callback
+// (`options.stderr`). This provider never set it, so that output was dropped
+// on the floor — including the one line the CLI writes when it winds itself
+// down:
+//
+//     Background tasks still running after <N>s; terminating.
+//     Set CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS=0 to wait indefinitely.
+//
+// That message therefore never reached the service log, which is why a run
+// ended by the background-wait ceiling looks, from the outside, exactly like
+// a run that vanished without a trace. Wiring the callback is what turns that
+// guess into a reading.
+//
+// The same channel also carries SDK debug output, so it is forwarded under
+// three limits. None of them is cosmetic:
+//
+//   1. Redaction before logging — stderr can carry argv fragments and paths.
+//   2. A length cap per line — one runaway line must not swamp the journal.
+//   3. A rate limit per RUN — a CLI stuck in a write loop would otherwise
+//      flood the log. The counters live in the run's closure and die with it;
+//      a per-session map would need someone to clean it up, and that is
+//      exactly the kind of bookkeeping that gets forgotten.
+const CLI_STDERR_MAX_LINE_CHARS = 500;
+const CLI_STDERR_MAX_LINES_PER_WINDOW = 50;
+const CLI_STDERR_WINDOW_MS = 60 * 1000;
+
+// Redaction runs BEFORE truncation. Truncating first can cut a secret in half
+// and leave the tail in place: the pattern no longer matches, so the filter
+// stops working silently on exactly the line that needed it.
+const CLI_STDERR_REDACTIONS = [
+  /-----BEGIN[^-]{0,40}PRIVATE KEY-----/g,
+  /\b(sk|pk|ghp|gho|ghs|github_pat|xox[abprs])[-_][A-Za-z0-9_-]{8,}/g,
+  /\bsk-ant-[A-Za-z0-9_-]{16,}/g,
+  /\bAKIA[0-9A-Z]{12,}\b/g,
+  /\beyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{4,}/g,
+  /api\.telegram\.org\/bot[^/\s]+/g,
+  /[A-Za-z0-9_-]*(TOKEN|KEY|SECRET|PASSWORD|PASSWD|CREDENTIAL|APIKEY)[A-Za-z0-9_-]*\s*[=:]\s*\S+/gi,
+];
+
+/**
+ * Redacts well-known secret shapes from one line of CLI stderr.
+ *
+ * @param {string} text - Raw stderr text.
+ * @returns {string} The same text with secret-shaped runs replaced.
+ */
+function redactCliStderr(text) {
+  let out = String(text);
+  for (const pattern of CLI_STDERR_REDACTIONS) {
+    out = out.replace(pattern, '<redacted>');
+  }
+  return out;
+}
+
+/**
+ * Formats one CLI stderr line for the service log: redact, then cap.
+ *
+ * Kept as a pure function so both halves are testable on their own. The order
+ * matters and is the reason this is one function rather than two calls at the
+ * call site: capping first could split a secret and leave its tail readable.
+ *
+ * @param {string} sessionTag - Short session identifier for correlation.
+ * @param {string} line - One raw stderr line, already trimmed.
+ * @returns {string} The line to hand to the logger.
+ */
+function formatCliStderrLine(sessionTag, line) {
+  const safe = redactCliStderr(line);
+  const capped = safe.length > CLI_STDERR_MAX_LINE_CHARS
+    ? `${safe.slice(0, CLI_STDERR_MAX_LINE_CHARS - 1)}\u2026`
+    : safe;
+  return `[claude-cli-stderr] ${sessionTag} ${capped}`;
+}
+
 function resolveClaudeEffort(model, effort, modelsDefinition = CLAUDE_PREDEFINED_MODELS) {
   const selectedModel = modelsDefinition?.OPTIONS?.find((option) => option.value === model) || null;
   const allowedEfforts = selectedModel?.effort?.values
@@ -594,6 +666,18 @@ async function queryClaudeSDK(command, options = {}, ws, context) {
   // Process-map key: the app session id when the caller supplied one, else
   // the provider-native id once captured (legacy/direct API callers).
   const sessionKey = () => sessionId || capturedSessionId || null;
+  // Short, greppable session tag for the CLI stderr lines below.
+  const sessionTag = () => String(sessionKey() || 'unknown').slice(0, 8);
+  // Rate-limit state for CLI stderr. Scoped to this run, dies with this run.
+  let stderrWindowStart = 0;
+  let stderrLinesInWindow = 0;
+  let stderrDropped = 0;
+  const flushStderrDropped = () => {
+    if (stderrDropped > 0) {
+      console.error(`[claude-cli-stderr] ${sessionTag()} [throttled ${stderrDropped}]`);
+      stderrDropped = 0;
+    }
+  };
   // Wall-clock start of this run, so every run_end can report a duration.
   const runStartedAt = Date.now();
   // Guarantees exactly one terminal lifecycle record per run: the success path
@@ -684,6 +768,31 @@ async function queryClaudeSDK(command, options = {}, ws, context) {
     // `result`. The message list is reusable, but each query attempt needs its
     // own stream because an async generator cannot be replayed once consumed.
     const promptMessages = await buildPromptMessages(command, options.images, options.files, options.cwd);
+
+    // Forward the CLI child's stderr into the service log; see the limits
+    // documented at CLI_STDERR_MAX_LINE_CHARS above.
+    sdkOptions.stderr = (data) => {
+      const now = Date.now();
+      if (now - stderrWindowStart >= CLI_STDERR_WINDOW_MS) {
+        // Report what the previous window swallowed before opening a new one.
+        // A throttle that hides its own losses is a log that lies.
+        flushStderrDropped();
+        stderrWindowStart = now;
+        stderrLinesInWindow = 0;
+      }
+      for (const rawLine of String(data ?? '').split('\n')) {
+        const line = rawLine.trim();
+        if (!line) {
+          continue;
+        }
+        if (stderrLinesInWindow >= CLI_STDERR_MAX_LINES_PER_WINDOW) {
+          stderrDropped += 1;
+          continue;
+        }
+        stderrLinesInWindow += 1;
+        console.error(formatCliStderrLine(sessionTag(), line));
+      }
+    };
 
     sdkOptions.hooks = {
       Notification: [{
@@ -1029,6 +1138,9 @@ async function queryClaudeSDK(command, options = {}, ws, context) {
       clearTimeout(idleReleaseTimer);
       idleReleaseTimer = null;
     }
+    // A run that ends while its throttle window is still open would otherwise
+    // carry the dropped-line count to the grave.
+    flushStderrDropped();
     releasePromptStream();
   }
 }
@@ -1141,6 +1253,7 @@ export const claudeRuntime = {
 
 // Export public API
 export {
+  formatCliStderrLine,
   queryClaudeSDK,
   abortClaudeSDKSession,
   isClaudeSDKSessionActive,

--- a/server/modules/providers/list/claude/claude-runtime.provider.js
+++ b/server/modules/providers/list/claude/claude-runtime.provider.js
@@ -94,6 +94,10 @@ const TOOLS_REQUIRING_INTERACTION = new Set(['AskUserQuestion', 'ExitPlanMode'])
 const CLI_STDERR_MAX_LINE_CHARS = 500;
 const CLI_STDERR_MAX_LINES_PER_WINDOW = 50;
 const CLI_STDERR_WINDOW_MS = 60 * 1000;
+// Upper bound on a partial line held back between chunks. The SDK forwards raw
+// `data` events, so a logical line can arrive in pieces; without a bound, a
+// stream that never emits a newline would grow this buffer without limit.
+const CLI_STDERR_MAX_PENDING_CHARS = 8 * 1024;
 
 // Redaction runs BEFORE truncation. Truncating first can cut a secret in half
 // and leave the tail in place: the pattern no longer matches, so the filter
@@ -133,6 +137,54 @@ function redactCliStderr(text) {
  * @param {string} line - One raw stderr line, already trimmed.
  * @returns {string} The line to hand to the logger.
  */
+/**
+ * Reassembles complete lines from raw stderr chunks.
+ *
+ * The SDK forwards the child's `stderr` `data` events verbatim — it calls
+ * `options.stderr` straight from the data handler, with no line framing. A
+ * logical line can therefore arrive split across two chunks, and a secret
+ * split that way slips past redaction because neither half matches the
+ * pattern on its own.
+ *
+ * Kept as a factory so the buffering is testable on its own: this is exactly
+ * the kind of state that is easy to get subtly wrong and impossible to see
+ * afterwards in a log that looks plausible.
+ *
+ * @param {(line: string) => void} emit - Receives each complete line.
+ * @param {number} [maxPending] - Cap on a held-back fragment.
+ * @returns {{push: (chunk: string) => void, flush: () => void}}
+ */
+function createCliStderrChunker(emit, maxPending = CLI_STDERR_MAX_PENDING_CHARS) {
+  let pending = '';
+  return {
+    push(chunk) {
+      pending += String(chunk ?? '');
+      // A stream that never emits a newline must not grow this buffer forever.
+      // Flushing early can in principle split a secret, but at this size that
+      // needs a line two orders of magnitude longer than any credential
+      // format — unbounded memory is the worse failure.
+      if (pending.length > maxPending && !pending.includes('\n')) {
+        emit(pending);
+        pending = '';
+        return;
+      }
+      const parts = pending.split('\n');
+      pending = parts.pop() ?? '';
+      for (const line of parts) {
+        emit(line);
+      }
+    },
+    // Anything still buffered is a real line; it just never got its newline
+    // before the run ended.
+    flush() {
+      if (pending) {
+        emit(pending);
+        pending = '';
+      }
+    },
+  };
+}
+
 function formatCliStderrLine(sessionTag, line) {
   const safe = redactCliStderr(line);
   const capped = safe.length > CLI_STDERR_MAX_LINE_CHARS
@@ -672,6 +724,8 @@ async function queryClaudeSDK(command, options = {}, ws, context) {
   let stderrWindowStart = 0;
   let stderrLinesInWindow = 0;
   let stderrDropped = 0;
+  // Assigned once the SDK options are built; the cleanup path needs it.
+  let stderrChunker = null;
   const flushStderrDropped = () => {
     if (stderrDropped > 0) {
       console.error(`[claude-cli-stderr] ${sessionTag()} [throttled ${stderrDropped}]`);
@@ -771,7 +825,14 @@ async function queryClaudeSDK(command, options = {}, ws, context) {
 
     // Forward the CLI child's stderr into the service log; see the limits
     // documented at CLI_STDERR_MAX_LINE_CHARS above.
-    sdkOptions.stderr = (data) => {
+    // One place where a finished line is emitted, used by both the streaming
+    // path and the flush during cleanup. Two code paths for the same job are
+    // how a redaction rule ends up applied in one of them and not the other.
+    const emitStderrLine = (rawLine) => {
+      const line = rawLine.trim();
+      if (!line) {
+        return;
+      }
       const now = Date.now();
       if (now - stderrWindowStart >= CLI_STDERR_WINDOW_MS) {
         // Report what the previous window swallowed before opening a new one.
@@ -780,19 +841,16 @@ async function queryClaudeSDK(command, options = {}, ws, context) {
         stderrWindowStart = now;
         stderrLinesInWindow = 0;
       }
-      for (const rawLine of String(data ?? '').split('\n')) {
-        const line = rawLine.trim();
-        if (!line) {
-          continue;
-        }
-        if (stderrLinesInWindow >= CLI_STDERR_MAX_LINES_PER_WINDOW) {
-          stderrDropped += 1;
-          continue;
-        }
-        stderrLinesInWindow += 1;
-        console.error(formatCliStderrLine(sessionTag(), line));
+      if (stderrLinesInWindow >= CLI_STDERR_MAX_LINES_PER_WINDOW) {
+        stderrDropped += 1;
+        return;
       }
+      stderrLinesInWindow += 1;
+      console.error(formatCliStderrLine(sessionTag(), line));
     };
+
+    stderrChunker = createCliStderrChunker(emitStderrLine);
+    sdkOptions.stderr = (data) => stderrChunker.push(data);
 
     sdkOptions.hooks = {
       Notification: [{
@@ -1138,6 +1196,9 @@ async function queryClaudeSDK(command, options = {}, ws, context) {
       clearTimeout(idleReleaseTimer);
       idleReleaseTimer = null;
     }
+    // Anything still buffered is a real line the CLI wrote; it just never got
+    // its newline before the run ended.
+    stderrChunker?.flush();
     // A run that ends while its throttle window is still open would otherwise
     // carry the dropped-line count to the grave.
     flushStderrDropped();
@@ -1253,6 +1314,7 @@ export const claudeRuntime = {
 
 // Export public API
 export {
+  createCliStderrChunker,
   formatCliStderrLine,
   queryClaudeSDK,
   abortClaudeSDKSession,

--- a/server/modules/providers/tests/claude-cli-stderr.test.ts
+++ b/server/modules/providers/tests/claude-cli-stderr.test.ts
@@ -1,7 +1,10 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 
-import { formatCliStderrLine } from '@/modules/providers/list/claude/claude-runtime.provider.js';
+import {
+  createCliStderrChunker,
+  formatCliStderrLine,
+} from '@/modules/providers/list/claude/claude-runtime.provider.js';
 
 const TAG = 'abc12345';
 
@@ -73,4 +76,69 @@ test('claude cli stderr: a secret straddling the cut is still redacted', () => {
 
   assert.ok(!out.includes('sk-ant-aaaaaaaaaaaaaaaa'));
   assert.ok(out.includes('<redacted>'));
+});
+
+// --- chunk reassembly ------------------------------------------------------
+//
+// The SDK forwards raw `data` events, so these are the cases that decide
+// whether redaction can be bypassed by nothing more than unlucky timing.
+
+test('claude cli stderr: a line split across chunks is reassembled', () => {
+  const seen: string[] = [];
+  const chunker = createCliStderrChunker((line) => seen.push(line));
+
+  chunker.push('Error: ENOENT: no such ');
+  assert.deepEqual(seen, [], 'nothing may be emitted before the newline');
+  chunker.push('file or directory\n');
+
+  assert.deepEqual(seen, ['Error: ENOENT: no such file or directory']);
+});
+
+test('claude cli stderr: a secret split across chunks is still redacted', () => {
+  const seen: string[] = [];
+  const chunker = createCliStderrChunker((line) => seen.push(formatCliStderrLine('tag', line)));
+
+  // Neither half matches the pattern on its own — that is the whole point.
+  chunker.push('auth: sk-ant-abcdefgh');
+  chunker.push('ijklmnopqrstuvwxyz0123\n');
+
+  assert.equal(seen.length, 1);
+  assert.ok(seen[0].includes('<redacted>'));
+  assert.ok(!seen[0].includes('sk-ant-abcdefghijklmnopqrstuvwxyz0123'));
+});
+
+test('claude cli stderr: several lines in one chunk all come through', () => {
+  const seen: string[] = [];
+  const chunker = createCliStderrChunker((line) => seen.push(line));
+
+  chunker.push('one\ntwo\nthree\n');
+
+  assert.deepEqual(seen, ['one', 'two', 'three']);
+});
+
+test('claude cli stderr: the trailing fragment is flushed, not lost', () => {
+  const seen: string[] = [];
+  const chunker = createCliStderrChunker((line) => seen.push(line));
+
+  chunker.push('a complete line\nand a dangling one');
+  assert.deepEqual(seen, ['a complete line']);
+
+  chunker.flush();
+  assert.deepEqual(seen, ['a complete line', 'and a dangling one']);
+
+  // Flushing twice must not emit the fragment again.
+  chunker.flush();
+  assert.equal(seen.length, 2);
+});
+
+test('claude cli stderr: a newline-less stream does not buffer without bound', () => {
+  const seen: string[] = [];
+  const chunker = createCliStderrChunker((line) => seen.push(line), 32);
+
+  chunker.push('x'.repeat(20));
+  assert.deepEqual(seen, [], 'below the cap it keeps buffering');
+
+  chunker.push('y'.repeat(20));
+  assert.equal(seen.length, 1, 'above the cap it gives up and emits');
+  assert.equal(seen[0].length, 40);
 });

--- a/server/modules/providers/tests/claude-cli-stderr.test.ts
+++ b/server/modules/providers/tests/claude-cli-stderr.test.ts
@@ -89,7 +89,7 @@ test('claude cli stderr: a line split across chunks is reassembled', () => {
   const chunker = createCliStderrChunker((line) => seen.push(line));
 
   chunker.push('Error: ENOENT: no such ');
-  assert.deepEqual(seen, [], 'nothing may be emitted before the newline');
+  assert.equal(seen.length, 0, 'nothing may be emitted before the newline');
   chunker.push('file or directory\n');
 
   assert.deepEqual(seen, ['Error: ENOENT: no such file or directory']);
@@ -137,7 +137,7 @@ test('claude cli stderr: a newline-less stream does not buffer without bound', (
   const chunker = createCliStderrChunker((line) => seen.push(line), 32);
 
   chunker.push('x'.repeat(20));
-  assert.deepEqual(seen, [], 'below the cap it keeps buffering');
+  assert.equal(seen.length, 0, 'below the cap it keeps buffering');
 
   chunker.push('y'.repeat(20));
   assert.equal(seen.length, 1, 'above the cap it gives up and emits');

--- a/server/modules/providers/tests/claude-cli-stderr.test.ts
+++ b/server/modules/providers/tests/claude-cli-stderr.test.ts
@@ -3,6 +3,7 @@ import test from 'node:test';
 
 import {
   createCliStderrChunker,
+  createCliStderrEmitter,
   createCliStderrFormatter,
   formatCliStderrLine,
 } from '@/modules/providers/list/claude/claude-runtime.provider.js';
@@ -186,4 +187,98 @@ test('claude cli stderr: a one-line PEM block does not swallow what follows', ()
 
   assert.ok(oneLine.includes('<redacted private key>'));
   assert.equal(after, '[claude-cli-stderr] tag ordinary diagnostics');
+});
+
+// --- The handover between throttle and PEM state ---------------------------
+//
+// Two mechanisms, each correct on its own. The bug lived where they meet: the
+// formatter used to run only for lines the throttle let through, so a
+// suppressed END marker left the block state stuck open for the rest of the
+// run. These tests pin both directions — the state must advance for every
+// line, and it must still redact what genuinely belongs to the block.
+
+/** Builds an emitter with a hand-driven clock, so a window can be closed
+ *  without waiting a real minute. */
+function emitterHarness() {
+  const written: string[] = [];
+  const notices: number[] = [];
+  let clock = 1_000;
+  const emitter = createCliStderrEmitter({
+    format: createCliStderrFormatter(() => 'tag'),
+    sink: (text: string) => { written.push(text); },
+    throttleNotice: (dropped: number) => { notices.push(dropped); },
+    now: () => clock,
+  });
+  return {
+    written,
+    notices,
+    push: (line: string) => emitter.push(line),
+    flushDropped: () => emitter.flushDropped(),
+    advance: (ms: number) => { clock += ms; },
+  };
+}
+
+test('claude cli stderr: a throttled END marker does not redact the rest of the run', () => {
+  const h = emitterHarness();
+
+  h.push('-----BEGIN PRIVATE KEY-----');
+  // Fill the window. Everything here is inside the block, so it is redacted
+  // where it is written at all; the point is that the window ends full.
+  for (let i = 0; i < 60; i += 1) h.push(`keyMaterialLine${i}`);
+  // This is the line that used to be lost: dropped by the throttle, and with
+  // it the state transition that closes the block.
+  h.push('-----END PRIVATE KEY-----');
+
+  assert.ok(h.notices.length === 0, 'losses are reported at the window boundary, not before');
+
+  h.advance(61_000);
+  h.push('Error: ENOENT: no such file or directory');
+
+  const last = h.written[h.written.length - 1];
+  // Exact equality, not "does not contain the placeholder": a weaker assertion
+  // would also pass if the formatting drifted.
+  assert.equal(last, '[claude-cli-stderr] tag Error: ENOENT: no such file or directory');
+  // The dropped lines are still accounted for: 62 pushed (BEGIN + 60 + END),
+  // 50 fit in the window, 12 were dropped.
+  assert.deepEqual(h.notices, [12]);
+});
+
+test('claude cli stderr: a throttled body line stays redacted when the block is still open', () => {
+  const h = emitterHarness();
+
+  h.push('-----BEGIN PRIVATE KEY-----');
+  for (let i = 0; i < 60; i += 1) h.push(`filler${i}`);
+  // Still INSIDE the block — no END marker anywhere. The window rolls over,
+  // and the next line must remain suppressed.
+  h.advance(61_000);
+  h.push('MIIEowIBAAKCAQEAxRealKeyMaterialAfterTheWindow');
+
+  const last = h.written[h.written.length - 1];
+  assert.equal(last, '[claude-cli-stderr] tag <redacted private key>');
+  assert.ok(!h.written.join('\n').includes('MIIEowIBAAKCAQEAxRealKeyMaterialAfterTheWindow'));
+});
+
+test('claude cli stderr: the run-end flush still reports what the throttle swallowed', () => {
+  const h = emitterHarness();
+
+  for (let i = 0; i < 60; i += 1) h.push(`line${i}`);
+  assert.equal(h.notices.length, 0);
+
+  // The run ends with the window still open; the count must not go to the grave.
+  h.flushDropped();
+  assert.deepEqual(h.notices, [10]);
+
+  // Flushing twice must not invent a second report.
+  h.flushDropped();
+  assert.deepEqual(h.notices, [10]);
+});
+
+test('claude cli stderr: blank lines are ignored and do not consume the window', () => {
+  const h = emitterHarness();
+
+  h.push('   ');
+  h.push('');
+  h.push('real line');
+
+  assert.deepEqual(h.written, ['[claude-cli-stderr] tag real line']);
 });

--- a/server/modules/providers/tests/claude-cli-stderr.test.ts
+++ b/server/modules/providers/tests/claude-cli-stderr.test.ts
@@ -3,6 +3,7 @@ import test from 'node:test';
 
 import {
   createCliStderrChunker,
+  createCliStderrFormatter,
   formatCliStderrLine,
 } from '@/modules/providers/list/claude/claude-runtime.provider.js';
 
@@ -141,4 +142,48 @@ test('claude cli stderr: a newline-less stream does not buffer without bound', (
   chunker.push('y'.repeat(20));
   assert.equal(seen.length, 1, 'above the cap it gives up and emits');
   assert.equal(seen[0].length, 40);
+});
+
+// --- PEM blocks ------------------------------------------------------------
+
+test('claude cli stderr: a whole PEM block is suppressed, not just its header', () => {
+  const out: string[] = [];
+  const format = createCliStderrFormatter(() => 'tag');
+
+  const block = [
+    '-----BEGIN RSA PRIVATE KEY-----',
+    'MIIEowIBAAKCAQEAxKeyMaterialLine1',
+    'AAAAB3NzaC1yc2EAAAADAQABAAABgQKeyMaterialLine2',
+    '-----END RSA PRIVATE KEY-----',
+  ];
+  for (const line of block) out.push(format(line));
+
+  assert.equal(out.length, 4);
+  for (const line of out) {
+    assert.ok(line.includes('<redacted private key>'), `leaked: ${line}`);
+  }
+  assert.ok(!out.join('\n').includes('MIIEowIBAAKCAQEAxKeyMaterialLine1'));
+  assert.ok(!out.join('\n').includes('AAAAB3NzaC1yc2EAAAADAQABAAABgQKeyMaterialLine2'));
+});
+
+test('claude cli stderr: output after the END marker is readable again', () => {
+  const format = createCliStderrFormatter(() => 'tag');
+
+  format('-----BEGIN PRIVATE KEY-----');
+  format('bodyLineThatMustNotAppear');
+  format('-----END PRIVATE KEY-----');
+  const after = format('Error: ENOENT: no such file or directory');
+
+  assert.equal(after, '[claude-cli-stderr] tag Error: ENOENT: no such file or directory');
+  assert.ok(!after.includes('<redacted private key>'));
+});
+
+test('claude cli stderr: a one-line PEM block does not swallow what follows', () => {
+  const format = createCliStderrFormatter(() => 'tag');
+
+  const oneLine = format('-----BEGIN PRIVATE KEY----- abc -----END PRIVATE KEY-----');
+  const after = format('ordinary diagnostics');
+
+  assert.ok(oneLine.includes('<redacted private key>'));
+  assert.equal(after, '[claude-cli-stderr] tag ordinary diagnostics');
 });

--- a/server/modules/providers/tests/claude-cli-stderr.test.ts
+++ b/server/modules/providers/tests/claude-cli-stderr.test.ts
@@ -1,0 +1,76 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { formatCliStderrLine } from '@/modules/providers/list/claude/claude-runtime.provider.js';
+
+const TAG = 'abc12345';
+
+// The line this whole channel exists for. If it ever stops passing through
+// intact, a run ended by the background-wait ceiling goes back to looking like
+// a run that vanished for no reason.
+test('claude cli stderr: the wind-down message survives formatting intact', () => {
+  const line = 'Background tasks still running after 1800s; terminating. '
+    + 'Set CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS=0 to wait indefinitely.';
+
+  const out = formatCliStderrLine(TAG, line);
+
+  assert.ok(out.startsWith(`[claude-cli-stderr] ${TAG} `));
+  assert.ok(out.includes('Background tasks still running after 1800s'));
+  assert.ok(out.includes('terminating'));
+});
+
+test('claude cli stderr: secret-shaped runs are redacted', () => {
+  const cases = [
+    'spawn failed: ANTHROPIC_API_KEY=sk-ant-abcdefghijklmnopqrstuvwxyz0123',
+    'GET https://api.telegram.org/bot123456:AAHfakefaketoken/getUpdates failed',
+    'auth header: Bearer ghp_AAAABBBBCCCCDDDDEEEEFFFF0123',
+    'env: AWS key AKIAIOSFODNN7EXAMPLE rejected',
+  ];
+
+  for (const input of cases) {
+    const out = formatCliStderrLine(TAG, input);
+    assert.ok(out.includes('<redacted>'), `not redacted: ${input}`);
+    assert.ok(!out.includes('sk-ant-abcdefghijklmnopqrstuvwxyz0123'));
+    assert.ok(!out.includes('AAHfakefaketoken'));
+    assert.ok(!out.includes('ghp_AAAABBBBCCCCDDDDEEEEFFFF0123'));
+  }
+});
+
+// The counter-direction. A filter that redacts everything is as useless as one
+// that redacts nothing — it would quietly destroy the diagnostics this channel
+// was opened for.
+test('claude cli stderr: ordinary diagnostics pass through untouched', () => {
+  const line = 'Error: ENOENT: no such file or directory, open /tmp/does-not-exist';
+
+  const out = formatCliStderrLine(TAG, line);
+
+  assert.equal(out, `[claude-cli-stderr] ${TAG} ${line}`);
+  assert.ok(!out.includes('<redacted>'));
+});
+
+test('claude cli stderr: long lines are capped, short ones are not', () => {
+  const long = 'x'.repeat(4000);
+  const short = 'x'.repeat(10);
+
+  const cappedOut = formatCliStderrLine(TAG, long);
+  const shortOut = formatCliStderrLine(TAG, short);
+
+  const prefix = `[claude-cli-stderr] ${TAG} `;
+  assert.equal(cappedOut.slice(prefix.length).length, 500);
+  assert.ok(cappedOut.endsWith('…'));
+  assert.equal(shortOut, `${prefix}${short}`);
+  assert.ok(!shortOut.endsWith('…'));
+});
+
+// Redaction has to run BEFORE truncation. If it ran after, a secret sitting
+// across the cut would lose its tail, stop matching the pattern, and the
+// visible head would be logged in the clear.
+test('claude cli stderr: a secret straddling the cut is still redacted', () => {
+  const secret = `sk-ant-${'a'.repeat(60)}`;
+  const line = `${'p'.repeat(480)} ${secret}`;
+
+  const out = formatCliStderrLine(TAG, line);
+
+  assert.ok(!out.includes('sk-ant-aaaaaaaaaaaaaaaa'));
+  assert.ok(out.includes('<redacted>'));
+});


### PR DESCRIPTION
Closes #1163

# Log Claude run lifecycle transitions, and stop discarding the CLI's stderr

Two small, independent commits. Both are observability only — no behaviour
change outside console output.

Motivation, incidents and measurements: see the linked issue.

---

## 1. `feat(claude): log run lifecycle transitions`

The provider logs one ad-hoc line when the message loop starts and nothing when
a run ends. There is no consistent prefix, no session correlation, and no
terminal record. When something goes wrong *around* a run, the log holds nothing
to correlate against.

This adds one greppable record per lifecycle transition:

```
[Claude SDK] lifecycle run_start {"sessionKey":"…","resumed":true,…}
[Claude SDK] lifecycle run_end   {"reason":"completed","exitCode":0,"durationMs":1811214}
```

Transitions: `run_start`, `session_created`, `abort_requested`, `run_end`.
Every `run_end` carries a reason, an exit code and a duration.

**Exactly one terminal record per run.** The success path emits `run_end` before
the notification calls; a throw from one of those would otherwise reach the
`catch` and log a second, contradicting record. A guard prevents that.

**The superseded path is included**, and it is the reason this PR is not purely
cosmetic. A run whose session id is taken over by a newer run is interrupted and
winds down silently — deliberately so, because the replacing run owns all
client-facing events. That silence extended to the log, which meant a run that
had been alive for an hour could disappear leaving no trace at all. It now emits
`run_end` with `reason: "superseded"`. **Client-facing behaviour is unchanged**:
the superseded run still sends nothing to the socket.

The two pre-existing ad-hoc log lines (`Starting async generator loop for
session:` and `Aborting SDK session:`) are replaced by their structured
equivalents.

**Scope note:** the Agent SDK owns the CLI child process, so this provider holds
no process handle and cannot report a spawn, a raw exit status or a signal. The
*run* is the smallest unit observable from here.

## 2. `feat(claude): forward CLI stderr to the service log`

The SDK exposes `options.stderr` for the CLI child's stderr. The provider never
set it, so that output was discarded — including the line the CLI prints when it
terminates its own background work:

```
Background tasks still running after <N>s; terminating.
Set CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS=0 to wait indefinitely.
```

The provider itself passes `CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS` into the
child, so it configures a behaviour whose only announcement it then throws away.
Measured on a self-hosted instance: **0 occurrences** of that message in the
journal since 2026-08-01, while the string is present in the installed binary.

Because the same channel also carries SDK debug output, forwarding is bounded:

| Limit | Value | Why |
|---|---|---|
| Redaction | before truncation | truncating first can split a secret and leave its readable head in the log while the pattern stops matching |
| Line cap | 500 chars | one runaway line must not swamp the journal |
| Rate limit | 50 lines / 60 s, **per run** | a CLI stuck in a write loop would otherwise flood the log |

The rate-limit counters live in the run's closure and die with it — a
per-session map would need someone to clean it up. Dropped lines are
**announced** (`[throttled N]`) at the next window and flushed in the `finally`
block: a throttle that hides its own losses is a log that lies.

Line formatting is extracted as a pure function (`formatCliStderrLine`) so both
halves are testable.

### Tests

`server/modules/providers/tests/claude-cli-stderr.test.ts`, 5 assertions:

- the wind-down message survives formatting intact
- secret-shaped runs (`sk-ant-…`, bot tokens in URLs, `ghp_…`, `AKIA…`) are redacted
- **counter-direction:** ordinary diagnostics (`ENOENT: no such file…`) pass through **untouched** — a filter that redacts everything is as useless as one that redacts nothing
- long lines are capped, short lines are not
- a secret straddling the 500-character cut is still redacted (this is the test that pins the redact-then-truncate order)

```
npx tsx --tsconfig server/tsconfig.json --test server/modules/providers/tests/claude-cli-stderr.test.ts
# tests 5 / pass 5 / fail 0
```

---

## What this does not claim

The lifecycle records give a run a timestamp, an owner and a duration. They do
**not** say who ended it. The gain is correlatability, not proof — but today
there is nothing at all to correlate, which is the actual problem.

The stderr wiring closes a channel that is currently dead. Our own reproduction
(in the issue) happens to take the stdin-EOF path and therefore does **not**
produce a stderr line; we are reporting that rather than implying coverage we
did not measure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Improved Claude CLI activity reporting, including run-start events when setup encounters an error.
  * Improved diagnostic logging by reassembling streamed messages before processing and redacting credentials, tokens, and private-key blocks.
  * Limited overly long diagnostic lines and controlled excessive output to keep logs readable.
  * Improved handling of streamed and trailing diagnostics, including throttling notices and duplicate prevention.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->