### PR TITLE
fix(codex): restore user prompts from canonical typed rollout rows

### DIFF
--- a/server/modules/providers/list/codex/codex-sessions.provider.ts
+++ b/server/modules/providers/list/codex/codex-sessions.provider.ts
@@ -208,12 +208,7 @@ function extractCodexTextContent(content: unknown): string {
 
       const record = item as AnyRecord;
       if (
-        (
-          record.type === 'input_text'
-          || record.type === 'output_text'
-          || record.type === 'text'
-          || record.type === 'Text'
-        )
+        (record.type === 'input_text' || record.type === 'output_text' || record.type === 'text')
         && typeof record.text === 'string'
       ) {
         return record.text;
@@ -225,16 +220,7 @@ function extractCodexTextContent(content: unknown): string {
     .join('\n');
 }
 
-/**
- * Reads the image attachments Codex persists inside a typed `UserMessage`
- * item.
- *
- * Typed content keeps the same shapes as live `UserInput` values: local
- * images carry a filesystem `path`, pre-encoded images carry an `image_url`
- * data URI. Both map onto the attachment shape the UI already renders for
- * legacy `user_message` events; audio and other non-image inputs are not
- * drawn in history.
- */
+/** Reads image inputs from a typed UserMessage item. */
 function extractCodexTypedUserImages(
   content: unknown,
 ): Array<{ path?: string; data?: string }> | undefined {
@@ -249,24 +235,18 @@ function extractCodexTypedUserImages(
       continue;
     }
 
-    if (entry.type === 'local_image') {
-      const entryPath = readNonEmptyString(entry.path);
-      if (entryPath) {
-        attachments.push(...toImageAttachments([entryPath]));
-      }
+    const value = entry.type === 'local_image'
+      ? readNonEmptyString(entry.path)
+      : entry.type === 'image'
+        ? readNonEmptyString(entry.image_url)
+        : undefined;
+    if (!value) {
       continue;
     }
-
-    if (entry.type === 'image') {
-      const imageUrl = readNonEmptyString(entry.image_url);
-      if (!imageUrl) {
-        continue;
-      }
-      if (imageUrl.startsWith('data:')) {
-        attachments.push({ data: imageUrl });
-      } else {
-        attachments.push(...toImageAttachments([imageUrl]));
-      }
+    if (value.startsWith('data:')) {
+      attachments.push({ data: value });
+    } else {
+      attachments.push(...toImageAttachments([value]));
     }
   }
 
@@ -1251,14 +1231,6 @@ async function getCodexSessionMessages(sessionId: string): Promise<CodexHistoryR
   const turns = createCodexTurnTracker();
   /** Turns whose prompt already carries the anchor, so only the first does. */
   const anchoredTurnIds = new Set<string>();
-  /** User rows built from typed `UserMessage` items, keyed by their turn. */
-  const typedUserRows = new Map<AnyRecord, string>();
-  /**
-   * User rows built from legacy `user_message` events, keyed by their turn id
-   * (undefined when no turn could be attributed). Removed only when a typed
-   * row exists for the same turn.
-   */
-  const legacyUserRows = new Map<AnyRecord, string | undefined>();
 
   const fileStream = fsSync.createReadStream(sessionFilePath);
   const rl = readline.createInterface({ input: fileStream, crlfDelay: Infinity });
@@ -1373,13 +1345,8 @@ async function getCodexSessionMessages(sessionId: string): Promise<CodexHistoryR
         continue;
       }
 
-      // Canonical (paginated) rollouts record every completed turn item as an
-      // `item_completed` event carrying the typed item. Real user prompts are
-      // `UserMessage` items there; the older `user_message` event fan-out no
-      // longer exists in these files. Wire-level `response_item` rows are
-      // deliberately not used for prompts: they can carry internal content
-      // (hook prompts, environment scaffolding) that must stay out of the
-      // transcript.
+      // Paginated rollouts carry user prompts as `item_completed` /
+      // `UserMessage`; wire `response_item` user rows are internal, not prompts.
       if (payload.type === 'item_completed') {
         const item = readObjectRecord(payload.item);
         if (item?.type === 'UserMessage') {
@@ -1389,7 +1356,7 @@ async function getCodexSessionMessages(sessionId: string): Promise<CodexHistoryR
             // Only the first prompt of a turn is anchored, matching the legacy
             // `user_message` branch below: a turn can hold several prompts and
             // the edit cut is per turn.
-            const turnId = readNonEmptyString(payload.turn_id as string | undefined)
+            const turnId = readNonEmptyString(payload.turn_id)
               ?? turns.getCurrentTurnId();
             const isFirstPromptOfTurn = Boolean(turnId) && !anchoredTurnIds.has(turnId as string);
             if (isFirstPromptOfTurn) {
@@ -1403,9 +1370,6 @@ async function getCodexSessionMessages(sessionId: string): Promise<CodexHistoryR
               ...(isFirstPromptOfTurn ? { turnId } : {}),
             };
             messages.push(row);
-            if (turnId) {
-              typedUserRows.set(row, turnId);
-            }
           }
         }
         continue;
@@ -1428,7 +1392,6 @@ async function getCodexSessionMessages(sessionId: string): Promise<CodexHistoryR
           images: extractCodexUserImages(payload),
           ...(isFirstPromptOfTurn ? { turnId } : {}),
         });
-        legacyUserRows.set(messages[messages.length - 1], turnId);
       }
       continue;
     }
