### PR TITLE
fix(cursor): resolve the cursor agent binary as \`agent\` or \`cursor-agent\`

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -65,6 +65,7 @@
           "server/shared/utils.{js,ts}",
           "server/shared/frontmatter.ts",
           "server/shared/claude-cli-path.ts",
+          "server/shared/cursor-cli-path.ts",
           "server/shared/image-attachments.ts",
           "server/shared/message-unification.ts"
         ],

--- a/server/modules/providers/list/cursor/cursor-auth.provider.ts
+++ b/server/modules/providers/list/cursor/cursor-auth.provider.ts
@@ -1,5 +1,6 @@
 import spawn from 'cross-spawn';
 
+import { resolveCursorAgentCommand } from '@/shared/cursor-cli-path.js';
 import type { IProviderAuth } from '@/shared/interfaces.js';
 import type { ProviderAuthStatus } from '@/shared/types.js';
 
@@ -16,7 +17,7 @@ export class CursorProviderAuth implements IProviderAuth {
    */
   private checkInstalled(): boolean {
     try {
-      spawn.sync('cursor-agent', ['--version'], { stdio: 'ignore', timeout: 5000 });
+      spawn.sync(resolveCursorAgentCommand(), ['--version'], { stdio: 'ignore', timeout: 5000 });
       return true;
     } catch {
       return false;
@@ -74,7 +75,7 @@ export class CursorProviderAuth implements IProviderAuth {
       }, 5000);
 
       try {
-        childProcess = spawn('cursor-agent', ['status']);
+        childProcess = spawn(resolveCursorAgentCommand(), ['status']);
       } catch {
         clearTimeout(timeout);
         processCompleted = true;

--- a/server/modules/providers/list/cursor/cursor-runtime.provider.js
+++ b/server/modules/providers/list/cursor/cursor-runtime.provider.js
@@ -5,6 +5,7 @@ import {
   appendImagesInputTag,
   normalizeAttachmentDescriptors
 } from '@/shared/image-attachments.js';
+import { resolveCursorAgentCommand } from '@/shared/cursor-cli-path.js';
 import { notifyRunFailed, notifyRunStopped } from '@/modules/notifications/index.js';
 import { createCompleteMessage, createNormalizedMessage, flattenPromptForWindowsShell } from '@/shared/utils.js';
 
@@ -156,7 +157,7 @@ async function spawnCursor(command, options = {}, ws, context) {
         console.log('Retrying Cursor CLI with --trust after workspace trust prompt');
       }
 
-      const cursorProcess = spawnFunction('cursor-agent', args, {
+      const cursorProcess = spawnFunction(resolveCursorAgentCommand(), args, {
         cwd: workingDir,
         stdio: ['pipe', 'pipe', 'pipe'],
         env: { ...process.env } // Inherit all environment variables

--- a/server/modules/websocket/services/shell-websocket.service.ts
+++ b/server/modules/websocket/services/shell-websocket.service.ts
@@ -5,6 +5,7 @@ import path from 'node:path';
 import pty, { type IPty } from 'node-pty';
 import { WebSocket, type RawData } from 'ws';
 
+import { resolveCursorAgentCommand } from '@/shared/cursor-cli-path.js';
 import { parseIncomingJsonObject } from '@/shared/utils.js';
 
 type ShellIncomingMessage = {
@@ -195,9 +196,9 @@ function buildShellCommand(
 
   if (provider === 'cursor') {
     if (resumeSessionId) {
-      return `cursor-agent --resume="${resumeSessionId}"`;
+      return `${resolveCursorAgentCommand()} --resume="${resumeSessionId}"`;
     }
-    return 'cursor-agent';
+    return resolveCursorAgentCommand();
   }
 
   if (provider === 'codex') {

--- a/server/shared/cursor-cli-path.ts
+++ b/server/shared/cursor-cli-path.ts
@@ -1,0 +1,58 @@
+import { existsSync } from 'node:fs';
+import path from 'node:path';
+
+/**
+ * Resolves the Cursor agent CLI command.
+ *
+ * Cursor's official CLI installs as `agent` (curl https://cursor.com/install
+ * -fsS | bash puts `agent` in ~/.local/bin), while this codebase and older
+ * setups used `cursor-agent`. Prefer an explicit CURSOR_CLI_PATH override,
+ * then whichever of `cursor-agent` / `agent` actually exists on PATH (checked
+ * once and cached), falling back to `cursor-agent` to preserve prior behavior.
+ */
+
+type ResolveCursorAgentDependencies = {
+  existsSync?: (p: string) => boolean;
+  env?: NodeJS.ProcessEnv;
+};
+
+const CANDIDATES = ['cursor-agent', 'agent'];
+
+let cached: string | null = null;
+
+const isExecutableOnPath = (
+  command: string,
+  env: NodeJS.ProcessEnv,
+  exists: (p: string) => boolean,
+): boolean => {
+  const pathValue = (env.PATH || '').split(path.delimiter);
+  return pathValue.some((dir) => dir && exists(path.join(dir, command)));
+};
+
+export function resolveCursorAgentCommand(
+  dependencies: ResolveCursorAgentDependencies = {},
+): string {
+  const deps: Required<ResolveCursorAgentDependencies> = {
+    existsSync: dependencies.existsSync ?? existsSync,
+    env: dependencies.env ?? process.env,
+  };
+
+  const explicit = (deps.env.CURSOR_CLI_PATH || '').trim();
+  if (explicit) {
+    return explicit;
+  }
+
+  if (cached) {
+    return cached;
+  }
+
+  for (const candidate of CANDIDATES) {
+    if (isExecutableOnPath(candidate, deps.env, deps.existsSync)) {
+      cached = candidate;
+      return candidate;
+    }
+  }
+
+  // No candidate on PATH; keep the historical default.
+  return 'cursor-agent';
+}

--- a/src/modules/provider-auth/ProviderLoginModal.tsx
+++ b/src/modules/provider-auth/ProviderLoginModal.tsx
@@ -47,7 +47,7 @@ const getProviderCommand = ({
   }
 
   if (provider === 'cursor') {
-    return 'cursor-agent login';
+    return 'cursor-agent login || agent login';
   }
 
   if (provider === 'codex') {


### PR DESCRIPTION
## Summary

Fixes the Cursor provider so it finds Cursor's real CLI. Cursor's official installer (`curl https://cursor.com/install -fsS | bash`) puts an `agent` binary on PATH, while this codebase hard-coded `cursor-agent`. On machines that only have `agent` (fresh Linux installs, containers, CI), the provider reported **"Cursor CLI not found or not installed"** even when the CLI and a valid login existed.

