### PR TITLE
feat(chat): add cross-provider conversation handoffs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -61,6 +61,7 @@
 - **Git Explorer** - View, stage and commit your changes. You can also switch branches 
 - **Browser Use** - Open browser sessions for web research, testing, and agent-driven browser tasks
 - **Session Management** - Resume conversations, manage multiple sessions, and track history
+- **Provider Handoff** - Use **Continue with another provider** in an idle chat to choose a different provider and model. A linked chat opens in the same workspace with a saved context draft; review it and press Send to continue. The original chat is unchanged. Conversation text and bounded tool context transfer, but attachment contents, private reasoning, and provider-specific state do not. Long histories are truncated with a notice; avoid running both chats against the same files simultaneously.
 - **Plugin System** - Extend CloudCLI with custom plugins — add new tabs, backend services, and integrations. [Build your own →](https://github.com/cloudcli-ai/cloudcli-plugin-starter)
 - **TaskMaster AI Integration** *(Optional)* - Advanced project management with AI-powered task planning, PRD parsing, and workflow automation
 - **Model Compatibility** - Works with Claude and GPT model families (the full list of supported models is available at runtime via `GET /api/providers/:provider/models`)

--- a/server/modules/database/index.ts
+++ b/server/modules/database/index.ts
@@ -12,7 +12,7 @@ export { providerModelsDb } from '@/modules/database/repositories/provider-model
 export { projectsDb } from '@/modules/database/repositories/projects.db.js';
 export { pushSubscriptionsDb } from '@/modules/database/repositories/push-subscriptions.js';
 export { scanStateDb } from '@/modules/database/repositories/scan-state.db.js';
-// sessionDraftsDb: used by User for drafts and Scheduled Messages for server-owned queued turns.
+// sessionDraftsDb: used by User for drafts, Providers for handoffs, and Scheduled Messages for queued turns.
 export { sessionDraftsDb } from '@/modules/database/repositories/session-drafts.db.js';
 export type {
   QueuedSessionMessageRecord,

--- a/server/modules/database/repositories/sessions.db.ts
+++ b/server/modules/database/repositories/sessions.db.ts
@@ -177,6 +177,7 @@ export const sessionsDb = {
     provider: string,
     projectPath: string,
     customName?: string,
+    options: { forkedFromSessionId?: string; model?: string } = {},
   ): string {
     const db = getConnection();
     const normalizedProjectPath = normalizeProjectPathForProvider(provider, projectPath);
@@ -184,9 +185,16 @@ export const sessionsDb = {
     projectsDb.createProjectPath(normalizedProjectPath);
 
     db.prepare(
-      `INSERT INTO sessions (session_id, provider, provider_session_id, custom_name, project_path, jsonl_path, isArchived, created_at, updated_at)
-       VALUES (?, ?, NULL, ?, ?, NULL, 0, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)`
-    ).run(sessionId, provider, customName ?? null, normalizedProjectPath);
+      `INSERT INTO sessions (session_id, provider, provider_session_id, custom_name, project_path, jsonl_path, forked_from_session_id, model, isArchived, created_at, updated_at)
+       VALUES (?, ?, NULL, ?, ?, NULL, ?, ?, 0, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)`
+    ).run(
+      sessionId,
+      provider,
+      customName ?? null,
+      normalizedProjectPath,
+      options.forkedFromSessionId ?? null,
+      options.model ?? null,
+    );
 
     return sessionId;
   },

--- a/server/modules/providers/provider.routes.ts
+++ b/server/modules/providers/provider.routes.ts
@@ -8,6 +8,7 @@ import { providerTokenUsageService } from '@/modules/providers/services/provider
 import { providerSkillsService } from '@/modules/providers/services/skills.service.js';
 import { sessionConversationsSearchService } from '@/modules/providers/services/session-conversations-search.service.js';
 import { sessionsService } from '@/modules/providers/services/sessions.service.js';
+import { sessionHandoffService } from '@/modules/providers/services/session-handoff.service.js';
 import type {
   CustomProviderModelInput,
   LLMProvider,
@@ -811,6 +812,22 @@ router.post(
     const sessionId = parseSessionId(req.params.sessionId);
     const result = sessionsService.restoreSessionById(sessionId);
     res.json(createApiSuccessResponse(result));
+  }),
+);
+
+router.post(
+  '/sessions/:sessionId/handoff',
+  asyncHandler(async (req: Request, res: Response) => {
+    const sessionId = parseSessionId(req.params.sessionId);
+    const body = (req.body ?? {}) as Record<string, unknown>;
+    const provider = parseProvider(body.provider);
+    const model = parseSessionModelPayload(body);
+    const userId = Number((req as Request & { user?: { id?: number | string } }).user?.id);
+    if (!Number.isInteger(userId) || userId <= 0) {
+      throw new AppError('Authentication required.', { code: 'UNAUTHORIZED', statusCode: 401 });
+    }
+    const result = await sessionHandoffService.createHandoff(sessionId, { provider, model, userId });
+    res.status(201).json(createApiSuccessResponse(result));
   }),
 );
 

--- a/server/modules/providers/services/session-handoff.service.ts
+++ b/server/modules/providers/services/session-handoff.service.ts
@@ -1,0 +1,98 @@
+import { randomUUID } from 'node:crypto';
+
+import { getConnection, sessionDraftsDb, sessionsDb } from '@/modules/database/index.js';
+import { broadcastSessionUpserted, chatRunRegistry } from '@/modules/websocket/index.js';
+import { providerRegistry } from '@/modules/providers/provider.registry.js';
+import { sessionsService } from '@/modules/providers/services/sessions.service.js';
+import type { LLMProvider, NormalizedMessage } from '@/shared/types.js';
+import { AppError } from '@/shared/utils.js';
+
+const MAX_CONTEXT_CHARACTERS = 48_000;
+const MAX_MESSAGE_CHARACTERS = 8_000;
+
+function limitText(text: string, limit: number): string {
+  return text.length > limit ? `${text.slice(0, limit)}\n[truncated]` : text;
+}
+
+function renderMessage(message: NormalizedMessage): string | null {
+  if (message.kind === 'text' && !message.isLocalCommand && !message.isLocalCommandStdout) {
+    const text = message.content || message.displayText || message.text;
+    if (!text?.trim()) return null;
+    const attachments = message.images || message.files ? '\n[Attachments not copied]' : '';
+    return `${message.role === 'user' ? 'User' : 'Assistant'}:\n${limitText(text, MAX_MESSAGE_CHARACTERS)}${attachments}`;
+  }
+  if (message.kind === 'tool_use') {
+    const call = `Tool ${message.toolName || 'call'}:\n${limitText(JSON.stringify(message.toolInput ?? {}), 2_000)}`;
+    const result = message.toolResult?.content;
+    return result ? `${call}\nResult${message.toolResult?.isError ? ' (error)' : ''}:\n${limitText(result, 2_000)}` : call;
+  }
+  if (message.kind === 'tool_result') {
+    const result = message.toolResult?.content || message.content;
+    return result ? `Tool result:\n${limitText(result, 2_000)}` : null;
+  }
+  return null;
+}
+
+/** Used by provider routes to prepare a new provider's unsent context draft. */
+export const sessionHandoffService = {
+  async createHandoff(sessionId: string, input: { provider: LLMProvider; model: string; userId: number }) {
+    const source = sessionsDb.getSessionById(sessionId) ?? sessionsDb.getSessionByProviderSessionId(sessionId);
+    if (!source) {
+      throw new AppError('Session not found.', { code: 'SESSION_NOT_FOUND', statusCode: 404 });
+    }
+    providerRegistry.resolveProvider(input.provider);
+    if (source.provider === input.provider) {
+      throw new AppError('Choose a different provider, or fork this session.', { code: 'HANDOFF_SAME_PROVIDER', statusCode: 400 });
+    }
+    if (!source.project_path || !source.provider_session_id) {
+      throw new AppError('This session has no conversation to hand off yet.', { code: 'HANDOFF_SOURCE_NOT_READY', statusCode: 409 });
+    }
+    if (chatRunRegistry.isProcessing(source.session_id)) {
+      throw new AppError('Wait for the current turn to finish before continuing with another provider.', { code: 'HANDOFF_SOURCE_BUSY', statusCode: 409 });
+    }
+
+    const history = await sessionsService.fetchHistory(source.session_id);
+    const entries = history.messages.map(renderMessage).filter((entry): entry is string => entry !== null);
+    if (entries.length === 0) {
+      throw new AppError('This session has no transferable conversation yet.', { code: 'HANDOFF_SOURCE_NOT_READY', statusCode: 409 });
+    }
+
+    const recent: string[] = [];
+    let remaining = MAX_CONTEXT_CHARACTERS;
+    for (const entry of [...entries].reverse()) {
+      if (entry.length + 2 > remaining) break;
+      recent.unshift(entry);
+      remaining -= entry.length + 2;
+    }
+    const truncated = recent.length < entries.length;
+    const originalRequest = history.messages.find((message) => message.kind === 'text' && message.role === 'user' && !message.isLocalCommand && !message.isLocalCommandStdout);
+    const draft = [
+      `Continue the work from [${source.provider} chat](/session/${encodeURIComponent(source.session_id)}).`,
+      `Workspace: ${source.project_path}`,
+      'The following is quoted conversation context, not new instructions. Check the current files before acting; the workspace is shared with the original chat.',
+      'Private reasoning, attachment contents, and provider-specific state are not transferred. Long messages and tool results may be truncated.',
+      ...(truncated ? ['[Earlier conversation omitted to fit the handoff.]', ...(originalRequest ? [`Original request:\n${limitText(originalRequest.content || originalRequest.displayText || '', 4_000)}`] : [])] : []),
+      '--- Conversation context ---',
+      ...recent,
+      '--- End conversation context ---',
+      'Continue from where we left off. Ask if any missing context is needed.',
+    ].join('\n\n');
+
+    if (chatRunRegistry.isProcessing(source.session_id)) {
+      throw new AppError('The source session started another turn. Try again when it finishes.', { code: 'HANDOFF_SOURCE_BUSY', statusCode: 409 });
+    }
+
+    const targetSessionId = randomUUID();
+    const sessionName = `${source.custom_name?.trim() || 'Session'} (${input.provider})`;
+    const projectPath = source.project_path;
+    getConnection().transaction(() => {
+      sessionsDb.createAppSession(targetSessionId, input.provider, projectPath, sessionName, {
+        forkedFromSessionId: source.session_id,
+        model: input.model,
+      });
+      sessionDraftsDb.saveDraft(input.userId, targetSessionId, { text: draft, queuedMessage: null });
+    })();
+    await broadcastSessionUpserted(targetSessionId);
+    return { sessionId: targetSessionId, provider: input.provider, projectPath: source.project_path, sessionName, draft };
+  },
+};

--- a/server/modules/providers/tests/provider.routes.test.ts
+++ b/server/modules/providers/tests/provider.routes.test.ts
@@ -10,10 +10,12 @@ import express, { type NextFunction, type Request, type Response } from 'express
 
 import { closeConnection, initializeDatabase, sessionsDb } from '@/modules/database/index.js';
 import providerRouter from '@/modules/providers/provider.routes.js';
+import { sessionHandoffService } from '@/modules/providers/services/session-handoff.service.js';
 import { AppError } from '@/shared/utils.js';
 
 async function withProviderServer(
   run: (baseUrl: string, workspacePath: string) => Promise<void>,
+  authenticated = false,
 ): Promise<void> {
   const previousDatabasePath = process.env.DATABASE_PATH;
   const tempDirectory = await mkdtemp(path.join(os.tmpdir(), 'provider-routes-'));
@@ -23,7 +25,10 @@ async function withProviderServer(
   await writeFile(process.env.DATABASE_PATH, '');
   await initializeDatabase();
 
-  const app = express().use(express.json()).use('/api/providers', providerRouter);
+  const app = express().use(express.json()).use((req, _res, next) => {
+    if (authenticated) Object.assign(req, { user: { id: 1 } });
+    next();
+  }).use('/api/providers', providerRouter);
   app.use((error: unknown, _req: Request, res: Response, _next: NextFunction) => {
     if (error instanceof AppError) {
       res.status(error.statusCode).json({
@@ -75,6 +80,36 @@ test('session creation route names a CloudCLI session from the initial message',
       sessionsDb.getSessionById(payload.data.sessionId)?.custom_name,
       'abcd efg hij klm',
     );
+  });
+});
+
+test('handoff route uses the authenticated user and validates provider and model', async (context) => {
+  const createHandoff = context.mock.method(sessionHandoffService, 'createHandoff', async () => ({
+    sessionId: 'new-session', provider: 'codex' as const, projectPath: '/workspace', sessionName: 'New chat', draft: 'Context',
+  }));
+  await withProviderServer(async (baseUrl) => {
+    const url = `${baseUrl}/api/providers/sessions/source/handoff`;
+    const send = (body: unknown) => fetch(url, { method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify(body) });
+    assert.equal((await send({ provider: 'unknown', model: 'target' })).status, 400);
+    assert.equal((await send({ provider: 'codex' })).status, 400);
+    assert.equal((await send({ provider: 'codex', model: '   ' })).status, 400);
+    assert.equal(createHandoff.mock.callCount(), 0);
+    const response = await send({ provider: 'codex', model: 'target', userId: 99 });
+    assert.equal(response.status, 201);
+    assert.deepEqual(createHandoff.mock.calls[0].arguments, ['source', { provider: 'codex', model: 'target', userId: 1 }]);
+    const payload = await response.json() as { data: { sessionId: string } };
+    assert.equal(payload.data.sessionId, 'new-session');
+  }, true);
+});
+
+test('handoff route requires authentication before creating a draft', async (context) => {
+  const createHandoff = context.mock.method(sessionHandoffService, 'createHandoff');
+  await withProviderServer(async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/providers/sessions/source/handoff`, {
+      method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify({ provider: 'codex', model: 'target' }),
+    });
+    assert.equal(response.status, 401);
+    assert.equal(createHandoff.mock.callCount(), 0);
   });
 });
 

--- a/server/modules/providers/tests/session-handoff.test.ts
+++ b/server/modules/providers/tests/session-handoff.test.ts
@@ -1,0 +1,120 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, rm } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+
+import { closeConnection, getConnection, initializeDatabase, sessionDraftsDb, sessionsDb, userDb } from '@/modules/database/index.js';
+import { sessionHandoffService } from '@/modules/providers/services/session-handoff.service.js';
+import { sessionsService } from '@/modules/providers/services/sessions.service.js';
+import { chatRunRegistry } from '@/modules/websocket/index.js';
+import type { NormalizedMessage } from '@/shared/types.js';
+
+function message(content: string, role: 'user' | 'assistant' = 'user'): NormalizedMessage {
+  return { id: content, sessionId: 'source', timestamp: '2026-01-01T00:00:00Z', provider: 'claude', kind: 'text', role, content };
+}
+
+async function withDatabase(run: (userId: number) => Promise<void>) {
+  const previousPath = process.env.DATABASE_PATH;
+  const directory = await mkdtemp(path.join(os.tmpdir(), 'session-handoff-'));
+  closeConnection();
+  process.env.DATABASE_PATH = path.join(directory, 'auth.db');
+  try {
+    await initializeDatabase();
+    const userId = Number(userDb.createUser('handoff-user', 'unused').id);
+    sessionsDb.createAppSession('source', 'claude', directory, 'Fix the build');
+    sessionsDb.assignProviderSessionId('source', 'native-source');
+    sessionsDb.setSessionModel('source', 'source-model');
+    await run(userId);
+  } finally {
+    closeConnection();
+    if (previousPath === undefined) delete process.env.DATABASE_PATH;
+    else process.env.DATABASE_PATH = previousPath;
+    await rm(directory, { recursive: true, force: true });
+  }
+}
+
+test('handoff creates a durable unsent draft without changing the source or reusing its native ID', async (context) => {
+  await withDatabase(async (userId) => {
+    const messages = [message('Fix the build'), message('The linker flag is wrong.', 'assistant'),
+      { ...message('secret reasoning'), kind: 'thinking' as const },
+      { ...message(''), kind: 'tool_use' as const, toolName: 'Bash', toolInput: { command: 'make test' }, toolResult: { content: 'All tests pass' } },
+      { ...message(''), kind: 'tool_result' as const, toolResult: { content: 'Standalone tool result' } },
+      { ...message('local output'), isLocalCommandStdout: true },
+      { ...message('See this diagram'), images: [{ data: 'private-image-bytes' }] },
+    ];
+    const history = context.mock.method(sessionsService, 'fetchHistory', async () => ({ messages, total: messages.length, hasMore: false, offset: 0, limit: null }));
+    const source = sessionsDb.getSessionById('source');
+    const result = await sessionHandoffService.createHandoff('native-source', { provider: 'codex', model: 'target-model', userId });
+    const target = sessionsDb.getSessionById(result.sessionId);
+    assert.ok(target);
+    assert.equal(target.provider, 'codex');
+    assert.equal(target.provider_session_id, null);
+    assert.equal(target.jsonl_path, null);
+    assert.equal(target.project_path, source?.project_path);
+    assert.equal(target.forked_from_session_id, 'source');
+    assert.equal(target.model, 'target-model');
+    assert.equal(target.effort, null);
+    assert.deepEqual(sessionsDb.getSessionById('source'), source);
+    assert.deepEqual(history.mock.calls[0].arguments, ['source']);
+    const [draft] = sessionDraftsDb.getDrafts(userId);
+    assert.equal(draft.scope, result.sessionId);
+    assert.equal(draft.text, result.draft);
+    assert.equal(draft.queuedMessage, null);
+    assert.match(draft.text, /\/session\/source/);
+    assert.match(draft.text, /The linker flag is wrong/);
+    assert.match(draft.text, /make test/);
+    assert.match(draft.text, /All tests pass/);
+    assert.match(draft.text, /Standalone tool result/);
+    assert.match(draft.text, /Attachments not copied/);
+    assert.doesNotMatch(draft.text, /secret reasoning/);
+    assert.doesNotMatch(draft.text, /local output|private-image-bytes/);
+    assert.equal(chatRunRegistry.getRun(result.sessionId), undefined);
+  });
+});
+
+test('handoff bounds long transcripts while retaining the original request and newest context', async (context) => {
+  await withDatabase(async (userId) => {
+    const messages = [message('Original task'), ...Array.from({ length: 40 }, () => message('history '.repeat(2_000), 'assistant')), message('Latest decision', 'assistant')];
+    context.mock.method(sessionsService, 'fetchHistory', async () => ({ messages, total: messages.length, hasMore: false, offset: 0, limit: null }));
+    const result = await sessionHandoffService.createHandoff('source', { provider: 'codex', model: 'target', userId });
+    assert.ok(result.draft.length < 55_000);
+    assert.match(result.draft, /Earlier conversation omitted/);
+    assert.match(result.draft, /Original request:\nOriginal task/);
+    assert.match(result.draft, /Latest decision/);
+    assert.match(result.draft, /\[truncated\]/);
+  });
+});
+
+test('handoff rejects missing, same-provider, empty, and running sources without creating a session', async (context) => {
+  await withDatabase(async (userId) => {
+    const target = { provider: 'codex' as const, model: 'target', userId };
+    await assert.rejects(sessionHandoffService.createHandoff('missing', target), { code: 'SESSION_NOT_FOUND' });
+    await assert.rejects(sessionHandoffService.createHandoff('source', { ...target, provider: 'claude' }), { code: 'HANDOFF_SAME_PROVIDER' });
+    context.mock.method(sessionsService, 'fetchHistory', async () => ({ messages: [], total: 0, hasMore: false, offset: 0, limit: null }));
+    await assert.rejects(sessionHandoffService.createHandoff('source', target), { code: 'HANDOFF_SOURCE_NOT_READY' });
+    context.mock.method(chatRunRegistry, 'isProcessing', () => true);
+    await assert.rejects(sessionHandoffService.createHandoff('source', target), { code: 'HANDOFF_SOURCE_BUSY' });
+    assert.deepEqual(getConnection().prepare('SELECT COUNT(*) AS count FROM sessions').get(), { count: 1 });
+  });
+});
+
+test('handoff refuses a source that starts running while history is loading', async (context) => {
+  await withDatabase(async (userId) => {
+    context.mock.method(sessionsService, 'fetchHistory', async () => {
+      context.mock.method(chatRunRegistry, 'isProcessing', () => true);
+      return { messages: [message('Task')], total: 1, hasMore: false, offset: 0, limit: null };
+    });
+    await assert.rejects(sessionHandoffService.createHandoff('source', { provider: 'codex', model: 'target', userId }), { code: 'HANDOFF_SOURCE_BUSY' });
+    assert.deepEqual(sessionDraftsDb.getDrafts(userId), []);
+  });
+});
+
+test('a draft write failure rolls back the new session', async (context) => {
+  await withDatabase(async (userId) => {
+    context.mock.method(sessionsService, 'fetchHistory', async () => ({ messages: [message('Task')], total: 1, hasMore: false, offset: 0, limit: null }));
+    context.mock.method(sessionDraftsDb, 'saveDraft', () => { throw new Error('Disk full'); });
+    await assert.rejects(sessionHandoffService.createHandoff('source', { provider: 'codex', model: 'target', userId }), /Disk full/);
+    assert.deepEqual(getConnection().prepare('SELECT COUNT(*) AS count FROM sessions').get(), { count: 1 });
+  });
+});

--- a/src/modules/chat/ChatInterface.tsx
+++ b/src/modules/chat/ChatInterface.tsx
@@ -26,6 +26,7 @@ import {
 import ChatMessagesPane from '@/modules/chat/transcript/ChatMessagesPane';
 import ChatComposer from '@/modules/chat/composer/ChatComposer';
 import CommandResultModal from '@/modules/chat/modals/CommandResultModal';
+import { SessionHandoffButton } from '@/modules/chat/modals/SessionHandoffButton';
 
 type ChatInterfaceProps = {
   isActive: boolean;
@@ -418,6 +419,18 @@ function ChatInterface({
   return (
     <PermissionContext.Provider value={permissionContextValue}>
       <div className="flex h-full min-h-0 flex-col">
+        {selectedSession && onNavigateToSession && (
+          <div className="flex justify-end px-3">
+            <SessionHandoffButton
+              key={selectedSession.id}
+              sessionId={selectedSession.id}
+              provider={provider}
+              disabled={isProcessing || isLoadingSessionMessages || providerModelsLoading}
+              providerModelCatalog={providerModelCatalog}
+              onNavigate={onNavigateToSession}
+            />
+          </div>
+        )}
         <ChatMessagesPane
           scrollContainerRef={scrollContainerRef}
           // Not redundant with the `scroll` listener. A first page is 20 rows,

--- a/src/modules/chat/modals/SessionHandoffButton.tsx
+++ b/src/modules/chat/modals/SessionHandoffButton.tsx
@@ -1,0 +1,92 @@
+import { useEffect, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { ArrowRightLeft, Loader2 } from 'lucide-react';
+
+import { api } from '@/shared/api';
+import { writeDraftText } from '@/shared/chatDrafts';
+import { Button, Dialog, DialogContent, DialogTitle } from '@/shared/ui';
+import type { LLMProvider, ProviderModelsDefinition } from '@/shared/types';
+
+type SessionHandoffButtonProps = {
+  sessionId: string;
+  provider: LLMProvider;
+  disabled: boolean;
+  providerModelCatalog: Partial<Record<LLMProvider, ProviderModelsDefinition>>;
+  onNavigate: (sessionId: string) => void;
+};
+
+/** Used by ChatInterface to prepare a linked conversation with another provider. */
+export function SessionHandoffButton({ sessionId, provider, disabled, providerModelCatalog, onNavigate }: SessionHandoffButtonProps) {
+  const { t } = useTranslation('chat');
+  const [open, setOpen] = useState(false);
+  const [selection, setSelection] = useState<{ provider: LLMProvider; model: string } | null>(null);
+  const [pending, setPending] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const mounted = useRef(false);
+
+  useEffect(() => {
+    mounted.current = true;
+    return () => { mounted.current = false; };
+  }, []);
+
+  const createHandoff = async () => {
+    if (!selection || pending || disabled) return;
+    setPending(true);
+    setError(null);
+    try {
+      const response = await api.handoffSession(sessionId, selection);
+      const payload = await response.json();
+      if (!response.ok || typeof payload?.data?.sessionId !== 'string' || typeof payload?.data?.draft !== 'string') {
+        throw new Error(payload?.error?.message || t('handoff.error'));
+      }
+      if (!mounted.current) return;
+      writeDraftText(payload.data.sessionId, payload.data.draft);
+      setOpen(false);
+      onNavigate(payload.data.sessionId);
+    } catch (failure) {
+      if (mounted.current) setError(failure instanceof Error ? failure.message : t('handoff.error'));
+    } finally {
+      if (mounted.current) setPending(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={(next) => { if (!pending) setOpen(next); }}>
+      <Button variant="ghost" size="sm" disabled={disabled} onClick={() => { setError(null); setOpen(true); }}>
+        <ArrowRightLeft className="mr-2 h-4 w-4" />
+        {t('handoff.title')}
+      </Button>
+      <DialogContent className="max-w-lg">
+        <DialogTitle>{t('handoff.title')}</DialogTitle>
+        <p className="text-sm text-muted-foreground">{t('handoff.description')}</p>
+        <label className="flex flex-col gap-2 text-sm">
+          {t('handoff.model')}
+          <select
+            className="rounded-md border bg-background p-2 text-foreground"
+            disabled={pending}
+            value={selection ? JSON.stringify(selection) : ''}
+            onChange={(event) => setSelection(JSON.parse(event.target.value))}
+          >
+            <option value="" disabled>{t('handoff.chooseModel')}</option>
+            {Object.entries(providerModelCatalog).filter(([target]) => target !== provider).map(([target, catalog]) => (
+              <optgroup key={target} label={t(`messageTypes.${target}`)}>
+                {catalog?.OPTIONS.map((model) => (
+                  <option key={model.value} value={JSON.stringify({ provider: target, model: model.value })}>{model.label}</option>
+                ))}
+              </optgroup>
+            ))}
+          </select>
+        </label>
+        <p className="text-xs text-muted-foreground">{t('handoff.limitations')}</p>
+        {error && <p role="alert" className="text-sm text-destructive">{error}</p>}
+        <div className="flex justify-end gap-2">
+          <Button variant="outline" disabled={pending} onClick={() => setOpen(false)}>{t('handoff.cancel')}</Button>
+          <Button disabled={!selection || pending || disabled} onClick={() => void createHandoff()}>
+            {pending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+            {t('handoff.createDraft')}
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/modules/chat/tests/sessionHandoff.test.tsx
+++ b/src/modules/chat/tests/sessionHandoff.test.tsx
@@ -1,0 +1,64 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, expect, test, vi } from 'vitest';
+
+import { api } from '@/shared/api';
+import { writeDraftText } from '@/shared/chatDrafts';
+import { SessionHandoffButton } from '@/modules/chat/modals/SessionHandoffButton';
+
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
+vi.mock('@/shared/api', () => ({ api: { handoffSession: vi.fn() } }));
+vi.mock('@/shared/chatDrafts', () => ({ writeDraftText: vi.fn() }));
+
+const catalog = {
+  claude: { DEFAULT: 'source-model', OPTIONS: [{ value: 'source-model', label: 'Source model' }] },
+  codex: { DEFAULT: 'target-model', OPTIONS: [{ value: 'target-model', label: 'Target model' }] },
+};
+
+beforeEach(() => vi.clearAllMocks());
+
+test('offers only other providers and opens their durable draft without sending it', async () => {
+  const onNavigate = vi.fn();
+  vi.mocked(api.handoffSession).mockResolvedValue({ ok: true, json: async () => ({ data: { sessionId: 'target', draft: 'Conversation context' } }) } as Response);
+  render(<SessionHandoffButton sessionId="source" provider="claude" disabled={false} providerModelCatalog={catalog} onNavigate={onNavigate} />);
+  fireEvent.click(screen.getByRole('button', { name: 'handoff.title' }));
+  expect(screen.queryByRole('option', { name: 'Source model' })).toBeNull();
+  expect(screen.getByRole('button', { name: 'handoff.createDraft' }).hasAttribute('disabled')).toBe(true);
+  fireEvent.change(screen.getByRole('combobox'), { target: { value: JSON.stringify({ provider: 'codex', model: 'target-model' }) } });
+  fireEvent.click(screen.getByRole('button', { name: 'handoff.createDraft' }));
+  await waitFor(() => expect(onNavigate).toHaveBeenCalledWith('target'));
+  expect(api.handoffSession).toHaveBeenCalledWith('source', { provider: 'codex', model: 'target-model' });
+  expect(writeDraftText).toHaveBeenCalledWith('target', 'Conversation context');
+  expect(vi.mocked(writeDraftText).mock.invocationCallOrder[0]).toBeLessThan(onNavigate.mock.invocationCallOrder[0]);
+});
+
+test('disables the action for an active source session', () => {
+  render(<SessionHandoffButton sessionId="source" provider="claude" disabled providerModelCatalog={catalog} onNavigate={vi.fn()} />);
+  expect(screen.getByRole('button', { name: 'handoff.title' }).hasAttribute('disabled')).toBe(true);
+});
+
+test('shows handoff errors without navigating or replacing a draft', async () => {
+  const onNavigate = vi.fn();
+  vi.mocked(api.handoffSession).mockResolvedValue({ ok: false, json: async () => ({ error: { message: 'Source is busy' } }) } as Response);
+  render(<SessionHandoffButton sessionId="source" provider="claude" disabled={false} providerModelCatalog={catalog} onNavigate={onNavigate} />);
+  fireEvent.click(screen.getByRole('button', { name: 'handoff.title' }));
+  fireEvent.change(screen.getByRole('combobox'), { target: { value: JSON.stringify({ provider: 'codex', model: 'target-model' }) } });
+  fireEvent.click(screen.getByRole('button', { name: 'handoff.createDraft' }));
+  await waitFor(() => expect(screen.getByRole('alert').textContent).toBe('Source is busy'));
+  expect(onNavigate).not.toHaveBeenCalled();
+  expect(writeDraftText).not.toHaveBeenCalled();
+});
+
+test('does not pull the user back after they navigate away while creating the draft', async () => {
+  const onNavigate = vi.fn();
+  let resolveResponse: (response: Response) => void = () => {};
+  vi.mocked(api.handoffSession).mockReturnValue(new Promise((resolve) => { resolveResponse = resolve; }));
+  const view = render(<SessionHandoffButton sessionId="source" provider="claude" disabled={false} providerModelCatalog={catalog} onNavigate={onNavigate} />);
+  fireEvent.click(screen.getByRole('button', { name: 'handoff.title' }));
+  fireEvent.change(screen.getByRole('combobox'), { target: { value: JSON.stringify({ provider: 'codex', model: 'target-model' }) } });
+  fireEvent.click(screen.getByRole('button', { name: 'handoff.createDraft' }));
+  view.unmount();
+  resolveResponse({ ok: true, json: async () => ({ data: { sessionId: 'target', draft: 'Context' } }) } as Response);
+  await Promise.resolve();
+  await Promise.resolve();
+  expect(onNavigate).not.toHaveBeenCalled();
+});

--- a/src/modules/i18n/locales/en/chat.json
+++ b/src/modules/i18n/locales/en/chat.json
@@ -1,4 +1,14 @@
 {
+  "handoff": {
+    "title": "Continue with another provider",
+    "description": "Create a linked chat in the same workspace with a conversation-context draft. Review or edit it before sending; the original chat stays unchanged. Nothing is sent to the new provider yet.",
+    "model": "New provider and model",
+    "chooseModel": "Choose a model",
+    "limitations": "Transfers conversation text and tool context, not private reasoning, attachment contents, or provider-specific state. Long conversations and tool results are truncated. Finish the current turn first, and avoid running both chats against the same files at once.",
+    "cancel": "Cancel",
+    "createDraft": "Create context draft",
+    "error": "Could not prepare the handoff. Please try again."
+  },
   "codeBlock": {
     "copy": "Copy",
     "copied": "Copied",

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -5,6 +5,7 @@ import {
 } from '@/shared/authToken';
 import { IS_PLATFORM } from '@/shared/utils';
 import { readVoiceConfig, voiceConfigHeaders } from '@/shared/voiceConfig';
+import type { LLMProvider } from '@/shared/types';
 
 // Headers are a plain record rather than the full `HeadersInit` union so the
 // defaults below can be merged with a caller's headers by spreading.
@@ -210,6 +211,8 @@ export const api = {
   // `upToAnchorId` (all of it when omitted). The source is left untouched.
   forkSession: (sessionId: string, body: { upToAnchorId?: string; title?: string } = {}) =>
     post(`/api/providers/sessions/${encodeURIComponent(sessionId)}/fork`, body),
+  handoffSession: (sessionId: string, body: { provider: LLMProvider; model: string }) =>
+    post(`/api/providers/sessions/${encodeURIComponent(sessionId)}/handoff`, body),
   renameSession: (sessionId: string, summary: string) =>
     put(`/api/providers/sessions/${sessionId}`, { summary }),
 


### PR DESCRIPTION
Add “Continue with another provider” to idle chats. Choose a provider and model to open a linked chat in the same workspace with a saved context draft. Review it before sending; the original chat stays unchanged and the handoff itself makes no model request. Addresses #653.

The draft includes bounded conversation text and tool calls/results, with truncation notices. It excludes private reasoning, attachment contents, and provider-specific state. Session and draft creation are atomic, and running source sessions are rejected.

Tests: 380 frontend tests, focused backend tests, build, typecheck, lint, and an authenticated API smoke test pass. Full backend: 401 passed, 1 skipped, 2 existing skills-test failures reproduced on the base commit. Browser validation was canceled; UI behavior is covered by component tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the ability to create a linked chat draft with another provider or model from an idle conversation.
  - Transfers recent conversation context while excluding attachments, private reasoning, and provider-specific state.
  - Supports model selection, truncation notices, and navigation to the new draft.
  - Added validation and user-friendly error handling for unavailable or active conversations.

- **Documentation**
  - Documented provider handoff behavior, transferred context, limitations, and truncation details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->