### PR TITLE
fix(editor): syntax highlighting for .mts, .cts, .mjs and .cjs

### DIFF
--- a/src/modules/code-editor/utils/editorExtensions.ts
+++ b/src/modules/code-editor/utils/editorExtensions.ts
@@ -38,8 +38,12 @@ export const getLanguageExtensions = (filename: string) => {
   switch (ext) {
     case 'js':
     case 'jsx':
+    case 'mjs':
+    case 'cjs':
     case 'ts':
     case 'tsx':
+    case 'mts':
+    case 'cts':
       return [javascript({ jsx: true, typescript: ext.includes('ts') })];
     case 'py':
       return [python()];


### PR DESCRIPTION
Node's explicit module extensions fell through to the default arm of the language switch, so a .mts or .cts file opened in the editor with no highlighting at all. The existing `ext.includes('ts')` check already picks TypeScript for the two new TS extensions and JavaScript for the other two, so the four cases are all that is missing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved language detection for JavaScript and TypeScript module files, including `.mjs`, `.cjs`, `.mts`, and `.cts`.
  * These file types now receive the appropriate syntax highlighting and editing support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->