### PR TITLE
fix(opencode): list OpenCode Go models with reasoning variants

### DIFF
--- a/server/modules/providers/list/opencode/opencode-models.provider.ts
+++ b/server/modules/providers/list/opencode/opencode-models.provider.ts
@@ -21,9 +21,9 @@ import {
  * Curated OpenCode catalog shipped as immutable CloudCLI defaults.
  *
  * OpenCode routes by `<providerID>/<modelID>`, so this list mirrors the
- * providers `opencode models --verbose` reports: the OpenCode Zen gateway plus
- * the Anthropic and OpenAI providers OpenCode can address directly with the
- * user's own credentials.
+ * providers `opencode models --verbose` reports: the OpenCode Zen gateway, the
+ * OpenCode Go subscription gateway, and the Anthropic and OpenAI providers
+ * OpenCode can address directly with the user's own credentials.
  */
 export const OPENCODE_PREDEFINED_MODELS: ProviderModelsDefinition = {
   OPTIONS: [
@@ -81,6 +81,178 @@ export const OPENCODE_PREDEFINED_MODELS: ProviderModelsDefinition = {
     { value: 'opencode/north-mini-code-free', label: 'North Mini Code Free', description: 'OpenCode Zen · Free' },
     { value: 'opencode/nemotron-3-ultra-free', label: 'Nemotron 3 Ultra Free', description: 'OpenCode Zen · Free' },
     { value: 'opencode/deepseek-v4-flash-free', label: 'DeepSeek V4 Flash Free', description: 'OpenCode Zen · Free' },
+    {
+      value: 'opencode-go/grok-4.6',
+      label: 'Grok 4.6',
+      description: 'OpenCode Go',
+      effort: {
+        values: [{ value: 'low' }, { value: 'medium' }, { value: 'high' }, { value: 'xhigh' }],
+      },
+    },
+    {
+      value: 'opencode-go/glm-5.3-flash',
+      label: 'GLM 5.3 Flash',
+      description: 'OpenCode Go',
+      effort: {
+        values: [{ value: 'low' }, { value: 'high' }, { value: 'max' }],
+      },
+    },
+    {
+      value: 'opencode-go/glm-5.3',
+      label: 'GLM 5.3',
+      description: 'OpenCode Go',
+      effort: {
+        values: [{ value: 'low' }, { value: 'high' }, { value: 'max' }],
+      },
+    },
+    {
+      value: 'opencode-go/glm-5.2',
+      label: 'GLM 5.2',
+      description: 'OpenCode Go',
+      effort: {
+        values: [{ value: 'high' }, { value: 'max' }],
+      },
+    },
+    { value: 'opencode-go/glm-5.1', label: 'GLM 5.1', description: 'OpenCode Go' },
+    {
+      value: 'opencode-go/gpt-5.6-luna',
+      label: 'GPT 5.6 Luna',
+      description: 'OpenCode Go',
+      effort: {
+        values: [
+          { value: 'none' },
+          { value: 'low' },
+          { value: 'medium' },
+          { value: 'high' },
+          { value: 'xhigh' },
+          { value: 'max' },
+        ],
+      },
+    },
+    {
+      value: 'opencode-go/kimi-k3',
+      label: 'Kimi K3',
+      description: 'OpenCode Go',
+      effort: {
+        values: [{ value: 'max' }],
+      },
+    },
+    { value: 'opencode-go/kimi-k2.7-code', label: 'Kimi K2.7 Code', description: 'OpenCode Go' },
+    { value: 'opencode-go/kimi-k2.6', label: 'Kimi K2.6', description: 'OpenCode Go' },
+    {
+      value: 'opencode-go/longcat-2.0',
+      label: 'LongCat 2.0',
+      description: 'OpenCode Go',
+      effort: {
+        values: [{ value: 'low' }, { value: 'medium' }, { value: 'high' }],
+      },
+    },
+    { value: 'opencode-go/mimo-v2.5', label: 'MiMo V2.5', description: 'OpenCode Go' },
+    { value: 'opencode-go/mimo-v2.5-pro', label: 'MiMo V2.5 Pro', description: 'OpenCode Go' },
+    {
+      value: 'opencode-go/minimax-m3',
+      label: 'MiniMax M3',
+      description: 'OpenCode Go',
+      effort: {
+        values: [{ value: 'none' }, { value: 'thinking' }],
+      },
+    },
+    { value: 'opencode-go/minimax-m2.7', label: 'MiniMax M2.7', description: 'OpenCode Go' },
+    {
+      value: 'opencode-go/muse-spark-1.3-contributor',
+      label: 'Muse Spark 1.3 Contributor',
+      description: 'OpenCode Go',
+      effort: {
+        values: [
+          { value: 'minimal' },
+          { value: 'low' },
+          { value: 'medium' },
+          { value: 'high' },
+          { value: 'xhigh' },
+        ],
+      },
+    },
+    {
+      value: 'opencode-go/muse-spark-1.2-contributor',
+      label: 'Muse Spark 1.2 Contributor',
+      description: 'OpenCode Go',
+      effort: {
+        values: [
+          { value: 'minimal' },
+          { value: 'low' },
+          { value: 'medium' },
+          { value: 'high' },
+          { value: 'xhigh' },
+        ],
+      },
+    },
+    {
+      value: 'opencode-go/qwen3.8-max',
+      label: 'Qwen3.8 Max',
+      description: 'OpenCode Go',
+      effort: {
+        values: [{ value: 'low' }, { value: 'medium' }, { value: 'xhigh' }],
+      },
+    },
+    {
+      value: 'opencode-go/qwen3.8-flash',
+      label: 'Qwen3.8 Flash',
+      description: 'OpenCode Go',
+      effort: {
+        values: [{ value: 'low' }, { value: 'medium' }, { value: 'xhigh' }],
+      },
+    },
+    { value: 'opencode-go/qwen3.7-max', label: 'Qwen3.7 Max', description: 'OpenCode Go' },
+    { value: 'opencode-go/qwen3.7-plus', label: 'Qwen3.7 Plus', description: 'OpenCode Go' },
+    { value: 'opencode-go/qwen3.6-plus', label: 'Qwen3.6 Plus', description: 'OpenCode Go' },
+    {
+      value: 'opencode-go/deepseek-v4-pro',
+      label: 'DeepSeek V4 Pro',
+      description: 'OpenCode Go',
+      effort: {
+        values: [{ value: 'high' }, { value: 'max' }],
+      },
+    },
+    {
+      value: 'opencode-go/deepseek-v4-flash',
+      label: 'DeepSeek V4 Flash',
+      description: 'OpenCode Go',
+      effort: {
+        values: [{ value: 'low' }, { value: 'high' }, { value: 'max' }],
+      },
+    },
+    {
+      value: 'opencode-go/deepseek-v4-flash-vision-exp',
+      label: 'DeepSeek V4 Flash Vision Exp',
+      description: 'OpenCode Go',
+      effort: {
+        values: [{ value: 'low' }, { value: 'high' }, { value: 'max' }],
+      },
+    },
+    {
+      value: 'opencode-go/hy4-preview',
+      label: 'Hy4 Preview',
+      description: 'OpenCode Go',
+      effort: {
+        values: [{ value: 'none' }, { value: 'high' }],
+      },
+    },
+    {
+      value: 'opencode-go/hy3',
+      label: 'Hy3',
+      description: 'OpenCode Go',
+      effort: {
+        values: [{ value: 'none' }, { value: 'low' }, { value: 'high' }],
+      },
+    },
+    {
+      value: 'opencode-go/omen-alpha',
+      label: 'Omen Alpha',
+      description: 'OpenCode Go',
+      effort: {
+        values: [{ value: 'low' }, { value: 'high' }],
+      },
+    },
     { value: 'anthropic/claude-opus-5', label: 'Claude Opus 5', description: 'Anthropic' },
     { value: 'anthropic/claude-opus-5-fast', label: 'Claude Opus 5 Fast', description: 'Anthropic' },
     { value: 'anthropic/claude-fable-5', label: 'Claude Fable 5', description: 'Anthropic' },

--- a/server/modules/providers/tests/opencode-models.test.ts
+++ b/server/modules/providers/tests/opencode-models.test.ts
@@ -66,7 +66,7 @@ test('OpenCode exposes only the curated predefined catalog', async () => {
   const providerIds = new Set(
     OPENCODE_PREDEFINED_MODELS.OPTIONS.map((option) => option.value.split('/')[0]),
   );
-  assert.deepEqual([...providerIds].sort(), ['anthropic', 'opencode', 'openai'].sort());
+  assert.deepEqual([...providerIds].sort(), ['anthropic', 'opencode', 'opencode-go', 'openai'].sort());
   assert.equal(
     OPENCODE_PREDEFINED_MODELS.OPTIONS.every((option) => /^[a-z0-9-]+\/.+/.test(option.value)),
     true,
@@ -85,6 +85,34 @@ test('OpenCode exposes only the curated predefined catalog', async () => {
   assert.ok(
     OPENCODE_PREDEFINED_MODELS.OPTIONS.some((option) => option.value === 'openai/gpt-5.6'),
   );
+  // The Go gateway carries its own provider id, so its models must be curated
+  // too - a Go subscriber otherwise authenticates while the picker offers
+  // nothing they can run.
+  const opencodeGoOptions = OPENCODE_PREDEFINED_MODELS.OPTIONS.filter(
+    (option) => option.value.startsWith('opencode-go/'),
+  );
+  assert.equal(opencodeGoOptions.length, 27);
+  assert.ok(opencodeGoOptions.every((option) => option.description === 'OpenCode Go'));
+  const glmFlash = opencodeGoOptions.find(
+    (option) => option.value === 'opencode-go/glm-5.3-flash',
+  );
+  assert.ok(glmFlash);
+  // Effort choices come from `opencode models --verbose` variants; the runtime
+  // turns a selected value into `--variant`, so the values have to match the
+  // CLI's exactly.
+  assert.deepEqual(
+    glmFlash?.effort?.values.map((value) => value.value),
+    ['low', 'high', 'max'],
+  );
+  assert.ok(
+    opencodeGoOptions
+      .filter((option) => !option.effort)
+      .every((option) =>
+        ['glm-5.1', 'kimi-k2.6', 'kimi-k2.7-code', 'mimo-v2.5', 'mimo-v2.5-pro',
+          'minimax-m2.7', 'qwen3.6-plus', 'qwen3.7-max', 'qwen3.7-plus']
+          .includes(option.value.slice('opencode-go/'.length)),
+      ),
+  );
 });
 
 test('OpenCode offers only models the install can route to', async () => {
@@ -100,6 +128,23 @@ test('OpenCode offers only models the install can route to', async () => {
       assert.deepEqual([...providerIds], ['anthropic']);
       assert.ok(catalog.OPTIONS.length > 0);
       assert.equal(catalog.DEFAULT.startsWith('anthropic/'), true);
+      assert.ok(catalog.OPTIONS.some((option) => option.value === catalog.DEFAULT));
+      assert.equal((await adapter.getCurrentActiveModel()).model, catalog.DEFAULT);
+    },
+  );
+
+  // A Go subscriber's auth store holds only `opencode-go`, so the whole catalog
+  // has to resolve to Go models and the default has to move onto one of them
+  // instead of the unreachable Zen default.
+  await withOpenCodeHome(
+    (homeDir) => writeOpenCodeAuth(homeDir, { 'opencode-go': { type: 'api', key: 'test' } }),
+    async (adapter) => {
+      const catalog = await adapter.getSupportedModels();
+      const providerIds = new Set(catalog.OPTIONS.map((option) => option.value.split('/')[0]));
+
+      assert.deepEqual([...providerIds], ['opencode-go']);
+      assert.equal(catalog.OPTIONS.length, 27);
+      assert.equal(catalog.DEFAULT, 'opencode-go/grok-4.6');
       assert.ok(catalog.OPTIONS.some((option) => option.value === catalog.DEFAULT));
       assert.equal((await adapter.getCurrentActiveModel()).model, catalog.DEFAULT);
     },


### PR DESCRIPTION
## How to reproduce

1. Connect OpenCode Go (e.g. `opencode auth login`, or `/connect` → `OpenCode Go` in the TUI). `~/.local/share/opencode/auth.json` gains an `opencode-go` entry, and CloudCLI reports the opencode provider as authenticated.
2. Open the OpenCode model picker: every Go model is missing. On a Go-only install the connected-provider filter finds no `opencode-go` options and falls back to the full catalog, so the picker lists Zen/Anthropic/OpenAI models the CLI refuses outright (`Model opencode/claude-sonnet-4-6 is not valid`).
3. Equivalently, `GET /api/providers/opencode/models` returns `authenticated: true` with zero `opencode-go/*` OPTIONS.

## What this fixes

The OpenCode provider authenticated any credentials-file entry, so a subscriber who connected OpenCode Go (`opencode-go` in `auth.json`) counted as logged in — but the curated catalog shipped zero `opencode-go/*` entries. The connected-provider filter then found no Go options, fell back to the full catalog, and left Go users staring at a list of models their CLI rejects while every model they pay for was missing. #840 reported exactly this and was closed without a fix; the bug persists on main.

## What changed

- Add the 27 `opencode-go/<model-id>` entries `opencode models --verbose` reports (per the [OpenCode Go docs](https://opencode.ai/docs/go/)).
- Wire each model's reasoning variants from the same CLI output as effort metadata, so the existing effort picker resolves them through `--variant` (the runtime already validates and passes it).
- Labels follow the catalog's existing style; the CLI's marketing suffixes ("(2x usage)", "(New)") are dropped.
- `DEFAULT` stays `opencode/gpt-5.6-terra`; the filter already relocates the default to `opencode-go/grok-4.6` on Go-only installs.
- The docs also list `minimax-m2.5`, but the CLI does not report it, so it is deliberately left out; the catalog mirrors CLI output.

## What about screenshots

No UI markup changed — the picker renders whatever `OPTIONS` the models API returns; the fixtures and the API response are the verification surface.

## Tests

- The curated-catalog provider-set assertion gains `opencode-go`, with spot checks: 27 Go entries, effort values exactly as the CLI reports, and the models without variants carrying no effort field.
- New fixture: an auth store with only `opencode-go` resolves the whole catalog to Go models, with the default on the first one and `getCurrentActiveModel` agreeing.
- `npm test` (397 server tests pass), `npm run typecheck`, `npm run lint:server`, and `npm run build` all pass.

## Notes

- No file overlap with #1230 (per-model sampling settings); reviewed for conflicts.
- Users who manually added Go models through the model library may see duplicates once these entries are predefined; deduping custom vs. predefined rows is deliberately out of scope for this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added OpenCode Go subscription models to the predefined model catalog.
  - Added configurable effort levels for supported OpenCode Go models.
  - OpenCode Go authentication now resolves the available Go model catalog, with `grok-4.6` as the default.

- **Tests**
  - Added coverage validating OpenCode Go model availability, descriptions, effort settings, and default selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->