### PR TITLE
fix(claude): background agents were reported completed at launch

### DIFF
--- a/server/modules/providers/list/claude/claude-sessions.provider.ts
+++ b/server/modules/providers/list/claude/claude-sessions.provider.ts
@@ -487,12 +487,20 @@ async function getSessionMessages(
       const toolUseId = readAgentToolUseId(message);
       const notification = toolUseId ? notificationsByToolUseId.get(toolUseId) : undefined;
       // An async agent's launch row never tells you it finished — only the
-      // later notification does. When that notification is missing (a live run,
-      // or one compacted out of the transcript), the agent's own transcript is
-      // the evidence: a timeline that does not stop mid-tool-call is done.
+      // later notification does, so a missing notification is itself the signal
+      // that the agent is still outstanding.
+      //
+      // The agent's own transcript cannot stand in for that. A background agent
+      // routinely ends its turn cleanly while its work continues — it replies
+      // "I've started the command in the background, waiting for it to
+      // complete…" and stops. `endedMidToolCall` is then false even though no
+      // answer has arrived, which marked every background agent `completed` the
+      // moment it launched.
+      //
+      // `endedMidToolCall` remains the right evidence for a *synchronous* agent,
+      // where a dangling tool call is the only trace of an interrupted run.
       const isAwaitingAsyncAgent = message.toolUseResult?.isAsync === true
-        && !notification
-        && (!subagent || subagent.endedMidToolCall);
+        && !notification;
 
       if (subagent) {
         if (subagent.activity.length > 0) {

--- a/server/modules/providers/list/claude/claude-sessions.provider.ts
+++ b/server/modules/providers/list/claude/claude-sessions.provider.ts
@@ -497,8 +497,12 @@ async function getSessionMessages(
       // answer has arrived, which marked every background agent `completed` the
       // moment it launched.
       //
-      // `endedMidToolCall` remains the right evidence for a *synchronous* agent,
-      // where a dangling tool call is the only trace of an interrupted run.
+      // Note this whole predicate is gated on `isAsync`, so dropping the clause
+      // changes nothing for a synchronous agent — one has never been able to
+      // report `running` here, with or without a dangling tool call. That also
+      // leaves `endedMidToolCall` computed but unread; it is kept because it is
+      // the only in-file evidence of an interrupted run, and is what a staleness
+      // rule would need.
       const isAwaitingAsyncAgent = message.toolUseResult?.isAsync === true
         && !notification;
 

--- a/server/modules/providers/tests/claude-sessions.test.ts
+++ b/server/modules/providers/tests/claude-sessions.test.ts
@@ -219,7 +219,7 @@ async function dropTaskNotification(parentPath: string): Promise<void> {
   );
 }
 
-test('Claude history reads a missing notification off the agent\'s own transcript', { concurrency: false }, async () => {
+test('Claude history leaves an async agent running while its outcome is unknown', { concurrency: false }, async () => {
   const tempRoot = await mkdtemp(path.join(os.tmpdir(), 'claude-finished-agent-'));
 
   try {
@@ -237,10 +237,14 @@ test('Claude history reads a missing notification off the agent\'s own transcrip
         (message) => message.kind === 'tool_use' && message.toolId === AGENT_TOOL_USE_ID,
       );
 
-      // The notification can be compacted out of a long session. The agent's
-      // transcript ends on a resolved tool call, so it finished — reporting it
-      // as still running would leave a spinner on the card forever.
-      assert.equal(agentRow?.subagent?.status, 'completed');
+      // This case is ambiguous from the transcript alone: an agent whose
+      // notification was compacted away and one that is still working in the
+      // background both end their turn cleanly, so nothing on disk separates
+      // them. The tie is resolved in favour of the live agent — calling a
+      // running agent `completed` drops it from the UI while it is still
+      // working, which is worse than a stale spinner on an old session that
+      // the next load corrects.
+      assert.equal(agentRow?.subagent?.status, 'running');
       assert.equal(agentRow?.toolResult?.content, '', 'the launch acknowledgement must never show as a result');
     });
   } finally {

--- a/server/modules/providers/tests/claude-sessions.test.ts
+++ b/server/modules/providers/tests/claude-sessions.test.ts
@@ -240,10 +240,15 @@ test('Claude history leaves an async agent running while its outcome is unknown'
       // This case is ambiguous from the transcript alone: an agent whose
       // notification was compacted away and one that is still working in the
       // background both end their turn cleanly, so nothing on disk separates
-      // them. The tie is resolved in favour of the live agent — calling a
-      // running agent `completed` drops it from the UI while it is still
-      // working, which is worse than a stale spinner on an old session that
-      // the next load corrects.
+      // them. The tie is resolved in favour of the live agent, because calling
+      // a running agent `completed` drops it from the UI while it is still
+      // working.
+      //
+      // The cost is real and does not heal: once the notification has been
+      // compacted out, it is gone from the file, so a historical session keeps
+      // showing this agent as running on every load. Separating the two needs
+      // evidence the transcript does not carry — a staleness cutoff, or a
+      // liveness signal from the run registry.
       assert.equal(agentRow?.subagent?.status, 'running');
       assert.equal(agentRow?.toolResult?.content, '', 'the launch acknowledgement must never show as a result');
     });


### PR DESCRIPTION
## The bug

A background agent (`Agent` with `run_in_background: true`) is shown as
`completed` the instant it launches, and disappears from the UI while it is
still working.

## Why

An async agent is only *known* to have finished once its `<task-notification>`
arrives. The liveness check in `claude-sessions.provider.ts` additionally
required the agent's own transcript to end mid-tool-call:

```ts
const isAwaitingAsyncAgent = message.toolUseResult?.isAsync === true
  && !notification
  && (!subagent || subagent.endedMidToolCall);
```

That last clause is wrong for a background agent. One routinely ends its own
turn **cleanly** while its work continues — it replies *"I've started the
command in the background, waiting for it to complete…"* and stops. So
`endedMidToolCall` is `false` while no answer has arrived, and the agent is
reported `completed` immediately.

## The fix

Drop that clause. For an async agent, the absence of the notification *is* the
signal that it is still outstanding.

Note the predicate is gated on `isAsync`, so this cannot affect synchronous
agents — one short-circuits on the first conjunct and could never report
`running` here, with or without a dangling tool call. The change is confined to
the async branch.

## One existing expectation flips, deliberately

`Claude history reads a missing notification off the agent's own transcript`
asserted `completed` for exactly this shape, so it is updated (and renamed).

I'd rather be straight about it than bury it: **that scenario is genuinely
ambiguous.** A notification compacted out of a long session and a still-running
background agent look identical on disk — both end their turn cleanly with no
notification. Nothing in the transcript separates them.

The tie is now resolved in favour of the live agent, because the two error
modes are not symmetric:

|  | old behaviour | new behaviour |
|---|---|---|
| Background agent still working | **wrong, always** — vanishes at launch | correct |
| Notification compacted away | correct | shows `running` permanently |

The first is a wrong answer for *every* background agent, every time. The
second affects historical sessions whose notification has already been
compacted away — and to be clear, it **does not heal**: the notification is
gone from the file for good, and status is recomputed from the file on each
load, so that session keeps showing the agent as running. I originally wrote
that the next load corrects it; that was wrong.

Separating the two needs evidence the transcript does not carry — a staleness
cutoff on the agent's last activity would do it heuristically, a liveness
signal from the run registry exactly. I kept this PR to the one clause that is
wrong; glad to follow up with either if you have a preference.

## Two consequences worth flagging

- **`endedMidToolCall` is now computed but never read** — that clause was its
  only consumer. Kept, with a comment, because it is the only in-file trace of
  an interrupted run and is what a staleness rule would need. Happy to remove
  it instead.
- **`Claude history keeps an agent running when its transcript stops mid tool
  call` now passes for a different reason than its name** — its fixture sets
  `isAsync: true`, so it now passes on `!notification` alone. Left alone rather
  than rewritten, since it isn't what this PR is about.

## Verification

Observed on a live run: same agent, `isAsync` true, `hasNotification` false,
`endedMidToolCall` false — `isAwaitingAsyncAgent` went `false` → `true`, and
the agent now reports `running` while its work is outstanding.

`npm test` green (394 passing).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved status reporting for asynchronous agents when task completion notifications are unavailable.
  * Agents with an unknown outcome are now shown as still running instead of completed, reducing the risk of prematurely reporting unfinished work.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->