@@ -1828,37 +1791,6 @@ async function getCodexSessionMessages(sessionId: string): Promise<CodexHistoryR
   }
 
   await attachCodexSubagentTranscripts(sessionFilePath, subagentsByCallId);
-
-  // A file spanning a format boundary can carry the same prompt twice: once
-  // as a legacy `user_message` event and once as a typed `UserMessage` item
-  // for the same turn. Drop a legacy row only when a typed row for that exact
-  // turn exists — legacy-only turns from before the boundary must survive —
-  // then hand every remaining typed prompt its anchor afresh because the
-  // dropped legacy row may have claimed it first.
-  const typedTurnIds = new Set(typedUserRows.values());
-  if (typedTurnIds.size > 0 && legacyUserRows.size > 0) {
-    for (let index = messages.length - 1; index >= 0; index -= 1) {
-      const message = messages[index];
-      const legacyTurnId = legacyUserRows.get(message);
-      if (legacyTurnId && typedTurnIds.has(legacyTurnId)) {
-        messages.splice(index, 1);
-      }
-    }
-
-    anchoredTurnIds.clear();
-    for (const message of messages) {
-      const typedTurnId = typedUserRows.get(message);
-      if (!typedTurnId) {
-        continue;
-      }
-      if (!anchoredTurnIds.has(typedTurnId)) {
-        anchoredTurnIds.add(typedTurnId);
-        message.turnId = typedTurnId;
-      } else {
-        delete message.turnId;
-      }
-    }
-  }
 
   // A rollback is recorded after the turns it retires, so a prompt can be
   // anchored and then retired later in the same file. Its rows still render —

--- a/server/modules/providers/list/codex/codex-sessions.provider.ts
+++ b/server/modules/providers/list/codex/codex-sessions.provider.ts
@@ -208,7 +208,12 @@ function extractCodexTextContent(content: unknown): string {
 
       const record = item as AnyRecord;
       if (
-        (record.type === 'input_text' || record.type === 'output_text' || record.type === 'text')
+        (
+          record.type === 'input_text'
+          || record.type === 'output_text'
+          || record.type === 'text'
+          || record.type === 'Text'
+        )
         && typeof record.text === 'string'
       ) {
         return record.text;
@@ -218,6 +223,54 @@ function extractCodexTextContent(content: unknown): string {
     })
     .filter(Boolean)
     .join('\n');
+}
+
+/**
+ * Reads the image attachments Codex persists inside a typed `UserMessage`
+ * item.
+ *
+ * Typed content keeps the same shapes as live `UserInput` values: local
+ * images carry a filesystem `path`, pre-encoded images carry an `image_url`
+ * data URI. Both map onto the attachment shape the UI already renders for
+ * legacy `user_message` events; audio and other non-image inputs are not
+ * drawn in history.
+ */
+function extractCodexTypedUserImages(
+  content: unknown,
+): Array<{ path?: string; data?: string }> | undefined {
+  if (!Array.isArray(content)) {
+    return undefined;
+  }
+
+  const attachments: Array<{ path?: string; data?: string }> = [];
+  for (const rawEntry of content) {
+    const entry = readObjectRecord(rawEntry);
+    if (!entry) {
+      continue;
+    }
+
+    if (entry.type === 'local_image') {
+      const entryPath = readNonEmptyString(entry.path);
+      if (entryPath) {
+        attachments.push(...toImageAttachments([entryPath]));
+      }
+      continue;
+    }
+
+    if (entry.type === 'image') {
+      const imageUrl = readNonEmptyString(entry.image_url);
+      if (!imageUrl) {
+        continue;
+      }
+      if (imageUrl.startsWith('data:')) {
+        attachments.push({ data: imageUrl });
+      } else {
+        attachments.push(...toImageAttachments([imageUrl]));
+      }
+    }
+  }
+
+  return attachments.length > 0 ? attachments : undefined;
 }
 
 /**
@@ -1198,6 +1251,12 @@ async function getCodexSessionMessages(sessionId: string): Promise<CodexHistoryR
   const turns = createCodexTurnTracker();
   /** Turns whose prompt already carries the anchor, so only the first does. */
   const anchoredTurnIds = new Set<string>();
