### PR TITLE
fix(release): expose npm publish failures

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,13 +44,34 @@ jobs:
       - run: npm ci
 
       - name: Release
+        id: release
         run: |
-          ARGS="--ci --increment=${{ inputs.increment }}"
-          if [ -n "${{ inputs.release_name }}" ]; then
-            ARGS="$ARGS --github.releaseName=\"${{ inputs.release_name }}\""
+          # Stream subprocess output so publishing errors are visible immediately.
+          ARGS=(--ci --verbose --verbose "--increment=$RELEASE_INCREMENT")
+          if [ -n "$RELEASE_NAME" ]; then
+            ARGS+=("--github.releaseName=$RELEASE_NAME")
           fi
-          npx release-it $ARGS
+          npx release-it "${ARGS[@]}"
         env:
+          RELEASE_INCREMENT: ${{ inputs.increment }}
+          RELEASE_NAME: ${{ inputs.release_name }}
           GITHUB_TOKEN: ${{ secrets.RELEASE_PAT }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_CONFIG_LOGS_DIR: ${{ runner.temp }}/release-npm-logs
+
+      - name: Show npm failure details
+        if: failure() && steps.release.outcome == 'failure'
+        env:
+          NPM_CONFIG_LOGS_DIR: ${{ runner.temp }}/release-npm-logs
+        run: |
+          # Read npm's on-disk errors even if release-it truncates its console output.
+          shopt -s nullglob
+          LOGS=("$NPM_CONFIG_LOGS_DIR"/*debug*.log)
+          if [ ${#LOGS[@]} -eq 0 ]; then
+            echo "No npm debug logs were created by the release step."
+          fi
+          for LOG in "${LOGS[@]}"; do
+            echo "npm diagnostics: $(basename "$LOG")"
+            grep -E '^[0-9]+ (error|verbose (stack|exit|code))([[:space:]]|$)' "$LOG" || true
+          done

--- a/.release-it.json
+++ b/.release-it.json
@@ -7,7 +7,7 @@
   },
   "npm": {
     "publish": true,
-    "publishArgs": ["--access public"]
+    "publishArgs": ["--access public", "--loglevel warn"]
   },
   "github": {
     "release": true,


### PR DESCRIPTION
Reduce npm notice output and stream release logs so package listings do not obscure failures.

Print saved npm errors after failed releases to recover diagnostics lost to truncated output.

Quote release inputs so custom names retain spaces and literal characters.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved automated release handling by exposing release details and supporting optional release names.
  * Added more detailed release command output and temporary npm log storage for troubleshooting.
  * Added automatic diagnostics when a release fails, including relevant npm error information.
  * Reduced routine npm publish log noise while preserving warnings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->