### PR TITLE
fix(skills): a plugin that ships commands keeps its skills too

### DIFF
--- a/server/modules/providers/list/claude/claude-skills.provider.ts
+++ b/server/modules/providers/list/claude/claude-skills.provider.ts
@@ -158,12 +158,15 @@ export class ClaudeSkillsProvider extends SkillsProvider {
             continue;
           }
 
+          // A plugin may ship commands, skills, or both, and the CLI offers
+          // both halves. Reading only the first folder found hid every skill
+          // that sits beside a commands folder -- and hid the whole plugin when
+          // its commands are in a format this reader does not take.
           const commandsPath = path.join(pluginFolder, 'commands');
           if (await pathExistsAsDirectory(commandsPath)) {
             skills.push(
               ...(await this.listPluginCommandSkills(commandsPath, pluginId, pluginName)),
             );
-            continue;
           }
 
           const skillsPath = path.join(pluginFolder, 'skills');

--- a/server/modules/providers/tests/skills.test.ts
+++ b/server/modules/providers/tests/skills.test.ts
@@ -69,7 +69,8 @@ const writeClaudePluginCommand = async (
 
 /**
  * This test covers Claude user/project skill folders plus plugin discovery from
- * installed plugin command files and fallback plugin skill files.
+ * installed plugin command files and plugin skill files, including a plugin that
+ * ships both.
  */
 test('providerSkillsService lists claude user, project, and enabled plugin skills', { concurrency: false }, async () => {
   const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'llm-skills-claude-'));
@@ -144,11 +145,19 @@ test('providerSkillsService lists claude user, project, and enabled plugin skill
     );
     await writeSkill(
       path.join(commandPluginInstallPath, 'skills'),
-      'ignored-command-plugin-skill-dir',
-      'ignored-command-plugin-skill',
-      'Command plugin fallback skill should be ignored',
+      'command-plugin-skill-dir',
+      'command-plugin-skill',
+      'Skill shipped beside plugin commands',
     );
     await writeClaudePluginManifest(skillPluginInstallPath, 'ExampleSkills');
+    // A commands folder holding nothing this reader takes must not hide the
+    // skills beside it: plugins do ship commands in other agents' formats.
+    await fs.mkdir(path.join(skillPluginInstallPath, 'commands'), { recursive: true });
+    await fs.writeFile(
+      path.join(skillPluginInstallPath, 'commands', 'other-agent.toml'),
+      'description = "Command for another agent"\n',
+      'utf8',
+    );
     await writeSkill(
       path.join(skillPluginInstallPath, 'skills'),
       'claude-plugin-dir',
@@ -280,7 +289,14 @@ test('providerSkillsService lists claude user, project, and enabled plugin skill
     assert.equal(pluginCommand?.command, '/Notion:insert-row');
     assert.equal(pluginCommand?.description, 'Insert a Notion database row');
     assert.match(pluginCommand?.sourcePath ?? '', /commands[\\/]insert-row\.md$/);
-    assert.equal(byName.has('ignored-command-plugin-skill'), false);
+    // A plugin that ships commands keeps its skills: the CLI offers both, so
+    // the menu lists both rather than letting the commands folder hide them.
+    const commandPluginSkill = byName.get('command-plugin-skill');
+    assert.equal(commandPluginSkill?.scope, 'plugin');
+    assert.equal(commandPluginSkill?.pluginName, 'Notion');
+    assert.equal(commandPluginSkill?.pluginId, 'notion@notion-marketplace');
+    assert.equal(commandPluginSkill?.command, '/Notion:command-plugin-skill');
+    assert.equal(commandPluginSkill?.description, 'Skill shipped beside plugin commands');
 
     const pluginSkill = byName.get('claude-plugin');
     assert.equal(pluginSkill?.scope, 'plugin');


### PR DESCRIPTION
Fixes #1273.

## The bug

`listPluginSkills` read a plugin's `commands/` **or** its `skills/`, whichever it found first — the mere existence of a commands folder ended that plugin's turn:

```ts
if (await pathExistsAsDirectory(commandsPath)) {
  skills.push(...(await this.listPluginCommandSkills(commandsPath, pluginId, pluginName)));
  continue;                       // <- skills/ never looked at
}
```

Two consequences:

* a plugin shipping **both** contributes only its commands — its skills are silently dropped;
* since `listPluginCommandSkills` accepts `.md` only, a plugin whose commands are in another agent's format loses **both** halves — nothing matches, and the `continue` walks past the skills beside them. Such a plugin is absent from the slash menu entirely, with no error anywhere.

The CLI offers both halves for the same plugin, so those skills work in a terminal and are missing from the web menu. `DietrichGebert/ponytail` is the second shape: six `commands/*.toml`, six real skills, zero menu entries.

## The change

Read both folders. That is the whole fix — no new helper, no new option:

```diff
   const commandsPath = path.join(pluginFolder, 'commands');
   if (await pathExistsAsDirectory(commandsPath)) {
     skills.push(
       ...(await this.listPluginCommandSkills(commandsPath, pluginId, pluginName)),
     );
-    continue;
   }
```

Nothing else is needed:

* the `skills/` branch below already `continue`s for a plugin with no skills folder, so a commands-only plugin behaves exactly as before;
* `dedupeProviderSkills` in `useSlashCommands` keys on `skill.command`, so a name present in both folders is still listed once.

This hides nothing that is shown today — it only stops hiding.

## Test

`skills.test.ts` asserted the old exclusivity (`ignored-command-plugin-skill`), so that fixture is now asserted the other way, and the plugin that ships skills gains a `commands/other-agent.toml` to cover the format the reader does not take:

* the command plugin's skill is listed, with the plugin's own name, id and `/Notion:command-plugin-skill` command;
* the skills plugin still lists all three of its skills with a non-`.md` commands folder present.

Reverting the provider change alone fails that test.

## Checks

`npm run typecheck` clean (client and server), `oxlint` clean on both touched files, `npm test` 396 passing / 1 pre-existing skip.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Claude plugins that include both commands and skills now correctly show their skills in discovery results.
  * Skills are no longer hidden when unrelated command files are present.

* **Tests**
  * Added coverage confirming skills remain discoverable alongside plugin commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->