+  /** True once the file carries canonical `item_completed` typed rows. */
+  let hasTypedItems = false;
+  /** User rows built from typed `UserMessage` items, keyed by their turn. */
+  const typedUserRows = new Map<AnyRecord, string>();
+  /** User rows built from legacy `user_message` events, removed when typed rows win. */
+  const legacyUserRows = new Set<AnyRecord>();
 
   const fileStream = fsSync.createReadStream(sessionFilePath);
   const rl = readline.createInterface({ input: fileStream, crlfDelay: Infinity });
@@ -1312,6 +1371,45 @@ async function getCodexSessionMessages(sessionId: string): Promise<CodexHistoryR
         continue;
       }
 
+      // Canonical (paginated) rollouts record every completed turn item as an
+      // `item_completed` event carrying the typed item. Real user prompts are
+      // `UserMessage` items there; the older `user_message` event fan-out no
+      // longer exists in these files. Wire-level `response_item` rows are
+      // deliberately not used for prompts: they can carry internal content
+      // (hook prompts, environment scaffolding) that must stay out of the
+      // transcript.
+      if (payload.type === 'item_completed') {
+        hasTypedItems = true;
+        const item = readObjectRecord(payload.item);
+        if (item?.type === 'UserMessage') {
+          const content = extractCodexTextContent(item.content);
+          const images = extractCodexTypedUserImages(item.content);
+          if (content.trim() || images?.length) {
+            // Only the first prompt of a turn is anchored, matching the legacy
+            // `user_message` branch below: a turn can hold several prompts and
+            // the edit cut is per turn.
+            const turnId = readNonEmptyString(payload.turn_id as string | undefined)
+              ?? turns.getCurrentTurnId();
+            const isFirstPromptOfTurn = Boolean(turnId) && !anchoredTurnIds.has(turnId as string);
+            if (isFirstPromptOfTurn) {
+              anchoredTurnIds.add(turnId as string);
+            }
+            const row: AnyRecord = {
+              type: 'user',
+              timestamp,
+              message: { role: 'user', content },
+              ...(images ? { images } : {}),
+              ...(isFirstPromptOfTurn ? { turnId } : {}),
+            };
+            messages.push(row);
+            if (turnId) {
+              typedUserRows.set(row, turnId);
+            }
+          }
+        }
+        continue;
+      }
+
       if (isVisibleCodexUserMessage(payload)) {
         // Only the first prompt of a turn is anchored. A turn can hold more
         // than one — a follow-up queued while the turn was running is written
@@ -1329,6 +1427,7 @@ async function getCodexSessionMessages(sessionId: string): Promise<CodexHistoryR
           images: extractCodexUserImages(payload),
           ...(isFirstPromptOfTurn ? { turnId } : {}),
         });
+        legacyUserRows.add(messages[messages.length - 1]);
       }
       continue;
     }
@@ -1728,6 +1827,34 @@ async function getCodexSessionMessages(sessionId: string): Promise<CodexHistoryR
   }
 
   await attachCodexSubagentTranscripts(sessionFilePath, subagentsByCallId);
+
+  // A canonical file carries typed `UserMessage` items; any legacy
+  // `user_message` events in the same file are the same prompts written twice
+  // (for example after a rollback over a format boundary). Keep the typed rows
+  // and drop the legacy ones, then hand every remaining typed prompt its
+  // anchor afresh because the legacy row may have claimed it first.
+  if (hasTypedItems && legacyUserRows.size > 0) {
+    for (let index = messages.length - 1; index >= 0; index -= 1) {
+      if (legacyUserRows.has(messages[index])) {
+        messages.splice(index, 1);
+      }
+    }
+    if (typedUserRows.size > 0) {
+      anchoredTurnIds.clear();
+      for (const message of messages) {
+        const typedTurnId = typedUserRows.get(message);
+        if (!typedTurnId) {
+          continue;
+        }
+        if (!anchoredTurnIds.has(typedTurnId)) {
+          anchoredTurnIds.add(typedTurnId);
+          message.turnId = typedTurnId;
+        } else {
+          delete message.turnId;
+        }
+      }
+    }
+  }
 
   // A rollback is recorded after the turns it retires, so a prompt can be
   // anchored and then retired later in the same file. Its rows still render —

--- a/server/modules/providers/list/codex/codex-sessions.provider.ts
+++ b/server/modules/providers/list/codex/codex-sessions.provider.ts
@@ -1251,12 +1251,14 @@ async function getCodexSessionMessages(sessionId: string): Promise<CodexHistoryR
   const turns = createCodexTurnTracker();
   /** Turns whose prompt already carries the anchor, so only the first does. */
   const anchoredTurnIds = new Set<string>();
