### PR TITLE
fix: pass USER/LOGNAME to plugin subprocess env for macOS Keychain access

### DIFF
--- a/server/modules/plugins/plugin-process.service.ts
+++ b/server/modules/plugins/plugin-process.service.ts
@@ -21,11 +21,17 @@ const startingPlugins = new Map();
  * site-packages and fails to import; SystemRoot, PATHEXT and TEMP are needed to
  * resolve system DLLs, executable extensions and a temp directory. None of
  * these carry secrets, so the ones that are set get passed straight through.
+ * USER/LOGNAME are needed on macOS/Linux for any child that reads the login
+ * keychain (e.g. a `claude` CLI spawned by cloudcli-cron) - without them the
+ * keychain lookup silently fails and the CLI reports "Not logged in" even
+ * though the account is authenticated.
  */
 function buildPluginEnv(name) {
   const env = {
     PATH: process.env.PATH,
     HOME: process.env.HOME,
+    USER: process.env.USER,
+    LOGNAME: process.env.LOGNAME,
     NODE_ENV: process.env.NODE_ENV || 'production',
     PLUGIN_NAME: name,
   };


### PR DESCRIPTION
## What changed

`buildPluginEnv()` in `server/modules/plugins/plugin-process.service.ts` strips plugin server subprocesses down to `PATH`, `HOME`, `NODE_ENV`, and `PLUGIN_NAME` only (added in #851 for Windows bootstrap needs). This adds `USER` and `LOGNAME` to that allowlist.

## Why

Any plugin that spawns the `claude` CLI as a further child process (e.g. the community `cloudcli-cron` scheduled-prompts plugin) breaks on macOS: without `$USER` in the environment, `claude`'s Keychain credential read silently fails and the CLI reports `Not logged in · Please run /login` even though the account is fully authenticated interactively.

Reproduced directly:

```bash
env -i PATH="$PATH" HOME="$HOME" NODE_ENV=production PLUGIN_NAME=x \
  claude -p "say ok" --dangerously-skip-permissions
# => "Not logged in · Please run /login" (exit 1)
```

Bisecting which single variable fixes it - testing `USER`, `LOGNAME`, `TMPDIR`, `SHELL`, `LANG`, `XPC_SERVICE_NAME`, `__CF_USER_TEXT_ENCODING` added back one at a time - showed `USER` alone is sufficient to restore a successful Keychain read on macOS. `LOGNAME` is included alongside it since some CLIs read one or the other, and neither carries secrets, consistent with the existing Windows-essentials allowlist in the same function.

This surfaced while debugging a scheduled prompt in `cloudcli-cron` that failed "Not logged in" on every headless run while the exact same command succeeded instantly when run manually in an interactive terminal - the only difference being the subprocess environment the plugin host hands down.

## Out of scope

Not touching the Windows-essentials branch or any other part of `buildPluginEnv()`.

## Test plan

- [x] Reproduced the failure with the minimal env via `env -i` as shown above
- [x] Confirmed adding `USER` alone (without any other var) fixes it
- [x] `npm run build:server` passes
- [x] Verified with a real `cloudcli-cron` scheduled prompt run end-to-end after rebuilding and restarting the app - previously failing run now succeeds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Plugin subprocesses now receive the host user identity, improving compatibility with login keychain access on macOS and Linux.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->