### PR TITLE
Log Claude run lifecycle transitions

### DIFF
--- a/server/modules/providers/list/claude/claude-runtime.provider.js
+++ b/server/modules/providers/list/claude/claude-runtime.provider.js
@@ -724,6 +724,12 @@ async function queryClaudeSDK(command, options = {}, ws, context) {
   const sessionKey = () => sessionId || capturedSessionId || null;
   // Wall-clock start of this run, so every run_end can report a duration.
   const runStartedAt = Date.now();
+  // Identifies THIS run, not the conversation. `sessionKey` cannot do that job:
+  // a superseding run reuses the same key while the older one is still
+  // unwinding, so without this the two runs' records interleave under identical
+  // session and user fields and cannot be told apart afterwards -- which is the
+  // one thing these records exist for.
+  const runId = createRequestId();
   // Guarantees exactly one terminal lifecycle record per run: the success path
   // emits run_end before the notification calls, and a throw from one of those
   // would otherwise reach the catch and log a second, contradicting one.
@@ -734,6 +740,7 @@ async function queryClaudeSDK(command, options = {}, ws, context) {
     }
     runEndLogged = true;
     logRunLifecycle('run_end', {
+      runId,
       sessionKey: sessionKey(),
       providerSessionId: capturedSessionId || null,
       userId: ws?.userId || null,
@@ -803,6 +810,7 @@ async function queryClaudeSDK(command, options = {}, ws, context) {
     }
     runStartLogged = true;
     logRunLifecycle('run_start', {
+      runId,
       sessionKey: sessionKey(),
       providerSessionId: providerSessionId || null,
       // A run either resumes a known provider session or creates a new one.
@@ -992,6 +1000,7 @@ async function queryClaudeSDK(command, options = {}, ws, context) {
         if (!providerSessionId && !sessionCreatedSent) {
           sessionCreatedSent = true;
           logRunLifecycle('session_created', {
+            runId,
             sessionKey: sessionKey(),
             providerSessionId: capturedSessionId,
             userId: ws?.userId || null

--- a/server/modules/providers/list/claude/claude-runtime.provider.js
+++ b/server/modules/providers/list/claude/claude-runtime.provider.js
@@ -370,6 +370,23 @@ function getAllSessions() {
 }
 
 /**
+ * Emits one greppable line per lifecycle transition of a Claude run.
+ *
+ * The Agent SDK owns the CLI child process, so this provider never holds a
+ * process handle: the *run* is the smallest unit it can observe. These records
+ * therefore report when a run started, which session it belonged to, who owned
+ * it, and how and why it ended.
+ *
+ * @param {string} event - Lifecycle transition: run_start, session_created,
+ *   abort_requested or run_end.
+ * @param {Object} fields - Event payload; serialized as JSON so log processors
+ *   can parse it without a format-specific reader.
+ */
+function logRunLifecycle(event, fields) {
+  console.log(`[Claude SDK] lifecycle ${event}`, JSON.stringify(fields));
+}
+
+/**
  * Transforms SDK messages to WebSocket format expected by frontend
  * @param {Object} sdkMessage - SDK message object
  * @returns {Object} Transformed message ready for WebSocket
@@ -705,6 +722,24 @@ async function queryClaudeSDK(command, options = {}, ws, context) {
   // Process-map key: the app session id when the caller supplied one, else
   // the provider-native id once captured (legacy/direct API callers).
   const sessionKey = () => sessionId || capturedSessionId || null;
+  // Wall-clock start of this run, so every run_end can report a duration.
+  const runStartedAt = Date.now();
+  // Guarantees exactly one terminal lifecycle record per run: the success path
+  // emits run_end before the notification calls, and a throw from one of those
+  // would otherwise reach the catch and log a second, contradicting one.
+  let runEndLogged = false;
+  const logRunEnd = (fields) => {
+    if (runEndLogged) {
+      return;
+    }
+    runEndLogged = true;
+    logRunLifecycle('run_end', {
+      sessionKey: sessionKey(),
+      providerSessionId: capturedSessionId || null,
+      userId: ws?.userId || null,
+      ...fields
+    });
+  };
 
   const emitNotification = (event) => {
     notifyUserIfEnabled({
@@ -917,7 +952,15 @@ async function queryClaudeSDK(command, options = {}, ws, context) {
     }
 
     // Process streaming messages
-    console.log('Starting async generator loop for session:', capturedSessionId || 'NEW');
+    logRunLifecycle('run_start', {
+      sessionKey: sessionKey(),
+      providerSessionId: providerSessionId || null,
+      // A run either resumes a known provider session or creates a new one.
+      resumed: Boolean(providerSessionId),
+      userId: ws?.userId || null,
+      model: sdkOptions.model || null,
+      permissionMode: sdkOptions.permissionMode || null
+    });
     for await (const message of queryInstance) {
       // Capture session ID from first message
       if (message.session_id && !capturedSessionId) {
@@ -933,6 +976,11 @@ async function queryClaudeSDK(command, options = {}, ws, context) {
         // Send session-created event only once for sessions with nothing to resume
         if (!providerSessionId && !sessionCreatedSent) {
           sessionCreatedSent = true;
+          logRunLifecycle('session_created', {
+            sessionKey: sessionKey(),
+            providerSessionId: capturedSessionId,
+            userId: ws?.userId || null
+          });
           ws.send(createNormalizedMessage({ kind: 'session_created', newSessionId: capturedSessionId, sessionId: capturedSessionId, provider: 'claude' }));
         }
       } else {
@@ -1042,6 +1090,17 @@ async function queryClaudeSDK(command, options = {}, ws, context) {
         stopReason: wasAborted ? 'aborted' : 'completed'
       });
     }
+    // A superseded run skips the block above entirely — it owns none of the
+    // client-facing events. Without a record here it would end as a run_start
+    // with no run_end, which is exactly how such a run becomes invisible at
+    // the moment something unusual happened to it.
+    logRunEnd(superseded
+      ? { reason: 'superseded', exitCode: null, durationMs: Date.now() - runStartedAt }
+      : {
+        reason: wasAborted ? 'aborted' : 'completed',
+        exitCode: wasAborted ? null : 0,
+        durationMs: Date.now() - runStartedAt
+      });
     // Complete
 
   } catch (error) {
@@ -1056,6 +1115,16 @@ async function queryClaudeSDK(command, options = {}, ws, context) {
     if (supersededInstances.has(queryInstance)) {
       // Interrupted because a newer run took over this session id; that run
       // owns the abort flag and all further client-facing events.
+      //
+      // The run stays silent toward the CLIENT — that is deliberate and
+      // unchanged. It does get a log record, though: this is the path an
+      // interrupted run actually takes, and without a record it vanishes
+      // here without a trace.
+      logRunEnd({
+        reason: 'superseded',
+        exitCode: null,
+        durationMs: Date.now() - runStartedAt
+      });
       return;
     }
 
@@ -1063,6 +1132,11 @@ async function queryClaudeSDK(command, options = {}, ws, context) {
     if (wasAborted) {
       // The abort already produced the terminal complete; a generator throw
       // caused by interrupt() is expected noise, not a user-facing error.
+      logRunEnd({
+        reason: 'aborted',
+        exitCode: null,
+        durationMs: Date.now() - runStartedAt
+      });
       return;
     }
 
@@ -1076,9 +1150,18 @@ async function queryClaudeSDK(command, options = {}, ws, context) {
     // reported completion and then failed during its post-turn hold still
     // surfaces the error, but must not emit a second terminal complete.
     ws.send(createNormalizedMessage({ kind: 'error', content: errorContent, sessionId: capturedSessionId || sessionId || null, provider: 'claude' }));
+    // The logging sits after the guard on purpose: it belongs to the RUN, not
+    // to the client-facing message, and runEndLogged gives it its own
+    // exactly-once guarantee.
     if (!turnCompleteSent) {
       ws.send(createCompleteMessage({ provider: 'claude', sessionId: capturedSessionId || sessionId || null, exitCode: 1 }));
     }
+    logRunEnd({
+      reason: 'error',
+      exitCode: 1,
+      durationMs: Date.now() - runStartedAt,
+      error: error?.message || String(error)
+    });
     notifyRunFailed({
       userId: ws?.userId || null,
       provider: 'claude',
@@ -1111,7 +1194,7 @@ async function abortClaudeSDKSession(sessionId) {
   }
 
   try {
-    console.log(`Aborting SDK session: ${sessionId}`);
+    logRunLifecycle('abort_requested', { sessionKey: sessionId });
 
     // Mark before interrupting so the run loop knows not to emit its own
     // terminal complete (the abort handler sends the aborted one).

--- a/server/modules/providers/list/claude/claude-runtime.provider.js
+++ b/server/modules/providers/list/claude/claude-runtime.provider.js
@@ -401,6 +401,13 @@ function logRunLifecycle(event, fields) {
  *
  * Pure on purpose -- this is the part worth testing without a live SDK.
  *
+ * The message itself has to survive `JSON.stringify()` in `logRunLifecycle()`.
+ * `error` is whatever got thrown -- there is no guarantee `error.message` is a
+ * string, or that stringifying it cannot itself throw (a BigInt message, or an
+ * object whose `toString()` throws). By the time this runs, `logRunEnd()` has
+ * already set `runEndLogged`, so a throw here would drop the terminal record
+ * entirely with no fallback able to re-emit it.
+ *
  * @param {Object} args
  * @param {boolean} args.turnCompleteSent - Client already got a terminal complete.
  * @param {*} args.error - The thrown value.
@@ -411,7 +418,12 @@ function logRunLifecycle(event, fields) {
  *   reader treats `error` as "this run failed".
  */
 function resolveRunEndOutcome({ turnCompleteSent, error }) {
-  const message = error?.message || String(error);
+  let message;
+  try {
+    message = String(error?.message ?? error);
+  } catch {
+    message = 'Unserializable error';
+  }
   if (turnCompleteSent) {
     return { reason: 'completed', exitCode: 0, lateError: message };
   }

--- a/server/modules/providers/list/claude/claude-runtime.provider.js
+++ b/server/modules/providers/list/claude/claude-runtime.provider.js
@@ -387,6 +387,38 @@ function logRunLifecycle(event, fields) {
 }
 
 /**
+ * Decides the terminal outcome of a run that ended by throwing.
+ *
+ * A run can fail AFTER it already reported success: the `result` message sends
+ * the client a terminal complete with exit code 0, and the held stream can then
+ * throw while winding down. Recording `error`/1 for that run gives it two
+ * contradicting terminal outcomes -- the client was told it worked, the log says
+ * it did not. Whoever reads the two together later cannot tell which is true.
+ *
+ * So the outcome the client already saw wins, and the late failure is recorded
+ * beside it as `lateError` rather than replacing it. Nothing is lost: the error
+ * is still in the record, it just no longer contradicts the run's own result.
+ *
+ * Pure on purpose -- this is the part worth testing without a live SDK.
+ *
+ * @param {Object} args
+ * @param {boolean} args.turnCompleteSent - Client already got a terminal complete.
+ * @param {*} args.error - The thrown value.
+ * @returns {{reason: string, exitCode: number|null, error?: string, lateError?: string}}
+ *   Fields for the run_end record. Exactly one of `error` / `lateError` is set:
+ *   `error` when the run failed outright, `lateError` when it had already
+ *   reported success. Which one carries the message is the whole point -- a
+ *   reader treats `error` as "this run failed".
+ */
+function resolveRunEndOutcome({ turnCompleteSent, error }) {
+  const message = error?.message || String(error);
+  if (turnCompleteSent) {
+    return { reason: 'completed', exitCode: 0, lateError: message };
+  }
+  return { reason: 'error', exitCode: 1, error: message };
+}
+
+/**
  * Transforms SDK messages to WebSocket format expected by frontend
  * @param {Object} sdkMessage - SDK message object
  * @returns {Object} Transformed message ready for WebSocket
@@ -1175,10 +1207,8 @@ async function queryClaudeSDK(command, options = {}, ws, context) {
     // exact blind spot this logging was added to remove, reappearing on the
     // path where it matters most.
     logRunEnd({
-      reason: 'error',
-      exitCode: 1,
-      durationMs: Date.now() - runStartedAt,
-      error: error?.message || String(error)
+      ...resolveRunEndOutcome({ turnCompleteSent, error }),
+      durationMs: Date.now() - runStartedAt
     });
 
     // Check if Claude CLI is installed for a clearer error message
@@ -1338,6 +1368,7 @@ export const claudeRuntime = {
 
 // Export public API
 export {
+  resolveRunEndOutcome,
   queryClaudeSDK,
   abortClaudeSDKSession,
   isClaudeSDKSessionActive,

--- a/server/modules/providers/list/claude/claude-runtime.provider.js
+++ b/server/modules/providers/list/claude/claude-runtime.provider.js
@@ -1167,6 +1167,20 @@ async function queryClaudeSDK(command, options = {}, ws, context) {
       return;
     }
 
+    // The run's terminal record goes FIRST, before anything that can throw on
+    // the way to it. Everything below talks to the outside world:
+    // `isProviderInstalled()` can reject, and `ws.send()` throws on a socket
+    // that closed while the run was failing. Either one used to jump straight
+    // to `finally`, and the run ended with no terminal record at all -- the
+    // exact blind spot this logging was added to remove, reappearing on the
+    // path where it matters most.
+    logRunEnd({
+      reason: 'error',
+      exitCode: 1,
+      durationMs: Date.now() - runStartedAt,
+      error: error?.message || String(error)
+    });
+
     // Check if Claude CLI is installed for a clearer error message
     const installed = await context.isProviderInstalled();
     const errorContent = !installed
@@ -1177,18 +1191,9 @@ async function queryClaudeSDK(command, options = {}, ws, context) {
     // reported completion and then failed during its post-turn hold still
     // surfaces the error, but must not emit a second terminal complete.
     ws.send(createNormalizedMessage({ kind: 'error', content: errorContent, sessionId: capturedSessionId || sessionId || null, provider: 'claude' }));
-    // The logging sits after the guard on purpose: it belongs to the RUN, not
-    // to the client-facing message, and runEndLogged gives it its own
-    // exactly-once guarantee.
     if (!turnCompleteSent) {
       ws.send(createCompleteMessage({ provider: 'claude', sessionId: capturedSessionId || sessionId || null, exitCode: 1 }));
     }
-    logRunEnd({
-      reason: 'error',
-      exitCode: 1,
-      durationMs: Date.now() - runStartedAt,
-      error: error?.message || String(error)
-    });
     notifyRunFailed({
       userId: ws?.userId || null,
       provider: 'claude',
@@ -1197,6 +1202,24 @@ async function queryClaudeSDK(command, options = {}, ws, context) {
       error
     });
   } finally {
+    // Last resort, and it runs FIRST here on purpose: every path above either
+    // records its own outcome or throws on the way there. A throw inside the
+    // catch block itself has no other place left to be noticed, and a run that
+    // ends without any terminal record is indistinguishable from one that is
+    // still going. `runEndLogged` keeps this from ever double-counting a run
+    // that already reported properly.
+    //
+    // `logRunStart()` comes first so the net cannot itself produce the shape
+    // 67bae5cd removed -- a `run_end` with no matching `run_start`. Today no
+    // path reaches here unstarted; stating it here keeps that true when the
+    // paths above change.
+    logRunStart();
+    logRunEnd({
+      reason: 'unknown',
+      exitCode: null,
+      durationMs: Date.now() - runStartedAt
+    });
+
     // Always close stdin — otherwise an aborted or failed run leaves the CLI
     // process (and its MCP servers) alive until the server exits.
     if (idleReleaseTimer) {

--- a/server/modules/providers/list/claude/claude-runtime.provider.js
+++ b/server/modules/providers/list/claude/claude-runtime.provider.js
@@ -789,6 +789,29 @@ async function queryClaudeSDK(command, options = {}, ws, context) {
   // Hoisted above the try so the catch's cleanup can tell whether this run
   // still owns the activeSessions entry (or was superseded by a newer run).
   let queryInstance = null;
+  // Hoisted so the catch path can still report what was resolved when setup
+  // failed part-way through.
+  let sdkOptions = null;
+  // Guarantees a run_start for every run_end. The record is emitted where its
+  // payload is complete -- but everything above that point can throw, and a
+  // run_end without a matching run_start reads like a run that started before
+  // the log did. That is exactly the confusion this logging exists to remove.
+  let runStartLogged = false;
+  const logRunStart = () => {
+    if (runStartLogged) {
+      return;
+    }
+    runStartLogged = true;
+    logRunLifecycle('run_start', {
+      sessionKey: sessionKey(),
+      providerSessionId: providerSessionId || null,
+      // A run either resumes a known provider session or creates a new one.
+      resumed: Boolean(providerSessionId),
+      userId: ws?.userId || null,
+      model: sdkOptions?.model || null,
+      permissionMode: sdkOptions?.permissionMode || null
+    });
+  };
 
   try {
     const resolvedModel = await context.resolveResumeModel(sessionId, options.model);
@@ -799,7 +822,7 @@ async function queryClaudeSDK(command, options = {}, ws, context) {
       console.warn('[Claude SDK] Unable to load provider models for effort validation:', error);
     }
 
-    const sdkOptions = mapCliOptionsToSDK({
+    sdkOptions = mapCliOptionsToSDK({
       ...options,
       providerSessionId,
       model: resolvedModel || options.model,
@@ -952,15 +975,7 @@ async function queryClaudeSDK(command, options = {}, ws, context) {
     }
 
     // Process streaming messages
-    logRunLifecycle('run_start', {
-      sessionKey: sessionKey(),
-      providerSessionId: providerSessionId || null,
-      // A run either resumes a known provider session or creates a new one.
-      resumed: Boolean(providerSessionId),
-      userId: ws?.userId || null,
-      model: sdkOptions.model || null,
-      permissionMode: sdkOptions.permissionMode || null
-    });
+    logRunStart();
     for await (const message of queryInstance) {
       // Capture session ID from first message
       if (message.session_id && !capturedSessionId) {
@@ -1105,6 +1120,9 @@ async function queryClaudeSDK(command, options = {}, ws, context) {
 
   } catch (error) {
     console.error('SDK query error:', error);
+
+    // Setup may have thrown before the run_start above was reached.
+    logRunStart();
 
     // Clean up session on error — only while this run still owns the map entry
     // (a superseding run may have replaced it).

--- a/server/modules/providers/tests/claude-run-lifecycle.test.ts
+++ b/server/modules/providers/tests/claude-run-lifecycle.test.ts
@@ -1,0 +1,48 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { resolveRunEndOutcome } from '@/modules/providers/list/claude/claude-runtime.provider.js';
+
+// A run that never reported success records the failure as the failure it is.
+test('claude run lifecycle: a plain failure ends as error/1', () => {
+  const out = resolveRunEndOutcome({
+    turnCompleteSent: false,
+    error: new Error('spawn ENOENT'),
+  });
+
+  assert.equal(out.reason, 'error');
+  assert.equal(out.exitCode, 1);
+  assert.equal(out.error, 'spawn ENOENT');
+  assert.equal(out.lateError, undefined);
+});
+
+// The counter-direction, and the reason this function exists: the client was
+// already told the turn completed with exit code 0. Recording error/1 here
+// would leave one run with two terminal outcomes that contradict each other.
+test('claude run lifecycle: a failure after the terminal complete keeps the completed outcome', () => {
+  const out = resolveRunEndOutcome({
+    turnCompleteSent: true,
+    error: new Error('stream closed during post-turn hold'),
+  });
+
+  assert.equal(out.reason, 'completed');
+  assert.equal(out.exitCode, 0);
+  assert.equal(out.lateError, 'stream closed during post-turn hold');
+  // The completed outcome must not carry an `error` field -- that is the field
+  // a reader takes as "this run failed".
+  assert.equal(out.error, undefined);
+});
+
+// The late failure is preserved, not swallowed. A rule that quietly dropped the
+// error would trade one wrong record for a missing one.
+test('claude run lifecycle: the late failure is still recorded', () => {
+  const out = resolveRunEndOutcome({ turnCompleteSent: true, error: new Error('boom') });
+
+  assert.ok(Object.values(out).includes('boom'));
+});
+
+// Not everything thrown is an Error.
+test('claude run lifecycle: a non-Error throw is still described', () => {
+  assert.equal(resolveRunEndOutcome({ turnCompleteSent: false, error: 'plain string' }).error, 'plain string');
+  assert.equal(resolveRunEndOutcome({ turnCompleteSent: false, error: null }).error, 'null');
+});

--- a/server/modules/providers/tests/claude-run-lifecycle.test.ts
+++ b/server/modules/providers/tests/claude-run-lifecycle.test.ts
@@ -46,3 +46,39 @@ test('claude run lifecycle: a non-Error throw is still described', () => {
   assert.equal(resolveRunEndOutcome({ turnCompleteSent: false, error: 'plain string' }).error, 'plain string');
   assert.equal(resolveRunEndOutcome({ turnCompleteSent: false, error: null }).error, 'null');
 });
+
+// A truthy, non-string `message` (BigInt is the concrete case CodeRabbit
+// found) used to reach JSON.stringify() in logRunLifecycle() unconverted --
+// `error?.message || String(error)` only stringifies on the FALSY branch.
+// JSON.stringify() cannot serialise a BigInt, and by the point this throws,
+// logRunEnd() has already marked the run as logged, so no fallback re-emits
+// it: one run, no terminal record at all.
+test('claude run lifecycle: a BigInt message is stringified, not passed through', () => {
+  const out = resolveRunEndOutcome({
+    turnCompleteSent: false,
+    error: { message: 1n },
+  });
+
+  assert.equal(out.error, '1');
+  assert.doesNotThrow(() => JSON.stringify(out));
+});
+
+// The counter-case for the same fix: a falsy-but-meaningful message (empty
+// string, zero) must not be discarded in favour of `String(error)` the way
+// `||` would. `??` only falls back on null/undefined.
+test('claude run lifecycle: a falsy-but-defined message is kept, not replaced', () => {
+  assert.equal(resolveRunEndOutcome({ turnCompleteSent: false, error: { message: '' } }).error, '');
+  assert.equal(resolveRunEndOutcome({ turnCompleteSent: false, error: { message: 0 } }).error, '0');
+});
+
+// Defence in depth: even a value whose own stringification throws (a
+// deliberately hostile `toString()`, e.g. from a Proxy) must not take down
+// the terminal record with it.
+test('claude run lifecycle: an unstringifiable error falls back instead of throwing', () => {
+  const hostile = { message: { toString() { throw new Error('nope'); } } };
+
+  const out = resolveRunEndOutcome({ turnCompleteSent: false, error: hostile });
+
+  assert.equal(out.error, 'Unserializable error');
+  assert.doesNotThrow(() => JSON.stringify(out));
+});


### PR DESCRIPTION
## What

The Claude provider starts and finishes CLI runs without recording either
event. This adds one greppable line per transition — `run_start`,
`abort_requested`, `run_end` — carrying the session tag, the reason a run
ended, the CLI exit code and the wall-clock duration. It is log output
only: no behaviour change, no API change, nothing the user sees.

## Why

When a run disappears, the server log currently says nothing at all, so
"the turn completed" and "the process vanished" look identical from the
outside. That is the whole diagnostic gap: without a terminal record per
run there is no way to tell a clean finish from a kill, a timeout, or a
recycle — you can only guess from the absence of further output.

## Reproduction steps

1. On current `main`, confirm the gap is real:

   ```
   grep -nE 'run_start|run_end|lifecycle' \
     server/modules/providers/list/claude/claude-runtime.provider.js
   ```

   No matches. (Measured on `5af09903`, 2026-09-07.)

2. Start the server: `npm run server:dev`.

3. Open a session in the UI, send one message, let the turn finish
   normally.

4. Read the server output. The run leaves **no record** — there is no
   line saying a run began, and none saying it ended.

5. Now force the other case: send a second message and kill the CLI child
   while it is working (`pkill -f 'claude.*--print'`). The turn stops.
   The log again shows nothing — step 4 and step 5 are indistinguishable
   in the log, which is the bug.

6. With this PR, the same two runs print:

   ```
   [Claude SDK] lifecycle run_start session=<tag> ...
   [Claude SDK] lifecycle run_end   session=<tag> reason=completed exitCode=0 durationMs=...
   [Claude SDK] lifecycle run_end   session=<tag> reason=<cause>   exitCode=<n> durationMs=...
   ```

   `run_end` is emitted exactly once per run, and every `run_end` is
   paired with a `run_start`.

## Notes

- Verified against `main` (`5af09903`): `npm test` → 397 tests, 396 pass,
  0 fail, 1 skipped — identical to the baseline on `main`.
  `node --check` on the changed file passes.
- This is one half of #1218, which the maintainer closed asking for
  separate PRs with reproduction steps. The review history for this code
  — two CodeRabbit rounds, all threads resolved — is on #1218.
- The stderr half is the companion PR; it builds on this one.

Closes #1163


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Logging**
  * Added structured lifecycle logging for Claude SDK runs, including start, session creation, abort requests, and completion.
  * Completion logs now include the outcome, exit code, and run duration.
  * Improved consistency of logs across completed, aborted, superseded, and failed runs.
  * Preserved details of errors that occur after a run has already completed successfully.
* **Testing**
  * Added coverage for run completion outcomes, late failures, and non-standard errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->