## What changed

- **New `server/shared/cursor-cli-path.ts`**: resolves the Cursor agent command by preferring an explicit `CURSOR_CLI_PATH` override, then whichever of `cursor-agent` / `agent` actually exists on PATH (probed once and cached), falling back to `cursor-agent` to preserve prior behavior.
- **Cursor auth provider** (`cursor-auth.provider.ts`): `checkInstalled()` and `checkCursorLogin()` now spawn the resolved command instead of the hard-coded `cursor-agent`.
- **Cursor runtime** (`cursor-runtime.provider.js`): session runs spawn the resolved command.
- **Shell websocket** (`shell-websocket.service.ts`): the interactive Cursor shell / resume command uses the resolved command.
- **Login modal** (`ProviderLoginModal.tsx`): Cursor login now runs `cursor-agent login || agent login` so it works whether the host has the old or new binary name.

## Verification

- `npm run typecheck` — passes (server + frontend).
- End-to-end (container + real API): with a host `agent` binary mounted on PATH, the Cursor provider status flips from *"Cursor CLI not found or not installed"* to *"Not logged in"*, i.e. the CLI is now detected and its login state is evaluated.

## Notes

- `cursor-agent` (older installs) and `agent` (current official installs) both resolve; `CURSOR_CLI_PATH` forces either for unusual layouts.
- This only fixes CLI *discovery*. Cursor authentication itself remains machine-bound, so a fresh host still needs its normal one-time `agent login`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic detection of the available Cursor CLI command.
  * Added an optional environment setting to specify a custom Cursor CLI path.
  * Cursor login now falls back to the alternate `agent login` command when needed.
  * Cursor sessions, installation checks, and status checks consistently use the detected CLI command.
  * Improved compatibility for environments where Cursor is installed under an alternate command name.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
