### PR TITLE
Forward the Claude CLI's stderr to the service log

### DIFF
--- a/server/modules/providers/list/claude/claude-runtime.provider.js
+++ b/server/modules/providers/list/claude/claude-runtime.provider.js
@@ -724,6 +724,12 @@ async function queryClaudeSDK(command, options = {}, ws, context) {
   const sessionKey = () => sessionId || capturedSessionId || null;
   // Wall-clock start of this run, so every run_end can report a duration.
   const runStartedAt = Date.now();
+  // Identifies THIS run, not the conversation. `sessionKey` cannot do that job:
+  // a superseding run reuses the same key while the older one is still
+  // unwinding, so without this the two runs' records interleave under identical
+  // session and user fields and cannot be told apart afterwards -- which is the
+  // one thing these records exist for.
+  const runId = createRequestId();
   // Guarantees exactly one terminal lifecycle record per run: the success path
   // emits run_end before the notification calls, and a throw from one of those
   // would otherwise reach the catch and log a second, contradicting one.
@@ -734,6 +740,7 @@ async function queryClaudeSDK(command, options = {}, ws, context) {
     }
     runEndLogged = true;
     logRunLifecycle('run_end', {
+      runId,
       sessionKey: sessionKey(),
       providerSessionId: capturedSessionId || null,
       userId: ws?.userId || null,
@@ -803,6 +810,7 @@ async function queryClaudeSDK(command, options = {}, ws, context) {
     }
     runStartLogged = true;
     logRunLifecycle('run_start', {
+      runId,
       sessionKey: sessionKey(),
       providerSessionId: providerSessionId || null,
       // A run either resumes a known provider session or creates a new one.
@@ -992,6 +1000,7 @@ async function queryClaudeSDK(command, options = {}, ws, context) {
         if (!providerSessionId && !sessionCreatedSent) {
           sessionCreatedSent = true;
           logRunLifecycle('session_created', {
+            runId,
             sessionKey: sessionKey(),
             providerSessionId: capturedSessionId,
             userId: ws?.userId || null

--- a/server/modules/providers/list/claude/claude-runtime.provider.js
+++ b/server/modules/providers/list/claude/claude-runtime.provider.js
@@ -370,6 +370,23 @@ function getAllSessions() {
 }
 
 /**
+ * Emits one greppable line per lifecycle transition of a Claude run.
+ *
+ * The Agent SDK owns the CLI child process, so this provider never holds a
+ * process handle: the *run* is the smallest unit it can observe. These records
+ * therefore report when a run started, which session it belonged to, who owned
+ * it, and how and why it ended.
+ *
+ * @param {string} event - Lifecycle transition: run_start, session_created,
+ *   abort_requested or run_end.
+ * @param {Object} fields - Event payload; serialized as JSON so log processors
+ *   can parse it without a format-specific reader.
+ */
+function logRunLifecycle(event, fields) {
+  console.log(`[Claude SDK] lifecycle ${event}`, JSON.stringify(fields));
+}
+
+/**
  * Transforms SDK messages to WebSocket format expected by frontend
  * @param {Object} sdkMessage - SDK message object
  * @returns {Object} Transformed message ready for WebSocket
@@ -705,6 +722,24 @@ async function queryClaudeSDK(command, options = {}, ws, context) {
   // Process-map key: the app session id when the caller supplied one, else
   // the provider-native id once captured (legacy/direct API callers).
   const sessionKey = () => sessionId || capturedSessionId || null;
+  // Wall-clock start of this run, so every run_end can report a duration.
+  const runStartedAt = Date.now();
+  // Guarantees exactly one terminal lifecycle record per run: the success path
+  // emits run_end before the notification calls, and a throw from one of those
+  // would otherwise reach the catch and log a second, contradicting one.
+  let runEndLogged = false;
+  const logRunEnd = (fields) => {
+    if (runEndLogged) {
+      return;
+    }
+    runEndLogged = true;
+    logRunLifecycle('run_end', {
+      sessionKey: sessionKey(),
+      providerSessionId: capturedSessionId || null,
+      userId: ws?.userId || null,
+      ...fields
+    });
+  };
 
   const emitNotification = (event) => {
     notifyUserIfEnabled({
@@ -917,7 +952,15 @@ async function queryClaudeSDK(command, options = {}, ws, context) {
     }
 
     // Process streaming messages
-    console.log('Starting async generator loop for session:', capturedSessionId || 'NEW');
+    logRunLifecycle('run_start', {
+      sessionKey: sessionKey(),
+      providerSessionId: providerSessionId || null,
+      // A run either resumes a known provider session or creates a new one.
+      resumed: Boolean(providerSessionId),
+      userId: ws?.userId || null,
+      model: sdkOptions.model || null,
+      permissionMode: sdkOptions.permissionMode || null
+    });
     for await (const message of queryInstance) {
       // Capture session ID from first message
       if (message.session_id && !capturedSessionId) {
@@ -933,6 +976,11 @@ async function queryClaudeSDK(command, options = {}, ws, context) {
         // Send session-created event only once for sessions with nothing to resume
         if (!providerSessionId && !sessionCreatedSent) {
           sessionCreatedSent = true;
+          logRunLifecycle('session_created', {
+            sessionKey: sessionKey(),
+            providerSessionId: capturedSessionId,
+            userId: ws?.userId || null
+          });
           ws.send(createNormalizedMessage({ kind: 'session_created', newSessionId: capturedSessionId, sessionId: capturedSessionId, provider: 'claude' }));
         }
       } else {
@@ -1042,6 +1090,17 @@ async function queryClaudeSDK(command, options = {}, ws, context) {
         stopReason: wasAborted ? 'aborted' : 'completed'
       });
     }
+    // A superseded run skips the block above entirely — it owns none of the
+    // client-facing events. Without a record here it would end as a run_start
+    // with no run_end, which is exactly how such a run becomes invisible at
+    // the moment something unusual happened to it.
+    logRunEnd(superseded
+      ? { reason: 'superseded', exitCode: null, durationMs: Date.now() - runStartedAt }
+      : {
+        reason: wasAborted ? 'aborted' : 'completed',
+        exitCode: wasAborted ? null : 0,
+        durationMs: Date.now() - runStartedAt
+      });
     // Complete
 
   } catch (error) {
@@ -1056,6 +1115,16 @@ async function queryClaudeSDK(command, options = {}, ws, context) {
     if (supersededInstances.has(queryInstance)) {
       // Interrupted because a newer run took over this session id; that run
       // owns the abort flag and all further client-facing events.
+      //
+      // The run stays silent toward the CLIENT — that is deliberate and
+      // unchanged. It does get a log record, though: this is the path an
+      // interrupted run actually takes, and without a record it vanishes
+      // here without a trace.
+      logRunEnd({
+        reason: 'superseded',
+        exitCode: null,
+        durationMs: Date.now() - runStartedAt
+      });
       return;
     }
 
@@ -1063,6 +1132,11 @@ async function queryClaudeSDK(command, options = {}, ws, context) {
     if (wasAborted) {
       // The abort already produced the terminal complete; a generator throw
       // caused by interrupt() is expected noise, not a user-facing error.
+      logRunEnd({
+        reason: 'aborted',
+        exitCode: null,
+        durationMs: Date.now() - runStartedAt
+      });
       return;
     }
 
@@ -1076,9 +1150,18 @@ async function queryClaudeSDK(command, options = {}, ws, context) {
     // reported completion and then failed during its post-turn hold still
     // surfaces the error, but must not emit a second terminal complete.
     ws.send(createNormalizedMessage({ kind: 'error', content: errorContent, sessionId: capturedSessionId || sessionId || null, provider: 'claude' }));
+    // The logging sits after the guard on purpose: it belongs to the RUN, not
+    // to the client-facing message, and runEndLogged gives it its own
+    // exactly-once guarantee.
     if (!turnCompleteSent) {
       ws.send(createCompleteMessage({ provider: 'claude', sessionId: capturedSessionId || sessionId || null, exitCode: 1 }));
     }
+    logRunEnd({
+      reason: 'error',
+      exitCode: 1,
+      durationMs: Date.now() - runStartedAt,
+      error: error?.message || String(error)
+    });
     notifyRunFailed({
       userId: ws?.userId || null,
       provider: 'claude',
@@ -1111,7 +1194,7 @@ async function abortClaudeSDKSession(sessionId) {
   }
 
   try {
-    console.log(`Aborting SDK session: ${sessionId}`);
+    logRunLifecycle('abort_requested', { sessionKey: sessionId });
 
     // Mark before interrupting so the run loop knows not to emit its own
     // terminal complete (the abort handler sends the aborted one).

--- a/server/modules/providers/list/claude/claude-runtime.provider.js
+++ b/server/modules/providers/list/claude/claude-runtime.provider.js
@@ -128,10 +128,20 @@ const CLI_STDERR_REDACTIONS = [
   // Opaque bearer/basic credentials: no recognisable prefix to key on, so the
   // scheme word is the only handle. Keep it -- "Bearer <redacted>" tells the
   // reader an auth header was involved, which "<redacted>" alone does not.
-  { pattern: /\b(Bearer|Basic)\s+[A-Za-z0-9._~+/=-]{8,}/gi, replacement: '$1 <redacted>' },
-  // Credentials in URL userinfo (scheme://user:pass@host). Host and scheme
-  // survive on purpose; they are the diagnostic half of the line.
-  { pattern: /\b([a-z][a-z0-9+.-]*:\/\/)[^/\s:@]+:[^/\s@]+@/gi, replacement: '$1<redacted>@' },
+  // No minimum length: `Basic dTpw` is the base64 of a two-character
+  // `u:p`, four characters long, and is exactly as real a credential as a
+  // longer one. A length floor here does not screen out prose -- "Basic
+  // authentication" already matched at the old floor of 8 -- it only
+  // screens out short secrets, which is the one thing this pattern exists
+  // to catch.
+  { pattern: /\b(Bearer|Basic)\s+[A-Za-z0-9._~+/=-]+/gi, replacement: '$1 <redacted>' },
+  // Credentials in URL userinfo (scheme://user[:pass]@host). The password is
+  // optional: a bare token used as the username (scheme://<token>@host, a
+  // common shape for registry/CI credentials) carries the same secret with
+  // no colon in sight, and the old mandatory `:pass` let it straight
+  // through. Host and scheme survive on purpose; they are the diagnostic
+  // half of the line.
+  { pattern: /\b([a-z][a-z0-9+.-]*:\/\/)[^/\s:@]+(?::[^/\s@]+)?@/gi, replacement: '$1<redacted>@' },
   { pattern: /\b(sk|pk|ghp|gho|ghs|github_pat|xox[abprs])[-_][A-Za-z0-9_-]{8,}/g, replacement: '<redacted>' },
   { pattern: /\bsk-ant-[A-Za-z0-9_-]{16,}/g, replacement: '<redacted>' },
   { pattern: /\bAKIA[0-9A-Z]{12,}\b/g, replacement: '<redacted>' },

--- a/server/modules/providers/list/claude/claude-runtime.provider.js
+++ b/server/modules/providers/list/claude/claude-runtime.provider.js
@@ -401,6 +401,13 @@ function logRunLifecycle(event, fields) {
  *
  * Pure on purpose -- this is the part worth testing without a live SDK.
  *
+ * The message itself has to survive `JSON.stringify()` in `logRunLifecycle()`.
+ * `error` is whatever got thrown -- there is no guarantee `error.message` is a
+ * string, or that stringifying it cannot itself throw (a BigInt message, or an
+ * object whose `toString()` throws). By the time this runs, `logRunEnd()` has
+ * already set `runEndLogged`, so a throw here would drop the terminal record
+ * entirely with no fallback able to re-emit it.
+ *
  * @param {Object} args
  * @param {boolean} args.turnCompleteSent - Client already got a terminal complete.
  * @param {*} args.error - The thrown value.
@@ -411,7 +418,12 @@ function logRunLifecycle(event, fields) {
  *   reader treats `error` as "this run failed".
  */
 function resolveRunEndOutcome({ turnCompleteSent, error }) {
-  const message = error?.message || String(error);
+  let message;
+  try {
+    message = String(error?.message ?? error);
+  } catch {
+    message = 'Unserializable error';
+  }
   if (turnCompleteSent) {
     return { reason: 'completed', exitCode: 0, lateError: message };
   }

--- a/server/modules/providers/list/claude/claude-runtime.provider.js
+++ b/server/modules/providers/list/claude/claude-runtime.provider.js
@@ -387,6 +387,38 @@ function logRunLifecycle(event, fields) {
 }
 
 /**
+ * Decides the terminal outcome of a run that ended by throwing.
+ *
+ * A run can fail AFTER it already reported success: the `result` message sends
+ * the client a terminal complete with exit code 0, and the held stream can then
+ * throw while winding down. Recording `error`/1 for that run gives it two
+ * contradicting terminal outcomes -- the client was told it worked, the log says
+ * it did not. Whoever reads the two together later cannot tell which is true.
+ *
+ * So the outcome the client already saw wins, and the late failure is recorded
+ * beside it as `lateError` rather than replacing it. Nothing is lost: the error
+ * is still in the record, it just no longer contradicts the run's own result.
+ *
+ * Pure on purpose -- this is the part worth testing without a live SDK.
+ *
+ * @param {Object} args
+ * @param {boolean} args.turnCompleteSent - Client already got a terminal complete.
+ * @param {*} args.error - The thrown value.
+ * @returns {{reason: string, exitCode: number|null, error?: string, lateError?: string}}
+ *   Fields for the run_end record. Exactly one of `error` / `lateError` is set:
+ *   `error` when the run failed outright, `lateError` when it had already
+ *   reported success. Which one carries the message is the whole point -- a
+ *   reader treats `error` as "this run failed".
+ */
+function resolveRunEndOutcome({ turnCompleteSent, error }) {
+  const message = error?.message || String(error);
+  if (turnCompleteSent) {
+    return { reason: 'completed', exitCode: 0, lateError: message };
+  }
+  return { reason: 'error', exitCode: 1, error: message };
+}
+
+/**
  * Transforms SDK messages to WebSocket format expected by frontend
  * @param {Object} sdkMessage - SDK message object
  * @returns {Object} Transformed message ready for WebSocket
@@ -1175,10 +1207,8 @@ async function queryClaudeSDK(command, options = {}, ws, context) {
     // exact blind spot this logging was added to remove, reappearing on the
     // path where it matters most.
     logRunEnd({
-      reason: 'error',
-      exitCode: 1,
-      durationMs: Date.now() - runStartedAt,
-      error: error?.message || String(error)
+      ...resolveRunEndOutcome({ turnCompleteSent, error }),
+      durationMs: Date.now() - runStartedAt
     });
 
     // Check if Claude CLI is installed for a clearer error message
@@ -1338,6 +1368,7 @@ export const claudeRuntime = {
 
 // Export public API
 export {
+  resolveRunEndOutcome,
   queryClaudeSDK,
   abortClaudeSDKSession,
   isClaudeSDKSessionActive,

--- a/server/modules/providers/list/claude/claude-runtime.provider.js
+++ b/server/modules/providers/list/claude/claude-runtime.provider.js
@@ -111,14 +111,26 @@ const CLI_STDERR_MAX_PENDING_CHARS = 8 * 1024;
 // Redaction runs BEFORE truncation. Truncating first can cut a secret in half
 // and leave the tail in place: the pattern no longer matches, so the filter
 // stops working silently on exactly the line that needed it.
+// Each entry replaces only the secret-shaped RUN, not the context around it.
+// Two of them keep a capture group deliberately: this channel exists to make a
+// failure readable, and a rule that blanks the whole line to hide the secret in
+// it takes the diagnosis away with it. `https://<redacted>@registry.example.com`
+// still says WHICH registry rejected the credentials.
 const CLI_STDERR_REDACTIONS = [
-  /-----BEGIN[^-]{0,40}PRIVATE KEY-----/g,
-  /\b(sk|pk|ghp|gho|ghs|github_pat|xox[abprs])[-_][A-Za-z0-9_-]{8,}/g,
-  /\bsk-ant-[A-Za-z0-9_-]{16,}/g,
-  /\bAKIA[0-9A-Z]{12,}\b/g,
-  /\beyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{4,}/g,
-  /api\.telegram\.org\/bot[^/\s]+/g,
-  /[A-Za-z0-9_-]*(TOKEN|KEY|SECRET|PASSWORD|PASSWD|CREDENTIAL|APIKEY)[A-Za-z0-9_-]*\s*[=:]\s*\S+/gi,
+  { pattern: /-----BEGIN[^-]{0,40}PRIVATE KEY-----/g, replacement: '<redacted>' },
+  // Opaque bearer/basic credentials: no recognisable prefix to key on, so the
+  // scheme word is the only handle. Keep it -- "Bearer <redacted>" tells the
+  // reader an auth header was involved, which "<redacted>" alone does not.
+  { pattern: /\b(Bearer|Basic)\s+[A-Za-z0-9._~+/=-]{8,}/gi, replacement: '$1 <redacted>' },
+  // Credentials in URL userinfo (scheme://user:pass@host). Host and scheme
+  // survive on purpose; they are the diagnostic half of the line.
+  { pattern: /\b([a-z][a-z0-9+.-]*:\/\/)[^/\s:@]+:[^/\s@]+@/gi, replacement: '$1<redacted>@' },
+  { pattern: /\b(sk|pk|ghp|gho|ghs|github_pat|xox[abprs])[-_][A-Za-z0-9_-]{8,}/g, replacement: '<redacted>' },
+  { pattern: /\bsk-ant-[A-Za-z0-9_-]{16,}/g, replacement: '<redacted>' },
+  { pattern: /\bAKIA[0-9A-Z]{12,}\b/g, replacement: '<redacted>' },
+  { pattern: /\beyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{4,}/g, replacement: '<redacted>' },
+  { pattern: /api\.telegram\.org\/bot[^/\s]+/g, replacement: '<redacted>' },
+  { pattern: /[A-Za-z0-9_-]*(TOKEN|KEY|SECRET|PASSWORD|PASSWD|CREDENTIAL|APIKEY)[A-Za-z0-9_-]*\s*[=:]\s*\S+/gi, replacement: '<redacted>' },
 ];
 
 /**
@@ -129,8 +141,8 @@ const CLI_STDERR_REDACTIONS = [
  */
 function redactCliStderr(text) {
   let out = String(text);
-  for (const pattern of CLI_STDERR_REDACTIONS) {
-    out = out.replace(pattern, '<redacted>');
+  for (const { pattern, replacement } of CLI_STDERR_REDACTIONS) {
+    out = out.replace(pattern, replacement);
   }
   return out;
 }

--- a/server/modules/providers/list/claude/claude-runtime.provider.js
+++ b/server/modules/providers/list/claude/claude-runtime.provider.js
@@ -78,6 +78,78 @@ const TOOLS_REQUIRING_INTERACTION = new Set(['AskUserQuestion', 'ExitPlanMode'])
 // selection is translated back into the two options the SDK actually understands here.
 const ULTRACODE_SDK_EFFORT = 'xhigh';
 
+// The SDK forwards the CLI child's stderr through an explicit callback
+// (`options.stderr`). This provider never set it, so that output was dropped
+// on the floor — including the one line the CLI writes when it winds itself
+// down:
+//
+//     Background tasks still running after <N>s; terminating.
+//     Set CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS=0 to wait indefinitely.
+//
+// That message therefore never reached the service log, which is why a run
+// ended by the background-wait ceiling looks, from the outside, exactly like
+// a run that vanished without a trace. Wiring the callback is what turns that
+// guess into a reading.
+//
+// The same channel also carries SDK debug output, so it is forwarded under
+// three limits. None of them is cosmetic:
+//
+//   1. Redaction before logging — stderr can carry argv fragments and paths.
+//   2. A length cap per line — one runaway line must not swamp the journal.
+//   3. A rate limit per RUN — a CLI stuck in a write loop would otherwise
+//      flood the log. The counters live in the run's closure and die with it;
+//      a per-session map would need someone to clean it up, and that is
+//      exactly the kind of bookkeeping that gets forgotten.
+const CLI_STDERR_MAX_LINE_CHARS = 500;
+const CLI_STDERR_MAX_LINES_PER_WINDOW = 50;
+const CLI_STDERR_WINDOW_MS = 60 * 1000;
+
+// Redaction runs BEFORE truncation. Truncating first can cut a secret in half
+// and leave the tail in place: the pattern no longer matches, so the filter
+// stops working silently on exactly the line that needed it.
+const CLI_STDERR_REDACTIONS = [
+  /-----BEGIN[^-]{0,40}PRIVATE KEY-----/g,
+  /\b(sk|pk|ghp|gho|ghs|github_pat|xox[abprs])[-_][A-Za-z0-9_-]{8,}/g,
+  /\bsk-ant-[A-Za-z0-9_-]{16,}/g,
+  /\bAKIA[0-9A-Z]{12,}\b/g,
+  /\beyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{4,}/g,
+  /api\.telegram\.org\/bot[^/\s]+/g,
+  /[A-Za-z0-9_-]*(TOKEN|KEY|SECRET|PASSWORD|PASSWD|CREDENTIAL|APIKEY)[A-Za-z0-9_-]*\s*[=:]\s*\S+/gi,
+];
+
+/**
+ * Redacts well-known secret shapes from one line of CLI stderr.
+ *
+ * @param {string} text - Raw stderr text.
+ * @returns {string} The same text with secret-shaped runs replaced.
+ */
+function redactCliStderr(text) {
+  let out = String(text);
+  for (const pattern of CLI_STDERR_REDACTIONS) {
+    out = out.replace(pattern, '<redacted>');
+  }
+  return out;
+}
+
+/**
+ * Formats one CLI stderr line for the service log: redact, then cap.
+ *
+ * Kept as a pure function so both halves are testable on their own. The order
+ * matters and is the reason this is one function rather than two calls at the
+ * call site: capping first could split a secret and leave its tail readable.
+ *
+ * @param {string} sessionTag - Short session identifier for correlation.
+ * @param {string} line - One raw stderr line, already trimmed.
+ * @returns {string} The line to hand to the logger.
+ */
+function formatCliStderrLine(sessionTag, line) {
+  const safe = redactCliStderr(line);
+  const capped = safe.length > CLI_STDERR_MAX_LINE_CHARS
+    ? `${safe.slice(0, CLI_STDERR_MAX_LINE_CHARS - 1)}\u2026`
+    : safe;
+  return `[claude-cli-stderr] ${sessionTag} ${capped}`;
+}
+
 function resolveClaudeEffort(model, effort, modelsDefinition = CLAUDE_PREDEFINED_MODELS) {
   const selectedModel = modelsDefinition?.OPTIONS?.find((option) => option.value === model) || null;
   const allowedEfforts = selectedModel?.effort?.values
@@ -766,6 +838,18 @@ async function queryClaudeSDK(command, options = {}, ws, context) {
   // Process-map key: the app session id when the caller supplied one, else
   // the provider-native id once captured (legacy/direct API callers).
   const sessionKey = () => sessionId || capturedSessionId || null;
+  // Short, greppable session tag for the CLI stderr lines below.
+  const sessionTag = () => String(sessionKey() || 'unknown').slice(0, 8);
+  // Rate-limit state for CLI stderr. Scoped to this run, dies with this run.
+  let stderrWindowStart = 0;
+  let stderrLinesInWindow = 0;
+  let stderrDropped = 0;
+  const flushStderrDropped = () => {
+    if (stderrDropped > 0) {
+      console.error(`[claude-cli-stderr] ${sessionTag()} [throttled ${stderrDropped}]`);
+      stderrDropped = 0;
+    }
+  };
   // Wall-clock start of this run, so every run_end can report a duration.
   const runStartedAt = Date.now();
   // Identifies THIS run, not the conversation. `sessionKey` cannot do that job:
@@ -890,6 +974,31 @@ async function queryClaudeSDK(command, options = {}, ws, context) {
     // `result`. The message list is reusable, but each query attempt needs its
     // own stream because an async generator cannot be replayed once consumed.
     const promptMessages = await buildPromptMessages(command, options.images, options.files, options.cwd);
+
+    // Forward the CLI child's stderr into the service log; see the limits
+    // documented at CLI_STDERR_MAX_LINE_CHARS above.
+    sdkOptions.stderr = (data) => {
+      const now = Date.now();
+      if (now - stderrWindowStart >= CLI_STDERR_WINDOW_MS) {
+        // Report what the previous window swallowed before opening a new one.
+        // A throttle that hides its own losses is a log that lies.
+        flushStderrDropped();
+        stderrWindowStart = now;
+        stderrLinesInWindow = 0;
+      }
+      for (const rawLine of String(data ?? '').split('\n')) {
+        const line = rawLine.trim();
+        if (!line) {
+          continue;
+        }
+        if (stderrLinesInWindow >= CLI_STDERR_MAX_LINES_PER_WINDOW) {
+          stderrDropped += 1;
+          continue;
+        }
+        stderrLinesInWindow += 1;
+        console.error(formatCliStderrLine(sessionTag(), line));
+      }
+    };
 
     sdkOptions.hooks = {
       Notification: [{
@@ -1268,6 +1377,9 @@ async function queryClaudeSDK(command, options = {}, ws, context) {
       clearTimeout(idleReleaseTimer);
       idleReleaseTimer = null;
     }
+    // A run that ends while its throttle window is still open would otherwise
+    // carry the dropped-line count to the grave.
+    flushStderrDropped();
     releasePromptStream();
   }
 }
@@ -1381,6 +1493,7 @@ export const claudeRuntime = {
 // Export public API
 export {
   resolveRunEndOutcome,
+  formatCliStderrLine,
   queryClaudeSDK,
   abortClaudeSDKSession,
   isClaudeSDKSessionActive,

--- a/server/modules/providers/list/claude/claude-runtime.provider.js
+++ b/server/modules/providers/list/claude/claude-runtime.provider.js
@@ -1167,6 +1167,20 @@ async function queryClaudeSDK(command, options = {}, ws, context) {
       return;
     }
 
+    // The run's terminal record goes FIRST, before anything that can throw on
+    // the way to it. Everything below talks to the outside world:
+    // `isProviderInstalled()` can reject, and `ws.send()` throws on a socket
+    // that closed while the run was failing. Either one used to jump straight
+    // to `finally`, and the run ended with no terminal record at all -- the
+    // exact blind spot this logging was added to remove, reappearing on the
+    // path where it matters most.
+    logRunEnd({
+      reason: 'error',
+      exitCode: 1,
+      durationMs: Date.now() - runStartedAt,
+      error: error?.message || String(error)
+    });
+
     // Check if Claude CLI is installed for a clearer error message
     const installed = await context.isProviderInstalled();
     const errorContent = !installed
@@ -1177,18 +1191,9 @@ async function queryClaudeSDK(command, options = {}, ws, context) {
     // reported completion and then failed during its post-turn hold still
     // surfaces the error, but must not emit a second terminal complete.
     ws.send(createNormalizedMessage({ kind: 'error', content: errorContent, sessionId: capturedSessionId || sessionId || null, provider: 'claude' }));
-    // The logging sits after the guard on purpose: it belongs to the RUN, not
-    // to the client-facing message, and runEndLogged gives it its own
-    // exactly-once guarantee.
     if (!turnCompleteSent) {
       ws.send(createCompleteMessage({ provider: 'claude', sessionId: capturedSessionId || sessionId || null, exitCode: 1 }));
     }
-    logRunEnd({
-      reason: 'error',
-      exitCode: 1,
-      durationMs: Date.now() - runStartedAt,
-      error: error?.message || String(error)
-    });
     notifyRunFailed({
       userId: ws?.userId || null,
       provider: 'claude',
@@ -1197,6 +1202,24 @@ async function queryClaudeSDK(command, options = {}, ws, context) {
       error
     });
   } finally {
+    // Last resort, and it runs FIRST here on purpose: every path above either
+    // records its own outcome or throws on the way there. A throw inside the
+    // catch block itself has no other place left to be noticed, and a run that
+    // ends without any terminal record is indistinguishable from one that is
+    // still going. `runEndLogged` keeps this from ever double-counting a run
+    // that already reported properly.
+    //
+    // `logRunStart()` comes first so the net cannot itself produce the shape
+    // 67bae5cd removed -- a `run_end` with no matching `run_start`. Today no
+    // path reaches here unstarted; stating it here keeps that true when the
+    // paths above change.
+    logRunStart();
+    logRunEnd({
+      reason: 'unknown',
+      exitCode: null,
+      durationMs: Date.now() - runStartedAt
+    });
+
     // Always close stdin — otherwise an aborted or failed run leaves the CLI
     // process (and its MCP servers) alive until the server exits.
     if (idleReleaseTimer) {

--- a/server/modules/providers/list/claude/claude-runtime.provider.js
+++ b/server/modules/providers/list/claude/claude-runtime.provider.js
@@ -146,6 +146,43 @@ function redactCliStderr(text) {
  * @param {string} line - One raw stderr line, already trimmed.
  * @returns {string} The line to hand to the logger.
  */
+// A PEM block spans many lines: a header, then base64 body lines that carry
+// the actual key material, then a footer. The single-line pattern above only
+// ever sees the header, so redacting line by line would blank the header and
+// print the key underneath it -- the worst of both worlds, because the log
+// then *looks* redacted.
+const PEM_BEGIN = /-----BEGIN[^-]{0,40}PRIVATE KEY-----/;
+const PEM_END = /-----END[^-]{0,40}PRIVATE KEY-----/;
+const PEM_PLACEHOLDER = '<redacted private key>';
+
+/**
+ * Formats stderr lines, suppressing whole PEM private-key blocks.
+ *
+ * Stateful by necessity: whether a base64 line is key material or ordinary
+ * output cannot be decided from the line itself. The state lives per run and
+ * dies with it.
+ *
+ * @param {() => string} sessionTag - Supplies the current session tag.
+ * @returns {(line: string) => string} Formatter for one stderr line.
+ */
+function createCliStderrFormatter(sessionTag) {
+  let insidePem = false;
+  return (line) => {
+    if (insidePem) {
+      if (PEM_END.test(line)) {
+        insidePem = false;
+      }
+      return formatCliStderrLine(sessionTag(), PEM_PLACEHOLDER);
+    }
+    if (PEM_BEGIN.test(line)) {
+      // A line carrying the whole block at once closes it again immediately.
+      insidePem = !PEM_END.test(line);
+      return formatCliStderrLine(sessionTag(), PEM_PLACEHOLDER);
+    }
+    return formatCliStderrLine(sessionTag(), line);
+  };
+}
+
 /**
  * Reassembles complete lines from raw stderr chunks.
  *
@@ -1031,6 +1068,9 @@ async function queryClaudeSDK(command, options = {}, ws, context) {
 
     // Forward the CLI child's stderr into the service log; see the limits
     // documented at CLI_STDERR_MAX_LINE_CHARS above.
+    // Per-run PEM state; see createCliStderrFormatter.
+    const formatStderrLine = createCliStderrFormatter(sessionTag);
+
     // One place where a finished line is emitted, used by both the streaming
     // path and the flush during cleanup. Two code paths for the same job are
     // how a redaction rule ends up applied in one of them and not the other.
@@ -1052,7 +1092,7 @@ async function queryClaudeSDK(command, options = {}, ws, context) {
         return;
       }
       stderrLinesInWindow += 1;
-      console.error(formatCliStderrLine(sessionTag(), line));
+      console.error(formatStderrLine(line));
     };
 
     stderrChunker = createCliStderrChunker(emitStderrLine);
@@ -1555,6 +1595,7 @@ export const claudeRuntime = {
 export {
   resolveRunEndOutcome,
   createCliStderrChunker,
+  createCliStderrFormatter,
   formatCliStderrLine,
   queryClaudeSDK,
   abortClaudeSDKSession,

--- a/server/modules/providers/list/claude/claude-runtime.provider.js
+++ b/server/modules/providers/list/claude/claude-runtime.provider.js
@@ -231,6 +231,67 @@ function createCliStderrChunker(emit, maxPending = CLI_STDERR_MAX_PENDING_CHARS)
   };
 }
 
+/**
+ * Rate-limits CLI stderr without letting the redaction state fall behind.
+ *
+ * The throttle and the PEM-block formatter are each correct on their own. The
+ * bug lived at their handover: the formatter used to be called only for lines
+ * that survived the throttle, so a suppressed END marker left `insidePem`
+ * stuck and every later line of the run came out as the placeholder. State
+ * must advance for EVERY line; only the writing is rate-limited.
+ *
+ * Kept as a factory for the same reason as the chunker above: this is state
+ * that is easy to get subtly wrong and impossible to see afterwards in a log
+ * that looks plausible.
+ *
+ * @param {object} deps
+ * @param {(line: string) => string} deps.format - Stateful line formatter.
+ * @param {(text: string) => void} deps.sink - Receives lines that pass.
+ * @param {(dropped: number) => void} deps.throttleNotice - Reports losses.
+ * @param {() => number} [deps.now] - Clock, injectable for tests.
+ * @returns {{push: (line: string) => void, flushDropped: () => void}}
+ */
+function createCliStderrEmitter({ format, sink, throttleNotice, now = Date.now }) {
+  let windowStart = 0;
+  let linesInWindow = 0;
+  let dropped = 0;
+
+  // A throttle that hides its own losses is a log that lies.
+  const flushDropped = () => {
+    if (dropped > 0) {
+      throttleNotice(dropped);
+      dropped = 0;
+    }
+  };
+
+  const push = (rawLine) => {
+    const line = String(rawLine ?? '').trim();
+    if (!line) {
+      return;
+    }
+    // BEFORE the throttle, unconditionally: the formatter carries the PEM
+    // block state across lines. Skipping it for a dropped line would lose the
+    // END marker and silently redact the rest of the run.
+    const formatted = format(line);
+    const stamp = now();
+    if (stamp - windowStart >= CLI_STDERR_WINDOW_MS) {
+      // Report what the previous window swallowed before opening a new one.
+      flushDropped();
+      windowStart = stamp;
+      linesInWindow = 0;
+    }
+    if (linesInWindow >= CLI_STDERR_MAX_LINES_PER_WINDOW) {
+      dropped += 1;
+      return;
+    }
+    linesInWindow += 1;
+    sink(formatted);
+  };
+
+  return { push, flushDropped };
+}
+
+
 function formatCliStderrLine(sessionTag, line) {
   const safe = redactCliStderr(line);
   const capped = safe.length > CLI_STDERR_MAX_LINE_CHARS
@@ -930,17 +991,9 @@ async function queryClaudeSDK(command, options = {}, ws, context) {
   // Short, greppable session tag for the CLI stderr lines below.
   const sessionTag = () => String(sessionKey() || 'unknown').slice(0, 8);
   // Rate-limit state for CLI stderr. Scoped to this run, dies with this run.
-  let stderrWindowStart = 0;
-  let stderrLinesInWindow = 0;
-  let stderrDropped = 0;
-  // Assigned once the SDK options are built; the cleanup path needs it.
+  // Assigned once the SDK options are built; the cleanup path needs both.
   let stderrChunker = null;
-  const flushStderrDropped = () => {
-    if (stderrDropped > 0) {
-      console.error(`[claude-cli-stderr] ${sessionTag()} [throttled ${stderrDropped}]`);
-      stderrDropped = 0;
-    }
-  };
+  let stderrEmitter = null;
   // Wall-clock start of this run, so every run_end can report a duration.
   const runStartedAt = Date.now();
   // Identifies THIS run, not the conversation. `sessionKey` cannot do that job:
@@ -1074,28 +1127,15 @@ async function queryClaudeSDK(command, options = {}, ws, context) {
     // One place where a finished line is emitted, used by both the streaming
     // path and the flush during cleanup. Two code paths for the same job are
     // how a redaction rule ends up applied in one of them and not the other.
-    const emitStderrLine = (rawLine) => {
-      const line = rawLine.trim();
-      if (!line) {
-        return;
-      }
-      const now = Date.now();
-      if (now - stderrWindowStart >= CLI_STDERR_WINDOW_MS) {
-        // Report what the previous window swallowed before opening a new one.
-        // A throttle that hides its own losses is a log that lies.
-        flushStderrDropped();
-        stderrWindowStart = now;
-        stderrLinesInWindow = 0;
-      }
-      if (stderrLinesInWindow >= CLI_STDERR_MAX_LINES_PER_WINDOW) {
-        stderrDropped += 1;
-        return;
-      }
-      stderrLinesInWindow += 1;
-      console.error(formatStderrLine(line));
-    };
+    stderrEmitter = createCliStderrEmitter({
+      format: formatStderrLine,
+      sink: (text) => console.error(text),
+      throttleNotice: (dropped) => console.error(
+        `[claude-cli-stderr] ${sessionTag()} [throttled ${dropped}]`,
+      ),
+    });
 
-    stderrChunker = createCliStderrChunker(emitStderrLine);
+    stderrChunker = createCliStderrChunker(stderrEmitter.push);
     sdkOptions.stderr = (data) => stderrChunker.push(data);
 
     sdkOptions.hooks = {
@@ -1480,7 +1520,7 @@ async function queryClaudeSDK(command, options = {}, ws, context) {
     stderrChunker?.flush();
     // A run that ends while its throttle window is still open would otherwise
     // carry the dropped-line count to the grave.
-    flushStderrDropped();
+    stderrEmitter?.flushDropped();
     releasePromptStream();
   }
 }
@@ -1595,6 +1635,7 @@ export const claudeRuntime = {
 export {
   resolveRunEndOutcome,
   createCliStderrChunker,
+  createCliStderrEmitter,
   createCliStderrFormatter,
   formatCliStderrLine,
   queryClaudeSDK,

--- a/server/modules/providers/list/claude/claude-runtime.provider.js
+++ b/server/modules/providers/list/claude/claude-runtime.provider.js
@@ -103,6 +103,10 @@ const ULTRACODE_SDK_EFFORT = 'xhigh';
 const CLI_STDERR_MAX_LINE_CHARS = 500;
 const CLI_STDERR_MAX_LINES_PER_WINDOW = 50;
 const CLI_STDERR_WINDOW_MS = 60 * 1000;
+// Upper bound on a partial line held back between chunks. The SDK forwards raw
+// `data` events, so a logical line can arrive in pieces; without a bound, a
+// stream that never emits a newline would grow this buffer without limit.
+const CLI_STDERR_MAX_PENDING_CHARS = 8 * 1024;
 
 // Redaction runs BEFORE truncation. Truncating first can cut a secret in half
 // and leave the tail in place: the pattern no longer matches, so the filter
@@ -142,6 +146,54 @@ function redactCliStderr(text) {
  * @param {string} line - One raw stderr line, already trimmed.
  * @returns {string} The line to hand to the logger.
  */
+/**
+ * Reassembles complete lines from raw stderr chunks.
+ *
+ * The SDK forwards the child's `stderr` `data` events verbatim — it calls
+ * `options.stderr` straight from the data handler, with no line framing. A
+ * logical line can therefore arrive split across two chunks, and a secret
+ * split that way slips past redaction because neither half matches the
+ * pattern on its own.
+ *
+ * Kept as a factory so the buffering is testable on its own: this is exactly
+ * the kind of state that is easy to get subtly wrong and impossible to see
+ * afterwards in a log that looks plausible.
+ *
+ * @param {(line: string) => void} emit - Receives each complete line.
+ * @param {number} [maxPending] - Cap on a held-back fragment.
+ * @returns {{push: (chunk: string) => void, flush: () => void}}
+ */
+function createCliStderrChunker(emit, maxPending = CLI_STDERR_MAX_PENDING_CHARS) {
+  let pending = '';
+  return {
+    push(chunk) {
+      pending += String(chunk ?? '');
+      // A stream that never emits a newline must not grow this buffer forever.
+      // Flushing early can in principle split a secret, but at this size that
+      // needs a line two orders of magnitude longer than any credential
+      // format — unbounded memory is the worse failure.
+      if (pending.length > maxPending && !pending.includes('\n')) {
+        emit(pending);
+        pending = '';
+        return;
+      }
+      const parts = pending.split('\n');
+      pending = parts.pop() ?? '';
+      for (const line of parts) {
+        emit(line);
+      }
+    },
+    // Anything still buffered is a real line; it just never got its newline
+    // before the run ended.
+    flush() {
+      if (pending) {
+        emit(pending);
+        pending = '';
+      }
+    },
+  };
+}
+
 function formatCliStderrLine(sessionTag, line) {
   const safe = redactCliStderr(line);
   const capped = safe.length > CLI_STDERR_MAX_LINE_CHARS
@@ -844,6 +896,8 @@ async function queryClaudeSDK(command, options = {}, ws, context) {
   let stderrWindowStart = 0;
   let stderrLinesInWindow = 0;
   let stderrDropped = 0;
+  // Assigned once the SDK options are built; the cleanup path needs it.
+  let stderrChunker = null;
   const flushStderrDropped = () => {
     if (stderrDropped > 0) {
       console.error(`[claude-cli-stderr] ${sessionTag()} [throttled ${stderrDropped}]`);
@@ -977,7 +1031,14 @@ async function queryClaudeSDK(command, options = {}, ws, context) {
 
     // Forward the CLI child's stderr into the service log; see the limits
     // documented at CLI_STDERR_MAX_LINE_CHARS above.
-    sdkOptions.stderr = (data) => {
+    // One place where a finished line is emitted, used by both the streaming
+    // path and the flush during cleanup. Two code paths for the same job are
+    // how a redaction rule ends up applied in one of them and not the other.
+    const emitStderrLine = (rawLine) => {
+      const line = rawLine.trim();
+      if (!line) {
+        return;
+      }
       const now = Date.now();
       if (now - stderrWindowStart >= CLI_STDERR_WINDOW_MS) {
         // Report what the previous window swallowed before opening a new one.
@@ -986,19 +1047,16 @@ async function queryClaudeSDK(command, options = {}, ws, context) {
         stderrWindowStart = now;
         stderrLinesInWindow = 0;
       }
-      for (const rawLine of String(data ?? '').split('\n')) {
-        const line = rawLine.trim();
-        if (!line) {
-          continue;
-        }
-        if (stderrLinesInWindow >= CLI_STDERR_MAX_LINES_PER_WINDOW) {
-          stderrDropped += 1;
-          continue;
-        }
-        stderrLinesInWindow += 1;
-        console.error(formatCliStderrLine(sessionTag(), line));
+      if (stderrLinesInWindow >= CLI_STDERR_MAX_LINES_PER_WINDOW) {
+        stderrDropped += 1;
+        return;
       }
+      stderrLinesInWindow += 1;
+      console.error(formatCliStderrLine(sessionTag(), line));
     };
+
+    stderrChunker = createCliStderrChunker(emitStderrLine);
+    sdkOptions.stderr = (data) => stderrChunker.push(data);
 
     sdkOptions.hooks = {
       Notification: [{
@@ -1377,6 +1435,9 @@ async function queryClaudeSDK(command, options = {}, ws, context) {
       clearTimeout(idleReleaseTimer);
       idleReleaseTimer = null;
     }
+    // Anything still buffered is a real line the CLI wrote; it just never got
+    // its newline before the run ended.
+    stderrChunker?.flush();
     // A run that ends while its throttle window is still open would otherwise
     // carry the dropped-line count to the grave.
     flushStderrDropped();
@@ -1493,6 +1554,7 @@ export const claudeRuntime = {
 // Export public API
 export {
   resolveRunEndOutcome,
+  createCliStderrChunker,
   formatCliStderrLine,
   queryClaudeSDK,
   abortClaudeSDKSession,

--- a/server/modules/providers/list/claude/claude-runtime.provider.js
+++ b/server/modules/providers/list/claude/claude-runtime.provider.js
@@ -107,6 +107,13 @@ const CLI_STDERR_WINDOW_MS = 60 * 1000;
 // `data` events, so a logical line can arrive in pieces; without a bound, a
 // stream that never emits a newline would grow this buffer without limit.
 const CLI_STDERR_MAX_PENDING_CHARS = 8 * 1024;
+// How much of an oversized, newline-less fragment survives an overflow
+// discard. A PEM header's longest possible match (see PEM_BEGIN below) is
+// well under 100 chars; keeping this much of the tail means a header that
+// started forming right at the discard boundary can still complete once the
+// rest of it arrives, instead of vanishing along with the rest of the
+// discarded fragment.
+const CLI_STDERR_OVERFLOW_TAIL_CHARS = 128;
 
 // Redaction runs BEFORE truncation. Truncating first can cut a secret in half
 // and leave the tail in place: the pattern no longer matches, so the filter
@@ -208,22 +215,41 @@ function createCliStderrFormatter(sessionTag) {
  * the kind of state that is easy to get subtly wrong and impossible to see
  * afterwards in a log that looks plausible.
  *
+ * The overflow branch used to hand the whole oversized fragment to `emit()`
+ * as if it were a complete line, then reset to `''`. If a PEM header started
+ * forming right at the cut, that fragment is an incomplete header the
+ * formatter's PEM_BEGIN regex correctly does not match -- and resetting to
+ * `''` throws the incomplete header away for good, so the formatter's
+ * `insidePem` state never turns on and the real key-body lines that follow
+ * pass through unredacted. Keeping a short, bounded tail instead of
+ * discarding everything means that header can still complete.
+ *
  * @param {(line: string) => void} emit - Receives each complete line.
  * @param {number} [maxPending] - Cap on a held-back fragment.
+ * @param {(discardedChars: number) => void} [onOverflow] - Told how many
+ *   characters of an oversized, newline-less fragment were dropped. Silence
+ *   here would mean an operator has no way to learn that some stderr bytes
+ *   never reached the log at all.
  * @returns {{push: (chunk: string) => void, flush: () => void}}
  */
-function createCliStderrChunker(emit, maxPending = CLI_STDERR_MAX_PENDING_CHARS) {
+function createCliStderrChunker(
+  emit,
+  maxPending = CLI_STDERR_MAX_PENDING_CHARS,
+  onOverflow = () => {},
+) {
   let pending = '';
   return {
     push(chunk) {
       pending += String(chunk ?? '');
       // A stream that never emits a newline must not grow this buffer forever.
-      // Flushing early can in principle split a secret, but at this size that
-      // needs a line two orders of magnitude longer than any credential
-      // format — unbounded memory is the worse failure.
+      // Discarding down to a short tail -- instead of to '' -- bounds memory
+      // the same way while still letting a PEM header that straddles the cut
+      // complete once the rest of it arrives (see the tail-size comment on
+      // CLI_STDERR_OVERFLOW_TAIL_CHARS).
       if (pending.length > maxPending && !pending.includes('\n')) {
-        emit(pending);
-        pending = '';
+        const kept = Math.min(pending.length, CLI_STDERR_OVERFLOW_TAIL_CHARS);
+        onOverflow(pending.length - kept);
+        pending = pending.slice(-kept);
         return;
       }
       const parts = pending.split('\n');
@@ -1147,7 +1173,13 @@ async function queryClaudeSDK(command, options = {}, ws, context) {
       ),
     });
 
-    stderrChunker = createCliStderrChunker(stderrEmitter.push);
+    stderrChunker = createCliStderrChunker(
+      stderrEmitter.push,
+      undefined,
+      (discardedChars) => console.error(
+        `[claude-cli-stderr] ${sessionTag()} [oversized line: discarded ${discardedChars} chars without a newline]`,
+      ),
+    );
     sdkOptions.stderr = (data) => stderrChunker.push(data);
 
     sdkOptions.hooks = {

--- a/server/modules/providers/list/claude/claude-runtime.provider.js
+++ b/server/modules/providers/list/claude/claude-runtime.provider.js
@@ -789,6 +789,29 @@ async function queryClaudeSDK(command, options = {}, ws, context) {
   // Hoisted above the try so the catch's cleanup can tell whether this run
   // still owns the activeSessions entry (or was superseded by a newer run).
   let queryInstance = null;
+  // Hoisted so the catch path can still report what was resolved when setup
+  // failed part-way through.
+  let sdkOptions = null;
+  // Guarantees a run_start for every run_end. The record is emitted where its
+  // payload is complete -- but everything above that point can throw, and a
+  // run_end without a matching run_start reads like a run that started before
+  // the log did. That is exactly the confusion this logging exists to remove.
+  let runStartLogged = false;
+  const logRunStart = () => {
+    if (runStartLogged) {
+      return;
+    }
+    runStartLogged = true;
+    logRunLifecycle('run_start', {
+      sessionKey: sessionKey(),
+      providerSessionId: providerSessionId || null,
+      // A run either resumes a known provider session or creates a new one.
+      resumed: Boolean(providerSessionId),
+      userId: ws?.userId || null,
+      model: sdkOptions?.model || null,
+      permissionMode: sdkOptions?.permissionMode || null
+    });
+  };
 
   try {
     const resolvedModel = await context.resolveResumeModel(sessionId, options.model);
@@ -799,7 +822,7 @@ async function queryClaudeSDK(command, options = {}, ws, context) {
       console.warn('[Claude SDK] Unable to load provider models for effort validation:', error);
     }
 
-    const sdkOptions = mapCliOptionsToSDK({
+    sdkOptions = mapCliOptionsToSDK({
       ...options,
       providerSessionId,
       model: resolvedModel || options.model,
@@ -952,15 +975,7 @@ async function queryClaudeSDK(command, options = {}, ws, context) {
     }
 
     // Process streaming messages
-    logRunLifecycle('run_start', {
-      sessionKey: sessionKey(),
-      providerSessionId: providerSessionId || null,
-      // A run either resumes a known provider session or creates a new one.
-      resumed: Boolean(providerSessionId),
-      userId: ws?.userId || null,
-      model: sdkOptions.model || null,
-      permissionMode: sdkOptions.permissionMode || null
-    });
+    logRunStart();
     for await (const message of queryInstance) {
       // Capture session ID from first message
       if (message.session_id && !capturedSessionId) {
@@ -1105,6 +1120,9 @@ async function queryClaudeSDK(command, options = {}, ws, context) {
 
   } catch (error) {
     console.error('SDK query error:', error);
+
+    // Setup may have thrown before the run_start above was reached.
+    logRunStart();
 
     // Clean up session on error — only while this run still owns the map entry
     // (a superseding run may have replaced it).

--- a/server/modules/providers/tests/claude-cli-stderr.test.ts
+++ b/server/modules/providers/tests/claude-cli-stderr.test.ts
@@ -1,7 +1,10 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 
-import { formatCliStderrLine } from '@/modules/providers/list/claude/claude-runtime.provider.js';
+import {
+  createCliStderrChunker,
+  formatCliStderrLine,
+} from '@/modules/providers/list/claude/claude-runtime.provider.js';
 
 const TAG = 'abc12345';
 
@@ -73,4 +76,69 @@ test('claude cli stderr: a secret straddling the cut is still redacted', () => {
 
   assert.ok(!out.includes('sk-ant-aaaaaaaaaaaaaaaa'));
   assert.ok(out.includes('<redacted>'));
+});
+
+// --- chunk reassembly ------------------------------------------------------
+//
+// The SDK forwards raw `data` events, so these are the cases that decide
+// whether redaction can be bypassed by nothing more than unlucky timing.
+
+test('claude cli stderr: a line split across chunks is reassembled', () => {
+  const seen: string[] = [];
+  const chunker = createCliStderrChunker((line) => seen.push(line));
+
+  chunker.push('Error: ENOENT: no such ');
+  assert.deepEqual(seen, [], 'nothing may be emitted before the newline');
+  chunker.push('file or directory\n');
+
+  assert.deepEqual(seen, ['Error: ENOENT: no such file or directory']);
+});
+
+test('claude cli stderr: a secret split across chunks is still redacted', () => {
+  const seen: string[] = [];
+  const chunker = createCliStderrChunker((line) => seen.push(formatCliStderrLine('tag', line)));
+
+  // Neither half matches the pattern on its own — that is the whole point.
+  chunker.push('auth: sk-ant-abcdefgh');
+  chunker.push('ijklmnopqrstuvwxyz0123\n');
+
+  assert.equal(seen.length, 1);
+  assert.ok(seen[0].includes('<redacted>'));
+  assert.ok(!seen[0].includes('sk-ant-abcdefghijklmnopqrstuvwxyz0123'));
+});
+
+test('claude cli stderr: several lines in one chunk all come through', () => {
+  const seen: string[] = [];
+  const chunker = createCliStderrChunker((line) => seen.push(line));
+
+  chunker.push('one\ntwo\nthree\n');
+
+  assert.deepEqual(seen, ['one', 'two', 'three']);
+});
+
+test('claude cli stderr: the trailing fragment is flushed, not lost', () => {
+  const seen: string[] = [];
+  const chunker = createCliStderrChunker((line) => seen.push(line));
+
+  chunker.push('a complete line\nand a dangling one');
+  assert.deepEqual(seen, ['a complete line']);
+
+  chunker.flush();
+  assert.deepEqual(seen, ['a complete line', 'and a dangling one']);
+
+  // Flushing twice must not emit the fragment again.
+  chunker.flush();
+  assert.equal(seen.length, 2);
+});
+
+test('claude cli stderr: a newline-less stream does not buffer without bound', () => {
+  const seen: string[] = [];
+  const chunker = createCliStderrChunker((line) => seen.push(line), 32);
+
+  chunker.push('x'.repeat(20));
+  assert.deepEqual(seen, [], 'below the cap it keeps buffering');
+
+  chunker.push('y'.repeat(20));
+  assert.equal(seen.length, 1, 'above the cap it gives up and emits');
+  assert.equal(seen[0].length, 40);
 });

--- a/server/modules/providers/tests/claude-cli-stderr.test.ts
+++ b/server/modules/providers/tests/claude-cli-stderr.test.ts
@@ -89,7 +89,7 @@ test('claude cli stderr: a line split across chunks is reassembled', () => {
   const chunker = createCliStderrChunker((line) => seen.push(line));
 
   chunker.push('Error: ENOENT: no such ');
-  assert.deepEqual(seen, [], 'nothing may be emitted before the newline');
+  assert.equal(seen.length, 0, 'nothing may be emitted before the newline');
   chunker.push('file or directory\n');
 
   assert.deepEqual(seen, ['Error: ENOENT: no such file or directory']);
@@ -137,7 +137,7 @@ test('claude cli stderr: a newline-less stream does not buffer without bound', (
   const chunker = createCliStderrChunker((line) => seen.push(line), 32);
 
   chunker.push('x'.repeat(20));
-  assert.deepEqual(seen, [], 'below the cap it keeps buffering');
+  assert.equal(seen.length, 0, 'below the cap it keeps buffering');
 
   chunker.push('y'.repeat(20));
   assert.equal(seen.length, 1, 'above the cap it gives up and emits');

--- a/server/modules/providers/tests/claude-cli-stderr.test.ts
+++ b/server/modules/providers/tests/claude-cli-stderr.test.ts
@@ -3,6 +3,7 @@ import test from 'node:test';
 
 import {
   createCliStderrChunker,
+  createCliStderrEmitter,
   createCliStderrFormatter,
   formatCliStderrLine,
 } from '@/modules/providers/list/claude/claude-runtime.provider.js';
@@ -186,4 +187,98 @@ test('claude cli stderr: a one-line PEM block does not swallow what follows', ()
 
   assert.ok(oneLine.includes('<redacted private key>'));
   assert.equal(after, '[claude-cli-stderr] tag ordinary diagnostics');
+});
+
+// --- The handover between throttle and PEM state ---------------------------
+//
+// Two mechanisms, each correct on its own. The bug lived where they meet: the
+// formatter used to run only for lines the throttle let through, so a
+// suppressed END marker left the block state stuck open for the rest of the
+// run. These tests pin both directions — the state must advance for every
+// line, and it must still redact what genuinely belongs to the block.
+
+/** Builds an emitter with a hand-driven clock, so a window can be closed
+ *  without waiting a real minute. */
+function emitterHarness() {
+  const written: string[] = [];
+  const notices: number[] = [];
+  let clock = 1_000;
+  const emitter = createCliStderrEmitter({
+    format: createCliStderrFormatter(() => 'tag'),
+    sink: (text: string) => { written.push(text); },
+    throttleNotice: (dropped: number) => { notices.push(dropped); },
+    now: () => clock,
+  });
+  return {
+    written,
+    notices,
+    push: (line: string) => emitter.push(line),
+    flushDropped: () => emitter.flushDropped(),
+    advance: (ms: number) => { clock += ms; },
+  };
+}
+
+test('claude cli stderr: a throttled END marker does not redact the rest of the run', () => {
+  const h = emitterHarness();
+
+  h.push('-----BEGIN PRIVATE KEY-----');
+  // Fill the window. Everything here is inside the block, so it is redacted
+  // where it is written at all; the point is that the window ends full.
+  for (let i = 0; i < 60; i += 1) h.push(`keyMaterialLine${i}`);
+  // This is the line that used to be lost: dropped by the throttle, and with
+  // it the state transition that closes the block.
+  h.push('-----END PRIVATE KEY-----');
+
+  assert.ok(h.notices.length === 0, 'losses are reported at the window boundary, not before');
+
+  h.advance(61_000);
+  h.push('Error: ENOENT: no such file or directory');
+
+  const last = h.written[h.written.length - 1];
+  // Exact equality, not "does not contain the placeholder": a weaker assertion
+  // would also pass if the formatting drifted.
+  assert.equal(last, '[claude-cli-stderr] tag Error: ENOENT: no such file or directory');
+  // The dropped lines are still accounted for: 62 pushed (BEGIN + 60 + END),
+  // 50 fit in the window, 12 were dropped.
+  assert.deepEqual(h.notices, [12]);
+});
+
+test('claude cli stderr: a throttled body line stays redacted when the block is still open', () => {
+  const h = emitterHarness();
+
+  h.push('-----BEGIN PRIVATE KEY-----');
+  for (let i = 0; i < 60; i += 1) h.push(`filler${i}`);
+  // Still INSIDE the block — no END marker anywhere. The window rolls over,
+  // and the next line must remain suppressed.
+  h.advance(61_000);
+  h.push('MIIEowIBAAKCAQEAxRealKeyMaterialAfterTheWindow');
+
+  const last = h.written[h.written.length - 1];
+  assert.equal(last, '[claude-cli-stderr] tag <redacted private key>');
+  assert.ok(!h.written.join('\n').includes('MIIEowIBAAKCAQEAxRealKeyMaterialAfterTheWindow'));
+});
+
+test('claude cli stderr: the run-end flush still reports what the throttle swallowed', () => {
+  const h = emitterHarness();
+
+  for (let i = 0; i < 60; i += 1) h.push(`line${i}`);
+  assert.equal(h.notices.length, 0);
+
+  // The run ends with the window still open; the count must not go to the grave.
+  h.flushDropped();
+  assert.deepEqual(h.notices, [10]);
+
+  // Flushing twice must not invent a second report.
+  h.flushDropped();
+  assert.deepEqual(h.notices, [10]);
+});
+
+test('claude cli stderr: blank lines are ignored and do not consume the window', () => {
+  const h = emitterHarness();
+
+  h.push('   ');
+  h.push('');
+  h.push('real line');
+
+  assert.deepEqual(h.written, ['[claude-cli-stderr] tag real line']);
 });

--- a/server/modules/providers/tests/claude-cli-stderr.test.ts
+++ b/server/modules/providers/tests/claude-cli-stderr.test.ts
@@ -3,6 +3,7 @@ import test from 'node:test';
 
 import {
   createCliStderrChunker,
+  createCliStderrFormatter,
   formatCliStderrLine,
 } from '@/modules/providers/list/claude/claude-runtime.provider.js';
 
@@ -141,4 +142,48 @@ test('claude cli stderr: a newline-less stream does not buffer without bound', (
   chunker.push('y'.repeat(20));
   assert.equal(seen.length, 1, 'above the cap it gives up and emits');
   assert.equal(seen[0].length, 40);
+});
+
+// --- PEM blocks ------------------------------------------------------------
+
+test('claude cli stderr: a whole PEM block is suppressed, not just its header', () => {
+  const out: string[] = [];
+  const format = createCliStderrFormatter(() => 'tag');
+
+  const block = [
+    '-----BEGIN RSA PRIVATE KEY-----',
+    'MIIEowIBAAKCAQEAxKeyMaterialLine1',
+    'AAAAB3NzaC1yc2EAAAADAQABAAABgQKeyMaterialLine2',
+    '-----END RSA PRIVATE KEY-----',
+  ];
+  for (const line of block) out.push(format(line));
+
+  assert.equal(out.length, 4);
+  for (const line of out) {
+    assert.ok(line.includes('<redacted private key>'), `leaked: ${line}`);
+  }
+  assert.ok(!out.join('\n').includes('MIIEowIBAAKCAQEAxKeyMaterialLine1'));
+  assert.ok(!out.join('\n').includes('AAAAB3NzaC1yc2EAAAADAQABAAABgQKeyMaterialLine2'));
+});
+
+test('claude cli stderr: output after the END marker is readable again', () => {
+  const format = createCliStderrFormatter(() => 'tag');
+
+  format('-----BEGIN PRIVATE KEY-----');
+  format('bodyLineThatMustNotAppear');
+  format('-----END PRIVATE KEY-----');
+  const after = format('Error: ENOENT: no such file or directory');
+
+  assert.equal(after, '[claude-cli-stderr] tag Error: ENOENT: no such file or directory');
+  assert.ok(!after.includes('<redacted private key>'));
+});
+
+test('claude cli stderr: a one-line PEM block does not swallow what follows', () => {
+  const format = createCliStderrFormatter(() => 'tag');
+
+  const oneLine = format('-----BEGIN PRIVATE KEY----- abc -----END PRIVATE KEY-----');
+  const after = format('ordinary diagnostics');
+
+  assert.ok(oneLine.includes('<redacted private key>'));
+  assert.equal(after, '[claude-cli-stderr] tag ordinary diagnostics');
 });

--- a/server/modules/providers/tests/claude-cli-stderr.test.ts
+++ b/server/modules/providers/tests/claude-cli-stderr.test.ts
@@ -1,0 +1,76 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { formatCliStderrLine } from '@/modules/providers/list/claude/claude-runtime.provider.js';
+
+const TAG = 'abc12345';
+
+// The line this whole channel exists for. If it ever stops passing through
+// intact, a run ended by the background-wait ceiling goes back to looking like
+// a run that vanished for no reason.
+test('claude cli stderr: the wind-down message survives formatting intact', () => {
+  const line = 'Background tasks still running after 1800s; terminating. '
+    + 'Set CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS=0 to wait indefinitely.';
+
+  const out = formatCliStderrLine(TAG, line);
+
+  assert.ok(out.startsWith(`[claude-cli-stderr] ${TAG} `));
+  assert.ok(out.includes('Background tasks still running after 1800s'));
+  assert.ok(out.includes('terminating'));
+});
+
+test('claude cli stderr: secret-shaped runs are redacted', () => {
+  const cases = [
+    'spawn failed: ANTHROPIC_API_KEY=sk-ant-abcdefghijklmnopqrstuvwxyz0123',
+    'GET https://api.telegram.org/bot123456:AAHfakefaketoken/getUpdates failed',
+    'auth header: Bearer ghp_AAAABBBBCCCCDDDDEEEEFFFF0123',
+    'env: AWS key AKIAIOSFODNN7EXAMPLE rejected',
+  ];
+
+  for (const input of cases) {
+    const out = formatCliStderrLine(TAG, input);
+    assert.ok(out.includes('<redacted>'), `not redacted: ${input}`);
+    assert.ok(!out.includes('sk-ant-abcdefghijklmnopqrstuvwxyz0123'));
+    assert.ok(!out.includes('AAHfakefaketoken'));
+    assert.ok(!out.includes('ghp_AAAABBBBCCCCDDDDEEEEFFFF0123'));
+  }
+});
+
+// The counter-direction. A filter that redacts everything is as useless as one
+// that redacts nothing — it would quietly destroy the diagnostics this channel
+// was opened for.
+test('claude cli stderr: ordinary diagnostics pass through untouched', () => {
+  const line = 'Error: ENOENT: no such file or directory, open /tmp/does-not-exist';
+
+  const out = formatCliStderrLine(TAG, line);
+
+  assert.equal(out, `[claude-cli-stderr] ${TAG} ${line}`);
+  assert.ok(!out.includes('<redacted>'));
+});
+
+test('claude cli stderr: long lines are capped, short ones are not', () => {
+  const long = 'x'.repeat(4000);
+  const short = 'x'.repeat(10);
+
+  const cappedOut = formatCliStderrLine(TAG, long);
+  const shortOut = formatCliStderrLine(TAG, short);
+
+  const prefix = `[claude-cli-stderr] ${TAG} `;
+  assert.equal(cappedOut.slice(prefix.length).length, 500);
+  assert.ok(cappedOut.endsWith('…'));
+  assert.equal(shortOut, `${prefix}${short}`);
+  assert.ok(!shortOut.endsWith('…'));
+});
+
+// Redaction has to run BEFORE truncation. If it ran after, a secret sitting
+// across the cut would lose its tail, stop matching the pattern, and the
+// visible head would be logged in the clear.
+test('claude cli stderr: a secret straddling the cut is still redacted', () => {
+  const secret = `sk-ant-${'a'.repeat(60)}`;
+  const line = `${'p'.repeat(480)} ${secret}`;
+
+  const out = formatCliStderrLine(TAG, line);
+
+  assert.ok(!out.includes('sk-ant-aaaaaaaaaaaaaaaa'));
+  assert.ok(out.includes('<redacted>'));
+});

--- a/server/modules/providers/tests/claude-cli-stderr.test.ts
+++ b/server/modules/providers/tests/claude-cli-stderr.test.ts
@@ -171,16 +171,90 @@ test('claude cli stderr: the trailing fragment is flushed, not lost', () => {
   assert.equal(seen.length, 2);
 });
 
+// An oversized, newline-less fragment used to be handed to `emit()` as if it
+// were one complete line, then thrown away. That is wrong on both ends: a
+// fragment that never got its newline is not a real line (see the PEM tests
+// below for what that costs), and resetting to '' meant an operator had no
+// way to learn stderr bytes were dropped at all. The fix discards down to a
+// short tail instead of to nothing, and announces the discard.
 test('claude cli stderr: a newline-less stream does not buffer without bound', () => {
   const seen: string[] = [];
-  const chunker = createCliStderrChunker((line) => seen.push(line), 32);
+  const overflows: number[] = [];
+  const chunker = createCliStderrChunker(
+    (line) => seen.push(line),
+    32,
+    (discardedChars) => overflows.push(discardedChars),
+  );
 
   chunker.push('x'.repeat(20));
   assert.equal(seen.length, 0, 'below the cap it keeps buffering');
 
-  chunker.push('y'.repeat(20));
-  assert.equal(seen.length, 1, 'above the cap it gives up and emits');
-  assert.equal(seen[0].length, 40);
+  chunker.push('y'.repeat(200));
+  assert.equal(seen.length, 0, 'an oversized fragment is discarded, not emitted as a line');
+  assert.deepEqual(overflows, [92], '220 buffered chars minus the 128-char tail that is kept');
+});
+
+// The counter-direction, and the reason the discard is a tail-keep rather
+// than a reset to '': dropping to '' also drops a PEM header that started
+// forming right at the cut, so the formatter never turns `insidePem` on for
+// the body lines that follow -- they leak in plain text. Keeping a short
+// tail across the discard means the header can still complete.
+test('claude cli stderr: a PEM header split across the overflow boundary is still detected', () => {
+  const seen: string[] = [];
+  const chunker = createCliStderrChunker((line) => seen.push(line), 50);
+  const format = createCliStderrFormatter(() => 'tag');
+
+  const header = '-----BEGIN PRIVATE KEY-----';
+  const headerFirstHalf = header.slice(0, 15);
+  const headerSecondHalf = header.slice(15);
+
+  // Push enough filler that the header's first half arrives right at the
+  // overflow boundary, with no newline yet -- the exact shape the finding
+  // describes.
+  chunker.push('x'.repeat(200) + headerFirstHalf);
+  assert.equal(seen.length, 0, 'still buffering, nothing to reassemble into a line yet');
+
+  // The rest of the header, plus a key-material body line and the END
+  // marker, arrives in the next chunk.
+  chunker.push(`${headerSecondHalf}\nMIIEsecretKeyMaterial\n-----END PRIVATE KEY-----\nordinary after\n`);
+
+  const formatted = seen.map((line) => format(line));
+
+  assert.ok(
+    formatted[0].includes('<redacted private key>'),
+    `the reassembled header line must be recognised as PEM: ${formatted[0]}`,
+  );
+  assert.ok(
+    formatted[1].includes('<redacted private key>'),
+    `the body line must be redacted while the block is open: ${formatted[1]}`,
+  );
+  assert.ok(!formatted.join('\n').includes('MIIEsecretKeyMaterial'), 'the key material itself must not appear');
+  assert.equal(formatted[3], '[claude-cli-stderr] tag ordinary after', 'the block must close, not stay stuck open');
+});
+
+// The other half of the same fix: an ordinary oversized line -- no PEM
+// anywhere near it -- must not start looking like key material just because
+// some of it survives the discard, and the run must recover normally once a
+// newline finally arrives.
+test('claude cli stderr: an ordinary oversized line discards cleanly, without false PEM detection', () => {
+  const seen: string[] = [];
+  const overflows: number[] = [];
+  const chunker = createCliStderrChunker(
+    (line) => seen.push(line),
+    50,
+    (discardedChars) => overflows.push(discardedChars),
+  );
+  const format = createCliStderrFormatter(() => 'tag');
+
+  chunker.push('z'.repeat(300));
+  assert.equal(overflows.length, 1);
+  assert.ok(overflows[0] > 0);
+
+  chunker.push('\nordinary diagnostics\n');
+
+  const formatted = seen.map((line) => format(line));
+  assert.ok(!formatted.some((line) => line.includes('<redacted private key>')), 'nothing here is PEM');
+  assert.equal(formatted[formatted.length - 1], '[claude-cli-stderr] tag ordinary diagnostics');
 });
 
 // --- PEM blocks ------------------------------------------------------------

--- a/server/modules/providers/tests/claude-cli-stderr.test.ts
+++ b/server/modules/providers/tests/claude-cli-stderr.test.ts
@@ -53,6 +53,44 @@ test('claude cli stderr: ordinary diagnostics pass through untouched', () => {
   assert.ok(!out.includes('<redacted>'));
 });
 
+// The URL rule below keys on `user:pass@`. A plain URL -- including one with a
+// port, which also contains a colon -- must survive untouched, or the rule
+// would blank exactly the addresses a reader needs to see.
+test('claude cli stderr: URLs without credentials are left alone', () => {
+  for (const line of [
+    'GET https://registry.example.com/pkg failed with 503',
+    'connect ECONNREFUSED http://127.0.0.1:8080/health',
+    'proxy postgres://db.internal:5432/app unreachable',
+  ]) {
+    const out = formatCliStderrLine(TAG, line);
+    assert.equal(out, `[claude-cli-stderr] ${TAG} ${line}`, `wrongly redacted: ${line}`);
+  }
+});
+
+// Opaque credentials with no recognisable prefix: nothing in the token itself
+// marks it as a secret, so the scheme word is the only handle there is.
+test('claude cli stderr: opaque bearer and basic credentials are redacted', () => {
+  const bearer = formatCliStderrLine(TAG, 'auth: Bearer aGVsbG8td29ybGQtb3BhcXVlLXZhbHVl');
+  assert.ok(!bearer.includes('aGVsbG8td29ybGQtb3BhcXVlLXZhbHVl'), bearer);
+  // The scheme word survives -- "Bearer <redacted>" still says what kind of
+  // credential was involved.
+  assert.ok(bearer.includes('Bearer <redacted>'), bearer);
+
+  const basic = formatCliStderrLine(TAG, 'auth: Basic dXNlcjpwYXNzd29yZA==');
+  assert.ok(!basic.includes('dXNlcjpwYXNzd29yZA'), basic);
+  assert.ok(basic.includes('Basic <redacted>'), basic);
+});
+
+// Credentials in URL userinfo. The host is the diagnostic half of the line and
+// must survive -- knowing WHICH registry rejected the login is the point.
+test('claude cli stderr: URL credentials go, the host stays', () => {
+  const out = formatCliStderrLine(TAG, 'npm ERR! https://deploy:hunter2primary@registry.example.com/pkg 401');
+
+  assert.ok(!out.includes('hunter2primary'), out);
+  assert.ok(!out.includes('deploy:'), out);
+  assert.ok(out.includes('https://<redacted>@registry.example.com/pkg'), out);
+});
+
 test('claude cli stderr: long lines are capped, short ones are not', () => {
   const long = 'x'.repeat(4000);
   const short = 'x'.repeat(10);

--- a/server/modules/providers/tests/claude-cli-stderr.test.ts
+++ b/server/modules/providers/tests/claude-cli-stderr.test.ts
@@ -81,6 +81,23 @@ test('claude cli stderr: opaque bearer and basic credentials are redacted', () =
   assert.ok(basic.includes('Basic <redacted>'), basic);
 });
 
+// A four-character credential is still a credential. The old `{8,}` floor
+// let exactly this shape -- short opaque Basic auth -- through unredacted.
+test('claude cli stderr: a short opaque credential is still redacted', () => {
+  const out = formatCliStderrLine(TAG, 'auth: Basic dTpw');
+  assert.ok(!out.includes('dTpw'), out);
+  assert.ok(out.includes('Basic <redacted>'), out);
+});
+
+// "Basic" as an ordinary word, not a scheme, must survive. The pattern only
+// fires on `Basic`/`Bearer` followed by whitespace and a token; punctuation
+// glued directly onto the word never satisfies that, so prose is untouched.
+test('claude cli stderr: "Basic" as a plain word in prose is left alone', () => {
+  const line = 'This tier supports Basic, Standard, and Pro plans.';
+  const out = formatCliStderrLine(TAG, line);
+  assert.equal(out, `[claude-cli-stderr] ${TAG} ${line}`, out);
+});
+
 // Credentials in URL userinfo. The host is the diagnostic half of the line and
 // must survive -- knowing WHICH registry rejected the login is the point.
 test('claude cli stderr: URL credentials go, the host stays', () => {
@@ -89,6 +106,17 @@ test('claude cli stderr: URL credentials go, the host stays', () => {
   assert.ok(!out.includes('hunter2primary'), out);
   assert.ok(!out.includes('deploy:'), out);
   assert.ok(out.includes('https://<redacted>@registry.example.com/pkg'), out);
+});
+
+// A token used AS the username, with no password at all -- a common shape
+// for registry/CI credentials (`https://<token>@host`). No colon anywhere in
+// the userinfo, so the old mandatory `:pass` group let this straight
+// through.
+test('claude cli stderr: a username-only URL credential is redacted, the host stays', () => {
+  const out = formatCliStderrLine(TAG, 'fetch https://build-token@registry.example/pkg failed');
+
+  assert.ok(!out.includes('build-token'), out);
+  assert.ok(out.includes('https://<redacted>@registry.example/pkg'), out);
 });
 
 test('claude cli stderr: long lines are capped, short ones are not', () => {

--- a/server/modules/providers/tests/claude-run-lifecycle.test.ts
+++ b/server/modules/providers/tests/claude-run-lifecycle.test.ts
@@ -1,0 +1,48 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { resolveRunEndOutcome } from '@/modules/providers/list/claude/claude-runtime.provider.js';
+
+// A run that never reported success records the failure as the failure it is.
+test('claude run lifecycle: a plain failure ends as error/1', () => {
+  const out = resolveRunEndOutcome({
+    turnCompleteSent: false,
+    error: new Error('spawn ENOENT'),
+  });
+
+  assert.equal(out.reason, 'error');
+  assert.equal(out.exitCode, 1);
+  assert.equal(out.error, 'spawn ENOENT');
+  assert.equal(out.lateError, undefined);
+});
+
+// The counter-direction, and the reason this function exists: the client was
+// already told the turn completed with exit code 0. Recording error/1 here
+// would leave one run with two terminal outcomes that contradict each other.
+test('claude run lifecycle: a failure after the terminal complete keeps the completed outcome', () => {
+  const out = resolveRunEndOutcome({
+    turnCompleteSent: true,
+    error: new Error('stream closed during post-turn hold'),
+  });
+
+  assert.equal(out.reason, 'completed');
+  assert.equal(out.exitCode, 0);
+  assert.equal(out.lateError, 'stream closed during post-turn hold');
+  // The completed outcome must not carry an `error` field -- that is the field
+  // a reader takes as "this run failed".
+  assert.equal(out.error, undefined);
+});
+
+// The late failure is preserved, not swallowed. A rule that quietly dropped the
+// error would trade one wrong record for a missing one.
+test('claude run lifecycle: the late failure is still recorded', () => {
+  const out = resolveRunEndOutcome({ turnCompleteSent: true, error: new Error('boom') });
+
+  assert.ok(Object.values(out).includes('boom'));
+});
+
+// Not everything thrown is an Error.
+test('claude run lifecycle: a non-Error throw is still described', () => {
+  assert.equal(resolveRunEndOutcome({ turnCompleteSent: false, error: 'plain string' }).error, 'plain string');
+  assert.equal(resolveRunEndOutcome({ turnCompleteSent: false, error: null }).error, 'null');
+});

--- a/server/modules/providers/tests/claude-run-lifecycle.test.ts
+++ b/server/modules/providers/tests/claude-run-lifecycle.test.ts
@@ -46,3 +46,39 @@ test('claude run lifecycle: a non-Error throw is still described', () => {
   assert.equal(resolveRunEndOutcome({ turnCompleteSent: false, error: 'plain string' }).error, 'plain string');
   assert.equal(resolveRunEndOutcome({ turnCompleteSent: false, error: null }).error, 'null');
 });
+
+// A truthy, non-string `message` (BigInt is the concrete case CodeRabbit
+// found) used to reach JSON.stringify() in logRunLifecycle() unconverted --
+// `error?.message || String(error)` only stringifies on the FALSY branch.
+// JSON.stringify() cannot serialise a BigInt, and by the point this throws,
+// logRunEnd() has already marked the run as logged, so no fallback re-emits
+// it: one run, no terminal record at all.
+test('claude run lifecycle: a BigInt message is stringified, not passed through', () => {
+  const out = resolveRunEndOutcome({
+    turnCompleteSent: false,
+    error: { message: 1n },
+  });
+
+  assert.equal(out.error, '1');
+  assert.doesNotThrow(() => JSON.stringify(out));
+});
+
+// The counter-case for the same fix: a falsy-but-meaningful message (empty
+// string, zero) must not be discarded in favour of `String(error)` the way
+// `||` would. `??` only falls back on null/undefined.
+test('claude run lifecycle: a falsy-but-defined message is kept, not replaced', () => {
+  assert.equal(resolveRunEndOutcome({ turnCompleteSent: false, error: { message: '' } }).error, '');
+  assert.equal(resolveRunEndOutcome({ turnCompleteSent: false, error: { message: 0 } }).error, '0');
+});
+
+// Defence in depth: even a value whose own stringification throws (a
+// deliberately hostile `toString()`, e.g. from a Proxy) must not take down
+// the terminal record with it.
+test('claude run lifecycle: an unstringifiable error falls back instead of throwing', () => {
+  const hostile = { message: { toString() { throw new Error('nope'); } } };
+
+  const out = resolveRunEndOutcome({ turnCompleteSent: false, error: hostile });
+
+  assert.equal(out.error, 'Unserializable error');
+  assert.doesNotThrow(() => JSON.stringify(out));
+});


### PR DESCRIPTION
## What

The Claude SDK hands the CLI child's stderr to the caller through one
explicit callback, `options.stderr`. This provider never sets it, so
everything the CLI writes there is dropped. This PR wires the callback and
forwards the output to the service log under three limits: redaction
before logging, a length cap per line, and a rate limit per run.

## Why

The CLI uses that channel to say why it is winding itself down — for
example `Background tasks still running after <N>s; terminating.` Because
the callback was never set, that explanation never reached the log, and a
run ended by the background-wait ceiling looked exactly like a run that
vanished for no reason. The limits are not cosmetic: stderr can carry argv
fragments and key material, so redaction runs *before* truncation (cutting
first would leave a half-secret that no longer matches the filter).

## Reproduction steps

1. On current `main`, confirm the callback is never set:

   ```
   grep -n stderr server/modules/providers/list/claude/claude-runtime.provider.js
   ```

   No matches at all. (Measured on `5af09903`, 2026-09-07.)

2. Confirm the CLI really does write there — the message exists in the
   shipped binary (`@anthropic-ai/claude-code` 2.1.228):

   ```
   strings -a "$(readlink -f "$(command -v claude)")" \
     | grep -c 'Background tasks still running'
   ```

   → `2`.

3. Confirm it never arrives. On a server that has been running since
   2026-08-01, **as of 2026-09-07**:

   ```
   journalctl -u <service> --since 2026-08-01 -o cat \
     | grep -c 'Background tasks still running'
   ```

   → `0`, although every run goes through the CLI that carries the string.
   (An absence measured at one point in time — it says the line is not
   arriving now, not that it never could.)

4. To force it rather than wait for it: start the server
   (`npm run server:dev`), open a session, and end a turn that leaves a
   background task running. On `main` the CLI's explanation is discarded;
   nothing is logged.

5. With this PR, the same run prints:

   ```
   [claude-cli-stderr] <tag> Background tasks still running after <N>s; terminating.
   [claude-cli-stderr] <tag> [throttled <N>]
   ```

   redacted, capped at 500 characters per line, and rate-limited to 50
   lines per minute per run, with a closing count of what the throttle
   swallowed.

## Notes

- **Builds on #1278** (the lifecycle half of #1218). Its two
  commits are the base of this branch, so they show up here until it
  merges; only the stderr commits belong to this PR.
- `npm test` → 414 tests, 413 pass, 0 fail, 1 skipped. That is the
  `main` baseline (396 pass) plus the 17 assertions this branch adds,
  covering chunk-split lines, whole-PEM-block suppression, the throttle,
  and blank-line handling. `node --check` on the changed file passes.
- This is one half of #1218, which the maintainer closed asking for
  separate PRs with reproduction steps. The review history — two
  CodeRabbit rounds, all threads resolved — is on #1218.

Refs #1163


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Claude CLI diagnostics are now forwarded to service logs.
  * Logs include clear lifecycle events for run starts, session creation, abort requests, and completion.
* **Bug Fixes**
  * Sensitive values and private-key content are redacted before logging.
  * Long or high-volume diagnostic output is safely limited while preserving readable lines.
  * Partial diagnostic lines are reassembled correctly, including output split across chunks.
  * Run completion is recorded consistently across successful, aborted, superseded, and failed runs, including late failures and unusual error formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->