### PR TITLE
fix(plugins): install dev dependencies so plugin builds succeed

### DIFF
--- a/server/modules/plugins/plugin-registry.service.ts
+++ b/server/modules/plugins/plugin-registry.service.ts
@@ -338,9 +338,12 @@ export function installPluginFromGit(url) {
 
       // Run npm install if package.json exists.
       // --ignore-scripts prevents postinstall hooks from executing arbitrary code.
+      // --include=dev is required: the server runs with NODE_ENV=production,
+      // which makes npm omit devDependencies by default — and plugins need
+      // them (typescript, vite, etc.) for the `npm run build` below.
       const packageJsonPath = path.join(tempDir, 'package.json');
       if (fs.existsSync(packageJsonPath)) {
-        const npmProcess = spawn('npm', ['install', '--ignore-scripts'], {
+        const npmProcess = spawn('npm', ['install', '--ignore-scripts', '--include=dev'], {
           cwd: tempDir,
           stdio: ['ignore', 'pipe', 'pipe'],
         });
@@ -404,10 +407,12 @@ export function updatePluginFromGit(name) {
         return reject(new Error(`Invalid manifest after update: ${validation.error}`));
       }
 
-      // Re-run npm install if package.json exists
+      // Re-run npm install if package.json exists.
+      // --include=dev: see installPluginFromGit — NODE_ENV=production makes
+      // npm omit devDependencies, breaking the build step below.
       const packageJsonPath = path.join(pluginDir, 'package.json');
       if (fs.existsSync(packageJsonPath)) {
-        const npmProcess = spawn('npm', ['install', '--ignore-scripts'], {
+        const npmProcess = spawn('npm', ['install', '--ignore-scripts', '--include=dev'], {
           cwd: pluginDir,
           stdio: ['ignore', 'pipe', 'pipe'],
         });


### PR DESCRIPTION
## Summary

Fixes plugin installation (and update) failing with an internal error for any plugin whose build needs devDependencies — including the official `cloudcli-plugin-starter`.

## Problem

The server runs with `NODE_ENV=production`, which makes `npm install` **omit devDependencies by default**. The plugin installer ran:

1. `git clone` the plugin repo
2. `npm install --ignore-scripts` → devDependencies skipped
3. `npm run build` (when the plugin declares a `build` script)

Plugins like `cloudcli-plugin-starter` declare `typescript` under `devDependencies` for their `build: tsc` script. Because typescript was never installed, step 3 failed with `sh: 1: tsc: not found` (exit 127) and `POST /api/plugins/install` returned HTTP 500.

## What changed

Added `--include=dev` to the `npm install` invocation in both paths that precede a plugin build:

- `installPluginFromGit` — fresh install
- `updatePluginFromGit` — update reinstall

`--ignore-scripts` is kept (postinstall hooks must not run arbitrary code); only devDependency omission is corrected.

## Verification

- Reproduced the failure in the production container (`NODE_ENV=production`): starter plugin install returned 500, `npm run build` → `tsc: not found`.
- With `--include=dev`: `tsc` is installed, `npm run build` exits 0, `dist/` is produced.
- End-to-end through the real API: `POST /api/plugins/install` for `cloudcli-ai/cloudcli-plugin-starter` returns `200 {"success":true,...}`, and the plugin lists as enabled.
- `npm run typecheck` passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Plugin installations and updates now include required development dependencies when running in production mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->