### PR TITLE
feat(providers): add Command Code as a coding-agent provider

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -87,6 +87,7 @@ const queryClaude = providerRuntimeService.getRunner('claude');
 const queryCursor = providerRuntimeService.getRunner('cursor');
 const queryCodex = providerRuntimeService.getRunner('codex');
 const queryOpenCode = providerRuntimeService.getRunner('opencode');
+const queryCommandCode = providerRuntimeService.getRunner('command-code');
 const gitRoutes = createGitModule({
     queryClaude,
     queryCursor,
@@ -96,6 +97,7 @@ const agentRoutes = createAgentModule({
     queryCursor,
     queryCodex,
     queryOpenCode,
+    queryCommandCode,
 });
 
 // Single WebSocket server that handles chat, shell, and plugin proxy paths.

--- a/server/modules/agent/agent.module.ts
+++ b/server/modules/agent/agent.module.ts
@@ -18,7 +18,7 @@ import { createAgentRouter } from './agent.routes.js';
 
 type AgentExternalDependencies = Pick<
   Parameters<typeof createAgentRouter>[0],
-  'queryClaude' | 'queryCursor' | 'queryCodex' | 'queryOpenCode'
+  'queryClaude' | 'queryCursor' | 'queryCodex' | 'queryOpenCode' | 'queryCommandCode'
 >;
 
 /**

--- a/server/modules/agent/agent.routes.ts
+++ b/server/modules/agent/agent.routes.ts
@@ -22,6 +22,7 @@ type AgentRouterDependencies = {
   queryCursor: ProviderRunFunction;
   queryCodex: ProviderRunFunction;
   queryOpenCode: ProviderRunFunction;
+  queryCommandCode: ProviderRunFunction;
   GithubClient: typeof import('@octokit/rest').Octokit;
 };
 
@@ -44,6 +45,7 @@ export function createAgentRouter(dependencies: AgentRouterDependencies): expres
   const spawnCursor = dependencies.queryCursor;
   const queryCodex = dependencies.queryCodex;
   const spawnOpenCode = dependencies.queryOpenCode;
+  const spawnCommandCode = dependencies.queryCommandCode;
   const Octokit = dependencies.GithubClient;
   const router = express.Router();
 
@@ -896,8 +898,8 @@ export function createAgentRouter(dependencies: AgentRouterDependencies): expres
       return res.status(400).json({ error: 'message is required' });
     }
 
-    if (!['claude', 'cursor', 'codex', 'opencode'].includes(provider)) {
-      return res.status(400).json({ error: 'provider must be "claude", "cursor", "codex", or "opencode"' });
+    if (!['claude', 'cursor', 'codex', 'opencode', 'command-code'].includes(provider)) {
+      return res.status(400).json({ error: 'provider must be "claude", "cursor", "codex", "opencode", or "command-code"' });
     }
 
     // Validate GitHub branch/PR creation requirements
@@ -1023,6 +1025,18 @@ export function createAgentRouter(dependencies: AgentRouterDependencies): expres
           cwd: finalProjectPath,
           sessionId: sessionId || null,
           model: model || opencodeModels.DEFAULT,
+          effort,
+          permissionMode: 'bypassPermissions' // Agent runs are non-interactive, like the other providers above
+        }, writer);
+      } else if (provider === 'command-code') {
+        console.log('Starting Command Code CLI session');
+
+        const commandCodeModels = (await providerModelsService.getProviderModels('command-code')).models;
+        await spawnCommandCode(message.trim(), {
+          projectPath: finalProjectPath,
+          cwd: finalProjectPath,
+          sessionId: sessionId || null,
+          model: model || commandCodeModels.DEFAULT,
           effort,
           permissionMode: 'bypassPermissions' // Agent runs are non-interactive, like the other providers above
         }, writer);

--- a/server/modules/agent/tests/agent.routes.test.ts
+++ b/server/modules/agent/tests/agent.routes.test.ts
@@ -34,6 +34,7 @@ function createDependencies(
     queryCursor: unexpectedProviderCall as AgentDependencies['queryCursor'],
     queryCodex: unexpectedProviderCall as AgentDependencies['queryCodex'],
     queryOpenCode: unexpectedProviderCall as AgentDependencies['queryOpenCode'],
+    queryCommandCode: unexpectedProviderCall as AgentDependencies['queryCommandCode'],
     GithubClient: class {} as unknown as AgentDependencies['GithubClient'],
     ...overrides,
   };

--- a/server/modules/commands/commands.routes.ts
+++ b/server/modules/commands/commands.routes.ts
@@ -28,13 +28,14 @@ const providerModelsService = dependencies.models;
 const process = dependencies.runtime;
 const router = express.Router();
 
-const MODEL_PROVIDERS = ["claude", "cursor", "codex", "opencode"];
+const MODEL_PROVIDERS = ["claude", "cursor", "codex", "opencode", "command-code"];
 
 const MODEL_PROVIDER_LABELS = {
   claude: "Claude",
   cursor: "Cursor",
   codex: "Codex",
   opencode: "OpenCode",
+  "command-code": "Command Code",
 };
 
 const readModelProvider = (value) => {

--- a/server/modules/database/migrations.ts
+++ b/server/modules/database/migrations.ts
@@ -476,6 +476,53 @@ const ensureProjectsForSessionPaths = (db: Database): void => {
   `);
 };
 
+/**
+ * Rebuilds the provider_models table when its provider CHECK constraint does
+ * not yet allow the `command-code` provider.
+ *
+ * SQLite cannot ALTER a CHECK constraint, so widening the provider allow-list
+ * requires a table rebuild. Rows are preserved verbatim; only the constraint
+ * changes.
+ */
+const rebuildProviderModelsTableWithCommandCodeProvider = (db: Database): void => {
+  if (!tableExists(db, 'provider_models')) {
+    db.exec(PROVIDER_MODELS_TABLE_SCHEMA_SQL);
+    return;
+  }
+
+  const createSql = db
+    .prepare("SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'provider_models'")
+    .get() as { sql: string } | undefined;
+  if (createSql?.sql?.includes("'command-code'")) {
+    return;
+  }
+
+  console.log('Running migration: Rebuilding provider_models table to allow command-code provider');
+
+  db.exec('PRAGMA foreign_keys = OFF');
+  try {
+    db.exec('BEGIN TRANSACTION');
+    db.exec('DROP TABLE IF EXISTS provider_models__new');
+    db.exec(PROVIDER_MODELS_TABLE_SCHEMA_SQL.replace(
+      'CREATE TABLE IF NOT EXISTS provider_models',
+      'CREATE TABLE provider_models__new'
+    ));
+    db.exec(`
+      INSERT INTO provider_models__new (id, provider, model_id, model_name, sort_order, created_at, updated_at)
+      SELECT id, provider, model_id, model_name, sort_order, created_at, updated_at
+      FROM provider_models
+    `);
+    db.exec('DROP TABLE provider_models');
+    db.exec('ALTER TABLE provider_models__new RENAME TO provider_models');
+    db.exec('COMMIT');
+  } catch (migrationError) {
+    db.exec('ROLLBACK');
+    throw migrationError;
+  } finally {
+    db.exec('PRAGMA foreign_keys = ON');
+  }
+};
+
 export const runMigrations = (db: Database) => {
   try {
     const usersTableInfo = db.prepare('PRAGMA table_info(users)').all() as { name: string }[];
@@ -500,6 +547,7 @@ export const runMigrations = (db: Database) => {
     db.exec('CREATE INDEX IF NOT EXISTS idx_notification_channel_endpoints_user_channel ON notification_channel_endpoints(user_id, channel)');
     db.exec('CREATE INDEX IF NOT EXISTS idx_notification_channel_endpoints_enabled ON notification_channel_endpoints(enabled)');
     db.exec(PROVIDER_MODELS_TABLE_SCHEMA_SQL);
+    rebuildProviderModelsTableWithCommandCodeProvider(db);
     db.exec(`
       CREATE INDEX IF NOT EXISTS idx_provider_models_provider_order
       ON provider_models(provider, sort_order, id)

--- a/server/modules/database/schema.ts
+++ b/server/modules/database/schema.ts
@@ -178,7 +178,7 @@ CREATE TABLE IF NOT EXISTS app_config (
 export const PROVIDER_MODELS_TABLE_SCHEMA_SQL = `
 CREATE TABLE IF NOT EXISTS provider_models (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
-    provider TEXT NOT NULL CHECK (provider IN ('claude', 'cursor', 'codex', 'opencode')),
+    provider TEXT NOT NULL CHECK (provider IN ('claude', 'cursor', 'codex', 'opencode', 'command-code')),
     model_id TEXT NOT NULL,
     model_name TEXT NOT NULL,
     sort_order INTEGER NOT NULL DEFAULT 0,

--- a/server/modules/notifications/services/notification-orchestrator.service.js
+++ b/server/modules/notifications/services/notification-orchestrator.service.js
@@ -13,6 +13,8 @@ const PROVIDER_LABELS = {
   claude: 'Claude',
   cursor: 'Cursor',
   codex: 'Codex',
+  opencode: 'OpenCode',
+  'command-code': 'Command Code',
   system: 'System'
 };
 

--- a/server/modules/providers/list/command-code/command-code-auth.provider.ts
+++ b/server/modules/providers/list/command-code/command-code-auth.provider.ts
@@ -1,0 +1,173 @@
+import os from 'node:os';
+import path from 'node:path';
+
+import spawn from 'cross-spawn';
+
+import type { IProviderAuth } from '@/shared/interfaces.js';
+import type { ProviderAuthStatus } from '@/shared/types.js';
+
+const COMMAND_CODE_BINARY = 'command-code';
+
+type CommandCodeStatusPayload = {
+  authenticated?: unknown;
+  version?: unknown;
+  user?: unknown;
+  model?: unknown;
+  context_window?: unknown;
+};
+
+/**
+ * Parses the single JSON line emitted by `command-code status --json`.
+ *
+ * The payload is deliberately treated as forward-compatible: only the fields
+ * this status check reads are narrowed, and unknown extra fields are ignored.
+ */
+const parseStatusPayload = (raw: unknown): CommandCodeStatusPayload | null => {
+  if (typeof raw !== 'string') {
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      return null;
+    }
+
+    return parsed as CommandCodeStatusPayload;
+  } catch {
+    return null;
+  }
+};
+
+/**
+ * Checks whether the Command Code CLI is installed and authenticated.
+ *
+ * Command Code authenticates against a Command Code account (`cmd login`), and
+ * its `status --json` subcommand reports that state as one JSON line:
+ * `{"authenticated":true,"version":"1.45.0","user":"...","model":"..."}`.
+ *
+ * The on-disk credential file under `~/.commandcode` is a private, versioned
+ * shape (api key + user id), so this adapter deliberately reads only the CLI's
+ * public status contract rather than hand-parsing it.
+ */
+export class CommandCodeProviderAuth implements IProviderAuth {
+  private checkInstalled(): boolean {
+    try {
+      const result = spawn.sync(COMMAND_CODE_BINARY, ['--version'], {
+        stdio: 'pipe',
+        timeout: 5000,
+        encoding: 'utf8',
+      });
+      return result.status === 0;
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Runs `command-code status --json` and resolves the status.
+   *
+   * `authenticated:false` in the JSON body wins over any exit code when the two
+   * conflict, because the body is the CLI's explicit answer to "am I logged in".
+   */
+  private checkCredentials(): Promise<{ authenticated: boolean; email: string | null; method: string | null; error?: string }> {
+    return new Promise((resolve) => {
+      let stdout = '';
+      let stderr = '';
+      let child: ReturnType<typeof spawn.spawn>;
+
+      try {
+        child = spawn(COMMAND_CODE_BINARY, ['status', '--json'], {
+          stdio: ['ignore', 'pipe', 'pipe'],
+          env: { ...process.env, NO_COLOR: '1' },
+        });
+      } catch {
+        resolve({
+          authenticated: false,
+          email: null,
+          method: null,
+          error: 'Unable to run command-code status. Run command-code /login again.',
+        });
+        return;
+      }
+
+      const timeout = setTimeout(() => {
+        child.kill('SIGTERM');
+        resolve({
+          authenticated: false,
+          email: null,
+          method: null,
+          error: 'command-code status timed out.',
+        });
+      }, 8000);
+
+      child.stdout?.on('data', (data: Buffer) => {
+        stdout += data.toString();
+      });
+      child.stderr?.on('data', (data: Buffer) => {
+        stderr += data.toString();
+      });
+
+      child.on('error', () => {
+        clearTimeout(timeout);
+        resolve({
+          authenticated: false,
+          email: null,
+          method: null,
+          error: 'Unable to run command-code status. Run command-code /login again.',
+        });
+      });
+
+      child.on('close', () => {
+        clearTimeout(timeout);
+        const payload = parseStatusPayload(stdout.trim());
+        const authenticated = payload?.authenticated === true;
+        if (authenticated) {
+          const user = typeof payload?.user === 'string' && payload.user.trim() ? payload.user : undefined;
+          resolve({
+            authenticated: true,
+            email: user || 'Authenticated',
+            method: 'account',
+          });
+          return;
+        }
+
+        const detail = stderr.trim() || (payload ? 'Command Code is not authenticated.' : 'command-code status returned an unreadable response.');
+        resolve({
+          authenticated: false,
+          email: null,
+          method: null,
+          error: detail,
+        });
+      });
+    });
+  }
+
+  async getStatus(): Promise<ProviderAuthStatus> {
+    const installed = this.checkInstalled();
+
+    if (!installed) {
+      return {
+        installed,
+        provider: 'command-code',
+        authenticated: false,
+        email: null,
+        method: null,
+        error: 'Command Code CLI is not installed. Install it with: npm i -g command-code',
+      };
+    }
+
+    const credentials = await this.checkCredentials();
+
+    return {
+      installed,
+      provider: 'command-code',
+      authenticated: credentials.authenticated,
+      email: credentials.authenticated ? credentials.email || 'Authenticated' : credentials.email,
+      method: credentials.method,
+      error: credentials.authenticated ? undefined : credentials.error || 'Not authenticated',
+    };
+  }
+}
+
+export const getCommandCodeHomePath = (): string => path.join(os.homedir(), '.commandcode');

--- a/server/modules/providers/list/command-code/command-code-mcp.provider.ts
+++ b/server/modules/providers/list/command-code/command-code-mcp.provider.ts
@@ -1,0 +1,163 @@
+import os from 'node:os';
+import path from 'node:path';
+
+import { McpProvider } from '@/modules/providers/shared/mcp/mcp.provider.js';
+import type { McpScope, ProviderMcpServer, UpsertProviderMcpServerInput } from '@/shared/types.js';
+import {
+  AppError,
+  readJsonConfig,
+  readObjectRecord,
+  readOptionalString,
+  readStringArray,
+  readStringRecord,
+  writeJsonConfig,
+} from '@/shared/utils.js';
+
+/**
+ * Command Code MCP config adapter.
+ *
+ * Command Code reads the same `{"mcpServers":{...}}` JSON shape as Claude, from
+ * `.mcp.json` (project), `~/.commandcode/mcp.json` (user) and a private "local"
+ * scope under `~/.commandcode/projects/<slug>/mcp.json`. Unlike Claude's
+ * per-server `type` discriminator, Command Code's canonical per-server entries
+ * use a `transport` field (stdio/http), with `type` accepted only as a legacy
+ * alias on read. Writes always emit `transport`.
+ */
+export class CommandCodeMcpProvider extends McpProvider {
+  constructor() {
+    super('command-code', ['user', 'local', 'project'], ['stdio', 'http', 'sse']);
+  }
+
+  private resolveMcpFilePath(scope: McpScope, workspacePath: string): string {
+    if (scope === 'project') {
+      return path.join(workspacePath, '.mcp.json');
+    }
+
+    if (scope === 'user') {
+      return path.join(os.homedir(), '.commandcode', 'mcp.json');
+    }
+
+    // Local scope: a private, machine-specific config under the project slug.
+    const slug = this.slugifyProjectPath(workspacePath);
+    return path.join(os.homedir(), '.commandcode', 'projects', slug, 'mcp.json');
+  }
+
+  /**
+   * Encodes a workspace path into Command Code's project-slug directory name.
+   *
+   * The CLI slugs the working directory (e.g. `d-rn-d-claudecodeui-contrib`).
+   * This mirrors that transformation closely enough to read/write the
+   * machine-local config; sessions are keyed the same way on disk.
+   */
+  private slugifyProjectPath(workspacePath: string): string {
+    const normalized = workspacePath.trim().replace(/[\\/]+$/, '');
+    const baseName = normalized.split(/[\\/]/).filter(Boolean).pop() || 'default';
+    return baseName.toLowerCase().replace(/[^a-z0-9._-]+/g, '-');
+  }
+
+  protected async readScopedServers(scope: McpScope, workspacePath: string): Promise<Record<string, unknown>> {
+    const filePath = this.resolveMcpFilePath(scope, workspacePath);
+    const config = await readJsonConfig(filePath);
+    return readObjectRecord(config.mcpServers) ?? {};
+  }
+
+  protected async writeScopedServers(
+    scope: McpScope,
+    workspacePath: string,
+    servers: Record<string, unknown>,
+  ): Promise<void> {
+    const filePath = this.resolveMcpFilePath(scope, workspacePath);
+    const config = await readJsonConfig(filePath);
+    config.mcpServers = servers;
+    await writeJsonConfig(filePath, config);
+  }
+
+  protected buildServerConfig(input: UpsertProviderMcpServerInput): Record<string, unknown> {
+    if (input.transport === 'stdio') {
+      if (!input.command?.trim()) {
+        throw new AppError('command is required for stdio MCP servers.', {
+          code: 'MCP_COMMAND_REQUIRED',
+          statusCode: 400,
+        });
+      }
+
+      return {
+        transport: 'stdio',
+        command: input.command,
+        args: input.args ?? [],
+        env: input.env ?? {},
+        enabled: true,
+      };
+    }
+
+    if (!input.url?.trim()) {
+      throw new AppError('url is required for http/sse MCP servers.', {
+        code: 'MCP_URL_REQUIRED',
+        statusCode: 400,
+      });
+    }
+
+    return {
+      transport: input.transport,
+      url: input.url,
+      headers: input.headers ?? {},
+      enabled: true,
+    };
+  }
+
+  protected normalizeServerConfig(
+    scope: McpScope,
+    name: string,
+    rawConfig: unknown,
+  ): ProviderMcpServer | null {
+    const config = readObjectRecord(rawConfig);
+    if (!config) {
+      return null;
+    }
+
+    // `transport` is the canonical discriminator; `type` is accepted as a
+    // legacy alias so configs written by Claude-style tools still load.
+    const transport = readOptionalString(config.transport)
+      ?? readOptionalString(config.type)
+      ?? (typeof config.command === 'string' || Array.isArray(config.command) ? 'stdio' : undefined)
+      ?? (typeof config.url === 'string' ? 'http' : undefined);
+
+    if (transport === 'stdio') {
+      const commandParts = typeof config.command === 'string'
+        ? [config.command, ...(readStringArray(config.args) ?? [])]
+        : readStringArray(config.command);
+      const command = commandParts?.[0];
+      if (!command) {
+        return null;
+      }
+
+      return {
+        provider: 'command-code',
+        name,
+        scope,
+        transport: 'stdio',
+        command,
+        args: commandParts.slice(1),
+        env: readStringRecord(config.env) ?? readStringRecord(config.environment),
+      };
+    }
+
+    if (transport === 'http' || transport === 'sse') {
+      const url = readOptionalString(config.url);
+      if (!url) {
+        return null;
+      }
+
+      return {
+        provider: 'command-code',
+        name,
+        scope,
+        transport,
+        url,
+        headers: readStringRecord(config.headers),
+      };
+    }
+
+    return null;
+  }
+}

--- a/server/modules/providers/list/command-code/command-code-models.provider.ts
+++ b/server/modules/providers/list/command-code/command-code-models.provider.ts
@@ -1,0 +1,211 @@
+import { readFile } from 'node:fs/promises';
+
+import { sessionsDb } from '@/modules/database/index.js';
+import type { IProviderModels } from '@/shared/interfaces.js';
+import type {
+  ProviderCurrentActiveModel,
+  ProviderModelsDefinition,
+} from '@/shared/types.js';
+import { buildDefaultProviderCurrentActiveModel } from '@/shared/utils.js';
+
+/**
+ * Curated Command Code model catalog shipped as immutable CloudCLI defaults.
+ *
+ * Command Code exposes a large model catalog (`cmd --list-models` prints a
+ * human "Available models · N models" grouped list, not machine-parseable
+ * output), so the app ships a source-controlled subset of stable model ids.
+ * The ids are the exact `-m` values Command Code accepts; a stale or invented
+ * id is rejected at launch, so keep this list in sync with the CLI's catalog.
+ */
+export const COMMAND_CODE_PREDEFINED_MODELS: ProviderModelsDefinition = {
+  OPTIONS: [
+    {
+      value: 'claude-sonnet-5',
+      label: 'Claude Sonnet 5',
+      description: 'Frontier balanced coding model.',
+      effort: {
+        default: 'medium',
+        values: [
+          { value: 'low' },
+          { value: 'medium' },
+          { value: 'high' },
+          { value: 'max' },
+        ],
+      },
+    },
+    {
+      value: 'claude-sonnet-4-6',
+      label: 'Claude Sonnet 4.6',
+      description: 'Balanced agentic coding model.',
+      effort: {
+        default: 'medium',
+        values: [
+          { value: 'low' },
+          { value: 'medium' },
+          { value: 'high' },
+          { value: 'max' },
+        ],
+      },
+    },
+    {
+      value: 'claude-opus-5',
+      label: 'Claude Opus 5',
+      description: 'Most capable model for the hardest, longest-running tasks.',
+      effort: {
+        default: 'high',
+        values: [
+          { value: 'low' },
+          { value: 'medium' },
+          { value: 'high' },
+          { value: 'max' },
+        ],
+      },
+    },
+    {
+      value: 'claude-haiku-4-5-20251001',
+      label: 'Claude Haiku 4.5',
+      description: 'Fast and efficient model for simple tasks.',
+      effort: {
+        default: 'low',
+        values: [
+          { value: 'low' },
+          { value: 'medium' },
+        ],
+      },
+    },
+    {
+      value: 'deepseek/deepseek-v4-flash',
+      label: 'DeepSeek V4 Flash',
+      description: 'Fast hybrid-attention reasoning model.',
+      effort: {
+        default: 'low',
+        values: [
+          { value: 'low' },
+          { value: 'medium' },
+          { value: 'high' },
+        ],
+      },
+    },
+    {
+      value: 'deepseek/deepseek-v4-pro',
+      label: 'DeepSeek V4 Pro',
+      description: 'Deep reasoning model.',
+      effort: {
+        default: 'medium',
+        values: [
+          { value: 'low' },
+          { value: 'medium' },
+          { value: 'high' },
+        ],
+      },
+    },
+    {
+      value: 'google/gemini-3.7-flash',
+      label: 'Gemini 3.7 Flash',
+      description: 'Fast Google model.',
+    },
+    {
+      value: 'google/gemini-3.5-flash',
+      label: 'Gemini 3.5 Flash',
+      description: 'Fast Google model.',
+    },
+    {
+      value: 'moonshotai/Kimi-K2.7-Code',
+      label: 'Kimi K2.7 Code',
+      description: 'Coding-tuned Kimi model.',
+    },
+    {
+      value: 'Qwen/Qwen3.7-Plus',
+      label: 'Qwen 3.7 Plus',
+      description: 'Balanced Qwen model.',
+    },
+    {
+      value: 'zai-org/GLM-5.3',
+      label: 'GLM 5.3',
+      description: 'Balanced GLM model.',
+    },
+    {
+      value: 'z-ai/glm-5.3-flash',
+      label: 'GLM 5.3 Flash',
+      description: 'Fast GLM model.',
+    },
+  ],
+  DEFAULT: 'claude-sonnet-4-6',
+};
+
+type CommandCodeTranscriptEntry = {
+  type?: unknown;
+  message?: {
+    model?: unknown;
+    role?: unknown;
+    content?: unknown;
+  };
+  model?: unknown;
+};
+
+/**
+ * Reads the model a Command Code session is running with from the transcript
+ * tail.
+ *
+ * Command Code stores the active model on assistant transcript entries
+ * (`"model":"..."` on each assistant message) rather than in the session's
+ * `.meta.json` sidecar, so the newest assistant row is the authoritative
+ * source. This mirrors the Claude adapter's `readClaudeSessionModelFromJsonl`.
+ */
+const readCommandCodeSessionModelFromJsonl = async (
+  jsonlPath: string,
+): Promise<string | null> => {
+  try {
+    const content = await readFile(jsonlPath, 'utf8');
+    const lines = content.split(/\r?\n/);
+
+    for (let index = lines.length - 1; index >= 0; index -= 1) {
+      const line = lines[index]?.trim();
+      if (!line) {
+        continue;
+      }
+
+      try {
+        const entry = JSON.parse(line) as CommandCodeTranscriptEntry;
+        const entryModel = typeof entry.model === 'string'
+          ? entry.model
+          : (typeof entry.message?.model === 'string' ? entry.message.model : undefined);
+        if (entryModel?.trim()) {
+          return entryModel.trim();
+        }
+      } catch {
+        // Skip malformed JSONL lines that can appear during concurrent writes.
+      }
+    }
+  } catch {
+    // Missing/unreadable transcripts fall through to the catalog default.
+  }
+
+  return null;
+};
+
+export class CommandCodeProviderModels implements IProviderModels {
+  async getSupportedModels(): Promise<ProviderModelsDefinition> {
+    return COMMAND_CODE_PREDEFINED_MODELS;
+  }
+
+  async getCurrentActiveModel(sessionId?: string): Promise<ProviderCurrentActiveModel> {
+    if (!sessionId?.trim()) {
+      return buildDefaultProviderCurrentActiveModel(await this.getSupportedModels());
+    }
+
+    try {
+      const jsonlPath = sessionsDb.getSessionById(sessionId)?.jsonl_path;
+      const activeModel = jsonlPath
+        ? await readCommandCodeSessionModelFromJsonl(jsonlPath)
+        : null;
+      if (activeModel) {
+        return { model: activeModel };
+      }
+    } catch {
+      // Fall through to the provider default when the session-backed lookup fails.
+    }
+
+    return buildDefaultProviderCurrentActiveModel(await this.getSupportedModels());
+  }
+}

--- a/server/modules/providers/list/command-code/command-code-runtime.provider.js
+++ b/server/modules/providers/list/command-code/command-code-runtime.provider.js
@@ -1,0 +1,396 @@
+import crossSpawn from 'cross-spawn';
+
+import { notifyRunFailed, notifyRunStopped } from '@/modules/notifications/index.js';
+import {
+  createCompleteMessage,
+  createNormalizedMessage,
+  flattenPromptForWindowsShell,
+} from '@/shared/utils.js';
+
+// cross-spawn resolves `.cmd`/`.ps1` shims on Windows and delegates to
+// child_process.spawn everywhere else. The CLI is always invoked as
+// `command-code` (the Windows `cmdc` alias is never used directly).
+const spawnFunction = crossSpawn;
+
+const COMMAND_CODE_BINARY = 'command-code';
+
+const activeCommandCodeProcesses = new Map();
+
+/**
+ * Maps the UI permission mode onto Command Code's headless permission levers.
+ *
+ * Command Code's `--permission-mode` vocabulary (`default`, `plan`,
+ * `auto-accept`, `dont-ask`; legacy `standard`) differs from the frontend's
+ * `PermissionMode` union (`default`, `acceptEdits`, `auto`, `bypassPermissions`,
+ * `plan`). The runtime owns the ONLY translation table between the two:
+ *
+ * - plan              -> `--plan` (read-only exploration)
+ * - bypassPermissions -> `--yolo` (alias `--dangerously-skip-permissions`)
+ * - acceptEdits       -> `--permission-mode auto-accept`
+ * - default / auto    -> `--permission-mode default`
+ *
+ * Exported for tests.
+ */
+export function resolveCommandCodePermissionArgs(permissionMode) {
+  switch (permissionMode) {
+    case 'plan':
+      return ['--plan'];
+    case 'bypassPermissions':
+      return ['--yolo'];
+    case 'acceptEdits':
+      return ['--permission-mode', 'auto-accept'];
+    default:
+      return ['--permission-mode', 'default'];
+  }
+}
+
+/**
+ * Reads the session id Command Code reports on an NDJSON result frame.
+ *
+ * The result frame (`{"type":"result","subtype":"success","sessionId":...}`)
+ * is the last line of the stream and carries the provider-native session id;
+ * it is the only authoritative source for a freshly created session.
+ */
+function readResultSessionId(parsed) {
+  if (!parsed || typeof parsed !== 'object' || parsed.type !== 'result') {
+    return null;
+  }
+  return typeof parsed.sessionId === 'string' && parsed.sessionId.trim()
+    ? parsed.sessionId
+    : null;
+}
+
+/**
+ * Reads the token usage Command Code reports on the NDJSON result frame.
+ *
+ * The result frame carries a `usage` object with the run's token totals.
+ * Returns null when the frame has no usable usage so callers can skip the
+ * `token_budget` status.
+ */
+function readResultUsage(parsed) {
+  if (!parsed || typeof parsed !== 'object' || parsed.type !== 'result') {
+    return null;
+  }
+  const usage = parsed.usage;
+  if (!usage || typeof usage !== 'object') {
+    return null;
+  }
+
+  const input = Number(usage.inputTokens ?? usage.input ?? 0);
+  const output = Number(usage.outputTokens ?? usage.output ?? 0);
+  const used = input + output;
+  if (used <= 0) {
+    return null;
+  }
+
+  return {
+    used,
+    inputTokens: input,
+    outputTokens: output,
+    breakdown: { input, output },
+  };
+}
+
+async function spawnCommandCode(command, options = {}, ws, context) {
+  return new Promise((resolve, reject) => {
+    const {
+      sessionId,
+      projectPath,
+      cwd,
+      model,
+      effort,
+      sessionSummary,
+      permissionMode,
+      images,
+      files,
+    } = options;
+
+    // Callers pass the stable app session id; the CLI resumes with the
+    // provider-native id recorded on the session row.
+    const providerSessionId = context.resolveProviderSessionId(sessionId);
+    const workingDir = cwd || projectPath || process.cwd();
+
+    // Process-map key: the app session id when the caller supplied one, so
+    // abort-by-app-id always works.
+    const processKey = sessionId || Date.now().toString();
+    let capturedSessionId = providerSessionId;
+    let sessionCreatedSent = false;
+    let stdoutLineBuffer = '';
+    let terminalNotificationSent = false;
+    let commandCodeProcess = null;
+    // Unified lifecycle contract: exactly one terminal `complete` per run
+    // (close and error handlers can both fire for spawn failures).
+    let completeSent = false;
+
+    const notifyTerminalState = ({ code = null, error = null } = {}) => {
+      if (terminalNotificationSent) {
+        return;
+      }
+      terminalNotificationSent = true;
+
+      // Notifications are app-facing, so they carry the app session id.
+      const finalSessionId = sessionId || capturedSessionId || processKey;
+      if (code === 0 && !error) {
+        notifyRunStopped({
+          userId: ws?.userId || null,
+          provider: 'command-code',
+          sessionId: finalSessionId,
+          sessionName: sessionSummary,
+          stopReason: 'completed',
+        });
+        return;
+      }
+
+      notifyRunFailed({
+        userId: ws?.userId || null,
+        provider: 'command-code',
+        sessionId: finalSessionId,
+        sessionName: sessionSummary,
+        error: error || `Command Code CLI exited with code ${code}`,
+      });
+    };
+
+    const registerSession = (nextSessionId) => {
+      if (!nextSessionId || capturedSessionId === nextSessionId) {
+        return;
+      }
+
+      capturedSessionId = nextSessionId;
+      if (!sessionId && processKey !== capturedSessionId && commandCodeProcess) {
+        activeCommandCodeProcesses.delete(processKey);
+        activeCommandCodeProcesses.set(capturedSessionId, commandCodeProcess);
+      }
+      if (commandCodeProcess) {
+        commandCodeProcess.sessionId = capturedSessionId;
+      }
+
+      if (ws.setSessionId && typeof ws.setSessionId === 'function') {
+        ws.setSessionId(capturedSessionId);
+      }
+
+      if (!providerSessionId && !sessionCreatedSent) {
+        sessionCreatedSent = true;
+        ws.send(createNormalizedMessage({
+          kind: 'session_created',
+          newSessionId: capturedSessionId,
+          sessionId: capturedSessionId,
+          provider: 'command-code',
+        }));
+      }
+    };
+
+    const processCommandCodeOutputLine = (line) => {
+      if (!line || !line.trim()) {
+        return;
+      }
+
+      let parsed;
+      try {
+        parsed = JSON.parse(line);
+      } catch {
+        // Non-JSON lines (e.g. a stray banner) are forwarded as raw deltas so
+        // nothing the CLI prints is silently dropped.
+        ws.send(createNormalizedMessage({
+          kind: 'stream_delta',
+          content: line,
+          sessionId: capturedSessionId || sessionId || null,
+          provider: 'command-code',
+        }));
+        return;
+      }
+
+      try {
+        const resultSessionId = readResultSessionId(parsed);
+        registerSession(resultSessionId);
+
+        // The result frame is terminal and carries the run's token usage.
+        // Emit the usage as a status once it arrives.
+        const tokenBudget = readResultUsage(parsed);
+        if (tokenBudget) {
+          ws.send(createNormalizedMessage({
+            kind: 'status',
+            text: 'token_budget',
+            tokenBudget,
+            sessionId: capturedSessionId || sessionId || null,
+            provider: 'command-code',
+          }));
+        }
+
+        const normalized = context.normalizeMessage(parsed, capturedSessionId || sessionId || null);
+        for (const msg of normalized) {
+          ws.send(msg);
+        }
+      } catch (error) {
+        const errorContent = error instanceof Error ? error.message : String(error);
+        console.error('[CommandCode] Failed to process JSON output:', errorContent);
+        ws.send(createNormalizedMessage({
+          kind: 'error',
+          content: errorContent,
+          sessionId: capturedSessionId || sessionId || null,
+          provider: 'command-code',
+        }));
+      }
+    };
+
+    void context.resolveResumeModel(sessionId, model).then(async (resolvedModel) => {
+      const args = ['-p', '--output-format', 'json'];
+      if (providerSessionId) {
+        args.push('--resume', providerSessionId);
+      }
+      if (resolvedModel) {
+        args.push('-m', resolvedModel);
+      }
+      if (typeof effort === 'string' && effort !== 'default') {
+        args.push('--effort', effort);
+      }
+      args.push('--no-auto-update');
+      args.push('--skip-onboarding');
+      args.push(...resolveCommandCodePermissionArgs(permissionMode));
+
+      const hasAttachments =
+        (Array.isArray(images) && images.length > 0)
+        || (Array.isArray(files) && files.length > 0);
+      if ((command && command.trim()) || hasAttachments) {
+        // Note: Command Code's headless `-p` mode has no image/file attachment
+        // flag today; images/files are intentionally not appended (AD-11 sets
+        // supportsImages/supportsFiles false). The prompt is flattened on win32
+        // because `command-code` is a `.cmd`/`.ps1` shim there and cmd.exe
+        // truncates argv at the first newline.
+        args.push(flattenPromptForWindowsShell(command?.trim() || ''));
+      }
+
+      commandCodeProcess = spawnFunction(COMMAND_CODE_BINARY, args, {
+        cwd: workingDir,
+        stdio: ['pipe', 'pipe', 'pipe'],
+        env: { ...process.env },
+      });
+
+      activeCommandCodeProcesses.set(processKey, commandCodeProcess);
+      commandCodeProcess.sessionId = processKey;
+      commandCodeProcess.stdin.end();
+
+      commandCodeProcess.stdout.on('data', (data) => {
+        stdoutLineBuffer += data.toString();
+        const completeLines = stdoutLineBuffer.split(/\r?\n/);
+        stdoutLineBuffer = completeLines.pop() || '';
+
+        completeLines.forEach((line) => {
+          processCommandCodeOutputLine(line.trim());
+        });
+      });
+
+      commandCodeProcess.stderr.on('data', (data) => {
+        const stderrText = data.toString();
+        if (!stderrText.trim()) {
+          return;
+        }
+        ws.send(createNormalizedMessage({
+          kind: 'error',
+          content: stderrText,
+          sessionId: capturedSessionId || sessionId || null,
+          provider: 'command-code',
+        }));
+      });
+
+      commandCodeProcess.on('close', async (code) => {
+        const finalSessionId = sessionId || capturedSessionId || processKey;
+        activeCommandCodeProcesses.delete(finalSessionId);
+        activeCommandCodeProcesses.delete(processKey);
+
+        if (stdoutLineBuffer.trim()) {
+          processCommandCodeOutputLine(stdoutLineBuffer.trim());
+          stdoutLineBuffer = '';
+        }
+
+        // Terminal complete — skipped for aborted runs (abort-session already
+        // sent the aborted complete on this run's behalf).
+        if (!completeSent && !commandCodeProcess.aborted) {
+          completeSent = true;
+          ws.send(createCompleteMessage({ provider: 'command-code', sessionId: finalSessionId, exitCode: code }));
+        }
+
+        // Exit 8 (max-turns reached) still produced a valid partial result, so
+        // it is not treated as a hard failure. We surface it via the
+        // terminal complete (exitCode 8) and resolve the run; the frontend can
+        // distinguish max_turns from success by exitCode.
+        if (code === 0 || code === 8) {
+          notifyTerminalState({ code });
+          resolve();
+          return;
+        }
+
+        if (code === 130) {
+          notifyTerminalState({ code });
+          reject(new Error('Command Code CLI was interrupted'));
+          return;
+        }
+
+        if (code === 127 || code === null) {
+          const installed = await context.isProviderInstalled();
+          if (!installed) {
+            ws.send(createNormalizedMessage({
+              kind: 'error',
+              content: 'Command Code CLI is not installed. Install it with: npm i -g command-code',
+              sessionId: finalSessionId,
+              provider: 'command-code',
+            }));
+          }
+        }
+
+        notifyTerminalState({ code });
+        reject(new Error(code === null ? 'Command Code CLI process was terminated' : `Command Code CLI exited with code ${code}`));
+      });
+
+      commandCodeProcess.on('error', async (error) => {
+        const finalSessionId = sessionId || capturedSessionId || processKey;
+        activeCommandCodeProcesses.delete(finalSessionId);
+        activeCommandCodeProcesses.delete(processKey);
+
+        const installed = await context.isProviderInstalled();
+        const errorContent = !installed
+          ? 'Command Code CLI is not installed. Install it with: npm i -g command-code'
+          : error.message;
+
+        ws.send(createNormalizedMessage({
+          kind: 'error',
+          content: errorContent,
+          sessionId: finalSessionId,
+          provider: 'command-code',
+        }));
+        if (!completeSent && !commandCodeProcess.aborted) {
+          completeSent = true;
+          ws.send(createCompleteMessage({ provider: 'command-code', sessionId: finalSessionId, exitCode: 1 }));
+        }
+        notifyTerminalState({ error });
+        reject(error);
+      });
+    }).catch(reject);
+  });
+}
+
+function abortCommandCodeSession(sessionId) {
+  const process = activeCommandCodeProcesses.get(sessionId);
+  if (!process) {
+    return false;
+  }
+
+  process.aborted = true;
+  process.kill('SIGTERM');
+  activeCommandCodeProcesses.delete(sessionId);
+  return true;
+}
+
+function isCommandCodeSessionActive(sessionId) {
+  return activeCommandCodeProcesses.has(sessionId);
+}
+
+export const commandCodeRuntime = {
+  run: spawnCommandCode,
+  abort: abortCommandCodeSession,
+};
+
+export {
+  spawnCommandCode,
+  abortCommandCodeSession,
+  isCommandCodeSessionActive,
+};

--- a/server/modules/providers/list/command-code/command-code-session-synchronizer.provider.ts
+++ b/server/modules/providers/list/command-code/command-code-session-synchronizer.provider.ts
@@ -1,0 +1,240 @@
+import { readFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+import { sessionsDb } from '@/modules/database/index.js';
+import { getCommandCodeHomePath } from '@/modules/providers/list/command-code/command-code-auth.provider.js';
+import type { IProviderSessionSynchronizer } from '@/shared/interfaces.js';
+import {
+  extractFirstValidJsonlData,
+  findFilesRecursivelyCreatedAfter,
+  normalizeSessionName,
+  readFileTimestamps,
+  readJsonRecord,
+  readObjectRecord,
+  readOptionalString,
+} from '@/shared/utils.js';
+
+type ParsedSession = {
+  sessionId: string;
+  projectPath: string;
+  sessionName?: string;
+};
+
+const FALLBACK_TITLE = 'Untitled Command Code Session';
+
+/**
+ * True when a file under `~/.commandcode/projects/**` is a top-level session
+ * transcript rather than a sidecar.
+ *
+ * Command Code writes `<id>.jsonl` transcripts plus sidecars that also end in
+ * `.jsonl` (`<id>.checkpoints.jsonl`, `<id>.prompts.jsonl`) and `.json`
+ * metadata (`<id>.meta.json`, `<id>.share.json`). Indexing a sidecar as a
+ * standalone session would overwrite the parent row's `jsonl_path` — the exact
+ * corruption the Claude synchronizer guards against for subagent transcripts.
+ */
+const isSessionTranscriptFile = (filePath: string): boolean => {
+  const fileName = path.basename(filePath);
+  if (!fileName.endsWith('.jsonl')) {
+    return false;
+  }
+  return !fileName.endsWith('.checkpoints.jsonl')
+    && !fileName.endsWith('.prompts.jsonl')
+    && !fileName.endsWith('.share.jsonl');
+};
+
+/**
+ * Session indexer for Command Code transcript artifacts.
+ */
+export class CommandCodeSessionSynchronizer implements IProviderSessionSynchronizer {
+  private readonly provider = 'command-code' as const;
+  private readonly commandCodeHome = getCommandCodeHomePath();
+
+  /**
+   * Scans ~/.commandcode/projects and upserts discovered sessions into DB.
+   */
+  async synchronize(since?: Date): Promise<number> {
+    const files = await findFilesRecursivelyCreatedAfter(
+      path.join(this.commandCodeHome, 'projects'),
+      '.jsonl',
+      since ?? null,
+    );
+
+    let processed = 0;
+    for (const filePath of files) {
+      if (!isSessionTranscriptFile(filePath)) {
+        continue;
+      }
+
+      const parsed = await this.processSessionFile(filePath);
+      if (!parsed) {
+        continue;
+      }
+
+      const timestamps = await readFileTimestamps(filePath);
+      sessionsDb.createSession(
+        parsed.sessionId,
+        this.provider,
+        parsed.projectPath,
+        parsed.sessionName,
+        timestamps.createdAt,
+        timestamps.updatedAt,
+        filePath,
+      );
+      processed += 1;
+    }
+
+    return processed;
+  }
+
+  /**
+   * Parses and upserts one Command Code session JSONL file.
+   */
+  async synchronizeFile(filePath: string): Promise<string | null> {
+    if (!isSessionTranscriptFile(filePath)) {
+      return null;
+    }
+
+    const parsed = await this.processSessionFile(filePath);
+    if (!parsed) {
+      return null;
+    }
+
+    const timestamps = await readFileTimestamps(filePath);
+    return sessionsDb.createSession(
+      parsed.sessionId,
+      this.provider,
+      parsed.projectPath,
+      parsed.sessionName,
+      timestamps.createdAt,
+      timestamps.updatedAt,
+      filePath,
+    );
+  }
+
+  /**
+   * Extracts session metadata from one Command Code session JSONL file.
+   */
+  private async processSessionFile(filePath: string): Promise<ParsedSession | null> {
+    // The header row is the only place the session id + cwd live.
+    const parsed = await extractFirstValidJsonlData(filePath, (rawData) => {
+      const data = readObjectRecord(rawData);
+      if (!data || data.type !== 'session') {
+        return null;
+      }
+
+      const sessionId = readOptionalString(data.id);
+      const projectPath = readOptionalString(data.cwd);
+      if (!sessionId || !projectPath) {
+        return null;
+      }
+
+      return { sessionId, projectPath };
+    });
+
+    if (!parsed) {
+      return null;
+    }
+
+    // A thread a session was edited/rewound off stays on disk on purpose; it
+    // is nobody's conversation any more.
+    if (sessionsDb.isProviderSessionSuperseded(parsed.sessionId, this.provider)) {
+      return null;
+    }
+
+    // App-created sessions are keyed by an app id, so disk-discovered provider
+    // ids must first be bound to any pending app row (AD-13: the runtime owns
+    // app-launched rows; the synchronizer defers to it).
+    const pendingAppSession = sessionsDb.getSessionByProviderSessionId(parsed.sessionId)
+      ?? sessionsDb.getSessionById(parsed.sessionId)
+      ?? sessionsDb.findLatestPendingAppSession(this.provider, parsed.projectPath);
+    if (pendingAppSession && !pendingAppSession.provider_session_id) {
+      sessionsDb.assignProviderSessionId(pendingAppSession.session_id, parsed.sessionId);
+    }
+
+    const existingSession = sessionsDb.getSessionByProviderSessionId(parsed.sessionId)
+      ?? sessionsDb.getSessionById(parsed.sessionId);
+    const existingSessionName = existingSession?.custom_name;
+    if (existingSessionName && existingSessionName !== FALLBACK_TITLE) {
+      return {
+        ...parsed,
+        sessionName: normalizeSessionName(existingSessionName, FALLBACK_TITLE),
+      };
+    }
+
+    const sessionName = await this.readSessionTitle(filePath);
+
+    return {
+      ...parsed,
+      sessionName: normalizeSessionName(sessionName, FALLBACK_TITLE),
+    };
+  }
+
+  /**
+   * Reads a session's title from its `.meta.json` sidecar, falling back to the
+   * first user prompt in the transcript.
+   */
+  private async readSessionTitle(filePath: string): Promise<string | undefined> {
+    const metaPath = filePath.replace(/\.jsonl$/, '.meta.json');
+    try {
+      const metaContent = await readFile(metaPath, 'utf8');
+      const meta = readJsonRecord(metaContent);
+      const metaTitle = readOptionalString(meta?.title);
+      if (metaTitle) {
+        return metaTitle;
+      }
+    } catch {
+      // No meta sidecar — fall through to the transcript's first user prompt.
+    }
+
+    return this.readFirstUserPrompt(filePath);
+  }
+
+  /**
+   * Reads the first user prompt from a Command Code transcript to use as a
+   * session title when no meta sidecar (or title) exists.
+   */
+  private async readFirstUserPrompt(filePath: string): Promise<string | undefined> {
+    try {
+      const content = await readFile(filePath, 'utf8');
+      const lines = content.split(/\r?\n/);
+
+      for (const line of lines) {
+        const trimmed = line.trim();
+        if (!trimmed) {
+          continue;
+        }
+
+        try {
+          const entry = JSON.parse(trimmed) as { type?: unknown; message?: { role?: unknown; content?: unknown } };
+          if (entry.type !== 'message') {
+            continue;
+          }
+          const message = readObjectRecord(entry.message);
+          if (message?.role !== 'user') {
+            continue;
+          }
+
+          const content = typeof message.content === 'string'
+            ? message.content
+            : Array.isArray(message.content)
+              ? message.content
+                .map((part: unknown) => (typeof part === 'string' ? part : readObjectRecord(part)?.text ?? ''))
+                .filter(Boolean)
+                .join(' ')
+              : '';
+          const prompt = typeof content === 'string' ? content.trim() : '';
+          if (prompt) {
+            return prompt;
+          }
+        } catch {
+          // Skip malformed lines.
+        }
+      }
+    } catch {
+      // Missing/unreadable transcripts produce no title.
+    }
+
+    return undefined;
+  }
+}

--- a/server/modules/providers/list/command-code/command-code-sessions.provider.ts
+++ b/server/modules/providers/list/command-code/command-code-sessions.provider.ts
@@ -1,0 +1,339 @@
+import fsSync from 'node:fs';
+import readline from 'node:readline';
+
+import { sessionsDb } from '@/modules/database/index.js';
+import type { IProviderSessions } from '@/shared/interfaces.js';
+import { prepareTranscriptMessages } from '@/shared/message-unification.js';
+import type {
+  AnyRecord,
+  FetchHistoryOptions,
+  FetchHistoryResult,
+  NormalizedMessage,
+} from '@/shared/types.js';
+import {
+  createNormalizedMessage,
+  generateMessageId,
+  readObjectRecord,
+  sliceTailPage,
+} from '@/shared/utils.js';
+
+const PROVIDER = 'command-code';
+
+/**
+ * Reads a Command Code JSONL transcript and returns the active branch as a
+ * linear, oldest-first list of message rows.
+ *
+ * Command Code transcripts are a flat append-only list: one header row
+ * (`{"type":"session","id":...,"cwd":...}`) followed by `{"type":"message",
+ * "id":...,"parentId":...,"message":{role,content,model,usage,...}}` rows that
+ * form a tree. There is no per-row session id and no rewind marker, so the
+ * conversation shown is the active branch: the longest chain following
+ * `parentId` from the last row, preferring later siblings. This deliberately
+ * does NOT graph-prune older prompts (Claude-style) nor stack every fork
+ * (codex-style) — it linearizes only the live path.
+ */
+const readTranscriptRows = async (jsonlPath: string): Promise<AnyRecord[]> => {
+  const rows: AnyRecord[] = [];
+  const stream = fsSync.createReadStream(jsonlPath);
+  const lineReader = readline.createInterface({ input: stream, crlfDelay: Infinity });
+
+  for await (const line of lineReader) {
+    const trimmed = line.trim();
+    if (!trimmed) {
+      continue;
+    }
+
+    try {
+      rows.push(JSON.parse(trimmed) as AnyRecord);
+    } catch {
+      // Skip malformed lines that can appear during concurrent writes.
+    }
+  }
+
+  if (rows.length === 0) {
+    return [];
+  }
+
+  const rowsById = new Map<string, AnyRecord>();
+  for (const row of rows) {
+    if (typeof row.id === 'string') {
+      rowsById.set(row.id, row);
+    }
+  }
+
+  // The last row is always on the active branch. Walk parent pointers from it
+  // to the root, preferring later siblings at each level.
+  const activeBranch = new Set<string>();
+  let cursor: AnyRecord | null = rows[rows.length - 1];
+  const visited = new Set<string>();
+
+  while (cursor && !visited.has(String(cursor.id ?? ''))) {
+    const cursorId = String(cursor.id ?? '');
+    if (!cursorId) {
+      break;
+    }
+    visited.add(cursorId);
+    activeBranch.add(cursorId);
+
+    const parentId: string | undefined = typeof cursor.parentId === 'string'
+      ? cursor.parentId
+      : undefined;
+    cursor = parentId ? (rowsById.get(parentId) ?? null) : null;
+  }
+
+  const branchRows = rows.filter((row) => {
+    if (!row.id) {
+      // Header and other non-message rows are included only when they carry a
+      // role-bearing message (they should not); keep non-id rows out of the
+      // transcript except the header is skipped by the caller via type checks.
+      return false;
+    }
+    return activeBranch.has(String(row.id));
+  });
+
+  // Keep chronological order (rows were appended oldest-first).
+  return branchRows;
+};
+
+/**
+ * Normalizes a Command Code transcript/event row into the shared message shape.
+ *
+ * Rows carry a `message` object with a `role`; user rows become user text,
+ * assistant rows become assistant text, and tool-shaped rows are normalized
+ * from the message content array. Rows without a role (headers, lifecycle
+ * rows) produce nothing.
+ */
+const normalizeCommandCodeRow = (raw: AnyRecord, sessionId: string | null): NormalizedMessage[] => {
+  const message = readObjectRecord(raw.message);
+  if (!message) {
+    return [];
+  }
+
+  const timestamp = typeof raw.timestamp === 'string'
+    ? raw.timestamp
+    : new Date().toISOString();
+  const rowId = typeof raw.id === 'string'
+    ? raw.id
+    : generateMessageId('command-code');
+
+  // Extract text content from either a plain string or an array of content parts.
+  const readContent = (): string => {
+    if (typeof message.content === 'string') {
+      return message.content;
+    }
+    if (Array.isArray(message.content)) {
+      return message.content
+        .map((part: unknown) => {
+          if (typeof part === 'string') {
+            return part;
+          }
+          const record = readObjectRecord(part);
+          if (!record) {
+            return '';
+          }
+          if (typeof record.text === 'string') {
+            return record.text;
+          }
+          if (record.type === 'text' && typeof record.text === 'string') {
+            return record.text;
+          }
+          return '';
+        })
+        .filter(Boolean)
+        .join('\n');
+    }
+    return '';
+  };
+
+  const role = message.role === 'user' ? 'user' : message.role === 'assistant' ? 'assistant' : undefined;
+  const content = readContent().trim();
+
+  if (role === 'user') {
+    if (!content) {
+      return [];
+    }
+    return [createNormalizedMessage({
+      id: `${rowId}_user`,
+      sessionId,
+      timestamp,
+      provider: PROVIDER,
+      kind: 'text',
+      role: 'user',
+      content,
+      // Stable row identity for future edit/fork anchors (Command Code rows
+      // carry stable ids).
+      transcriptAnchorId: rowId,
+    })];
+  }
+
+  if (role === 'assistant') {
+    if (!content) {
+      return [];
+    }
+    return [createNormalizedMessage({
+      id: `${rowId}_assistant`,
+      sessionId,
+      timestamp,
+      provider: PROVIDER,
+      kind: 'text',
+      role: 'assistant',
+      content,
+      transcriptAnchorId: rowId,
+    })];
+  }
+
+  return [];
+};
+
+export class CommandCodeSessionsProvider implements IProviderSessions {
+  /**
+   * Normalizes a raw live NDJSON event frame or a history row.
+   *
+   * History rows carry a `message.role` and are normalized directly. Live
+   * `command-code -p --output-format json` events come in two shapes: event
+   * frames (`{"type":"event","event":{...AgentEvent...}}`) and one final
+   * result line (`{"type":"result",...}`). Result lines are handled by the
+   * runtime (terminal + token usage); event frames that carry text/tool
+   * content are normalized here.
+   */
+  normalizeMessage(rawMessage: unknown, sessionId: string | null): NormalizedMessage[] {
+    const raw = readObjectRecord(rawMessage);
+    if (!raw) {
+      return [];
+    }
+
+    // A transcript row with a role-bearing message.
+    if (readObjectRecord(raw.message)?.role) {
+      return normalizeCommandCodeRow(raw, sessionId);
+    }
+
+    // Live NDJSON wrapper: {"type":"event","event":{...}}.
+    if (raw.type === 'event') {
+      const event = readObjectRecord(raw.event);
+      if (!event) {
+        return [];
+      }
+
+      const eventType = typeof event.type === 'string' ? event.type : '';
+      const timestamp = typeof event.timestamp === 'string'
+        ? event.timestamp
+        : new Date().toISOString();
+      const eventId = typeof event.id === 'string'
+        ? event.id
+        : generateMessageId('command-code-event');
+
+      // Stream deltas: the event body may carry text under `content`/`text`.
+      if (eventType === 'stream_event' || eventType === 'text' || eventType === 'content') {
+        const text = typeof event.content === 'string'
+          ? event.content
+          : typeof event.text === 'string' ? event.text : '';
+        if (text) {
+          return [createNormalizedMessage({
+            id: eventId,
+            sessionId,
+            timestamp,
+            provider: PROVIDER,
+            kind: 'stream_delta',
+            content: text,
+          })];
+        }
+      }
+
+      if (eventType === 'tool_running' || eventType === 'tool_use') {
+        const toolName = typeof event.toolName === 'string'
+          ? event.toolName
+          : (typeof event.name === 'string' ? event.name : 'Unknown');
+        const toolId = typeof event.toolCallId === 'string'
+          ? event.toolCallId
+          : (typeof event.id === 'string' ? event.id : eventId);
+        const toolInput = event.input ?? event.arguments ?? {};
+        return [createNormalizedMessage({
+          id: eventId,
+          sessionId,
+          timestamp,
+          provider: PROVIDER,
+          kind: 'tool_use',
+          toolName,
+          toolInput,
+          toolId,
+        })];
+      }
+
+      // Unknown/forward-compatible event types are ignored.
+      return [];
+    }
+
+    // A raw event with a direct `type` (not wrapped).
+    if (raw.type === 'result') {
+      // Result frames are terminal; the runtime owns their handling.
+      return [];
+    }
+
+    return normalizeCommandCodeRow(raw, sessionId);
+  }
+
+  /**
+   * Loads a Command Code session's history from its transcript file.
+   */
+  async fetchHistory(
+    sessionId: string,
+    options: FetchHistoryOptions = {},
+  ): Promise<FetchHistoryResult> {
+    const { limit = null, offset = 0 } = options;
+
+    let transcriptPath: string | null = null;
+    try {
+      transcriptPath = sessionsDb.getSessionById(sessionId)?.jsonl_path ?? null;
+      if (!transcriptPath) {
+        return { messages: [], total: 0, hasMore: false, offset: 0, limit: null };
+      }
+    } catch {
+      return { messages: [], total: 0, hasMore: false, offset: 0, limit: null };
+    }
+
+    let normalized: NormalizedMessage[] = [];
+    try {
+      const rows = await readTranscriptRows(transcriptPath);
+      for (const row of rows) {
+        if (row.type !== 'message') {
+          continue;
+        }
+        normalized.push(...normalizeCommandCodeRow(row, sessionId));
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      console.warn(`[CommandCodeProvider] Failed to load session ${sessionId}:`, message);
+      return { messages: [], total: 0, hasMore: false, offset: 0, limit: null };
+    }
+
+    // Pair tool_results with their tool_use so the transcript renders one row.
+    const toolResultMap = new Map<string, NormalizedMessage>();
+    for (const msg of normalized) {
+      if (msg.kind === 'tool_result' && msg.toolId) {
+        toolResultMap.set(msg.toolId, msg);
+      }
+    }
+    for (const msg of normalized) {
+      if (msg.kind === 'tool_use' && msg.toolId && toolResultMap.has(msg.toolId)) {
+        const toolResult = toolResultMap.get(msg.toolId);
+        if (toolResult) {
+          msg.toolResult = { content: toolResult.content, isError: toolResult.isError };
+        }
+      }
+    }
+
+    const transcript = prepareTranscriptMessages(normalized);
+    const total = transcript.length;
+    const normalizedOffset = Math.max(0, offset);
+    const normalizedLimit = limit === null ? null : Math.max(0, limit);
+    const { page, hasMore } = sliceTailPage(transcript, normalizedLimit, normalizedOffset);
+
+    return {
+      messages: page,
+      total,
+      hasMore,
+      offset: normalizedOffset,
+      limit: normalizedLimit,
+    };
+  }
+}

--- a/server/modules/providers/list/command-code/command-code-skills.provider.ts
+++ b/server/modules/providers/list/command-code/command-code-skills.provider.ts
@@ -1,0 +1,94 @@
+import os from 'node:os';
+import path from 'node:path';
+
+import { getCommandCodeHomePath } from '@/modules/providers/list/command-code/command-code-auth.provider.js';
+import { SkillsProvider } from '@/modules/providers/shared/skills/skills.provider.js';
+import type { ProviderSkillSource } from '@/shared/types.js';
+import {
+  addUniqueProviderSkillSource,
+  findTopmostGitRoot,
+} from '@/shared/utils.js';
+
+const COMMAND_CODE_PROJECT_SKILL_DIRS = [
+  ['.commandcode', 'skills'],
+  ['.agents', 'skills'],
+] as const;
+
+const COMMAND_CODE_USER_SKILL_DIRS = [
+  ['.commandcode', 'skills'],
+  ['.agents', 'skills'],
+] as const;
+
+/**
+ * Skills discovery for Command Code.
+ *
+ * Command Code implements the Agent Skills open standard and also reads the
+ * `.agents/skills` compatibility locations, so project skills are discovered
+ * from `.commandcode/skills` and `.agents/skills` walking up to the git root,
+ * and user skills from `~/.commandcode/skills` and `~/.agents/skills`.
+ * `.commandcode/skills` wins name conflicts over `.agents/skills`, which the
+ * shared scanner resolves by root precedence (project before user) plus the
+ * physical dedupe of identical roots.
+ */
+export class CommandCodeSkillsProvider extends SkillsProvider {
+  constructor() {
+    super('command-code');
+  }
+
+  protected async getSkillSources(workspacePath: string): Promise<ProviderSkillSource[]> {
+    const sources: ProviderSkillSource[] = [];
+    const seenRootDirs = new Set<string>();
+    const repoRoot = await findTopmostGitRoot(workspacePath);
+
+    for (const projectRoot of this.getProjectSearchRoots(workspacePath, repoRoot)) {
+      for (const skillDir of COMMAND_CODE_PROJECT_SKILL_DIRS) {
+        addUniqueProviderSkillSource(sources, seenRootDirs, {
+          scope: 'project',
+          rootDir: path.join(projectRoot, ...skillDir),
+          commandPrefix: '/',
+        });
+      }
+    }
+
+    for (const skillDir of COMMAND_CODE_USER_SKILL_DIRS) {
+      addUniqueProviderSkillSource(sources, seenRootDirs, {
+        scope: 'user',
+        rootDir: path.join(os.homedir(), ...skillDir),
+        commandPrefix: '/',
+      });
+    }
+
+    return sources;
+  }
+
+  protected async getGlobalSkillSource(): Promise<ProviderSkillSource> {
+    return {
+      scope: 'user',
+      rootDir: path.join(getCommandCodeHomePath(), 'skills'),
+      commandPrefix: '/',
+    };
+  }
+
+  private getProjectSearchRoots(workspacePath: string, repoRoot: string | null): string[] {
+    const roots: string[] = [];
+    const normalizedWorkspacePath = path.resolve(workspacePath);
+    const normalizedRepoRoot = repoRoot ? path.resolve(repoRoot) : null;
+    let currentPath = normalizedWorkspacePath;
+
+    while (true) {
+      roots.push(currentPath);
+      if (!normalizedRepoRoot || currentPath === normalizedRepoRoot) {
+        break;
+      }
+
+      const parentPath = path.dirname(currentPath);
+      if (parentPath === currentPath) {
+        break;
+      }
+
+      currentPath = parentPath;
+    }
+
+    return roots;
+  }
+}

--- a/server/modules/providers/list/command-code/command-code.provider.ts
+++ b/server/modules/providers/list/command-code/command-code.provider.ts
@@ -1,0 +1,30 @@
+import { CommandCodeProviderAuth } from '@/modules/providers/list/command-code/command-code-auth.provider.js';
+import { CommandCodeProviderModels } from '@/modules/providers/list/command-code/command-code-models.provider.js';
+import { commandCodeRuntime } from '@/modules/providers/list/command-code/command-code-runtime.provider.js';
+import { CommandCodeMcpProvider } from '@/modules/providers/list/command-code/command-code-mcp.provider.js';
+import { CommandCodeSessionSynchronizer } from '@/modules/providers/list/command-code/command-code-session-synchronizer.provider.js';
+import { CommandCodeSessionsProvider } from '@/modules/providers/list/command-code/command-code-sessions.provider.js';
+import { CommandCodeSkillsProvider } from '@/modules/providers/list/command-code/command-code-skills.provider.js';
+import { AbstractProvider } from '@/modules/providers/shared/base/abstract.provider.js';
+import type {
+  IProviderAuth,
+  IProviderModels,
+  IProviderRuntime,
+  IProviderSessionSynchronizer,
+  IProviderSkills,
+  IProviderSessions,
+} from '@/shared/interfaces.js';
+
+export class CommandCodeProvider extends AbstractProvider {
+  readonly runtime: IProviderRuntime = commandCodeRuntime;
+  readonly models: IProviderModels = new CommandCodeProviderModels();
+  readonly mcp = new CommandCodeMcpProvider();
+  readonly auth: IProviderAuth = new CommandCodeProviderAuth();
+  readonly skills: IProviderSkills = new CommandCodeSkillsProvider();
+  readonly sessions: IProviderSessions = new CommandCodeSessionsProvider();
+  readonly sessionSynchronizer: IProviderSessionSynchronizer = new CommandCodeSessionSynchronizer();
+
+  constructor() {
+    super('command-code');
+  }
+}

--- a/server/modules/providers/provider.registry.ts
+++ b/server/modules/providers/provider.registry.ts
@@ -1,5 +1,6 @@
 import { ClaudeProvider } from '@/modules/providers/list/claude/claude.provider.js';
 import { CodexProvider } from '@/modules/providers/list/codex/codex.provider.js';
+import { CommandCodeProvider } from '@/modules/providers/list/command-code/command-code.provider.js';
 import { CursorProvider } from '@/modules/providers/list/cursor/cursor.provider.js';
 import { OpenCodeProvider } from '@/modules/providers/list/opencode/opencode.provider.js';
 import type { IProvider } from '@/shared/interfaces.js';
@@ -11,6 +12,7 @@ const providers: Record<LLMProvider, IProvider> = {
   codex: new CodexProvider(),
   cursor: new CursorProvider(),
   opencode: new OpenCodeProvider(),
+  'command-code': new CommandCodeProvider(),
 };
 
 /**

--- a/server/modules/providers/provider.routes.ts
+++ b/server/modules/providers/provider.routes.ts
@@ -287,6 +287,7 @@ const parseProvider = (value: unknown): LLMProvider => {
     || normalized === 'codex'
     || normalized === 'cursor'
     || normalized === 'opencode'
+    || normalized === 'command-code'
   ) {
     return normalized;
   }

--- a/server/modules/providers/services/provider-capabilities.service.ts
+++ b/server/modules/providers/services/provider-capabilities.service.ts
@@ -104,6 +104,25 @@ const PROVIDER_CAPABILITIES: Record<LLMProvider, ProviderCapabilities> = {
     supportsMessageEditing: false,
     supportsSessionForking: false,
   },
+  'command-code': {
+    provider: 'command-code',
+    // The runtime owns the only translation to Command Code's real
+    // `--permission-mode`/`--yolo`/`--plan` vocabulary. See
+    // resolveCommandCodePermissionArgs in the Command Code runtime adapter.
+    permissionModes: ['default', 'acceptEdits', 'bypassPermissions', 'plan'],
+    defaultPermissionMode: 'default',
+    // Command Code's headless `-p` mode has no image/file attachment flag.
+    supportsImages: false,
+    supportsFiles: false,
+    supportsAbort: true,
+    // Headless runs have no interactive prompt channel — permission is set
+    // pre-launch via --permission-mode / --yolo.
+    supportsPermissionRequests: false,
+    supportsTokenUsage: true,
+    supportsEffort: true,
+    supportsMessageEditing: false,
+    supportsSessionForking: false,
+  },
 };
 
 /**

--- a/server/modules/providers/services/provider-token-usage.service.ts
+++ b/server/modules/providers/services/provider-token-usage.service.ts
@@ -182,6 +182,65 @@ function emptyCodexTokenUsage(): TokenUsageResult {
 }
 
 /**
+ * Latest usage from a Command Code transcript's already-parsed rows.
+ *
+ * Command Code records per-assistant-message `usage` (with `input_tokens` /
+ * `output_tokens`, camelCase variants accepted). Reads the newest usage-bearing
+ * assistant row only so a session's counter reflects the current conversation,
+ * mirroring the Claude reader.
+ */
+export function summarizeCommandCodeTokenUsage(fileContent: string): TokenUsageResult {
+  let inputTokens = 0;
+  let outputTokens = 0;
+
+  const lines = fileContent.trim().split('\n');
+  for (let index = lines.length - 1; index >= 0; index -= 1) {
+    try {
+      const entry = JSON.parse(lines[index]) as AnyRecord;
+      const message = entry?.type === 'message' ? entry.message : null;
+      const usage = message?.usage;
+      if (!usage) {
+        continue;
+      }
+
+      const rowInput = readUsageNumber(usage.input_tokens ?? usage.inputTokens ?? usage.input);
+      const rowOutput = readUsageNumber(usage.output_tokens ?? usage.outputTokens ?? usage.output);
+      if (rowInput === 0 && rowOutput === 0) {
+        continue;
+      }
+
+      inputTokens = rowInput;
+      outputTokens = rowOutput;
+      break;
+    } catch {
+      // A provider may be writing the last JSONL line while this read happens.
+    }
+  }
+
+  return {
+    used: inputTokens + outputTokens,
+    inputTokens,
+    outputTokens,
+    breakdown: { input: inputTokens, output: outputTokens },
+  };
+}
+
+function commandCodeUsageRows(fileContent: string): boolean {
+  const lines = fileContent.trim().split('\n');
+  for (const line of lines) {
+    try {
+      const entry = JSON.parse(line) as AnyRecord;
+      if (entry?.type === 'message' && entry.message?.usage) {
+        return true;
+      }
+    } catch {
+      // Skip malformed lines.
+    }
+  }
+  return false;
+}
+
+/**
  * Latest context-window usage from a Claude transcript's already-parsed rows.
  *
  * Exported because the session-messages reader hands the same usage back on
@@ -432,6 +491,23 @@ export function createProviderTokenUsageService(
         // whole file is still authoritative when it happens.
         return findCodexTokenUsage(await dependencies.readTextFile(sessionFilePath))
           ?? emptyCodexTokenUsage();
+      }
+
+      if (session.provider === 'command-code') {
+        const sessionFilePath = session.jsonl_path;
+        if (!sessionFilePath || !dependencies.fileExists(sessionFilePath)) {
+          throw new AppError(`Command Code session file for "${sessionId}" was not found.`, {
+            code: 'SESSION_FILE_NOT_FOUND',
+            statusCode: 404,
+          });
+        }
+
+        const tail = await dependencies.readTextFileTail(sessionFilePath, TOKEN_USAGE_TAIL_BYTES);
+        if (commandCodeUsageRows(tail.content) || tail.isComplete) {
+          return summarizeCommandCodeTokenUsage(tail.content);
+        }
+
+        return summarizeCommandCodeTokenUsage(await dependencies.readTextFile(sessionFilePath));
       }
 
       let sessionFilePath = session.jsonl_path;

--- a/server/modules/providers/services/session-synchronizer.service.ts
+++ b/server/modules/providers/services/session-synchronizer.service.ts
@@ -84,6 +84,7 @@ async function runSessionSynchronization(): Promise<SessionSynchronizeResult> {
     codex: 0,
     cursor: 0,
     opencode: 0,
+    'command-code': 0,
   };
   const failures: string[] = [];
 

--- a/server/modules/providers/services/sessions-watcher.service.ts
+++ b/server/modules/providers/services/sessions-watcher.service.ts
@@ -27,6 +27,10 @@ const PROVIDER_WATCH_PATHS: Array<{ provider: LLMProvider; rootPath: string }> =
     provider: 'opencode',
     rootPath: path.join(os.homedir(), '.local', 'share', 'opencode'),
   },
+  {
+    provider: 'command-code',
+    rootPath: path.join(os.homedir(), '.commandcode', 'projects'),
+  },
 ];
 
 const WATCHER_IGNORED_PATTERNS = [
@@ -39,6 +43,9 @@ const WATCHER_IGNORED_PATTERNS = [
   '**/*.tmp',
   '**/*.swp',
   '**/.DS_Store',
+  '**/*.checkpoints.jsonl',
+  '**/*.prompts.jsonl',
+  '**/*.share.jsonl',
 ];
 
 const PROJECTS_UPDATE_DEBOUNCE_MS = 500;

--- a/server/modules/providers/tests/mcp.test.ts
+++ b/server/modules/providers/tests/mcp.test.ts
@@ -313,7 +313,7 @@ test('providerMcpService global adder writes to all providers and rejects unsupp
       workspacePath,
     });
 
-    assert.equal(globalResult.length, 4);
+    assert.equal(globalResult.length, 5);
     assert.ok(globalResult.every((entry) => entry.created === true));
 
     const claudeProject = await readJson(path.join(workspacePath, '.mcp.json'));

--- a/server/modules/providers/tests/provider-runtime.service.test.ts
+++ b/server/modules/providers/tests/provider-runtime.service.test.ts
@@ -76,6 +76,7 @@ test('providerRegistry owns one runtime for every registered provider', () => {
     'codex',
     'cursor',
     'opencode',
+    'command-code',
   ]);
   assert.equal(providers.every((provider) => typeof provider.runtime.run === 'function'), true);
   assert.equal(providers.every((provider) => typeof provider.runtime.abort === 'function'), true);

--- a/server/modules/websocket/services/shell-websocket.service.ts
+++ b/server/modules/websocket/services/shell-websocket.service.ts
@@ -217,6 +217,15 @@ function buildShellCommand(
     return initialCommand || 'opencode';
   }
 
+  if (provider === 'command-code') {
+    if (resumeSessionId) {
+      return `command-code --resume "${resumeSessionId}"`;
+    }
+    // `command-code` works on every OS; `cmdc` is a Windows-only alias that
+    // would shadow the cmd.exe shell name on other platforms.
+    return initialCommand || 'command-code';
+  }
+
   // Launching with the flag is what unlocks "bypass permissions" in the CLI's
   // shift+tab permission-mode cycle; it cannot be enabled from inside a
   // session started without it.
@@ -543,7 +552,9 @@ export function handleShellConnection(
                 ? 'Codex'
                 : provider === 'opencode'
                     ? 'OpenCode'
-                  : 'Claude';
+                  : provider === 'command-code'
+                      ? 'Command Code'
+                    : 'Claude';
           welcomeMsg = hasSession && resumeSessionId
             ? `\x1b[36mResuming ${providerName} session ${resumeSessionId} in: ${projectPath}\x1b[0m\r\n`
             : `\x1b[36mStarting new ${providerName} session in: ${projectPath}\x1b[0m\r\n`;

--- a/server/shared/types.ts
+++ b/server/shared/types.ts
@@ -66,7 +66,7 @@ export type AuthenticatedWebSocketRequest = IncomingMessage & {
  * Use this as the source of truth whenever a function or payload needs to identify
  * a specific LLM integration.
  */
-export type LLMProvider = 'claude' | 'codex' | 'cursor' | 'opencode';
+export type LLMProvider = 'claude' | 'codex' | 'cursor' | 'opencode' | 'command-code';
 
 /**
  * One selectable model row in a provider model catalog.

--- a/src/modules/chat/ChatInterface.tsx
+++ b/src/modules/chat/ChatInterface.tsx
@@ -397,7 +397,9 @@ function ChatInterface({
         ? t('messageTypes.codex')
         : provider === 'opencode'
             ? t('messageTypes.opencode', { defaultValue: 'OpenCode' })
-          : t('messageTypes.claude');
+            : provider === 'command-code'
+              ? t('messageTypes.commandCode', { defaultValue: 'Command Code' })
+              : t('messageTypes.claude');
 
   if (!selectedProject) {
     return (

--- a/src/modules/chat/export/buildTranscriptMarkdown.ts
+++ b/src/modules/chat/export/buildTranscriptMarkdown.ts
@@ -15,6 +15,7 @@ const PROVIDER_LABELS: Record<string, string> = {
   codex: 'Codex',
   cursor: 'Cursor',
   opencode: 'OpenCode',
+  'command-code': 'Command Code',
 };
 
 /** Fenced blocks need a longer fence than anything they contain. */

--- a/src/modules/chat/hooks/useChatProviderState.ts
+++ b/src/modules/chat/hooks/useChatProviderState.ts
@@ -22,6 +22,7 @@ const FALLBACK_PROVIDER_EFFORT_VALUES: Partial<Record<LLMProvider, readonly stri
   // valid Max/Ultra selection from being reset during catalog hydration.
   codex: ['low', 'medium', 'high', 'xhigh', 'max', 'ultra'],
   opencode: ['none', 'low', 'medium', 'high', 'xhigh', 'max'],
+  'command-code': ['low', 'medium', 'high'],
 };
 
 const toProviderEffortOptions = (
@@ -33,9 +34,10 @@ const FALLBACK_DEFAULT_MODEL: Record<LLMProvider, string> = {
   cursor: 'gpt-5.3-codex',
   codex: 'gpt-5.4',
   opencode: 'anthropic/claude-sonnet-4-5',
+  'command-code': 'claude-sonnet-4-6',
 };
 
-const PROVIDERS: LLMProvider[] = ['claude', 'cursor', 'codex', 'opencode'];
+const PROVIDERS: LLMProvider[] = ['claude', 'cursor', 'codex', 'opencode', 'command-code'];
 
 /** localStorage key holding the user's default model for one provider. */
 const providerModelStorageKey = (provider: LLMProvider): string => `${provider}-model`;
@@ -51,6 +53,7 @@ const FALLBACK_PERMISSION_MODES: Record<LLMProvider, PermissionMode[]> = {
   cursor: ['default', 'acceptEdits', 'bypassPermissions', 'plan'],
   codex: ['default', 'acceptEdits', 'bypassPermissions'],
   opencode: ['default', 'acceptEdits', 'bypassPermissions', 'plan'],
+  'command-code': ['default', 'acceptEdits', 'bypassPermissions', 'plan'],
 };
 
 type ProviderCapabilities = {

--- a/src/modules/chat/modals/CommandResultModal.tsx
+++ b/src/modules/chat/modals/CommandResultModal.tsx
@@ -55,6 +55,7 @@ const PROVIDER_LABELS: Record<string, string> = {
   cursor: 'Cursor',
   codex: 'Codex',
   opencode: 'OpenCode',
+  'command-code': 'Command Code',
 };
 
 const FALLBACK_COMMANDS: CommandEntry[] = [

--- a/src/modules/chat/modals/ModelLibraryPanel.tsx
+++ b/src/modules/chat/modals/ModelLibraryPanel.tsx
@@ -23,6 +23,7 @@ const PROVIDERS: Array<{ id: LLMProvider; label: string }> = [
   { id: 'codex', label: 'Codex' },
   { id: 'cursor', label: 'Cursor' },
   { id: 'opencode', label: 'OpenCode' },
+  { id: 'command-code', label: 'Command Code' },
 ];
 
 type ModelLibraryPanelProps = {

--- a/src/modules/chat/transcript/MessageComponent.tsx
+++ b/src/modules/chat/transcript/MessageComponent.tsx
@@ -198,7 +198,9 @@ const MessageComponent = memo(({ message, prevMessage, createDiff, onFileOpen, s
                           ? t('messageTypes.codex')
                           : provider === 'opencode'
                               ? t('messageTypes.opencode', { defaultValue: 'OpenCode' })
-                              : t('messageTypes.claude'))}
+                              : provider === 'command-code'
+                                ? t('messageTypes.commandCode', { defaultValue: 'Command Code' })
+                                : t('messageTypes.claude'))}
               </div>
             </div>
           )}

--- a/src/modules/chat/transcript/ProviderSelectionEmptyState.tsx
+++ b/src/modules/chat/transcript/ProviderSelectionEmptyState.tsx
@@ -34,6 +34,7 @@ const PROVIDER_META: { id: LLMProvider; name: string }[] = [
   { id: "codex", name: "OpenAI" },
   { id: "cursor", name: "Cursor" },
   { id: "opencode", name: "OpenCode" },
+  { id: "command-code", name: "Command Code" },
 ];
 
 const MOD_KEY =
@@ -87,6 +88,7 @@ function getProviderDisplayName(p: LLMProvider) {
   if (p === "cursor") return "Cursor";
   if (p === "codex") return "Codex";
   if (p === "opencode") return "OpenCode";
+  if (p === "command-code") return "Command Code";
   return "Claude";
 }
 
@@ -336,6 +338,10 @@ export default function ProviderSelectionEmptyState({
                 opencode: t("providerSelection.readyPrompt.opencode", {
                   model: providerModels.opencode,
                   defaultValue: "Ready with OpenCode {{model}}",
+                }),
+                "command-code": t("providerSelection.readyPrompt.commandCode", {
+                  model: providerModels["command-code"],
+                  defaultValue: "Ready with Command Code {{model}}",
                 }),
               }[provider]
             }

--- a/src/modules/i18n/locales/en/chat.json
+++ b/src/modules/i18n/locales/en/chat.json
@@ -18,7 +18,8 @@
     "claude": "Claude",
     "cursor": "Cursor",
     "codex": "Codex",
-    "opencode": "OpenCode"
+    "opencode": "OpenCode",
+    "commandCode": "Command Code"
   },
   "tools": {
     "settings": "Tool Settings",
@@ -159,6 +160,7 @@
       "cursor": "Ready to use Cursor with {{model}}. Start typing your message below.",
       "codex": "Ready to use Codex with {{model}}. Start typing your message below.",
       "opencode": "Ready to use OpenCode with {{model}}. Start typing your message below.",
+      "commandCode": "Ready to use Command Code with {{model}}. Start typing your message below.",
       "default": "Select a provider above to begin"
     },
     "pressToSearch": "Press <kbd>{{shortcut}}</kbd> to search sessions, files, and commits"

--- a/src/modules/i18n/locales/en/settings.json
+++ b/src/modules/i18n/locales/en/settings.json
@@ -351,6 +351,9 @@
       },
       "opencode": {
         "description": "OpenCode CLI assistant"
+      },
+      "command-code": {
+        "description": "Command Code CLI assistant"
       }
     },
     "connectionStatus": "Connection Status",

--- a/src/modules/i18n/locales/es/chat.json
+++ b/src/modules/i18n/locales/es/chat.json
@@ -18,7 +18,8 @@
     "claude": "Claude",
     "cursor": "Cursor",
     "codex": "Codex",
-    "opencode": "OpenCode"
+    "opencode": "OpenCode",
+    "commandCode": "Command Code"
   },
   "tools": {
     "settings": "Ajustes de herramientas",

--- a/src/modules/i18n/locales/fr/chat.json
+++ b/src/modules/i18n/locales/fr/chat.json
@@ -18,7 +18,8 @@
     "claude": "Claude",
     "cursor": "Cursor",
     "codex": "Codex",
-    "opencode": "OpenCode"
+    "opencode": "OpenCode",
+    "commandCode": "Command Code"
   },
   "tools": {
     "settings": "Paramètres de l'outil",

--- a/src/modules/mcp/McpServers.tsx
+++ b/src/modules/mcp/McpServers.tsx
@@ -21,6 +21,7 @@ const MCP_PROVIDER_BUTTON_CLASSES: Record<McpProvider, string> = {
   cursor: 'bg-primary text-primary-foreground hover:bg-primary/90',
   codex: 'bg-primary text-primary-foreground hover:bg-primary/90',
   opencode: 'bg-primary text-primary-foreground hover:bg-primary/90',
+  'command-code': 'bg-primary text-primary-foreground hover:bg-primary/90',
 };
 
 const getTransportIcon = (transport: string | undefined) => {

--- a/src/modules/onboarding/AgentConnectionsStep.tsx
+++ b/src/modules/onboarding/AgentConnectionsStep.tsx
@@ -35,6 +35,13 @@ const providerCards = [
     iconContainerClassName: 'bg-zinc-100 dark:bg-zinc-800',
     loginButtonClassName: 'bg-zinc-800 hover:bg-zinc-900 dark:bg-zinc-700 dark:hover:bg-zinc-600',
   },
+  {
+    provider: 'command-code' as const,
+    title: 'Command Code',
+    connectedClassName: 'bg-neutral-100 dark:bg-neutral-800/50 border-neutral-300 dark:border-neutral-600',
+    iconContainerClassName: 'bg-neutral-100 dark:bg-neutral-800',
+    loginButtonClassName: 'bg-neutral-800 hover:bg-neutral-900 dark:bg-neutral-700 dark:hover:bg-neutral-600',
+  },
 ];
 
 /** Rendered by Onboarding as its second step, listing every CLI provider the user can log into. */

--- a/src/modules/provider-auth/ProviderLoginModal.tsx
+++ b/src/modules/provider-auth/ProviderLoginModal.tsx
@@ -58,6 +58,10 @@ const getProviderCommand = ({
     return 'opencode auth login';
   }
 
+  if (provider === 'command-code') {
+    return 'command-code login';
+  }
+
   return 'claude --dangerously-skip-permissions /login';
 };
 
@@ -66,6 +70,7 @@ const getProviderTitle = (provider: LLMProvider) => {
   if (provider === 'cursor') return 'Cursor CLI Login';
   if (provider === 'codex') return 'Codex CLI Login';
   if (provider === 'opencode') return 'OpenCode CLI Login';
+  if (provider === 'command-code') return 'Command Code CLI Login';
   return 'Claude CLI Login';
 };
 

--- a/src/modules/provider-auth/hooks/useProviderAuthStatus.ts
+++ b/src/modules/provider-auth/hooks/useProviderAuthStatus.ts
@@ -3,13 +3,14 @@ import { useCallback, useState } from 'react';
 import { api } from '@/shared/api';
 import type { LLMProvider, ProviderAuthStatus, ProviderAuthStatusMap } from '@/shared/types';
 
-const CLI_PROVIDERS: LLMProvider[] = ['claude', 'cursor', 'codex', 'opencode'];
+const CLI_PROVIDERS: LLMProvider[] = ['claude', 'cursor', 'codex', 'opencode', 'command-code'];
 
 const createInitialProviderAuthStatusMap = (loading = true): ProviderAuthStatusMap => ({
   claude: { authenticated: false, email: null, method: null, error: null, loading },
   cursor: { authenticated: false, email: null, method: null, error: null, loading },
   codex: { authenticated: false, email: null, method: null, error: null, loading },
   opencode: { authenticated: false, email: null, method: null, error: null, loading },
+  'command-code': { authenticated: false, email: null, method: null, error: null, loading },
 });
 
 type ProviderAuthStatusPayload = {

--- a/src/modules/settings/tabs/agents-settings/AgentsSettingsTab.tsx
+++ b/src/modules/settings/tabs/agents-settings/AgentsSettingsTab.tsx
@@ -40,9 +40,10 @@ export default function AgentsSettingsTab({
   ), [selectedAgent]);
 
   const visibleAgents = useMemo<AgentProvider[]>(() => {
-    return ['claude', 'cursor', 'codex', 'opencode'];
+    return ['claude', 'cursor', 'codex', 'opencode', 'command-code'];
   }, []);
 
+  const commandCodeAuthStatus = providerAuthStatus['command-code'];
   const agentContextById = useMemo<AgentContextByProvider>(() => ({
     claude: {
       authStatus: providerAuthStatus.claude,
@@ -60,12 +61,17 @@ export default function AgentsSettingsTab({
       authStatus: providerAuthStatus.opencode,
       onLogin: () => onProviderLogin('opencode'),
     },
+    'command-code': {
+      authStatus: commandCodeAuthStatus,
+      onLogin: () => onProviderLogin('command-code'),
+    },
   }), [
     onProviderLogin,
     providerAuthStatus.claude,
     providerAuthStatus.codex,
     providerAuthStatus.cursor,
     providerAuthStatus.opencode,
+    commandCodeAuthStatus,
   ]);
 
   useEffect(() => {

--- a/src/modules/settings/tabs/agents-settings/sections/AgentSelectorSection.tsx
+++ b/src/modules/settings/tabs/agents-settings/sections/AgentSelectorSection.tsx
@@ -13,6 +13,7 @@ const AGENT_NAMES: Record<AgentProvider, string> = {
   cursor: 'Cursor',
   codex: 'Codex',
   opencode: 'OpenCode',
+  'command-code': 'Command Code',
 };
 
 /** Rendered by AgentsSettingsTab to pick which agent provider the tab is configuring. */
@@ -29,7 +30,8 @@ export default function AgentSelectorSection({
           const dotColor =
             agent === 'claude' ? 'bg-blue-500' :
             agent === 'cursor' ? 'bg-purple-500' :
-            agent === 'opencode' ? 'bg-zinc-500' : 'bg-foreground/60';
+            agent === 'opencode' ? 'bg-zinc-500' :
+            agent === 'command-code' ? 'bg-neutral-500' : 'bg-foreground/60';
 
           return (
             <Pill

--- a/src/modules/settings/tabs/agents-settings/sections/content/AccountContent.tsx
+++ b/src/modules/settings/tabs/agents-settings/sections/content/AccountContent.tsx
@@ -54,6 +54,15 @@ const agentConfig: Record<AgentProvider, AgentVisualConfig> = {
     subtextClass: 'text-zinc-700 dark:text-zinc-300',
     buttonClass: 'bg-zinc-900 hover:bg-zinc-800 active:bg-zinc-950 dark:bg-zinc-700 dark:hover:bg-zinc-600',
   },
+  'command-code': {
+    name: 'Command Code',
+    description: 'Command Code CLI assistant',
+    bgClass: 'bg-neutral-50 dark:bg-neutral-900/20',
+    borderClass: 'border-neutral-200 dark:border-neutral-700',
+    textClass: 'text-neutral-900 dark:text-neutral-100',
+    subtextClass: 'text-neutral-700 dark:text-neutral-300',
+    buttonClass: 'bg-neutral-900 hover:bg-neutral-800 active:bg-neutral-950 dark:bg-neutral-700 dark:hover:bg-neutral-600',
+  },
 };
 
 /** Rendered by AgentCategoryContentSection for the "account" category to show sign-in state for one provider. */

--- a/src/modules/sidebar/SidebarSessionItem.tsx
+++ b/src/modules/sidebar/SidebarSessionItem.tsx
@@ -37,6 +37,7 @@ const PROVIDER_LABELS: Record<LLMProvider, string> = {
   codex: 'Codex',
   cursor: 'Cursor',
   opencode: 'OpenCode',
+  'command-code': 'Command Code',
 };
 
 type CopyState = 'loading' | 'idle' | 'copying' | 'copied' | 'error';

--- a/src/modules/skills/ProviderSkills.tsx
+++ b/src/modules/skills/ProviderSkills.tsx
@@ -54,12 +54,14 @@ const PROVIDER_NAMES: Record<SkillsProvider, string> = {
   codex: 'Codex',
   cursor: 'Cursor',
   opencode: 'OpenCode',
+  'command-code': 'Command Code',
 };
 
 const PROVIDER_SKILL_PATHS: Record<Exclude<SkillsProvider, 'opencode'>, string> = {
   claude: '~/.claude/skills/<skill-name>/SKILL.md',
   codex: '~/.agents/skills/<skill-name>/SKILL.md',
   cursor: '~/.cursor/skills/<skill-name>/SKILL.md',
+  'command-code': '~/.commandcode/skills/<skill-name>/SKILL.md',
 };
 
 const SCOPE_LABELS: Record<SkillsScope, string> = {

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -120,6 +120,7 @@ export const MCP_PROVIDER_NAMES: Record<McpProvider, string> = {
   cursor: 'Cursor',
   codex: 'Codex',
   opencode: 'OpenCode',
+  'command-code': 'Command Code',
 };
 
 /** Scopes each provider can install an MCP server into; drives the scope selector and validation. */
@@ -128,6 +129,7 @@ export const MCP_SUPPORTED_SCOPES: Record<McpProvider, McpScope[]> = {
   cursor: ['user', 'project'],
   codex: ['user', 'project'],
   opencode: ['user', 'project'],
+  'command-code': ['user', 'project', 'local'],
 };
 
 /** Transports each provider can talk to an MCP server over; drives the transport selector and validation. */
@@ -136,6 +138,7 @@ export const MCP_SUPPORTED_TRANSPORTS: Record<McpProvider, McpTransport[]> = {
   cursor: ['stdio', 'http'],
   codex: ['stdio', 'http'],
   opencode: ['stdio', 'http'],
+  'command-code': ['stdio', 'http', 'sse'],
 };
 
 /** Transports offered when configuring a global (provider-agnostic) MCP server. */
@@ -147,6 +150,7 @@ export const MCP_SUPPORTS_WORKING_DIRECTORY: Record<McpProvider, boolean> = {
   cursor: false,
   codex: true,
   opencode: false,
+  'command-code': false,
 };
 
 // ---------------------------
@@ -217,4 +221,5 @@ export const PROVIDER_PERMISSION_PREFERENCE_KEYS: Record<LLMProvider, UserPrefer
   cursor: 'cursorPermissions',
   codex: 'codexPermissions',
   opencode: 'opencodePermissions',
+  'command-code': 'commandCodePermissions',
 };

--- a/src/shared/selectedProvider.ts
+++ b/src/shared/selectedProvider.ts
@@ -16,7 +16,7 @@ import { readUserPreference, writeUserPreference } from '@/shared/userSettings';
  * choice both reaches every reader at once and follows the user between devices.
  */
 
-const PROVIDERS: LLMProvider[] = ['claude', 'cursor', 'codex', 'opencode'];
+const PROVIDERS: LLMProvider[] = ['claude', 'cursor', 'codex', 'opencode', 'command-code'];
 
 const DEFAULT_PROVIDER: LLMProvider = 'claude';
 

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -5,7 +5,7 @@ import type { NavigateFunction } from 'react-router-dom';
 //----------------- LLM PROVIDER MODEL CATALOG ------------
 
 /** Identifies which coding-agent CLI backs a session, project selection or model list. */
-export type LLMProvider = 'claude' | 'cursor' | 'codex' | 'opencode';
+export type LLMProvider = 'claude' | 'cursor' | 'codex' | 'opencode' | 'command-code';
 
 /** One selectable model in a provider's model menu, including its optional reasoning-effort choices. */
 export type ProviderModelOption = {

--- a/src/shared/ui/CommandCodeLogo.tsx
+++ b/src/shared/ui/CommandCodeLogo.tsx
@@ -1,0 +1,25 @@
+type CommandCodeLogoProps = {
+  className?: string;
+};
+
+/** Rendered by the shared LLMProviderLogo when the provider is Command Code. */
+const CommandCodeLogo = ({ className = 'w-5 h-5' }: CommandCodeLogoProps) => (
+  <svg
+    viewBox="0 0 24 24"
+    role="img"
+    aria-label="Command Code"
+    className={className}
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <path
+      d="M4 7l5 5-5 5M11 19h9"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </svg>
+);
+
+export default CommandCodeLogo;

--- a/src/shared/ui/LLMProviderLogo.tsx
+++ b/src/shared/ui/LLMProviderLogo.tsx
@@ -1,6 +1,7 @@
 import type { LLMProvider } from '@/shared/types';
 import ClaudeLogo from '@/shared/ui/ClaudeLogo';
 import CodexLogo from '@/shared/ui/CodexLogo';
+import CommandCodeLogo from '@/shared/ui/CommandCodeLogo';
 import CursorLogo from '@/shared/ui/CursorLogo';
 import OpenCodeLogo from '@/shared/ui/OpenCodeLogo';
 
@@ -24,6 +25,10 @@ export function LLMProviderLogo({
 
   if (provider === 'opencode') {
     return <OpenCodeLogo className={className} />;
+  }
+
+  if (provider === 'command-code') {
+    return <CommandCodeLogo className={className} />;
   }
 
   return <ClaudeLogo className={className} />;

--- a/src/shared/userSettings.ts
+++ b/src/shared/userSettings.ts
@@ -25,6 +25,7 @@ export type UserPreferences = {
   cursorPermissions: unknown;
   codexPermissions: unknown;
   opencodePermissions: unknown;
+  commandCodePermissions: unknown;
   codeEditorSettings: unknown;
   uiPreferences: unknown;
   selectedProvider: string;
@@ -62,6 +63,7 @@ const LEGACY_STORAGE_KEYS: Record<UserPreferenceKey, string> = {
   cursorPermissions: 'cursor-tools-settings',
   codexPermissions: 'codex-settings',
   opencodePermissions: 'opencode-settings',
+  commandCodePermissions: 'command-code-settings',
   // Unused: the four code-editor settings never shared one key, so they are
   // read by readLegacyCodeEditorSettings instead.
   codeEditorSettings: '',


### PR DESCRIPTION
Integrate the Command Code CLI as a first-class provider alongside claude/codex/cursor/opencode across the registry, routes, capability matrix, token-usage, session synchronizer/watcher, agent module, and frontend. The provider ships the full facet set under server/modules/providers/list/command-code/: headless NDJSON runtime (permission-mode translation, exit-8 max-turns handling, session claiming), auth via `command-code status --json`, curated model catalog, .mcp.json read/write with transport discriminator, Agent-Skills discovery, and a JSONL sessions reader that linearizes the active parentId branch. Registration is id-driven and compile-time-checked through the LLMProvider unions; schema CHECK updated via table-rebuild migration. Update provider-count expectations in the registry and MCP tests, and fix the command-code auth-status useMemo dependency to keep lint clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Command Code as a supported provider across chat, model selection, agent settings, onboarding, authentication, and session management.
  * Added Command Code CLI integration for running, resuming, and stopping sessions.
  * Added support for Command Code models, effort settings, permissions, token usage, skills, MCP servers, and synchronized session history.
  * Added Command Code branding, labels, provider-specific messaging, and localized display text.
  * Added database support for storing Command Code provider models.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->