### PR TITLE
fix(chat): merge back-to-back queued messages instead of overwriting

### DIFF
--- a/src/components/chat/hooks/useChatComposerState.ts
+++ b/src/components/chat/hooks/useChatComposerState.ts
@@ -724,16 +724,21 @@ export function useChatComposerState({
         }
 
         // A message may already be queued for this turn (the user queued "A"
-        // and is now queuing "B" before the run finishes). Append onto it
-        // instead of replacing it so the earlier message is never dropped.
-        const existingDraft =
-          queuedSessionKey && queuedDraftSessionRef.current === queuedSessionKey ? queuedDraft : null;
+        // and is now queuing "B" before the run finishes). Re-read the
+        // persisted draft here rather than trusting the `queuedDraft` closure:
+        // two submissions can each be past their own upload await with
+        // neither having committed a re-render yet, so both closures would
+        // see the same stale (or empty) state and the second write would
+        // still clobber the first. Storage is read, merged, and written back
+        // with no `await` in between, so it stays correct even when two
+        // submissions' uploads resolve out of order.
+        const existingQueued = queuedSessionKey ? readQueuedMessage(queuedSessionKey) : null;
 
         const durableDraft: QueuedDraft = {
-          content: existingDraft ? mergeQueuedContent(existingDraft.content, currentInput) : currentInput,
-          attachments: existingDraft ? [...existingDraft.attachments, ...currentAttachments] : currentAttachments,
-          uploadedAttachments: existingDraft
-            ? [...(existingDraft.uploadedAttachments ?? []), ...uploadedAttachments]
+          content: existingQueued ? mergeQueuedContent(existingQueued.content, currentInput) : currentInput,
+          attachments: [...(queuedDraft?.attachments ?? []), ...currentAttachments],
+          uploadedAttachments: existingQueued
+            ? [...(existingQueued.attachments ?? []), ...uploadedAttachments]
             : uploadedAttachments,
           options: queuedOptions,
         };

--- a/src/components/chat/hooks/useChatComposerState.ts
+++ b/src/components/chat/hooks/useChatComposerState.ts
@@ -148,6 +148,15 @@ const createFakeSubmitEvent = () => {
   return { preventDefault: () => undefined } as unknown as FormEvent<HTMLFormElement>;
 };
 
+// Two messages queued back-to-back while a turn is in flight ("A" then "B")
+// must both reach Claude, not just the most recent one - join them into a
+// single message instead of the second replacing the first.
+const mergeQueuedContent = (existing: string, incoming: string): string => {
+  if (!existing.trim()) return incoming;
+  if (!incoming.trim()) return existing;
+  return `${existing}\n\n${incoming}`;
+};
+
 const MAX_ATTACHMENT_COUNT = 10;
 const MAX_ATTACHMENT_SIZE = 10 * 1024 * 1024;
 
@@ -714,10 +723,18 @@ export function useChatComposerState({
           return;
         }
 
+        // A message may already be queued for this turn (the user queued "A"
+        // and is now queuing "B" before the run finishes). Append onto it
+        // instead of replacing it so the earlier message is never dropped.
+        const existingDraft =
+          queuedSessionKey && queuedDraftSessionRef.current === queuedSessionKey ? queuedDraft : null;
+
         const durableDraft: QueuedDraft = {
-          content: currentInput,
-          attachments: currentAttachments,
-          uploadedAttachments,
+          content: existingDraft ? mergeQueuedContent(existingDraft.content, currentInput) : currentInput,
+          attachments: existingDraft ? [...existingDraft.attachments, ...currentAttachments] : currentAttachments,
+          uploadedAttachments: existingDraft
+            ? [...(existingDraft.uploadedAttachments ?? []), ...uploadedAttachments]
+            : uploadedAttachments,
           options: queuedOptions,
         };
         if (queuedSessionKey) {
@@ -940,6 +957,7 @@ export function useChatComposerState({
       onSessionProcessing,
       onSessionEstablished,
       provider,
+      queuedDraft,
       resetCommandMenuState,
       scrollToBottom,
       selectedProject,


### PR DESCRIPTION
## What

While a turn is running, queuing a second message replaced the first one instead of appending to it - both in React state and in the `queued_message_<sessionId>` localStorage record.

## Repro

1. Send a message that starts a long-running turn.
2. While it's still running, type "A" and press Enter - it gets queued (shown in the queued-message card).
3. Before the turn finishes, type "B" and press Enter.
4. The queued card now shows only "B". "A" is gone and is never sent.

## Fix

`useChatComposerState.ts`'s `handleSubmit` now checks for an existing queued draft for the session before building the new one, and merges into it instead of replacing it:
- text is joined with a blank line
- attachments and uploaded-attachment descriptors are concatenated
- send options use the latest snapshot (most recent model/permission settings win)

So queuing "A" then "B" mid-turn now delivers a single message containing both once the turn ends, instead of silently dropping "A".

## Testing

- `npm run typecheck` - passes
- `npx eslint src/components/chat/hooks/useChatComposerState.ts` - clean
- `npm run build` - passes
- Traced both the same-session queue path and the cross-session dispatch path (`useQueuedMessageAutoSend.ts`, which only reads/sends after a turn completes and needed no changes) to confirm the merged draft flows through unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved message queuing during active conversations.
  * Multiple queued messages are now combined instead of replacing earlier content.
  * Attachments and uploaded files are preserved across queued submissions.
  * Queued content remains accurate when messages or uploads finish in a different order.
  * Prevented newer submissions from overwriting previously queued text or attachments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->