### PR TITLE
fix(chat): keep transcript scroll and history writes owned by the visible session

### DIFF
--- a/src/modules/chat/ChatInterface.tsx
+++ b/src/modules/chat/ChatInterface.tsx
@@ -141,6 +141,7 @@ function ChatInterface({
     tokenBudget,
     setTokenBudget,
     visibleMessageCount,
+    handleUserScrollGesture,
     visibleMessages,
     loadEarlierMessages,
     loadAllMessages,
@@ -151,7 +152,6 @@ function ChatInterface({
     showLoadAllOverlay,
     createDiff,
     scrollContainerRef,
-    scrollToBottom,
     scrollToBottomAndReset,
     handleScroll,
     requestLatestMessages,
@@ -249,7 +249,6 @@ function ChatInterface({
     onSessionEstablished: handleSessionEstablished,
     onFileOpen,
     onShowSettings,
-    scrollToBottom,
     addMessage,
     setIsUserScrolledUp,
     setPendingPermissionRequests,
@@ -414,19 +413,15 @@ function ChatInterface({
     );
   }
 
-
   return (
     <PermissionContext.Provider value={permissionContextValue}>
       <div className="flex h-full min-h-0 flex-col">
         <ChatMessagesPane
           scrollContainerRef={scrollContainerRef}
-          // Not redundant with the `scroll` listener. A first page is 20 rows,
-          // tool results fold into their calls, and the "load earlier" link is
-          // hidden while more pages exist — so a short transcript is often not
-          // scrollable at all and never emits `scroll`. Wheel and touch are
-          // then the only way to reach the top pager or the "load all" overlay.
-          onWheel={handleScroll}
-          onTouchMove={handleScroll}
+          // A short transcript may not emit `scroll`, so wheel and touch
+          // gestures also run the top-pager check.
+          onScrollCheck={handleScroll}
+          onReadGesture={handleUserScrollGesture}
           isLoadingSessionMessages={isLoadingSessionMessages}
           isProcessing={isProcessing}
           hasActivityIndicator={hasActivityIndicator}

--- a/src/modules/chat/hooks/useChatComposerState.ts
+++ b/src/modules/chat/hooks/useChatComposerState.ts
@@ -60,7 +60,6 @@ type UseChatComposerStateArgs = {
   onSessionEstablished?: (sessionId: string, context: SessionEstablishedContext) => void;
   onFileOpen?: (filePath: string, diffInfo?: unknown) => void;
   onShowSettings?: () => void;
-  scrollToBottom: () => void;
   addMessage: (msg: ChatMessage) => void;
   setIsUserScrolledUp: (isScrolledUp: boolean) => void;
   setPendingPermissionRequests: Dispatch<SetStateAction<PendingPermissionRequest[]>>;
@@ -171,7 +170,6 @@ export function useChatComposerState({
   onSessionEstablished,
   onFileOpen,
   onShowSettings,
-  scrollToBottom,
   addMessage,
   setIsUserScrolledUp,
   setPendingPermissionRequests,
@@ -817,7 +815,6 @@ export function useChatComposerState({
       });
 
       setIsUserScrolledUp(false);
-      setTimeout(() => scrollToBottom(), 100);
 
       // One message shape for every provider. The backend resolves the
       // provider, project path, and provider-native resume id from the
@@ -864,7 +861,6 @@ export function useChatComposerState({
       onSessionEstablished,
       provider,
       resetCommandMenuState,
-      scrollToBottom,
       selectedProject,
       sendMessage,
       sessionKey,

--- a/src/modules/chat/hooks/useChatSessionState.ts
+++ b/src/modules/chat/hooks/useChatSessionState.ts
@@ -198,7 +198,7 @@ export function useChatSessionState({
   const [isLoadingMoreMessages, setIsLoadingMoreMessages] = useState(false);
   const [hasMoreMessages, setHasMoreMessages] = useState(false);
   const [totalMessages, setTotalMessages] = useState(0);
-  const [isUserScrolledUp, setIsUserScrolledUp] = useState(false);
+  const [isUserScrolledUp, setIsUserScrolledUpState] = useState(false);
   const [tokenBudget, setTokenBudget] = useState<Record<string, unknown> | null>(null);
   const [visibleMessageCount, setVisibleMessageCount] = useState(INITIAL_VISIBLE_MESSAGES);
   const [allMessagesLoaded, setAllMessagesLoaded] = useState(false);
@@ -219,22 +219,29 @@ export function useChatSessionState({
    */
   const searchScrollTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   /**
-   * `isUserScrolledUp` readable from a timer callback. Both deferred
-   * scroll-to-bottom calls are armed while the user is at the bottom and fire
-   * tens to hundreds of milliseconds later; without re-reading this at fire
-   * time, a scroll-up inside that window is silently undone.
+   * Scroll ownership is mirrored synchronously so a wheel or touch gesture can
+   * beat layout effects scheduled by the same render.
    */
   const isUserScrolledUpRef = useRef(false);
   const isLoadingMoreRef = useRef(false);
   const allMessagesLoadedRef = useRef(false);
   const topLoadLockRef = useRef(false);
   const pendingScrollRestoreRef = useRef<ScrollRestoreState | null>(null);
-  const pendingInitialScrollRef = useRef(true);
   const messagesOffsetRef = useRef(0);
   const scrollPositionRef = useRef({ height: 0, top: 0 });
   const loadAllFinishedTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const loadAllOverlayTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const lastLoadedSessionKeyRef = useRef<string | null>(null);
+  const transcriptGenerationRef = useRef(0);
+  const transcriptIdentityRef = useRef<string | null>(null);
+  const transcriptIdentity = `${selectedProject?.projectId ?? ''}:${selectedSession?.id ?? ''}`;
+  if (transcriptIdentityRef.current !== transcriptIdentity) {
+    transcriptIdentityRef.current = transcriptIdentity;
+    transcriptGenerationRef.current += 1;
+    isLoadingMoreRef.current = false;
+    isUserScrolledUpRef.current = false;
+  }
+  const transcriptGeneration = transcriptGenerationRef.current;
   /**
    * Tracks the last processed value from `useProjectsState.newSessionTrigger`.
    *
@@ -289,7 +296,7 @@ export function useChatSessionState({
     searchScrollActiveRef.current = false;
     topLoadLockRef.current = false;
     pendingScrollRestoreRef.current = null;
-    pendingInitialScrollRef.current = true;
+    setIsLoadingMoreMessages(false);
     lastLoadedSessionKeyRef.current = null;
 
     if (loadAllOverlayTimerRef.current) {
@@ -326,19 +333,28 @@ export function useChatSessionState({
   isActiveRef.current = isActive;
   activeSessionIdRef.current = activeSessionId;
 
+  const ownsTranscript = useCallback((
+    generation: number,
+    identity: string,
+    sessionId: string,
+  ) => (
+    generation === transcriptGenerationRef.current
+    && identity === transcriptIdentityRef.current
+    && activeSessionIdRef.current === sessionId
+  ), []);
+
   const latestRefreshExecutorRef = useRef<(sessionId: string) => Promise<boolean | void>>(
     async () => true,
   );
   latestRefreshExecutorRef.current = async (sessionId: string) => {
+    const requestGeneration = transcriptGenerationRef.current;
+    const requestIdentity = transcriptIdentityRef.current ?? '';
     const result = await sessionStore.refreshLatestFromServer(sessionId, {
       limit: SESSION_MESSAGES_PAGE_SIZE,
-      canRequest: () => (
-        isActiveRef.current
-        && activeSessionIdRef.current === sessionId
-      ),
+      canRequest: () => ownsTranscript(requestGeneration, requestIdentity, sessionId),
     });
     const slot = result.slot;
-    if (slot && activeSessionIdRef.current === sessionId) {
+    if (slot && ownsTranscript(requestGeneration, requestIdentity, sessionId)) {
       setHasMoreMessages(slot.hasMore);
       setTotalMessages(slot.total);
       messagesOffsetRef.current = slot.offset;
@@ -428,13 +444,10 @@ export function useChatSessionState({
     }
   }, [activeSessionId, sessionStore]);
 
-  // Mirrors the state into a ref so the two deferred scroll-to-bottom timers
-  // can re-read it at fire time. An effect rather than assignments next to each
-  // `setIsUserScrolledUp` call, because the setter is also returned from this
-  // hook and driven from the composer.
-  useEffect(() => {
-    isUserScrolledUpRef.current = isUserScrolledUp;
-  }, [isUserScrolledUp]);
+  const setIsUserScrolledUp = useCallback((next: boolean) => {
+    isUserScrolledUpRef.current = next;
+    setIsUserScrolledUpState(next);
+  }, []);
 
   const scrollToBottom = useCallback(() => {
     const container = scrollContainerRef.current;
@@ -458,6 +471,11 @@ export function useChatSessionState({
     return scrollHeight - scrollTop - clientHeight < 50;
   }, []);
 
+  const handleUserScrollGesture = useCallback(() => {
+    if (transcriptGeneration !== transcriptGenerationRef.current) return;
+    setIsUserScrolledUp(true);
+  }, [setIsUserScrolledUp, transcriptGeneration]);
+
   const loadOlderMessages = useCallback(
     async (container: HTMLDivElement) => {
       if (!isActive) return false;
@@ -465,18 +483,22 @@ export function useChatSessionState({
       if (allMessagesLoadedRef.current) return false;
       if (!hasMoreMessages || !selectedSession || !selectedProject) return false;
 
+      const requestGeneration = transcriptGeneration;
+      const requestIdentity = transcriptIdentity;
+      const requestSessionId = selectedSession.id;
+      if (!ownsTranscript(requestGeneration, requestIdentity, requestSessionId)) return false;
+
       isLoadingMoreRef.current = true;
       setIsLoadingMoreMessages(true);
       const scrollRestoreState = captureScrollRestoreState(container);
 
       try {
-        const result = await sessionStore.fetchMore(selectedSession.id, {
+        const result = await sessionStore.fetchMore(requestSessionId, {
           limit: SESSION_MESSAGES_PAGE_SIZE,
-          canRequest: () => (
-            isActiveRef.current
-            && activeSessionIdRef.current === selectedSession.id
-          ),
+          canRequest: () => ownsTranscript(requestGeneration, requestIdentity, requestSessionId),
         });
+        if (!ownsTranscript(requestGeneration, requestIdentity, requestSessionId)) return false;
+
         const { slot, prependedCount } = result;
         setHasMoreMessages(slot.hasMore);
         setTotalMessages(slot.total);
@@ -511,15 +533,27 @@ export function useChatSessionState({
         }
         return true;
       } finally {
-        isLoadingMoreRef.current = false;
-        setIsLoadingMoreMessages(false);
+        if (ownsTranscript(requestGeneration, requestIdentity, requestSessionId)) {
+          isLoadingMoreRef.current = false;
+          setIsLoadingMoreMessages(false);
+        }
       }
     },
-    [hasMoreMessages, isActive, isLoadingMoreMessages, selectedProject, selectedSession, sessionStore],
+    [
+      hasMoreMessages,
+      isActive,
+      isLoadingMoreMessages,
+      ownsTranscript,
+      selectedProject,
+      selectedSession,
+      sessionStore,
+      transcriptGeneration,
+      transcriptIdentity,
+    ],
   );
 
   const handleScroll = useCallback(async () => {
-    if (!isActive) return;
+    if (!isActive || transcriptGeneration !== transcriptGenerationRef.current) return;
     const container = scrollContainerRef.current;
     if (!container) return;
 
@@ -555,9 +589,18 @@ export function useChatSessionState({
         return;
       }
       const didLoad = await loadOlderMessages(container);
-      if (didLoad) topLoadLockRef.current = true;
+      if (didLoad && transcriptGeneration === transcriptGenerationRef.current) {
+        topLoadLockRef.current = true;
+      }
     }
-  }, [hasMoreMessages, isActive, isNearBottom, loadOlderMessages]);
+  }, [
+    hasMoreMessages,
+    isActive,
+    isNearBottom,
+    loadOlderMessages,
+    setIsUserScrolledUp,
+    transcriptGeneration,
+  ]);
 
   const wasChatActiveRef = useRef(isActive);
   useLayoutEffect(() => {
@@ -582,11 +625,11 @@ export function useChatSessionState({
     }
 
     if (becameActive) {
-      container.scrollTop = isUserScrolledUp
+      container.scrollTop = isUserScrolledUpRef.current
         ? scrollPositionRef.current.top
         : container.scrollHeight;
     }
-  }, [chatMessages.length, isActive, isUserScrolledUp]);
+  }, [chatMessages.length, isActive, transcriptGeneration]);
 
   // Reset scroll/pagination state on session change
   useEffect(() => {
@@ -607,57 +650,13 @@ export function useChatSessionState({
     searchScrollActiveRef.current = false;
     setSearchTarget(null);
 
-    pendingInitialScrollRef.current = true;
     setVisibleMessageCount(INITIAL_VISIBLE_MESSAGES);
+    setIsLoadingMoreMessages(false);
     topLoadLockRef.current = false;
     pendingScrollRestoreRef.current = null;
     wasNearTopRef.current = false;
     setIsUserScrolledUp(false);
-  }, [selectedProject?.projectId, selectedSession?.id]);
-
-  // Initial scroll to bottom — robust to lazy content reflow.
-  // The previous implementation fired one scrollToBottom() at +200ms and
-  // cleared the pending flag. When markdown blocks, code highlighting, or
-  // images finished rendering after that window, scrollHeight grew but
-  // nothing re-anchored the viewport, leaving the chat tab visually
-  // "scrolled way up" with the latest assistant message off-screen.
-  //
-  // This version re-scrolls every animation frame while scrollHeight is
-  // still growing, capped at ~1s (60 frames) or 3 consecutive stable
-  // frames. Cancels cleanly on session change via the pending flag.
-  useEffect(() => {
-    if (!isActive) return;
-    if (!pendingInitialScrollRef.current || !scrollContainerRef.current || isLoadingSessionMessages) return;
-    if (chatMessages.length === 0) { pendingInitialScrollRef.current = false; return; }
-    if (searchScrollActiveRef.current) { pendingInitialScrollRef.current = false; return; }
-
-    const container = scrollContainerRef.current;
-    let frame = 0;
-    let lastHeight = 0;
-    let stableCount = 0;
-    let rafId = 0;
-
-    const tick = () => {
-      if (!pendingInitialScrollRef.current || !scrollContainerRef.current) return;
-      container.scrollTop = container.scrollHeight;
-      if (container.scrollHeight === lastHeight) {
-        stableCount++;
-      } else {
-        stableCount = 0;
-        lastHeight = container.scrollHeight;
-      }
-      frame++;
-      if (stableCount < 3 && frame < 60) {
-        rafId = requestAnimationFrame(tick);
-      } else {
-        pendingInitialScrollRef.current = false;
-      }
-    };
-    rafId = requestAnimationFrame(tick);
-    return () => {
-      if (rafId) cancelAnimationFrame(rafId);
-    };
-  }, [chatMessages.length, isActive, isLoadingSessionMessages, scrollToBottom]);
+  }, [selectedProject?.projectId, selectedSession?.id, setIsUserScrolledUp]);
 
   // Session replay/subscription remains active regardless of which main tab is
   // visible. Only persisted-history HTTP traffic is visibility-gated below.
@@ -752,15 +751,15 @@ export function useChatSessionState({
     lastLoadedSessionKeyRef.current = sessionKey;
 
     // Fetch from server → store updates → chatMessages re-derives automatically
+    const requestGeneration = transcriptGeneration;
+    const requestIdentity = transcriptIdentity;
     setIsLoadingSessionMessages(true);
     sessionStore.fetchFromServer(selectedSessionId, {
       limit: SESSION_MESSAGES_PAGE_SIZE,
       offset: 0,
-      canRequest: () => (
-        isActiveRef.current
-        && activeSessionIdRef.current === selectedSessionId
-      ),
+      canRequest: () => ownsTranscript(requestGeneration, requestIdentity, selectedSessionId),
     }).then(slot => {
+      if (!ownsTranscript(requestGeneration, requestIdentity, selectedSessionId)) return;
       if (slot) {
         setHasMoreMessages(slot.hasMore);
         setTotalMessages(slot.total);
@@ -771,15 +770,20 @@ export function useChatSessionState({
       }
       setIsLoadingSessionMessages(false);
     }).catch(() => {
-      setIsLoadingSessionMessages(false);
+      if (ownsTranscript(requestGeneration, requestIdentity, selectedSessionId)) {
+        setIsLoadingSessionMessages(false);
+      }
     });
   }, [
     isActive,
+    ownsTranscript,
     resetStreamingState,
     requestLatestMessages,
     selectedProject,
     selectedSession?.id,
     sessionStore,
+    transcriptGeneration,
+    transcriptIdentity,
   ]);
 
   // Hidden refresh signals are coalesced. An initial page load supersedes a
@@ -803,18 +807,10 @@ export function useChatSessionState({
 
     const reloadExternalMessages = async () => {
       try {
-        // Skip store refresh during active streaming
+        // Skip store refresh during active streaming. The shared transcript
+        // layout effect owns any bottom follow after the refresh commits.
         if (!isProcessing) {
-          const shouldStickToBottom = isActiveRef.current && isNearBottom();
           await requestLatestMessages(selectedSession.id);
-
-          if (shouldStickToBottom) {
-            setTimeout(() => {
-              if (!isUserScrolledUpRef.current) {
-                scrollToBottom();
-              }
-            }, 200);
-          }
         }
       } catch (error) {
         console.error('Error reloading messages from external update:', error);
@@ -825,7 +821,6 @@ export function useChatSessionState({
   }, [
     externalMessageUpdate,
     requestLatestMessages,
-    scrollToBottom,
     selectedProject,
     selectedSession,
     isProcessing,
@@ -850,43 +845,48 @@ export function useChatSessionState({
     if (!isActive || !searchTarget || chatMessages.length === 0 || isLoadingSessionMessages) return;
 
     const target = searchTarget;
+    const requestGeneration = transcriptGeneration;
+    const requestIdentity = transcriptIdentity;
+    const requestSessionId = selectedSession?.id;
     setSearchTarget(null);
 
     const scrollToTarget = async () => {
-      if (!allMessagesLoadedRef.current && selectedSession && selectedProject) {
-          try {
-            // Load all messages into the store for search navigation
-            const slot = await sessionStore.fetchFromServer(selectedSession.id, {
-              limit: null,
-              offset: 0,
-              canRequest: () => (
-                isActiveRef.current
-                && activeSessionIdRef.current === selectedSession.id
-              ),
-            });
-            if (slot) {
-              // Fetch the whole transcript so an old hit can be found, but do
-              // not render all of it — the window below is widened to exactly
-              // what the resolved target needs.
-              setHasMoreMessages(false);
-              setTotalMessages(slot.total);
-              messagesOffsetRef.current = slot.offset;
-              setAllMessagesLoaded(true);
-              allMessagesLoadedRef.current = true;
-            } else if (!isActiveRef.current) {
-              setSearchTarget(target);
-              return;
-            }
-          } catch {
-            // Fall through and scroll in current messages
-          }
+      if (!requestSessionId || !ownsTranscript(requestGeneration, requestIdentity, requestSessionId)) {
+        return;
       }
+      if (!allMessagesLoadedRef.current && selectedProject) {
+        try {
+          // Load all messages into the store for search navigation
+          const slot = await sessionStore.fetchFromServer(requestSessionId, {
+            limit: null,
+            offset: 0,
+            canRequest: () => ownsTranscript(requestGeneration, requestIdentity, requestSessionId),
+          });
+          if (!ownsTranscript(requestGeneration, requestIdentity, requestSessionId)) return;
+          if (slot) {
+            // Fetch the whole transcript so an old hit can be found, but do
+            // not render all of it — the window below is widened to exactly
+            // what the resolved target needs.
+            setHasMoreMessages(false);
+            setTotalMessages(slot.total);
+            messagesOffsetRef.current = slot.offset;
+            setAllMessagesLoaded(true);
+            allMessagesLoadedRef.current = true;
+          } else if (!isActiveRef.current) {
+            setSearchTarget(target);
+            return;
+          }
+        } catch {
+          // Fall through and scroll in current messages
+        }
+      }
+      if (!ownsTranscript(requestGeneration, requestIdentity, requestSessionId)) return;
       // Resolve the target against the loaded transcript rather than the DOM.
       // The store is the freshest source here: the `fetchFromServer` above has
       // landed but `chatMessages` is from the render that scheduled this effect.
-      const messagesForSearch = activeSessionIdRef.current
-        ? normalizedToChatMessages(sessionStore.getMessages(activeSessionIdRef.current))
-        : chatMessages;
+      const messagesForSearch = normalizedToChatMessages(
+        sessionStore.getMessages(requestSessionId),
+      );
       const targetIndex = findSearchTargetIndex(messagesForSearch, target);
       if (targetIndex < 0) {
         // The target is not in the transcript at all. Scrolling somewhere
@@ -907,6 +907,7 @@ export function useChatSessionState({
       const targetTimestamp = messagesForSearch[targetIndex].timestamp;
 
       const scrollToRenderedTarget = (retriesLeft: number) => {
+        if (!ownsTranscript(requestGeneration, requestIdentity, requestSessionId)) return;
         const container = scrollContainerRef.current;
         if (!container) return;
 
@@ -956,13 +957,20 @@ export function useChatSessionState({
       setTokenBudget(null);
       return;
     }
+
+    const requestSessionId = selectedSession.id;
+    const requestGeneration = transcriptGeneration;
+    const requestIdentity = transcriptIdentity;
     const fetchInitialTokenUsage = async () => {
       try {
         // The provider module resolves storage and provider details from the session id.
-        const response = await api.providers.sessionTokenUsage(selectedSession.id);
+        const response = await api.providers.sessionTokenUsage(requestSessionId);
+        if (!ownsTranscript(requestGeneration, requestIdentity, requestSessionId)) return;
         if (response.ok) {
           const payload = await response.json();
-          setTokenBudget(payload.data ?? null);
+          if (ownsTranscript(requestGeneration, requestIdentity, requestSessionId)) {
+            setTokenBudget(payload.data ?? null);
+          }
         } else {
           setTokenBudget(null);
         }
@@ -971,7 +979,12 @@ export function useChatSessionState({
       }
     };
     fetchInitialTokenUsage();
-  }, [selectedSession?.id]);
+  }, [
+    ownsTranscript,
+    selectedSession?.id,
+    transcriptGeneration,
+    transcriptIdentity,
+  ]);
 
   const visibleMessages = useMemo(() => {
     if (chatMessages.length <= visibleMessageCount) return chatMessages;
@@ -985,20 +998,21 @@ export function useChatSessionState({
     scrollPositionRef.current = { height: container.scrollHeight, top: container.scrollTop };
   });
 
-  useEffect(() => {
-    if (!isActive) return;
+  useLayoutEffect(() => {
+    if (!isActive || isLoadingSessionMessages) return;
     if (!scrollContainerRef.current || chatMessages.length === 0) return;
     if (isLoadingMoreRef.current || isLoadingMoreMessages || pendingScrollRestoreRef.current) return;
-    if (searchScrollActiveRef.current) return;
+    if (searchScrollActiveRef.current || isUserScrolledUpRef.current) return;
 
-    if (!isUserScrolledUp) {
-      setTimeout(() => {
-        if (!isUserScrolledUpRef.current) {
-          scrollToBottom();
-        }
-      }, 50);
-    }
-  }, [chatMessages.length, isActive, isLoadingMoreMessages, isUserScrolledUp, scrollToBottom]);
+    scrollToBottom();
+  }, [
+    chatMessages,
+    isActive,
+    isLoadingMoreMessages,
+    isLoadingSessionMessages,
+    scrollToBottom,
+    transcriptGeneration,
+  ]);
 
   useEffect(() => {
     const container = scrollContainerRef.current;
@@ -1015,6 +1029,9 @@ export function useChatSessionState({
     if (!selectedSession || !selectedProject) return;
     if (isLoadingAllMessages) return;
     const requestSessionId = selectedSession.id;
+    const requestGeneration = transcriptGeneration;
+    const requestIdentity = transcriptIdentity;
+    if (!ownsTranscript(requestGeneration, requestIdentity, requestSessionId)) return;
     allMessagesLoadedRef.current = true;
     isLoadingMoreRef.current = true;
     setIsLoadingAllMessages(true);
@@ -1031,13 +1048,10 @@ export function useChatSessionState({
       const slot = await sessionStore.fetchFromServer(requestSessionId, {
         limit: null,
         offset: 0,
-        canRequest: () => (
-          isActiveRef.current
-          && activeSessionIdRef.current === requestSessionId
-        ),
+        canRequest: () => ownsTranscript(requestGeneration, requestIdentity, requestSessionId),
       });
 
-      if (currentSessionId !== requestSessionId) return;
+      if (!ownsTranscript(requestGeneration, requestIdentity, requestSessionId)) return;
 
       if (slot) {
         if (scrollRestoreState) {
@@ -1062,14 +1076,27 @@ export function useChatSessionState({
         setShowLoadAllOverlay(false);
       }
     } catch (error) {
-      console.error('Error loading all messages:', error);
-      allMessagesLoadedRef.current = false;
-      setShowLoadAllOverlay(false);
+      if (ownsTranscript(requestGeneration, requestIdentity, requestSessionId)) {
+        console.error('Error loading all messages:', error);
+        allMessagesLoadedRef.current = false;
+        setShowLoadAllOverlay(false);
+      }
     } finally {
-      isLoadingMoreRef.current = false;
-      setIsLoadingAllMessages(false);
+      if (ownsTranscript(requestGeneration, requestIdentity, requestSessionId)) {
+        isLoadingMoreRef.current = false;
+        setIsLoadingAllMessages(false);
+      }
     }
-  }, [isActive, selectedSession, selectedProject, isLoadingAllMessages, currentSessionId, sessionStore]);
+  }, [
+    isActive,
+    isLoadingAllMessages,
+    ownsTranscript,
+    selectedProject,
+    selectedSession,
+    sessionStore,
+    transcriptGeneration,
+    transcriptIdentity,
+  ]);
 
   /**
    * Fetches the whole transcript into the store and returns it, without
@@ -1115,6 +1142,7 @@ export function useChatSessionState({
     tokenBudget,
     setTokenBudget,
     visibleMessageCount,
+    handleUserScrollGesture,
     visibleMessages,
     loadEarlierMessages,
     loadAllMessages,

--- a/src/modules/chat/hooks/useChatSessionState.ts
+++ b/src/modules/chat/hooks/useChatSessionState.ts
@@ -26,6 +26,14 @@ const SEARCH_SCROLL_RETRIES = 20;
 const SEARCH_SCROLL_RETRY_DELAY_MS = 150;
 
 /**
+ * A deliberate upward reading gesture parks the transcript a few pixels above
+ * the bottom, inside the `isNearBottom` tolerance, and the gesture emits a
+ * scroll event of its own. Following therefore re-arms only once the view is
+ * back at the true bottom, so that event cannot cancel the gesture.
+ */
+const AT_BOTTOM_EPSILON_PX = 4;
+
+/**
  * Finds the rendered row for a resolved search target.
  *
  * Only an exact timestamp match counts while retries remain: the widened window
@@ -223,6 +231,9 @@ export function useChatSessionState({
    * beat layout effects scheduled by the same render.
    */
   const isUserScrolledUpRef = useRef(false);
+  // Set by an explicit upward gesture, cleared at the true bottom. Without it
+  // the scroll event the gesture emits resets the flag it just set.
+  const readingGestureRef = useRef(false);
   const isLoadingMoreRef = useRef(false);
   const allMessagesLoadedRef = useRef(false);
   const topLoadLockRef = useRef(false);
@@ -240,6 +251,7 @@ export function useChatSessionState({
     transcriptGenerationRef.current += 1;
     isLoadingMoreRef.current = false;
     isUserScrolledUpRef.current = false;
+    readingGestureRef.current = false;
   }
   const transcriptGeneration = transcriptGenerationRef.current;
   /**
@@ -473,6 +485,7 @@ export function useChatSessionState({
 
   const handleUserScrollGesture = useCallback(() => {
     if (transcriptGeneration !== transcriptGenerationRef.current) return;
+    readingGestureRef.current = true;
     setIsUserScrolledUp(true);
   }, [setIsUserScrolledUp, transcriptGeneration]);
 
@@ -557,8 +570,15 @@ export function useChatSessionState({
     const container = scrollContainerRef.current;
     if (!container) return;
 
-    const nearBottom = isNearBottom();
-    setIsUserScrolledUp(!nearBottom);
+    if (
+      container.scrollHeight - container.scrollTop - container.clientHeight
+      <= AT_BOTTOM_EPSILON_PX
+    ) {
+      readingGestureRef.current = false;
+    }
+    if (!readingGestureRef.current) {
+      setIsUserScrolledUp(!isNearBottom());
+    }
     scrollPositionRef.current = {
       height: container.scrollHeight,
       top: container.scrollTop,

--- a/src/modules/chat/hooks/useSessionStore.ts
+++ b/src/modules/chat/hooks/useSessionStore.ts
@@ -436,6 +436,9 @@ async function refreshLatestSlotFromServer(
     limit,
     offset: 0,
   });
+  if (!canRequest()) {
+    return { applied: false, changed: false, deferred: true };
+  }
 
   let nextServerMessages: NormalizedMessage[] | null = null;
   let nextHasMore = previousHasMore;
@@ -472,6 +475,9 @@ async function refreshLatestSlotFromServer(
       }
 
       const bridgePage = await requestSessionHistoryPage(sessionId, bridgeRequest);
+      if (!canRequest()) {
+        return { applied: false, changed: false, deferred: true };
+      }
       if (bridgePage.total !== latestPage.total) {
         console.warn(`[SessionStore] History changed while bridging ${sessionId}; retaining cached suffix.`);
         return { applied: false, changed: false, deferred: false };
@@ -602,6 +608,11 @@ export function useSessionStore() {
 
       try {
         const data = await requestSessionHistoryPage(sessionId, requestOptions);
+        if (!canRequest()) {
+          slot.status = 'idle';
+          notify(sessionId);
+          return null;
+        }
         slot.serverMessages = data.messages;
         slot.total = data.total;
         slot.hasMore = data.hasMore;
@@ -658,6 +669,7 @@ export function useSessionStore() {
             limit: opts.limit ?? SESSION_MESSAGES_PAGE_SIZE,
             offset: slot.offset,
           });
+          if (!canRequest()) break;
           const olderMerge = mergeOlderServerPage(cachedMessages, data.messages);
           const shiftedWhileFetching = (
             data.total !== expectedTotal

--- a/src/modules/chat/tests/composerDraftScoping.test.tsx
+++ b/src/modules/chat/tests/composerDraftScoping.test.tsx
@@ -58,7 +58,6 @@ const renderComposer = (selectedSession: ProjectSession | null) => renderHook(
     canAbortSession: false,
     tokenBudget: null,
     sendMessage: () => undefined,
-    scrollToBottom: () => undefined,
     addMessage: () => undefined,
     setIsUserScrolledUp: () => undefined,
     setPendingPermissionRequests: () => undefined,

--- a/src/modules/chat/tests/composerToolsSettingsResolution.test.ts
+++ b/src/modules/chat/tests/composerToolsSettingsResolution.test.ts
@@ -55,7 +55,6 @@ const submit = async (provider: LLMProvider) => {
       sendMessage: (message) => {
         sent.push(message as SentMessage);
       },
-      scrollToBottom: () => undefined,
       addMessage: () => undefined,
       setIsUserScrolledUp: () => undefined,
       setPendingPermissionRequests: () => undefined,

--- a/src/modules/chat/tests/sessionStoreTruncate.test.tsx
+++ b/src/modules/chat/tests/sessionStoreTruncate.test.tsx
@@ -60,6 +60,65 @@ async function loadedStore() {
   return view;
 }
 
+describe('history request ownership', () => {
+  it('does not apply a page after its transcript generation is retired', async () => {
+    sessionMessages.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        data: { messages: HISTORY.slice(2), total: HISTORY.length, hasMore: true },
+      }),
+    });
+
+    const { useSessionStore } = await import('@/modules/chat/hooks/useSessionStore');
+    const view = renderHook(() => useSessionStore());
+    await act(async () => {
+      await view.result.current.fetchFromServer('session-1', { limit: 2, offset: 0 });
+    });
+
+    type HistoryResponse = {
+      ok: boolean;
+      json: () => Promise<{
+        data: { messages: NormalizedMessage[]; total: number; hasMore: boolean };
+      }>;
+    };
+    let resolvePage!: (value: HistoryResponse) => void;
+    const page = new Promise<HistoryResponse>((resolve) => {
+      resolvePage = resolve;
+    });
+    sessionMessages.mockReturnValueOnce(page);
+
+    let ownsRequest = true;
+    let request!: Promise<unknown>;
+    await act(async () => {
+      request = view.result.current.fetchMore('session-1', {
+        limit: 2,
+        canRequest: () => ownsRequest,
+      });
+      await Promise.resolve();
+    });
+
+    ownsRequest = false;
+    await act(async () => {
+      resolvePage({
+        ok: true,
+        json: async () => ({
+          data: {
+            messages: HISTORY.slice(0, 2),
+            total: HISTORY.length,
+            hasMore: false,
+          },
+        }),
+      });
+      await request;
+    });
+
+    assert.deepEqual(
+      view.result.current.getMessages('session-1').map((message) => message.content),
+      ['second prompt', 'second answer'],
+    );
+  });
+});
+
 describe('truncateAt', () => {
   it('drops the anchored message and everything after it', async () => {
     const { result } = await loadedStore();

--- a/src/modules/chat/tests/transcriptScrollOwnership.test.tsx
+++ b/src/modules/chat/tests/transcriptScrollOwnership.test.tsx
@@ -6,10 +6,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { NormalizedMessage, Project, ProjectSession } from '@/shared/types';
 
 /**
- * The transcript's scroll position is written from five places coordinated by
- * refs and timers rather than by one owner. These are the two cases where that
- * coordination was observably wrong; both are timing bugs, so they are driven
- * on fake timers rather than by clicking.
+ * The transcript has several legitimate scroll writers. These tests pin
+ * ownership to the viewed session and to the reader's latest gesture.
  */
 
 vi.mock('@/shared/api', () => ({
@@ -63,17 +61,19 @@ function createContainer(scrollHeight: number, clientHeight: number) {
   return { element: element as HTMLDivElement, writes, scrollHeight };
 }
 
-function createStore(messagesBySession: Map<string, NormalizedMessage[]>) {
+function createStore(
+  messagesBySession: Map<string, NormalizedMessage[]>,
+  hasMoreBySession: Record<string, boolean> = {},
+) {
   // A hydrated slot, so the session-loading effect takes its early return
   // instead of re-fetching on every render.
   const slotFor = (sessionId: string) => ({
     fetchedAt: 1,
     status: 'idle' as const,
     total: messagesBySession.get(sessionId)?.length ?? 0,
-    hasMore: false,
+    hasMore: hasMoreBySession[sessionId] ?? false,
     offset: messagesBySession.get(sessionId)?.length ?? 0,
   });
-
   return {
     fetchFromServer: vi.fn(async (sessionId: string) => slotFor(sessionId)),
     fetchMore: vi.fn(async (sessionId: string) => ({ slot: slotFor(sessionId), prependedCount: 0 })),
@@ -96,34 +96,39 @@ function createStore(messagesBySession: Map<string, NormalizedMessage[]>) {
 async function renderChatSessionState(options: {
   session: ProjectSession;
   store: ReturnType<typeof createStore>;
+  externalMessageUpdate?: number;
 }) {
   const { useChatSessionState } = await import('@/modules/chat/hooks/useChatSessionState');
 
   return renderHook(
-    ({ session }: { session: ProjectSession }) =>
+    ({ session, externalMessageUpdate }: {
+      session: ProjectSession;
+      externalMessageUpdate?: number;
+    }) =>
       useChatSessionState({
         isActive: true,
         selectedProject: project,
         selectedSession: session,
         ws: null,
         sendMessage: vi.fn(),
+        externalMessageUpdate,
         resetStreamingState: vi.fn(),
         statusCheckSentAtRef: { current: new Map() },
         lastSeqRef: { current: new Map() },
         sessionStore: options.store as never,
       }),
-    { initialProps: { session: options.session } },
+    {
+      initialProps: {
+        session: options.session,
+        externalMessageUpdate: options.externalMessageUpdate,
+      },
+    },
   );
 }
-
 beforeEach(() => {
   vi.useFakeTimers();
-  // The initial-scroll effect is a separate writer that re-scrolls to the
-  // bottom every animation frame until the height settles. It would satisfy an
-  // assertion meant for the deferred timer, so it is silenced here — these
-  // tests are about which writer wins, and it is not one of the two.
-  vi.stubGlobal('requestAnimationFrame', () => 0);
-  vi.stubGlobal('cancelAnimationFrame', () => undefined);
+  // Search jump retries use timers. Layout is otherwise driven explicitly by
+  // the synthetic scroll container below.
   localStorage.clear();
 });
 
@@ -133,8 +138,8 @@ afterEach(() => {
   vi.resetModules();
 });
 
-describe('deferred scroll-to-bottom', () => {
-  it('does not yank the view back down when the user scrolls up inside the delay', async () => {
+describe('transcript follow ownership', () => {
+  it('does not yank the view back down after the user starts reading upward', async () => {
     const messages = new Map<string, NormalizedMessage[]>([
       [SESSION_A, [buildMessage(0, '2026-01-01T00:00:00.000Z')]],
     ]);
@@ -147,29 +152,26 @@ describe('deferred scroll-to-bottom', () => {
     const container = createContainer(5000, 500);
     (result.current.scrollContainerRef as { current: HTMLDivElement | null }).current = container.element;
 
-    // A new row lands while the user is at the bottom: a scroll is armed for +50ms.
+    act(() => {
+      result.current.handleUserScrollGesture();
+    });
+    container.writes.length = 0;
+
     messages.set(SESSION_A, [
       ...messages.get(SESSION_A)!,
       buildMessage(1, '2026-01-01T00:00:01.000Z'),
     ]);
     act(() => {
-      rerender({ session: { id: SESSION_A } as ProjectSession });
-    });
-
-    // ...and the user drags upward before it fires.
-    act(() => {
-      result.current.setIsUserScrolledUp(true);
-    });
-    container.writes.length = 0;
-
-    act(() => {
-      vi.advanceTimersByTime(200);
+      rerender({
+        session: { id: SESSION_A } as ProjectSession,
+        externalMessageUpdate: undefined,
+      });
     });
 
     assert.deepEqual(
       container.writes,
       [],
-      `a scroll armed before the user scrolled up must not fire afterwards; got ${JSON.stringify(container.writes)}`,
+      `a reader-owned viewport must not follow new rows; got ${JSON.stringify(container.writes)}`,
     );
   });
 
@@ -185,24 +187,171 @@ describe('deferred scroll-to-bottom', () => {
 
     const container = createContainer(5000, 500);
     (result.current.scrollContainerRef as { current: HTMLDivElement | null }).current = container.element;
+    container.writes.length = 0;
 
     messages.set(SESSION_A, [
       ...messages.get(SESSION_A)!,
       buildMessage(1, '2026-01-01T00:00:01.000Z'),
     ]);
     act(() => {
-      rerender({ session: { id: SESSION_A } as ProjectSession });
-    });
-    container.writes.length = 0;
-
-    act(() => {
-      vi.advanceTimersByTime(200);
+      rerender({
+        session: { id: SESSION_A } as ProjectSession,
+        externalMessageUpdate: undefined,
+      });
     });
 
     expect(container.writes).toContain(container.scrollHeight);
   });
 });
 
+describe('history page ownership', () => {
+  it('discards an older A page after navigating A to B to A', async () => {
+    const messages = new Map<string, NormalizedMessage[]>([
+      [SESSION_A, [buildMessage(0, '2026-01-01T00:00:00.000Z')]],
+      [SESSION_B, [buildMessage(1, '2026-01-01T00:00:01.000Z')]],
+    ]);
+    const store = createStore(messages, { [SESSION_A]: true });
+    type HistoryPage = {
+      slot: {
+        fetchedAt: number;
+        status: 'idle';
+        total: number;
+        hasMore: boolean;
+        offset: number;
+      };
+      prependedCount: number;
+    };
+    let resolvePage!: (value: HistoryPage) => void;
+    const page = new Promise<HistoryPage>((resolve) => {
+      resolvePage = resolve;
+    });
+    store.fetchMore.mockImplementationOnce(() => page);
+
+    const { result, rerender } = await renderChatSessionState({
+      session: { id: SESSION_A } as ProjectSession,
+      store,
+    });
+    await act(async () => {});
+
+    const container = createContainer(5000, 500);
+    container.element.scrollTop = 0;
+    (result.current.scrollContainerRef as { current: HTMLDivElement | null }).current = container.element;
+
+    let staleRequest!: Promise<void>;
+    act(() => {
+      staleRequest = result.current.handleScroll();
+    });
+
+    await act(async () => {
+      rerender({
+        session: { id: SESSION_B } as ProjectSession,
+        externalMessageUpdate: undefined,
+      });
+      await Promise.resolve();
+    });
+    await act(async () => {
+      rerender({
+        session: { id: SESSION_A } as ProjectSession,
+        externalMessageUpdate: undefined,
+      });
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      resolvePage({
+        slot: {
+          fetchedAt: 2,
+          status: 'idle',
+          total: 999,
+          hasMore: false,
+          offset: 999,
+        },
+        prependedCount: 20,
+      });
+      await staleRequest;
+    });
+
+    assert.notEqual(
+      result.current.totalMessages,
+      999,
+      'a page launched by the previous visit to A must not write into the new visit',
+    );
+    assert.equal(result.current.isLoadingMoreMessages, false);
+  });
+});
+
+
+describe('reconnect ownership', () => {
+  it('does not scroll the next session when the previous session refresh finishes', async () => {
+    const messages = new Map<string, NormalizedMessage[]>([
+      [SESSION_A, [buildMessage(0, '2026-01-01T00:00:00.000Z')]],
+      [SESSION_B, [buildMessage(1, '2026-01-01T00:00:01.000Z')]],
+    ]);
+    const store = createStore(messages);
+    type RefreshResult = {
+      slot: {
+        fetchedAt: number;
+        status: 'idle';
+        total: number;
+        hasMore: boolean;
+        offset: number;
+      };
+      applied: boolean;
+      changed: boolean;
+      deferred: boolean;
+    };
+    let resolveRefresh!: (value: RefreshResult) => void;
+    const refresh = new Promise<RefreshResult>((resolve) => {
+      resolveRefresh = resolve;
+    });
+    store.refreshLatestFromServer.mockImplementationOnce(() => refresh);
+
+    const { result, rerender } = await renderChatSessionState({
+      session: { id: SESSION_A } as ProjectSession,
+      store,
+    });
+    const container = createContainer(5000, 500);
+    (result.current.scrollContainerRef as { current: HTMLDivElement | null }).current = container.element;
+
+    await act(async () => {
+      rerender({
+        session: { id: SESSION_A } as ProjectSession,
+        externalMessageUpdate: 1,
+      });
+      await Promise.resolve();
+    });
+    await act(async () => {
+      rerender({
+        session: { id: SESSION_B } as ProjectSession,
+        externalMessageUpdate: 1,
+      });
+      await Promise.resolve();
+    });
+    container.writes.length = 0;
+
+    await act(async () => {
+      resolveRefresh({
+        slot: {
+          fetchedAt: 2,
+          status: 'idle',
+          total: 1,
+          hasMore: false,
+          offset: 1,
+        },
+        applied: true,
+        changed: false,
+        deferred: false,
+      });
+      await vi.advanceTimersByTimeAsync(250);
+    });
+
+    assert.deepEqual(
+      container.writes,
+      [],
+      'a reconnect refresh must not carry a bottom-follow into the next session',
+    );
+  });
+});
 describe('search jump ownership', () => {
   it('does not follow the user into the next session', { timeout: 20_000 }, async () => {
     const messages = new Map<string, NormalizedMessage[]>([
@@ -237,7 +386,10 @@ describe('search jump ownership', () => {
 
     // The user gives up waiting and opens a different session.
     await act(async () => {
-      rerender({ session: { id: SESSION_B } as ProjectSession });
+      rerender({
+        session: { id: SESSION_B } as ProjectSession,
+        externalMessageUpdate: undefined,
+      });
     });
 
     // Let the whole retry budget elapse (20 retries, 150ms apart).

--- a/src/modules/chat/tests/transcriptScrollOwnership.test.tsx
+++ b/src/modules/chat/tests/transcriptScrollOwnership.test.tsx
@@ -152,8 +152,15 @@ describe('transcript follow ownership', () => {
     const container = createContainer(5000, 500);
     (result.current.scrollContainerRef as { current: HTMLDivElement | null }).current = container.element;
 
+    // A 30px reading gesture. It sits inside the 50px `isNearBottom`
+    // tolerance and emits a scroll event of its own, so the flag it sets has
+    // to survive the handler that event runs.
     act(() => {
       result.current.handleUserScrollGesture();
+    });
+    container.element.scrollTop = container.scrollHeight - 500 - 30;
+    await act(async () => {
+      await result.current.handleScroll();
     });
     container.writes.length = 0;
 

--- a/src/modules/chat/transcript/ChatMessagesPane.tsx
+++ b/src/modules/chat/transcript/ChatMessagesPane.tsx
@@ -1,6 +1,6 @@
 import { useTranslation } from 'react-i18next';
-import { memo, useCallback, useMemo } from 'react';
-import type { Dispatch, RefObject, SetStateAction } from 'react';
+import { memo, useCallback, useMemo, useRef } from 'react';
+import type { Dispatch, RefObject, SetStateAction, TouchEvent, WheelEvent } from 'react';
 
 import type { ChatMessage,
   Project,
@@ -27,8 +27,8 @@ const INITIAL_MOUNTED_TAIL_ROWS = 30;
 
 type ChatMessagesPaneProps = {
   scrollContainerRef: RefObject<HTMLDivElement>;
-  onWheel: () => void;
-  onTouchMove: () => void;
+  onScrollCheck: () => void;
+  onReadGesture: () => void;
   isLoadingSessionMessages: boolean;
   /** True while the viewed session has an active provider run in flight. */
   isProcessing?: boolean;
@@ -83,8 +83,8 @@ type ChatMessagesPaneProps = {
  */
 function ChatMessagesPane({
   scrollContainerRef,
-  onWheel,
-  onTouchMove,
+  onScrollCheck,
+  onReadGesture,
   isLoadingSessionMessages,
   isProcessing = false,
   hasActivityIndicator = false,
@@ -165,11 +165,33 @@ function ChatMessagesPane({
     [messageKeyMap],
   );
 
+  const touchYRef = useRef<number | null>(null);
+  const handleWheel = useCallback((event: WheelEvent<HTMLDivElement>) => {
+    onScrollCheck();
+    if (event.deltaY < 0) onReadGesture();
+  }, [onReadGesture, onScrollCheck]);
+  const handleTouchStart = useCallback((event: TouchEvent<HTMLDivElement>) => {
+    touchYRef.current = event.touches[0]?.clientY ?? null;
+  }, []);
+  const handleTouchMove = useCallback((event: TouchEvent<HTMLDivElement>) => {
+    onScrollCheck();
+    const nextY = event.touches[0]?.clientY ?? null;
+    if (nextY !== null && touchYRef.current !== null && nextY > touchYRef.current) {
+      onReadGesture();
+    }
+    touchYRef.current = nextY;
+  }, [onReadGesture, onScrollCheck]);
+  const handleTouchEnd = useCallback(() => {
+    touchYRef.current = null;
+  }, []);
+
   return (
     <div
       ref={scrollContainerRef}
-      onWheel={onWheel}
-      onTouchMove={onTouchMove}
+      onWheel={handleWheel}
+      onTouchStart={handleTouchStart}
+      onTouchMove={handleTouchMove}
+      onTouchEnd={handleTouchEnd}
       className={`chat-messages-pane relative min-h-0 flex-1 overflow-y-auto overflow-x-hidden pt-3 sm:pt-4 ${
         hasActivityIndicator ? 'pb-12 sm:pb-14' : 'pb-3 sm:pb-4'
       }`}


### PR DESCRIPTION
Two transcript scroll writers act without checking who owns the viewport: the auto-follow, which recomputes "is the user reading?" from raw distance on every scroll event, and in-flight history requests, which apply their page into whatever transcript is on screen when they land.

## 1. A short reading gesture is cancelled by its own scroll event

`handleScroll` recomputes `isUserScrolledUp` from `isNearBottom()`, whose window is 50px. A deliberate upward gesture smaller than that leaves the flag `false`, so the next arriving row scrolls the view back to the bottom while the user is reading.

### Reproduction

1. Open a session with enough messages to scroll (60 short rows here).
2. Let it settle at the bottom.
3. Wheel **up 30px** — small, deliberate, still inside the 50px window.
4. Let one new message arrive.

The view snaps back to the bottom mid-read.

Chromium, 1280×900, one message appended between the two reads:

| | after the 30px gesture | after the message arrives |
|---|---|---|
| `main` | `scrollTop` 1252, 30px from bottom | `scrollTop` 1345, **0px from bottom** |
| this PR | `scrollTop` 1191, 30px from bottom | `scrollTop` **1191**, 93px from bottom |

On `main` the reader's position is discarded. With the PR `scrollTop` does not move at all; the distance grows only because the new row extended the content below.

Following re-arms when the viewport returns to the true bottom, so the "scroll to bottom" affordance still hands control back — verified in the same session: click it, `scrollTop` 1191 → 1284 (0px from bottom), and the next appended message is followed again.

## 2. An in-flight history page writes into the transcript that replaced it

A page requested for session A is applied when it resolves, even if the user has since switched to B, or left and re-entered A. The store had no way to ask whether the request still belongs to the visible transcript.

### Reproduction

1. Open session A and scroll to the top to start an older-history page.
2. Before it resolves, switch to session B, then back to A.

Holding that one request (`?limit=20&offset=20`) at the network layer makes it deterministic. On `main` the re-entered transcript stays parked at the top carrying the previous transcript's scroll state (`scrollTop` 0), and when the retired page lands the view jumps to `scrollTop` 1303. With this PR the re-entered transcript opens at the bottom (`scrollTop` 1107) and releasing the retired page contributes none of its rows: wrapper count stays 20, mounted rows stay 20, and the first rendered row stays `ALPHA-45` instead of becoming one of the older rows that page carried.

A no-release control pins what is and is not attributable to it. Holding the page and never releasing it leaves geometry byte-identical across the same interval (`scrollHeight` 1783, `scrollTop` 1107, both unchanged). Releasing it moves both by 53px (1836 / 1160) with the rendered row set unchanged, and the network log shows a further `?limit=20&offset=0` tail refresh firing after the release. That 53px is the follow-up refresh re-rendering A's tail, not the retired page's content entering the transcript.

## The change

- `useChatSessionState` derives a transcript generation from project + session identity and exposes `ownsTranscript(generation, identity, sessionId)`. Every async continuation — history pages, the latest-slot refresh, token usage, search jumps, reconnect refresh — checks it before touching state.
- `useSessionStore` request options take a `canRequest` predicate, so a retired request stops before its next hop instead of being filtered afterwards.
- An explicit upward gesture is recorded separately from the distance heuristic, and cleared when the viewport is back at the bottom.
- `ChatMessagesPane` distinguishes the two things the pane was conflating: `onScrollCheck` (any scroll, bookkeeping) and `onReadGesture` (deliberate upward wheel or touch drag).

## Tests

`src/modules/chat/tests/transcriptScrollOwnership.test.tsx`

- `does not yank the view back down after the user starts reading upward` — drives the gesture **and** the scroll event the gesture emits; fails on `main` with `got [5000]`, the follow write.
- `still sticks to the bottom when the user has not scrolled away`
- `discards an older A page after navigating A to B to A`
- `does not scroll the next session when the previous session refresh finishes`
- `does not follow the user into the next session`

`src/modules/chat/tests/sessionStoreTruncate.test.tsx` covers the store-side `canRequest` contract, including a page whose generation was retired mid-flight.

`npm run typecheck` clean; `npm run test:client` 377 tests in 52 files pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved chat scrolling so reading older messages no longer unexpectedly returns the view to the bottom.
  - Scrolling and touch gestures now more reliably preserve the reader’s position.
  - Prevented outdated message history or reconnect results from appearing after switching sessions or transcripts.
  - Prevented delayed responses from overwriting newer chat state.
  - Improved handling of interrupted or cancelled history loading requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
