### PR TITLE
fix(chat): stop scrolled-away messages rendering as tall empty boxes

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -588,20 +588,13 @@
     clip-path: inset(-8px -8px 0 -8px);
   }
 
-  .chat-message {
+  /*
+   * LazyMessageRow owns off-screen sizing through measured placeholders.
+   * Containing its stable wrapper without size containment or content visibility
+   * keeps those placeholder heights and mounted content heights authoritative.
+   */
+  .chat-message-row {
     contain: layout style paint;
-    content-visibility: auto;
-    contain-intrinsic-size: auto 180px;
-  }
-
-  .chat-message.assistant {
-    contain-intrinsic-size: auto 240px;
-  }
-
-  .chat-message.user,
-  .chat-message.tool,
-  .chat-message.error {
-    contain-intrinsic-size: auto 96px;
   }
 
   /* Mobile touch optimization and safe areas */

--- a/src/modules/chat/export/buildTranscriptHtml.tsx
+++ b/src/modules/chat/export/buildTranscriptHtml.tsx
@@ -102,9 +102,6 @@ ${styles}
     border: 1px solid hsl(var(--border)); background: transparent; color: inherit;
     border-radius: 0.5rem; padding: 0.375rem 0.75rem; font-size: 0.75rem; cursor: pointer;
   }
-  /* Off-screen skipping is a scrolling optimisation; in a printed document it
-     leaves blank pages. */
-  .chat-message { content-visibility: visible !important; contain-intrinsic-size: auto !important; }
   @media print {
     .chat-export-theme-toggle { display: none; }
     .chat-export-shell { max-width: none; padding: 0; }

--- a/src/modules/chat/transcript/LazyMessageRow.tsx
+++ b/src/modules/chat/transcript/LazyMessageRow.tsx
@@ -70,6 +70,7 @@ export default function LazyMessageRow({
   return (
     <div
       ref={elementRef}
+      className="chat-message-row"
       data-message-timestamp={timestamp || undefined}
       style={isMounted ? undefined : { height: measuredHeight ?? ESTIMATED_ROW_HEIGHT_PX }}
     >


### PR DESCRIPTION
Reopening #1167 with the reproduction it was missing — closed as "didn't have a clear reproduction step". No code change: head is still `e85f4c63`.

`content-visibility: auto` sizes a skipped element by `contain-intrinsic-size`, and `LazyMessageRow` measures that same element to build its placeholder. When the two disagree, the transcript scrolls itself.

`LazyMessageRow` measures `offsetHeight` at the moment a row leaves the lazy band, which is the viewport ± `LAZY_ROW_VIEWPORT_MARGIN_PX` (1200px, `useLazyRowObserver.ts`). `content-visibility: auto` renders a much narrower window than that. So a row that mounts inside the band but never reaches the viewport is skipped at measure time and reports its `contain-intrinsic-size` fallback — 96px for user/tool/error, 240px for assistant — instead of its real height. That wrong number becomes the placeholder height, the scroll height grows, and the browser's scroll anchoring slides the visible content to compensate.

The `auto` keyword is why it looks intermittent rather than broken: a row that *has* passed through the viewport remembers its real size, so the same row is wrong on one pass and right on the next.

## Reproduction

1. Open a Claude session with ~120 short, single-line messages.
2. Scroll to the very top so the whole transcript is loaded.
3. Jump to the middle of the transcript.
4. Wait ~1.5s **without touching anything**.

The transcript slides several hundred pixels under the cursor on its own.

Measured on Chromium at 1280×900, 120-message transcript, 676px message pane. Real row heights are 68px (user) and 87px (assistant):

| | `scrollTop` | `scrollHeight` | placeholder heights |
|---|---|---|---|
| on `main`, right after the jump | 5638 | 11276 | 68 ×50, 87 ×50 |
| on `main`, 1.5s later, no input | **5095** | **11819** | 68 ×41, 87 ×40, **96 ×3, 240 ×3** |
| with this PR, 1.5s later | 5638 | 11276 | 68 ×44, 87 ×43 |

Six rows adopted the intrinsic-size fallbacks instead of their real heights: `3 × (96 − 68) + 3 × (240 − 87) = 543px`, which is exactly the `scrollHeight` growth and exactly the distance the view moved — 80% of the visible pane, unprompted.

Paste this in DevTools at step 4 to see it directly:

```js
const p = document.querySelector('.chat-messages-pane');
const rows = [...p.querySelectorAll('[data-message-timestamp]')]
  .filter(e => !e.classList.contains('chat-message'));
const tally = {};
for (const r of rows.filter(r => r.style.height)) {
  const h = Math.round(parseFloat(r.style.height));
  tally[h] = (tally[h] || 0) + 1;
}
console.log({ scrollTop: p.scrollTop, scrollHeight: p.scrollHeight, placeholders: tally });
```

On `main` the tally contains `96` and `240` entries that match no rendered row. With this PR those two values never appear once the maneuver above has settled.

`100` in the tally is expected and is not the bug: it is `ESTIMATED_ROW_HEIGHT_PX`, the placeholder `LazyMessageRow` uses for a row it has not measured yet. Only `96` and `240` are the `contain-intrinsic-size` fallbacks this PR removes.

## The change

Keep the paint/layout isolation, drop the sizing. Containment moves to the wrapper `LazyMessageRow` actually owns and measures (`.chat-message-row`), so the height it reads is always the height it rendered. Messages are already paginated and rows outside the band are already unmounted, so skipping off-screen work bought little on top of that.

The export stylesheet in `buildTranscriptHtml.tsx` carried a `content-visibility: visible !important` override to stop skipped rows printing as blank pages. With no element carrying `content-visibility` any more, that override is dead and is removed with it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved chat transcript rendering so measured message heights remain accurate as content loads.
  - Increased consistency when displaying assistant, user, tool, and error messages in long conversations.
  - Updated transcript exports to preserve reliable message sizing without relying on visibility overrides.
  - Maintained layout containment for chat message rows to support stable rendering performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