-  /** True once the file carries canonical `item_completed` typed rows. */
-  let hasTypedItems = false;
   /** User rows built from typed `UserMessage` items, keyed by their turn. */
   const typedUserRows = new Map<AnyRecord, string>();
-  /** User rows built from legacy `user_message` events, removed when typed rows win. */
-  const legacyUserRows = new Set<AnyRecord>();
+  /**
+   * User rows built from legacy `user_message` events, keyed by their turn id
+   * (undefined when no turn could be attributed). Removed only when a typed
+   * row exists for the same turn.
+   */
+  const legacyUserRows = new Map<AnyRecord, string | undefined>();
 
   const fileStream = fsSync.createReadStream(sessionFilePath);
   const rl = readline.createInterface({ input: fileStream, crlfDelay: Infinity });
@@ -1379,7 +1381,6 @@ async function getCodexSessionMessages(sessionId: string): Promise<CodexHistoryR
       // (hook prompts, environment scaffolding) that must stay out of the
       // transcript.
       if (payload.type === 'item_completed') {
-        hasTypedItems = true;
         const item = readObjectRecord(payload.item);
         if (item?.type === 'UserMessage') {
           const content = extractCodexTextContent(item.content);
@@ -1427,7 +1428,7 @@ async function getCodexSessionMessages(sessionId: string): Promise<CodexHistoryR
           images: extractCodexUserImages(payload),
           ...(isFirstPromptOfTurn ? { turnId } : {}),
         });
-        legacyUserRows.add(messages[messages.length - 1]);
+        legacyUserRows.set(messages[messages.length - 1], turnId);
       }
       continue;
     }
@@ -1828,30 +1829,33 @@ async function getCodexSessionMessages(sessionId: string): Promise<CodexHistoryR
 
   await attachCodexSubagentTranscripts(sessionFilePath, subagentsByCallId);
 
