### PR TITLE
fix: explain Codex writer conflicts in web chat and allow terminal handoff

### DIFF
--- a/server/modules/websocket/services/shell-websocket.service.ts
+++ b/server/modules/websocket/services/shell-websocket.service.ts
@@ -29,6 +29,7 @@ type PtySessionEntry = {
   timeoutId: NodeJS.Timeout | null;
   projectPath: string;
   sessionId: string | null;
+  terminating?: boolean;
 };
 
 const ptySessionsMap = new Map<string, PtySessionEntry>();
@@ -203,11 +204,13 @@ function buildShellCommand(
   if (provider === 'codex') {
     if (resumeSessionId) {
       if (os.platform() === 'win32') {
-        return `codex resume "${resumeSessionId}"; if ($LASTEXITCODE -ne 0) { codex }`;
+        return `codex resume "${resumeSessionId}"`;
       }
-      return `codex resume "${resumeSessionId}" || codex`;
+      // Replace the shell so ending the PTY also ends the thread writer.
+      // A failed resume must not silently start an unrelated conversation.
+      return `exec codex resume "${resumeSessionId}"`;
     }
-    return 'codex';
+    return os.platform() === 'win32' ? 'codex' : 'exec codex';
   }
 
   if (provider === 'opencode') {
@@ -337,6 +340,11 @@ export function handleShellConnection(
             ? `_cmd_${Buffer.from(initialCommand).toString('base64').slice(0, 16)}`
             : '';
         ptySessionKey = `${projectPath}_${sessionId ?? 'default'}${commandSuffix}`;
+
+        if (ptySessionsMap.get(ptySessionKey)?.terminating) {
+          ws.send(JSON.stringify({ type: 'error', message: 'Terminal is stopping. Wait for it to exit before reconnecting.' }));
+          return;
+        }
 
         if (isLoginCommand || forceRestart) {
           const oldSession = ptySessionsMap.get(ptySessionKey);
@@ -516,6 +524,9 @@ export function handleShellConnection(
           }
 
           if (session && session.ws && session.ws.readyState === WebSocket.OPEN) {
+            if (session.terminating) {
+              session.ws.send(JSON.stringify({ type: 'terminated' }));
+            }
             session.ws.send(
               JSON.stringify({
                 type: 'output',
@@ -555,6 +566,24 @@ export function handleShellConnection(
             data: welcomeMsg,
           })
         );
+        return;
+      }
+
+      if (data.type === 'terminate') {
+        const session = ptySessionKey ? ptySessionsMap.get(ptySessionKey) : null;
+        // A replaced browser socket must never terminate the new owner's PTY.
+        if (session && session.ws === ws && session.pty === shellProcess) {
+          if (!session.terminating) {
+            session.terminating = true;
+            try {
+              session.pty.kill();
+            } catch (error) {
+              session.terminating = false;
+              throw error;
+            }
+          }
+        }
+        // Keep the entry until onExit confirms the process has released its lock.
         return;
       }
 

--- a/server/modules/websocket/tests/shell-websocket.service.test.ts
+++ b/server/modules/websocket/tests/shell-websocket.service.test.ts
@@ -1,10 +1,14 @@
 import assert from 'node:assert/strict';
 import { EventEmitter } from 'node:events';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, rmSync, rmdirSync } from 'node:fs';
+import { setTimeout as delay } from 'node:timers/promises';
 import os from 'node:os';
 import path from 'node:path';
 import test from 'node:test';
 
 import { WebSocket } from 'ws';
+import nodePty from 'node-pty';
 
 import { handleShellConnection } from '@/modules/websocket/services/shell-websocket.service.js';
 
@@ -47,6 +51,96 @@ function createFakePty() {
     },
   };
 }
+
+test('ending a real PTY releases a writer lock, while disconnect preserves it', {
+  skip: os.platform() !== 'linux' || spawnSync('flock', ['--version']).status !== 0,
+  timeout: 10000,
+}, async () => {
+  const directory = mkdtempSync(path.join(os.tmpdir(), 'cloudcli-terminal-lock-'));
+  const lock = path.join(directory, 'writer.lock');
+  const socket = createFakeSocket();
+  let terminal: ReturnType<typeof nodePty.spawn> | undefined;
+  const dependencies = {
+    resolveProviderSessionId: () => 'lock-test-thread',
+    spawnPty: (() => {
+      // --no-fork mirrors exec codex: the process owning the PTY holds the lock.
+      terminal = nodePty.spawn('flock', ['--no-fork', lock, 'sleep', '60'], {});
+      return terminal;
+    }) as typeof nodePty.spawn,
+  };
+  const init = JSON.stringify({ type: 'init', projectPath: directory,
+    sessionId: directory.split(path.sep).pop(), hasSession: true, provider: 'codex' });
+  const isLocked = () => spawnSync('flock', ['-n', lock, 'true']).status === 1;
+  try {
+    handleShellConnection(socket as never, dependencies);
+    socket.emit('message', init);
+    for (let i = 0; i < 100 && !isLocked(); i++) await delay(20);
+    assert.equal(isLocked(), true);
+    socket.emit('close');
+    assert.equal(isLocked(), true);
+    const replacement = createFakeSocket();
+    handleShellConnection(replacement as never, dependencies);
+    replacement.emit('message', init);
+    replacement.emit('message', JSON.stringify({ type: 'terminate' }));
+    for (let i = 0; i < 100 && !replacement.frames.some((frame) => JSON.parse(frame).type === 'terminated'); i++) await delay(20);
+    assert.equal(replacement.frames.some((frame) => JSON.parse(frame).type === 'terminated'), true);
+    assert.equal(isLocked(), false);
+  } finally {
+    try { terminal?.kill(); } catch { /* Already exited. */ }
+    rmSync(lock, { force: true });
+    // The directory contains only the test's lock file.
+    rmdirSync(directory);
+  }
+});
+
+test('ending a Codex terminal stops its writer without a fallback conversation', () => {
+  const terminal = createFakePty();
+  const socket = createFakeSocket();
+  let command = '';
+  handleShellConnection(socket as never, {
+    resolveProviderSessionId: () => 'test-codex-thread',
+    spawnPty: ((_shell: string, args: string[]) => {
+      command = args.join(' ');
+      return terminal as never;
+    }) as never,
+  });
+  socket.emit('message', JSON.stringify({
+    type: 'init', projectPath: process.cwd(), sessionId: 'terminate-codex',
+    hasSession: true, provider: 'codex',
+  }));
+  assert.match(command, /codex resume "test-codex-thread"/);
+  assert.doesNotMatch(command, /\|\||LASTEXITCODE/);
+  if (os.platform() !== 'win32') assert.match(command, /exec codex resume/);
+  socket.emit('message', JSON.stringify({ type: 'terminate' }));
+  assert.equal(terminal.killed, true);
+  assert.equal(socket.frames.some((frame) => JSON.parse(frame).type === 'terminated'), false);
+  terminal.emitExit();
+  assert.equal(socket.frames.some((frame) => JSON.parse(frame).type === 'terminated'), true);
+  socket.emit('close');
+});
+
+test('disconnect preserves a terminal but only its current socket may terminate it', () => {
+  const terminal = createFakePty();
+  const dependencies = {
+    resolveProviderSessionId: () => 'test-thread',
+    spawnPty: () => terminal as never,
+  };
+  const init = JSON.stringify({ type: 'init', projectPath: process.cwd(),
+    sessionId: 'terminate-owner', hasSession: true, provider: 'codex' });
+  const first = createFakeSocket();
+  handleShellConnection(first as never, dependencies);
+  first.emit('message', init);
+  first.emit('close');
+  assert.equal(terminal.killed, false);
+  const replacement = createFakeSocket();
+  handleShellConnection(replacement as never, dependencies);
+  replacement.emit('message', init);
+  first.emit('message', JSON.stringify({ type: 'terminate' }));
+  assert.equal(terminal.killed, false);
+  replacement.emit('message', JSON.stringify({ type: 'terminate' }));
+  assert.equal(terminal.killed, true);
+  terminal.emitExit();
+});
 
 test('a stale socket close cannot detach the socket that replaced it', () => {
   const pty = createFakePty();

--- a/src/modules/chat/tests/codexSessionConflict.test.tsx
+++ b/src/modules/chat/tests/codexSessionConflict.test.tsx
@@ -1,0 +1,34 @@
+import { render } from '@testing-library/react';
+import { expect, test } from 'vitest';
+
+import MessageComponent from '@/modules/chat/transcript/MessageComponent';
+import type { ChatMessage } from '@/shared/types';
+
+const conflict = 'Codex Exec exited with code 1: Reading prompt from stdin...\nERROR failed to initialize thread persistence: thread-store conflict: thread test-thread already has an active writer';
+
+test('web chat explains writer conflicts and retains the raw error in collapsed details', () => {
+  const { container, getByRole } = render(
+    <MessageComponent message={{ type: 'error', content: conflict, timestamp: new Date().toISOString() }}
+      prevMessage={null} createDiff={() => []} provider="codex" />,
+  );
+  expect(getByRole('alert').textContent).toContain('A completed reply does not close');
+  expect(getByRole('alert').textContent).toContain('End terminal');
+  const details = container.querySelector('details');
+  expect(details?.open).toBe(false);
+  expect(details?.textContent).toContain(conflict);
+});
+
+test('unrelated errors and quoted error text in user messages are not treated as conflicts', () => {
+  for (const [provider, type, content] of [
+    ['claude', 'error', conflict],
+    ['codex', 'user', conflict],
+    ['codex', 'error', 'Network unavailable'],
+  ] as const) {
+    const message: ChatMessage = { type, content, timestamp: new Date().toISOString() };
+    const { queryByRole, unmount } = render(
+      <MessageComponent message={message} prevMessage={null} createDiff={() => []} provider={provider} />,
+    );
+    expect(queryByRole('alert')).toBeNull();
+    unmount();
+  }
+});

--- a/src/modules/chat/transcript/CodexSessionConflict.tsx
+++ b/src/modules/chat/transcript/CodexSessionConflict.tsx
@@ -1,0 +1,21 @@
+import { useTranslation } from 'react-i18next';
+
+/** Used by MessageComponent for a failed web-chat resume of an occupied Codex thread. */
+export function CodexSessionConflict({ details }: { details: string }) {
+  const { t } = useTranslation('chat');
+  return (
+    <div role="alert" className="rounded-md border border-amber-500/40 p-3 text-sm">
+      <p className="font-medium">{t('codexSessionConflict.title', { defaultValue: 'This session is still open in another Codex process' })}</p>
+      <p className="mt-2">{t('codexSessionConflict.explanation', {
+        defaultValue: 'A completed reply does not close an interactive Codex session. Another terminal or client can still hold its write lock, so this chat message could not start.',
+      })}</p>
+      <p className="mt-2">{t('codexSessionConflict.recovery', {
+        defaultValue: 'If you opened this session in CloudCLI Terminal, reconnect to that terminal and choose End terminal, then resend here. For an external Codex client, exit that session there first. Ending a terminal interrupts any work still running in it.',
+      })}</p>
+      <details className="mt-3">
+        <summary className="cursor-pointer">{t('codexSessionConflict.details', { defaultValue: 'Technical details' })}</summary>
+        <pre className="mt-2 whitespace-pre-wrap break-words text-xs">{details}</pre>
+      </details>
+    </div>
+  );
+}

--- a/src/modules/chat/transcript/MessageComponent.tsx
+++ b/src/modules/chat/transcript/MessageComponent.tsx
@@ -15,6 +15,7 @@ import MessageCopyControl from '@/modules/chat/transcript/MessageCopyControl';
 import MessageSpeakControl from '@/modules/chat/transcript/MessageSpeakControl';
 import { useIsExportingTranscript } from '@/modules/chat/context/TranscriptRenderContext';
 import { MemoryCitations } from '@/modules/chat/transcript/MemoryCitations';
+import { CodexSessionConflict } from '@/modules/chat/transcript/CodexSessionConflict';
 
 type MessageComponentProps = {
   message: ChatMessage;
@@ -205,7 +206,9 @@ const MessageComponent = memo(({ message, prevMessage, createDiff, onFileOpen, s
 
           <div className="w-full">
 
-            {message.isSubagentContainer ? (
+            {provider === 'codex' && message.type === 'error' && /thread[^\r\n]*already has an active writer/i.test(String(message.content || '')) ? (
+              <CodexSessionConflict details={String(message.content)} />
+            ) : message.isSubagentContainer ? (
               /* A spawned agent owns its whole card — header, timeline and
                  result — so it never goes through the tool input/result pair. */
               <SubagentPanel
@@ -375,4 +378,3 @@ const MessageComponent = memo(({ message, prevMessage, createDiff, onFileOpen, s
 });
 
 export default MessageComponent;
-

--- a/src/modules/i18n/locales/en/chat.json
+++ b/src/modules/i18n/locales/en/chat.json
@@ -1,4 +1,10 @@
 {
+  "codexSessionConflict": {
+    "title": "This session is still open in another Codex process",
+    "explanation": "A completed reply does not close an interactive Codex session. Another terminal or client can still hold its write lock, so this chat message could not start.",
+    "recovery": "If you opened this session in CloudCLI Terminal, reconnect to that terminal and choose End terminal, then resend here. For an external Codex client, exit that session there first. Ending a terminal interrupts any work still running in it.",
+    "details": "Technical details"
+  },
   "codeBlock": {
     "copy": "Copy",
     "copied": "Copied",
@@ -196,6 +202,9 @@
     "actions": {
       "disconnect": "Disconnect",
       "disconnectTitle": "Disconnect from shell",
+      "endTerminal": "End terminal",
+      "endTerminalTitle": "Stop this terminal process to continue the session in chat. Running work will be interrupted.",
+      "codexWriterHint": "Codex keeps this session open even after a reply finishes. Use End terminal before continuing the same session in Chat.",
       "restart": "Restart",
       "restartTitle": "Restart Shell",
       "connect": "Continue in Shell",

--- a/src/modules/i18n/locales/zh-CN/chat.json
+++ b/src/modules/i18n/locales/zh-CN/chat.json
@@ -1,4 +1,10 @@
 {
+  "codexSessionConflict": {
+    "title": "此会话仍被另一个 Codex 进程占用",
+    "explanation": "回答结束后，交互式 Codex 会话仍可能保持打开。其他终端或客户端持有写锁，因此这条网页消息未能启动。",
+    "recovery": "如果你曾在 CloudCLI 的终端中打开此会话，请重新连接该终端，点击“结束终端”，然后回到这里重新发送。如果占用来自外部 Codex 客户端，请先在那里退出此会话。结束终端会中断其中尚未完成的任务。",
+    "details": "技术详情"
+  },
   "codeBlock": {
     "copy": "复制",
     "copied": "已复制",
@@ -183,6 +189,9 @@
     "actions": {
       "disconnect": "断开连接",
       "disconnectTitle": "断开 Shell 连接",
+      "endTerminal": "结束终端",
+      "endTerminalTitle": "停止此终端进程，以便在聊天中继续同一会话。正在执行的任务将被中断。",
+      "codexWriterHint": "Codex 回答结束后仍会占用此会话。切回聊天继续同一会话前，请点击“结束终端”。",
       "restart": "重启",
       "restartTitle": "重启 Shell（请先断开连接）",
       "connect": "在 Shell 中继续",

--- a/src/modules/shell/Shell.tsx
+++ b/src/modules/shell/Shell.tsx
@@ -69,6 +69,7 @@ export default function Shell({
     isConnecting,
     connectToShell,
     disconnectFromShell,
+    terminateShell,
   } = useShellRuntime({
     selectedProject,
     selectedSession,
@@ -234,8 +235,12 @@ export default function Shell({
       restartTimerRef.current = null;
     }
     setIsRestarting(false);
-    disconnectFromShell({ suppressAutoConnect: true });
-  }, [disconnectFromShell]);
+    if (shellProvider === 'codex') {
+      terminateShell();
+    } else {
+      disconnectFromShell({ suppressAutoConnect: true });
+    }
+  }, [disconnectFromShell, shellProvider, terminateShell]);
 
   useEffect(() => {
     if (
@@ -307,8 +312,8 @@ export default function Shell({
         statusNewSessionText={t('shell.status.newSession')}
         statusInitializingText={t('shell.status.initializing')}
         statusRestartingText={t('shell.status.restarting')}
-        disconnectLabel={t('shell.actions.disconnect')}
-        disconnectTitle={t('shell.actions.disconnectTitle')}
+        disconnectLabel={shellProvider === 'codex' ? t('shell.actions.endTerminal', { defaultValue: 'End terminal' }) : t('shell.actions.disconnect')}
+        disconnectTitle={shellProvider === 'codex' ? t('shell.actions.endTerminalTitle', { defaultValue: 'Stop this terminal process to continue the session in chat. Running work will be interrupted.' }) : t('shell.actions.disconnectTitle')}
         restartLabel={t('shell.actions.restart')}
         restartTitle={t('shell.actions.restartTitle')}
         disableRestart={isRestarting || !isInitialized}
@@ -320,6 +325,12 @@ export default function Shell({
           bypassPermissions ? 'shell.actions.bypassOnTitle' : 'shell.actions.bypassOffTitle',
         )}
       />
+
+      {shellProvider === 'codex' && isConnected && (
+        <p className="px-4 py-2 text-xs text-amber-200" role="note">
+          {t('shell.actions.codexWriterHint', { defaultValue: 'Codex keeps this session open even after a reply finishes. Use End terminal before continuing the same session in Chat.' })}
+        </p>
+      )}
 
       <div className="relative flex-1 overflow-hidden p-2">
         <div

--- a/src/modules/shell/hooks/useShellConnection.ts
+++ b/src/modules/shell/hooks/useShellConnection.ts
@@ -35,6 +35,7 @@ type UseShellConnectionResult = {
   closeSocket: () => void;
   connectToShell: (options?: { forceRestart?: boolean }) => void;
   disconnectFromShell: (options?: { suppressAutoConnect?: boolean }) => void;
+  terminateShell: () => void;
 };
 
 export function useShellConnection({
@@ -113,8 +114,16 @@ export function useShellConnection({
         terminalRef.current?.write(`\r\n\x1b[31m${detail}\x1b[0m\r\n`);
         return;
       }
+
+      if (message.type === 'terminated') {
+        // Only the process-exit acknowledgement means the thread lock is free.
+        closeSocket();
+        setIsConnected(false);
+        setIsConnecting(false);
+        connectingRef.current = false;
+      }
     },
-    [handleProcessCompletion, onOutputRef, terminalRef],
+    [closeSocket, handleProcessCompletion, onOutputRef, terminalRef],
   );
 
   const connectWebSocket = useCallback(
@@ -236,6 +245,12 @@ export function useShellConnection({
     forceRestartOnInitRef.current = false;
   }, [clearTerminalScreen, closeSocket]);
 
+  // Shell's explicit End terminal action; ordinary disconnects remain resumable.
+  const terminateShell = useCallback(() => {
+    suppressAutoConnectRef.current = true;
+    sendSocketMessage(wsRef.current, { type: 'terminate' });
+  }, [wsRef]);
+
   useEffect(() => {
     if (
       !autoConnect ||
@@ -256,5 +271,6 @@ export function useShellConnection({
     closeSocket,
     connectToShell,
     disconnectFromShell,
+    terminateShell,
   };
 }

--- a/src/modules/shell/hooks/useShellRuntime.ts
+++ b/src/modules/shell/hooks/useShellRuntime.ts
@@ -29,6 +29,7 @@ type UseShellRuntimeResult = {
   isConnecting: boolean;
   connectToShell: (options?: { forceRestart?: boolean }) => void;
   disconnectFromShell: (options?: { suppressAutoConnect?: boolean }) => void;
+  terminateShell: () => void;
 };
 
 export function useShellRuntime({
@@ -93,7 +94,7 @@ export function useShellRuntime({
     closeSocket,
   });
 
-  const { isConnected, isConnecting, connectToShell, disconnectFromShell } = useShellConnection({
+  const { isConnected, isConnecting, connectToShell, disconnectFromShell, terminateShell } = useShellConnection({
     wsRef,
     terminalRef,
     fitAddonRef,
@@ -146,5 +147,6 @@ export function useShellRuntime({
     isConnecting,
     connectToShell,
     disconnectFromShell,
+    terminateShell,
   };
 }

--- a/src/modules/shell/tests/shellErrorFrame.test.ts
+++ b/src/modules/shell/tests/shellErrorFrame.test.ts
@@ -16,6 +16,7 @@ vi.mock('@/modules/shell/utils/socket', async (importOriginal) => ({
 }));
 
 class FakeSocket {
+  static OPEN = 1;
   static last: FakeSocket | null = null;
 
   readyState = 1;
@@ -45,10 +46,11 @@ function renderConnection() {
   const clearTerminalScreen = vi.fn();
   const closeSocket = vi.fn();
   const terminalRef = ref({ write, cols: 80, rows: 24 } as unknown as Terminal | null);
+  const wsRef = ref<WebSocket | null>(null);
 
   const view = renderHook(() =>
     useShellConnection({
-      wsRef: ref<WebSocket | null>(null),
+      wsRef,
       terminalRef,
       fitAddonRef: ref({ fit: vi.fn() } as unknown as FitAddon | null),
       selectedProjectRef: ref<Project | null | undefined>({
@@ -98,6 +100,23 @@ describe('shell socket error frames', () => {
 
     expect(write).toHaveBeenCalledTimes(1);
     expect(write.mock.calls[0][0]).toContain('Invalid project path');
+  });
+
+  it('explicit termination waits for process exit before disconnecting', () => {
+    const { view, socket, closeSocket } = renderConnection();
+    closeSocket.mockImplementation(() => {
+      expect(socket.sent.map((frame) => JSON.parse(frame))).toContainEqual({ type: 'terminate' });
+    });
+    act(() => view.result.current.terminateShell());
+    expect(closeSocket).not.toHaveBeenCalled();
+    act(() => socket.onmessage?.({ data: JSON.stringify({ type: 'terminated' }) }));
+    expect(closeSocket).toHaveBeenCalledOnce();
+  });
+
+  it('ordinary disconnect never terminates the background process', () => {
+    const { view, socket } = renderConnection();
+    act(() => view.result.current.disconnectFromShell());
+    expect(socket.sent.map((frame) => JSON.parse(frame))).not.toContainEqual({ type: 'terminate' });
   });
 
   it('keeps the socket open so the message it just wrote is not cleared', () => {

--- a/src/modules/shell/utils/socket.ts
+++ b/src/modules/shell/utils/socket.ts
@@ -26,7 +26,7 @@ type ShellInputMessage = {
   data: string;
 };
 
-type ShellOutgoingMessage = ShellInitMessage | ShellResizeMessage | ShellInputMessage;
+type ShellOutgoingMessage = ShellInitMessage | ShellResizeMessage | ShellInputMessage | { type: 'terminate' };
 
 type ShellIncomingMessage =
   | { type: 'output'; data: string }


### PR DESCRIPTION
Web chat can fail with `thread ... already has an active writer` after a Codex reply has finished. An interactive Codex process still owns the thread while waiting for input. CloudCLI's Terminal Disconnect only detaches the WebSocket and retains that PTY for 30 minutes, so the completed reply/disconnected UI does not mean the writer was released.

This change adds an actionable writer-conflict explanation in the web chat transcript, with the original error available in collapsed details. For Codex terminals, the Disconnect action becomes explicitly labeled **End terminal**, with a warning that running work will be interrupted. It requests PTY termination and waits for the process-exit acknowledgement before disconnecting. Ordinary network disconnects keep their existing reconnect behavior.

On POSIX, launch Codex with `exec` so the terminal process is the thread writer. Remove the `resume || codex` fallback (and its Windows counterpart), which otherwise silently starts a new conversation when resume fails. Termination is restricted to the socket currently owning that PTY; a stale socket cannot stop its replacement. No lock files are deleted and no external Codex clients are killed automatically.

Reproduction:

1. Resume a Codex session in CloudCLI Terminal and let a reply finish.
2. Switch to Chat (or disconnect the terminal) and send into the same session.
3. Codex rejects the second writer. Previously this appeared as a raw CLI error with no explanation that a finished interactive session still owns a lock.
4. With this change, Chat explains the conflict. Reconnect to Terminal, choose End terminal, wait for disconnection, and resend in Chat. External clients must be exited in their own interface.

Validation:

- Backend shell tests, including a real Linux PTY holding an OS file lock: disconnect preserves the lock; explicit termination releases it.
- Frontend tests cover the web-chat conflict display, ordinary errors, disconnect versus termination, and waiting for exit acknowledgement.
- Full frontend suite, build, typecheck, and lint (existing lint warnings remain).

English and Simplified Chinese copy is included; other locales use English fallbacks. This is an explicit handoff, not automatic termination on chat send or a general cross-client lock manager. Windows process-tree behavior is not covered by the Linux integration test.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an option to explicitly end Codex terminal sessions so they can be continued in chat.
  * Added clear guidance when a Codex session remains active, including recovery steps and expandable technical details.
  * Added translated messaging in English and Simplified Chinese.

* **Bug Fixes**
  * Prevented reconnects while a terminal is shutting down.
  * Ensured terminal shutdown completes before the connection closes.
  * Preserved terminals during ordinary disconnects while restricting termination to the active connection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->