### PR TITLE
fix(chat): keep an option label containing ", " as one answer

### DIFF
--- a/src/modules/chat/tests/QuestionAnswerContent.test.tsx
+++ b/src/modules/chat/tests/QuestionAnswerContent.test.tsx
@@ -77,3 +77,31 @@ test('still renders a well-formed question + answer', () => {
   );
   assert.ok(html.includes('Pick one?'));
 });
+
+test('an option label containing ", " is kept as one answer', () => {
+  const html = renderToStaticMarkup(
+    React.createElement(QuestionAnswerContent, {
+      questions: [{ question: 'Pick one?', options: [{ label: 'Yes, always' }, { label: 'No' }] }],
+      answers: { 'Pick one?': 'Yes, always' },
+    }),
+  );
+  // Split on ", " would render "Yes" and "always" as two chips, both unmatched
+  // by an option and therefore both labelled custom.
+  assert.ok(html.includes('Yes, always'));
+  assert.ok(!html.includes('(custom)'));
+});
+
+test('a multi-select answer with no exact option still splits on ", "', () => {
+  const html = renderToStaticMarkup(
+    React.createElement(QuestionAnswerContent, {
+      questions: [{ question: 'Pick some?', multiSelect: true, options: [{ label: 'A' }, { label: 'B' }] }],
+      answers: { 'Pick some?': 'A, B' },
+    }),
+  );
+  // Both halves must match an option, so neither is labelled custom and the
+  // joined string never survives as a single chip.
+  assert.ok(html.includes('>A</span>'));
+  assert.ok(html.includes('>B</span>'));
+  assert.ok(!html.includes('A, B'));
+  assert.ok(!html.includes('(custom)'));
+});

--- a/src/modules/chat/tools/ContentRenderers/QuestionAnswerContent.tsx
+++ b/src/modules/chat/tools/ContentRenderers/QuestionAnswerContent.tsx
@@ -41,15 +41,20 @@ export const QuestionAnswerContent: React.FC<QuestionAnswerContentProps> = ({
         }
         const q = rawQuestion;
         const answer = answers?.[q.question];
-        // `answer` may be a non-string (or absent) in malformed payloads.
-        const answerLabels = typeof answer === 'string' ? answer.split(', ') : [];
-        const skipped = !answer;
-        const isExpanded = expandedIdx === idx;
         // `options` is typed as an array but comes from untrusted runtime data;
         // keep only valid entries so `.some`/`.map` below never throw.
         const options = Array.isArray(q.options)
           ? q.options.filter((opt) => opt && typeof opt === 'object' && typeof opt.label === 'string')
           : [];
+        // Match one exact option before splitting a multi-select answer. A
+        // single label may itself contain ", ".
+        const answerLabels = typeof answer !== 'string'
+          ? []
+          : options.some((option) => option.label === answer)
+            ? [answer]
+            : answer.split(', ');
+        const skipped = !answer;
+        const isExpanded = expandedIdx === idx;
 
         return (
           <div


### PR DESCRIPTION
Question/answer cards split a multi-select answer on ", " unconditionally,
so a single option whose own label contains ", " ("Yes, always") rendered as
two chips, neither matching an option, both marked (custom).

Match one exact option first and split only when no option matches, which
leaves genuine multi-select answers unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved answer display for options whose labels contain commas.
  * Corrected multi-select answer handling when no exact option match exists.

* **Tests**
  * Added regression coverage for comma-containing option labels and unmatched multi-select answers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->