-  // A canonical file carries typed `UserMessage` items; any legacy
-  // `user_message` events in the same file are the same prompts written twice
-  // (for example after a rollback over a format boundary). Keep the typed rows
-  // and drop the legacy ones, then hand every remaining typed prompt its
-  // anchor afresh because the legacy row may have claimed it first.
-  if (hasTypedItems && legacyUserRows.size > 0) {
+  // A file spanning a format boundary can carry the same prompt twice: once
+  // as a legacy `user_message` event and once as a typed `UserMessage` item
+  // for the same turn. Drop a legacy row only when a typed row for that exact
+  // turn exists — legacy-only turns from before the boundary must survive —
+  // then hand every remaining typed prompt its anchor afresh because the
+  // dropped legacy row may have claimed it first.
+  const typedTurnIds = new Set(typedUserRows.values());
+  if (typedTurnIds.size > 0 && legacyUserRows.size > 0) {
     for (let index = messages.length - 1; index >= 0; index -= 1) {
-      if (legacyUserRows.has(messages[index])) {
+      const message = messages[index];
+      const legacyTurnId = legacyUserRows.get(message);
+      if (legacyTurnId && typedTurnIds.has(legacyTurnId)) {
         messages.splice(index, 1);
       }
     }
-    if (typedUserRows.size > 0) {
-      anchoredTurnIds.clear();
-      for (const message of messages) {
-        const typedTurnId = typedUserRows.get(message);
-        if (!typedTurnId) {
-          continue;
-        }
-        if (!anchoredTurnIds.has(typedTurnId)) {
-          anchoredTurnIds.add(typedTurnId);
-          message.turnId = typedTurnId;
-        } else {
-          delete message.turnId;
-        }
+
+    anchoredTurnIds.clear();
+    for (const message of messages) {
+      const typedTurnId = typedUserRows.get(message);
+      if (!typedTurnId) {
+        continue;
+      }
+      if (!anchoredTurnIds.has(typedTurnId)) {
+        anchoredTurnIds.add(typedTurnId);
+        message.turnId = typedTurnId;
+      } else {
+        delete message.turnId;
       }
     }
   }

--- a/server/modules/providers/tests/codex-sessions.test.ts
+++ b/server/modules/providers/tests/codex-sessions.test.ts
@@ -561,17 +561,15 @@ test('Codex history restores user prompts from typed item_completed rows', { con
 
   try {
     const providerSessionId = 'codex-typed-1';
-    const transcriptPath = await writeCodexTranscript(tempRoot, providerSessionId, workspacePath);
     const prompt = 'Typed prompt that must survive a refresh';
-    // Mirrors a canonical Codex rollout: typed turn items arrive as
-    // event_msg/item_completed rows while wire response_item rows echo them.
+    const transcriptPath = path.join(tempRoot, '.codex', 'sessions', '2026', '07', '07', 'rollout-' + providerSessionId + '.jsonl');
+    await mkdir(path.dirname(transcriptPath), { recursive: true });
+    const lineEnd = String.fromCharCode(10);
     const typedLine = JSON.stringify({
       timestamp: '2026-09-07T17:59:17.000Z',
-      ordinal: 2,
       type: 'event_msg',
       payload: {
         type: 'item_completed',
-        thread_id: providerSessionId,
         turn_id: 'typed-turn-1',
         item: {
           type: 'UserMessage',
@@ -581,30 +579,16 @@ test('Codex history restores user prompts from typed item_completed rows', { con
             { type: 'local_image', path: '/tmp/prompt-picture.png', detail: null },
           ],
         },
-        started_at_ms: 1,
-        completed_at_ms: 2,
       },
-    });
-    const assistantLine = JSON.stringify({
-      timestamp: '2026-09-07T17:59:19.000Z',
-      ordinal: 3,
-      type: 'response_item',
-      payload: { type: 'message', role: 'assistant', content: [{ type: 'output_text', text: 'Working on it.' }] },
     });
     const wireUserEcho = JSON.stringify({
       timestamp: '2026-09-07T17:59:19.000Z',
-      ordinal: 4,
       type: 'response_item',
       payload: { type: 'message', role: 'user', content: [{ type: 'input_text', text: prompt }] },
     });
     await writeFile(
       transcriptPath,
-      [
-        JSON.stringify({ timestamp: '2026-09-07T17:59:16.000Z', ordinal: 1, type: 'session_meta', payload: { id: providerSessionId, cwd: workspacePath } }),
-        typedLine,
-        assistantLine,
-        wireUserEcho,
-      ].join('\n') + '\n',
+      [JSON.stringify({ type: 'session_meta', payload: { id: providerSessionId, cwd: workspacePath } }), typedLine, wireUserEcho].join(lineEnd) + lineEnd,
       'utf8',
     );
 
@@ -615,128 +599,11 @@ test('Codex history restores user prompts from typed item_completed rows', { con
 
       const history = await new CodexSessionsProvider().fetchHistory('app-typed-1');
       const users = history.messages.filter((message) => message.role === 'user');
-      const assistant = history.messages.find((message) => message.role === 'assistant');
-      const firstUserImages = users[0]?.images as Array<{ path?: string; data?: string }> | undefined;
+      const images = users[0]?.images as Array<{ path?: string; data?: string }> | undefined;
 
       assert.equal(users.length, 1, 'the wire user echo must not duplicate the typed prompt');
       assert.equal(users[0]?.content, prompt);
-      assert.equal(firstUserImages?.length, 1);
-      assert.equal(firstUserImages?.[0]?.path, '/tmp/prompt-picture.png');
-      assert.equal(assistant?.content, 'Working on it.');
-    });
-  } finally {
-    restoreHomeDir();
-    await rm(tempRoot, { recursive: true, force: true });
-  }
-});
-
-test('Codex history prefers typed user rows over legacy user_message events in one file', { concurrency: false }, async () => {
-  const tempRoot = await mkdtemp(path.join(os.tmpdir(), 'codex-hybrid-user-history-'));
-  const workspacePath = path.join(tempRoot, 'workspace');
-  await mkdir(workspacePath, { recursive: true });
-  const restoreHomeDir = patchHomeDir(tempRoot);
-
-  try {
-    const providerSessionId = 'codex-hybrid-1';
-    const transcriptPath = await writeCodexTranscript(tempRoot, providerSessionId, workspacePath);
-    await writeFile(
-      transcriptPath,
-      [
-        JSON.stringify({ timestamp: '2026-09-07T10:00:00.000Z', ordinal: 1, type: 'session_meta', payload: { id: providerSessionId, cwd: workspacePath } }),
-        JSON.stringify({
-          timestamp: '2026-09-07T10:00:01.000Z',
-          ordinal: 2,
-          type: 'event_msg',
-          payload: { type: 'user_message', message: 'Legacy copy of the prompt', turn_id: 'hybrid-turn-1' },
-        }),
-        JSON.stringify({
-          timestamp: '2026-09-07T10:00:02.000Z',
-          ordinal: 3,
-          type: 'event_msg',
-          payload: {
-            type: 'item_completed',
-            thread_id: providerSessionId,
-            turn_id: 'hybrid-turn-1',
-            item: { type: 'UserMessage', id: 'item-user-2', content: [{ type: 'text', text: 'Typed copy of the prompt', text_elements: [] }] },
-            started_at_ms: 1,
-            completed_at_ms: 2,
-          },
-        }),
-      ].join('\n') + '\n',
-      'utf8',
-    );
-
-    await withIsolatedDatabase(async () => {
-      sessionsDb.createAppSession('app-hybrid-1', 'codex', workspacePath);
-      sessionsDb.assignProviderSessionId('app-hybrid-1', providerSessionId);
-      await new CodexSessionSynchronizer().synchronize();
-
-      const history = await new CodexSessionsProvider().fetchHistory('app-hybrid-1');
-      const users = history.messages.filter((message) => message.role === 'user');
-
-      assert.equal(users.length, 1, 'legacy and typed copies of the same prompt must collapse');
-      assert.equal(users[0]?.content, 'Typed copy of the prompt');
-    });
-  } finally {
-    restoreHomeDir();
-    await rm(tempRoot, { recursive: true, force: true });
-  }
-});
-
-
-test('Codex history keeps legacy prompts for turns that have no typed copy', { concurrency: false }, async () => {
-  const tempRoot = await mkdtemp(path.join(os.tmpdir(), 'codex-mixed-era-history-'));
-  const workspacePath = path.join(tempRoot, 'workspace');
-  await mkdir(workspacePath, { recursive: true });
-  const restoreHomeDir = patchHomeDir(tempRoot);
-
-  try {
-    const providerSessionId = 'codex-mixed-era-1';
-    const transcriptPath = await writeCodexTranscript(tempRoot, providerSessionId, workspacePath);
-    // Turn 1 predates the canonical format and exists only as a legacy event;
-    // turn 2 was written after the format boundary and exists only as a typed
-    // item. Both prompts must render — dropping the legacy row would lose the
-    // earlier turn even though no typed copy of it exists.
-    await writeFile(
-      transcriptPath,
-      [
-        JSON.stringify({ timestamp: '2026-09-07T10:00:00.000Z', ordinal: 1, type: 'session_meta', payload: { id: providerSessionId, cwd: workspacePath } }),
-        JSON.stringify({
-          timestamp: '2026-09-07T10:00:01.000Z',
-          ordinal: 2,
-          type: 'event_msg',
-          payload: { type: 'user_message', message: 'Prompt from the legacy era', turn_id: 'legacy-only-turn' },
-        }),
-        JSON.stringify({
-          timestamp: '2026-09-07T10:00:02.000Z',
-          ordinal: 3,
-          type: 'event_msg',
-          payload: {
-            type: 'item_completed',
-            thread_id: providerSessionId,
-            turn_id: 'typed-only-turn',
-            item: { type: 'UserMessage', id: 'item-user-3', content: [{ type: 'text', text: 'Prompt from the typed era', text_elements: [] }] },
-            started_at_ms: 1,
-            completed_at_ms: 2,
-          },
-        }),
-      ].join('\n') + '\n',
-      'utf8',
-    );
-
-    await withIsolatedDatabase(async () => {
-      sessionsDb.createAppSession('app-mixed-era-1', 'codex', workspacePath);
-      sessionsDb.assignProviderSessionId('app-mixed-era-1', providerSessionId);
-      await new CodexSessionSynchronizer().synchronize();
-
-      const history = await new CodexSessionsProvider().fetchHistory('app-mixed-era-1');
-      const users = history.messages.filter((message) => message.role === 'user');
-
-      assert.equal(users.length, 2, 'a legacy-only turn must survive next to typed turns');
-      assert.deepEqual(users.map((message) => message.content), [
-        'Prompt from the legacy era',
-        'Prompt from the typed era',
-      ]);
+      assert.equal(images?.[0]?.path, '/tmp/prompt-picture.png');
     });
   } finally {
     restoreHomeDir();

--- a/server/modules/providers/tests/codex-sessions.test.ts
+++ b/server/modules/providers/tests/codex-sessions.test.ts
@@ -682,3 +682,64 @@ test('Codex history prefers typed user rows over legacy user_message events in o
     await rm(tempRoot, { recursive: true, force: true });
   }
 });
+
+
+test('Codex history keeps legacy prompts for turns that have no typed copy', { concurrency: false }, async () => {
+  const tempRoot = await mkdtemp(path.join(os.tmpdir(), 'codex-mixed-era-history-'));
+  const workspacePath = path.join(tempRoot, 'workspace');
+  await mkdir(workspacePath, { recursive: true });
+  const restoreHomeDir = patchHomeDir(tempRoot);
+
+  try {
+    const providerSessionId = 'codex-mixed-era-1';
+    const transcriptPath = await writeCodexTranscript(tempRoot, providerSessionId, workspacePath);
+    // Turn 1 predates the canonical format and exists only as a legacy event;
+    // turn 2 was written after the format boundary and exists only as a typed
+    // item. Both prompts must render — dropping the legacy row would lose the
+    // earlier turn even though no typed copy of it exists.
+    await writeFile(
+      transcriptPath,
+      [
+        JSON.stringify({ timestamp: '2026-09-07T10:00:00.000Z', ordinal: 1, type: 'session_meta', payload: { id: providerSessionId, cwd: workspacePath } }),
+        JSON.stringify({
+          timestamp: '2026-09-07T10:00:01.000Z',
+          ordinal: 2,
+          type: 'event_msg',
+          payload: { type: 'user_message', message: 'Prompt from the legacy era', turn_id: 'legacy-only-turn' },
+        }),
+        JSON.stringify({
+          timestamp: '2026-09-07T10:00:02.000Z',
+          ordinal: 3,
+          type: 'event_msg',
+          payload: {
+            type: 'item_completed',
+            thread_id: providerSessionId,
+            turn_id: 'typed-only-turn',
+            item: { type: 'UserMessage', id: 'item-user-3', content: [{ type: 'text', text: 'Prompt from the typed era', text_elements: [] }] },
+            started_at_ms: 1,
+            completed_at_ms: 2,
+          },
+        }),
+      ].join('\n') + '\n',
+      'utf8',
+    );
+
+    await withIsolatedDatabase(async () => {
+      sessionsDb.createAppSession('app-mixed-era-1', 'codex', workspacePath);
+      sessionsDb.assignProviderSessionId('app-mixed-era-1', providerSessionId);
+      await new CodexSessionSynchronizer().synchronize();
+
+      const history = await new CodexSessionsProvider().fetchHistory('app-mixed-era-1');
+      const users = history.messages.filter((message) => message.role === 'user');
+
+      assert.equal(users.length, 2, 'a legacy-only turn must survive next to typed turns');
+      assert.deepEqual(users.map((message) => message.content), [
+        'Prompt from the legacy era',
+        'Prompt from the typed era',
+      ]);
+    });
+  } finally {
+    restoreHomeDir();
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});

--- a/server/modules/providers/tests/codex-sessions.test.ts
+++ b/server/modules/providers/tests/codex-sessions.test.ts
@@ -551,3 +551,134 @@ test('an exec script that updates the plan yields the steps it set', () => {
     ],
   }]);
 });
+
+
+test('Codex history restores user prompts from typed item_completed rows', { concurrency: false }, async () => {
+  const tempRoot = await mkdtemp(path.join(os.tmpdir(), 'codex-typed-user-history-'));
+  const workspacePath = path.join(tempRoot, 'workspace');
+  await mkdir(workspacePath, { recursive: true });
+  const restoreHomeDir = patchHomeDir(tempRoot);
+
+  try {
+    const providerSessionId = 'codex-typed-1';
+    const transcriptPath = await writeCodexTranscript(tempRoot, providerSessionId, workspacePath);
+    const prompt = 'Typed prompt that must survive a refresh';
+    // Mirrors a canonical Codex rollout: typed turn items arrive as
+    // event_msg/item_completed rows while wire response_item rows echo them.
+    const typedLine = JSON.stringify({
+      timestamp: '2026-09-07T17:59:17.000Z',
+      ordinal: 2,
+      type: 'event_msg',
+      payload: {
+        type: 'item_completed',
+        thread_id: providerSessionId,
+        turn_id: 'typed-turn-1',
+        item: {
+          type: 'UserMessage',
+          id: 'item-user-1',
+          content: [
+            { type: 'text', text: prompt, text_elements: [] },
+            { type: 'local_image', path: '/tmp/prompt-picture.png', detail: null },
+          ],
+        },
+        started_at_ms: 1,
+        completed_at_ms: 2,
+      },
+    });
+    const assistantLine = JSON.stringify({
+      timestamp: '2026-09-07T17:59:19.000Z',
+      ordinal: 3,
+      type: 'response_item',
+      payload: { type: 'message', role: 'assistant', content: [{ type: 'output_text', text: 'Working on it.' }] },
+    });
+    const wireUserEcho = JSON.stringify({
+      timestamp: '2026-09-07T17:59:19.000Z',
+      ordinal: 4,
+      type: 'response_item',
+      payload: { type: 'message', role: 'user', content: [{ type: 'input_text', text: prompt }] },
+    });
+    await writeFile(
+      transcriptPath,
+      [
+        JSON.stringify({ timestamp: '2026-09-07T17:59:16.000Z', ordinal: 1, type: 'session_meta', payload: { id: providerSessionId, cwd: workspacePath } }),
+        typedLine,
+        assistantLine,
+        wireUserEcho,
+      ].join('\n') + '\n',
+      'utf8',
+    );
+
+    await withIsolatedDatabase(async () => {
+      sessionsDb.createAppSession('app-typed-1', 'codex', workspacePath);
+      sessionsDb.assignProviderSessionId('app-typed-1', providerSessionId);
+      await new CodexSessionSynchronizer().synchronize();
+
+      const history = await new CodexSessionsProvider().fetchHistory('app-typed-1');
+      const users = history.messages.filter((message) => message.role === 'user');
+      const assistant = history.messages.find((message) => message.role === 'assistant');
+      const firstUserImages = users[0]?.images as Array<{ path?: string; data?: string }> | undefined;
+
+      assert.equal(users.length, 1, 'the wire user echo must not duplicate the typed prompt');
+      assert.equal(users[0]?.content, prompt);
+      assert.equal(firstUserImages?.length, 1);
+      assert.equal(firstUserImages?.[0]?.path, '/tmp/prompt-picture.png');
+      assert.equal(assistant?.content, 'Working on it.');
+    });
+  } finally {
+    restoreHomeDir();
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test('Codex history prefers typed user rows over legacy user_message events in one file', { concurrency: false }, async () => {
+  const tempRoot = await mkdtemp(path.join(os.tmpdir(), 'codex-hybrid-user-history-'));
+  const workspacePath = path.join(tempRoot, 'workspace');
+  await mkdir(workspacePath, { recursive: true });
+  const restoreHomeDir = patchHomeDir(tempRoot);
+
+  try {
+    const providerSessionId = 'codex-hybrid-1';
+    const transcriptPath = await writeCodexTranscript(tempRoot, providerSessionId, workspacePath);
+    await writeFile(
+      transcriptPath,
+      [
+        JSON.stringify({ timestamp: '2026-09-07T10:00:00.000Z', ordinal: 1, type: 'session_meta', payload: { id: providerSessionId, cwd: workspacePath } }),
+        JSON.stringify({
+          timestamp: '2026-09-07T10:00:01.000Z',
+          ordinal: 2,
+          type: 'event_msg',
+          payload: { type: 'user_message', message: 'Legacy copy of the prompt', turn_id: 'hybrid-turn-1' },
+        }),
+        JSON.stringify({
+          timestamp: '2026-09-07T10:00:02.000Z',
+          ordinal: 3,
+          type: 'event_msg',
+          payload: {
+            type: 'item_completed',
+            thread_id: providerSessionId,
+            turn_id: 'hybrid-turn-1',
+            item: { type: 'UserMessage', id: 'item-user-2', content: [{ type: 'text', text: 'Typed copy of the prompt', text_elements: [] }] },
+            started_at_ms: 1,
+            completed_at_ms: 2,
+          },
+        }),
+      ].join('\n') + '\n',
+      'utf8',
+    );
+
+    await withIsolatedDatabase(async () => {
+      sessionsDb.createAppSession('app-hybrid-1', 'codex', workspacePath);
+      sessionsDb.assignProviderSessionId('app-hybrid-1', providerSessionId);
+      await new CodexSessionSynchronizer().synchronize();
+
+      const history = await new CodexSessionsProvider().fetchHistory('app-hybrid-1');
+      const users = history.messages.filter((message) => message.role === 'user');
+
+      assert.equal(users.length, 1, 'legacy and typed copies of the same prompt must collapse');
+      assert.equal(users[0]?.content, 'Typed copy of the prompt');
+    });
+  } finally {
+    restoreHomeDir();
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Problem

Closes #1205

Recent Codex releases (0.147+) no longer write the legacy `event_msg/user_message` fan-out into rollout files. Real user prompts are recorded as canonical typed rows — `event_msg` with payload type `item_completed` carrying a `UserMessage` item. The Codex history reader only created user messages from the legacy event, so after a refresh or reopen the transcript showed assistant messages, reasoning and tool activity but none of the user's own prompts. The prompt records were present in the JSONL all along.

## Change

- The history reader now also restores user rows from typed `UserMessage` items, using the same per-turn anchoring rules as the legacy branch (only the first prompt of a turn is anchored for edit/fork semantics).
- Text and images are carried through: typed content keeps `UserInput` shapes (`text`, `local_image`, `image`), mapped onto the same attachment rows the legacy path produced.
- Wire-level `response_item` rows remain unused for prompts, preserving the #488 safety rule that internal content (hook prompts, scaffolding) must never surface as a user message.
- When one file mixes typed and legacy copies of the same prompt (e.g. across a format boundary), the typed row wins and the legacy row is dropped so no duplicate bubbles render.
- Legacy-only files keep the existing path untouched, so older rollouts still render exactly as before.

## Validation

- New unit tests cover typed-row restoration with images and a wire user echo that must not duplicate, plus a mixed typed/legacy file that must collapse to one prompt.
- Existing Codex history, message-editing and provider tests still pass; server typecheck and oxlint are clean.
- Smoke-tested against a real Codex 0.153 rollout: every user prompt from the typed rows renders again after refresh.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved restoration of Codex prompts from typed transcript entries.
  * Unified local image paths and image URLs when restoring attached images.
  * Preserved typed and legacy prompts without turn-based deduplication or re-anchoring.
  * Codex text extraction no longer processes the `Text` content type.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->