### PR TITLE
fix(ws): reconnect broken chat channels

### DIFF
--- a/server/modules/websocket/README.md
+++ b/server/modules/websocket/README.md
@@ -33,7 +33,7 @@ Benefits:
 |---|---|
 | `services/websocket-server.service.ts` | Creates `WebSocketServer`, binds `verifyClient`, routes connection by pathname |
 | `services/websocket-auth.service.ts` | Authenticates upgrade requests and attaches `request.user` |
-| `services/chat-websocket.service.ts` | Handles the `/ws` chat protocol (`chat.send` / `chat.abort` / `chat.subscribe` / `chat.permission-response`) |
+| `services/chat-websocket.service.ts` | Handles the `/ws` chat protocol (`chat.send` / `chat.abort` / `chat.subscribe` / `chat.permission-response` / `chat.ping`) |
 | `services/chat-run-registry.service.ts` | Tracks live provider runs per app session id: seq numbering, event replay buffer, provider-id mapping, completion state |
 | `services/chat-session-writer.service.ts` | Gateway writer handed to provider runtimes: remaps provider session ids to app ids, swallows `session_created`, assigns `seq` |
 | `services/shell-websocket.service.ts` | Handles `/shell` PTY lifecycle, reconnect buffering, auth URL detection |
@@ -133,6 +133,7 @@ flowchart TD
   D -->|chat.abort| F[providerRuntimeService.abort + synthetic complete]
   D -->|chat.subscribe| G[chat_subscribed ack + attach socket + replay events seq > lastSeq]
   D -->|chat.permission-response| H[providerRuntimeService.resolveToolApproval]
+  D -->|chat.ping| J[send kind:pong with matching nonce]
   D -->|other| I[send kind:protocol_error]
 ```
 

--- a/server/modules/websocket/README.md
+++ b/server/modules/websocket/README.md
@@ -108,7 +108,7 @@ When a chat socket connects:
 
 1. Add socket to `connectedClients`.
 2. Parse each incoming message with `parseIncomingJsonObject`.
-3. Dispatch by `data.type` (four message types, none provider-specific).
+3. Dispatch by `data.type`; chat commands are provider-neutral.
 4. On close, remove socket from `connectedClients`.
 
 ### Session identity model
@@ -139,10 +139,31 @@ flowchart TD
 
 ### Chat Notes
 
-1. **Unified envelope**: every server-to-client frame carries a `kind` — either a provider `NormalizedMessage` kind or a gateway kind (`chat_subscribed`, `session_upserted`, `loading_progress`, `protocol_error`). There is no second `type`-based protocol.
+1. **Unified envelope**: every server-to-client frame carries a `kind` — either a provider `NormalizedMessage` kind or a gateway kind (`chat_subscribed`, `pong`, `session_upserted`, `loading_progress`, `protocol_error`). There is no second `type`-based protocol.
 2. **Unified terminal lifecycle**: every provider run ends with exactly one `complete` message built by `createCompleteMessage()` (`server/shared/utils.ts`): `{ kind: "complete", sessionId, actualSessionId, exitCode, success, aborted }`. The chat handler emits a synthetic `complete` for runs that crash or get aborted, and the run registry drops duplicate completes.
 3. **Per-run event log**: every live event gets a monotonically increasing `seq`. `chat.subscribe { sessions: [{ sessionId, lastSeq }] }` re-attaches the live stream to the requesting socket (any provider, not just Claude) and replays events with `seq > lastSeq`. If the buffer no longer covers `lastSeq`, the client refreshes over REST.
 4. `chat_subscribed` includes `isProcessing` (replaces `check-session-status`) and `pendingPermissions` (replaces `get-pending-permissions`).
+
+### Broken-channel recovery
+
+The browser sends `chat.ping { nonce }` every 30 seconds after connection or a
+matching pong. The gateway replies only to that socket with `{ kind: "pong",
+nonce }`, without invoking a provider. A missing matching pong after 3 seconds
+retires the socket and schedules a new connection after the existing 3-second
+retry delay. A handshake that stays connecting for 30 seconds is also retired.
+Only one handshake, ping, pong, or retry timer is active at a time.
+
+`visibilitychange` to visible and `pageshow` can probe earlier, but recovery does
+not require either event. Repeated page events do not extend a pending pong
+deadline. Browser suspension and background timer throttling can delay checks;
+the client cannot promise a wall-clock recovery deadline while timers are paused.
+
+On replacement, the selected chat sends `chat.subscribe` and waits for its
+matching `chat_subscribed` acknowledgement before refreshing the persisted tail.
+Replay follows the acknowledgement and can overlap the HTTP request. Hidden chat
+still subscribes but defers persisted-tail HTTP until activation. Initial session
+loading is unchanged, and visibility-only changes do not resubscribe.
+Failed application messages are not automatically resent.
 
 ## `/shell` Terminal Flow
 

--- a/server/modules/websocket/services/chat-websocket.service.ts
+++ b/server/modules/websocket/services/chat-websocket.service.ts
@@ -529,10 +529,11 @@ function handlePermissionResponse(data: AnyRecord, dependencies: ChatWebSocketDe
  * - `chat.abort`               { sessionId }
  * - `chat.subscribe`           { sessions: [{ sessionId, lastSeq? }] }
  * - `chat.permission-response` { requestId, allow, updatedInput?, message?, rememberEntry? }
+ * - `chat.ping`                { nonce }
  *
  * Outbound protocol (server to client): every frame is `kind`-based — either
  * a provider `NormalizedMessage` (with `seq`) or a gateway event
- * (`chat_subscribed`, `session_upserted`, `loading_progress`,
+ * (`chat_subscribed`, `pong`, `session_upserted`, `loading_progress`,
  * `protocol_error`).
  */
 /**
@@ -635,6 +636,12 @@ export function handleChatConnection(
           return;
         case 'chat.permission-response':
           handlePermissionResponse(data, dependencies);
+          return;
+        case 'chat.ping':
+          sendJson(ws, {
+            kind: 'pong',
+            nonce: typeof data.nonce === 'string' ? data.nonce : null,
+          });
           return;
         default:
           sendProtocolError(ws, 'UNKNOWN_MESSAGE_TYPE', `Unknown message type "${messageType}".`);

--- a/server/modules/websocket/tests/chat-ping.test.ts
+++ b/server/modules/websocket/tests/chat-ping.test.ts
@@ -1,0 +1,43 @@
+import assert from 'node:assert/strict';
+import { once } from 'node:events';
+import test from 'node:test';
+
+import { WebSocket, WebSocketServer } from 'ws';
+
+import { handleChatConnection } from '@/modules/websocket/services/chat-websocket.service.js';
+
+test('chat.ping answers its socket without invoking a provider or broadcasting', async (t) => {
+  const server = new WebSocketServer({ host: '127.0.0.1', port: 0 });
+  t.after(async () => {
+    for (const socket of server.clients) socket.terminate();
+    await new Promise<void>((resolve, reject) => server.close((error) => error ? reject(error) : resolve()));
+  });
+  server.on('connection', (socket, request) => handleChatConnection(socket, request, {
+    runtime: {
+      hasRuntime: () => assert.fail('ping must not inspect provider runtimes'),
+      run: async () => assert.fail('ping must not start a provider'),
+      abort: async () => assert.fail('ping must not abort a provider'),
+      resolveToolApproval: () => assert.fail('ping must not resolve approvals'),
+      getPendingApprovalsForSession: () => assert.fail('ping must not inspect approvals'),
+    },
+  }));
+  await once(server, 'listening');
+  const address = server.address();
+  assert.ok(address && typeof address === 'object');
+  const first = new WebSocket(`ws://127.0.0.1:${address.port}`);
+  const second = new WebSocket(`ws://127.0.0.1:${address.port}`);
+  t.after(() => { first.terminate(); second.terminate(); });
+  const secondFrames: unknown[] = [];
+  second.on('message', (data) => secondFrames.push(JSON.parse(data.toString())));
+  await Promise.all([once(first, 'open'), once(second, 'open')]);
+
+  const firstReply = once(first, 'message');
+  first.send(JSON.stringify({ type: 'chat.ping', nonce: 'first-probe' }));
+  const [reply] = await firstReply;
+  assert.deepEqual(JSON.parse(reply.toString()), { kind: 'pong', nonce: 'first-probe' });
+
+  const secondReply = once(second, 'message');
+  second.send(JSON.stringify({ type: 'chat.ping', nonce: 'second-probe' }));
+  await secondReply;
+  assert.deepEqual(secondFrames, [{ kind: 'pong', nonce: 'second-probe' }]);
+});

--- a/server/shared/types.ts
+++ b/server/shared/types.ts
@@ -203,6 +203,7 @@ export type MessageKind =
  */
 export type GatewayEventKind =
   | 'chat_subscribed'
+  | 'pong'
   | 'session_upserted'
   | 'loading_progress'
   | 'protocol_error';

--- a/src/modules/chat/ChatInterface.tsx
+++ b/src/modules/chat/ChatInterface.tsx
@@ -256,23 +256,6 @@ function ChatInterface({
     resolvePermissionModeForProvider,
   });
 
-  // On WebSocket reconnect, request a bounded persisted-tail sync (deferred
-  // while Chat is hidden), then re-subscribe — the
-  // `chat_subscribed` ack restores or clears the activity indicator, replays
-  // missed live events, and re-attaches a still-running stream to this socket.
-  const handleWebSocketReconnect = useCallback(async () => {
-    if (!selectedProject || !selectedSession) return;
-    await requestLatestMessages(selectedSession.id, isActive);
-    statusCheckSentAtRef.current.set(selectedSession.id, Date.now());
-    sendMessage({
-      type: 'chat.subscribe',
-      sessions: [{
-        sessionId: selectedSession.id,
-        lastSeq: lastSeqRef.current.get(selectedSession.id) ?? 0,
-      }],
-    });
-  }, [isActive, requestLatestMessages, selectedProject, selectedSession, sendMessage]);
-
   useChatRealtimeHandlers({
     isActive,
     subscribe,
@@ -288,7 +271,6 @@ function ChatInterface({
     statusCheckSentAtRef,
     onSessionProcessing,
     onSessionIdle,
-    onWebSocketReconnect: handleWebSocketReconnect,
     requestLatestMessages,
     sessionStore,
   });

--- a/src/modules/chat/ChatInterface.tsx
+++ b/src/modules/chat/ChatInterface.tsx
@@ -161,6 +161,7 @@ function ChatInterface({
     selectedSession,
     ws,
     sendMessage,
+    subscribe,
     externalMessageUpdate,
     newSessionTrigger,
     processingSessions,

--- a/src/modules/chat/hooks/useChatRealtimeHandlers.ts
+++ b/src/modules/chat/hooks/useChatRealtimeHandlers.ts
@@ -36,7 +36,6 @@ type UseChatRealtimeHandlersArgs = {
   statusCheckSentAtRef: MutableRefObject<Map<string, number>>;
   onSessionProcessing?: MarkSessionProcessing;
   onSessionIdle?: MarkSessionIdle;
-  onWebSocketReconnect?: () => void;
   requestLatestMessages: (sessionId: string, allowNetwork?: boolean) => Promise<void>;
   sessionStore: SessionStore;
 };
@@ -69,7 +68,6 @@ export function useChatRealtimeHandlers({
   statusCheckSentAtRef,
   onSessionProcessing,
   onSessionIdle,
-  onWebSocketReconnect,
   requestLatestMessages,
   sessionStore,
 }: UseChatRealtimeHandlersArgs) {
@@ -109,10 +107,6 @@ export function useChatRealtimeHandlers({
       }
 
       switch (msg.kind) {
-        case 'websocket_reconnected':
-          onWebSocketReconnect?.();
-          return;
-
         case 'history_truncated': {
           // An already-sent message was replaced. Every client watching this
           // session drops the superseded turns before the replacement streams
@@ -364,7 +358,6 @@ export function useChatRealtimeHandlers({
     statusCheckSentAtRef,
     onSessionProcessing,
     onSessionIdle,
-    onWebSocketReconnect,
     requestLatestMessages,
     sessionStore,
   ]);

--- a/src/modules/chat/hooks/useChatRealtimeHandlers.ts
+++ b/src/modules/chat/hooks/useChatRealtimeHandlers.ts
@@ -166,6 +166,10 @@ export function useChatRealtimeHandlers({
           return;
         }
 
+        // useChatSessionState owns reconnect catch-up; this is not a transcript row.
+        case 'websocket_reconnected':
+          return;
+
         // Sidebar/global events — owned by useProjectsState.
         case 'session_upserted':
         case 'loading_progress':

--- a/src/modules/chat/hooks/useChatSessionState.ts
+++ b/src/modules/chat/hooks/useChatSessionState.ts
@@ -235,6 +235,9 @@ export function useChatSessionState({
   const loadAllFinishedTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const loadAllOverlayTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const lastLoadedSessionKeyRef = useRef<string | null>(null);
+  // The last socket that carried this session's subscription. A new identity
+  // marks reconnect so the persisted-tail refresh can follow the subscribe.
+  const subscribedSocketRef = useRef<WebSocket | null>(null);
   /**
    * Tracks the last processed value from `useProjectsState.newSessionTrigger`.
    *
@@ -659,11 +662,15 @@ export function useChatSessionState({
     };
   }, [chatMessages.length, isActive, isLoadingSessionMessages, scrollToBottom]);
 
-  // Session replay/subscription remains active regardless of which main tab is
-  // visible. Only persisted-history HTTP traffic is visibility-gated below.
+  // This is the only owner of chat.subscribe. On reconnect the subscription
+  // goes first so the server attaches and replays missed seq frames before a
+  // persisted-tail refresh can merge the completed part of the turn.
   useEffect(() => {
     if (!selectedSession || !selectedProject || !ws) return;
 
+    const isReconnect = subscribedSocketRef.current !== null
+      && subscribedSocketRef.current !== ws;
+    subscribedSocketRef.current = ws;
     statusCheckSentAtRef.current.set(selectedSession.id, Date.now());
     sendMessage({
       type: 'chat.subscribe',
@@ -672,7 +679,19 @@ export function useChatSessionState({
         lastSeq: lastSeqRef.current.get(selectedSession.id) ?? 0,
       }],
     });
-  }, [lastSeqRef, selectedProject, selectedSession, sendMessage, statusCheckSentAtRef, ws]);
+    if (isReconnect) {
+      void requestLatestMessages(selectedSession.id, isActive);
+    }
+  }, [
+    isActive,
+    lastSeqRef,
+    requestLatestMessages,
+    selectedProject,
+    selectedSession,
+    sendMessage,
+    statusCheckSentAtRef,
+    ws,
+  ]);
 
   // Main session loading effect — store-based.
   //

--- a/src/modules/chat/hooks/useChatSessionState.ts
+++ b/src/modules/chat/hooks/useChatSessionState.ts
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } fr
 import type { MutableRefObject } from 'react';
 
 import { api } from '@/shared/api';
-import type { MarkSessionIdle, SessionActivityMap,Project,ProjectSession,LLMProvider,NormalizedMessage,ChatMessage,DiffCalculator } from '@/shared/types';
+import type { MarkSessionIdle, SessionActivityMap,Project,ProjectSession,LLMProvider,NormalizedMessage,ChatMessage,DiffCalculator,ServerEvent } from '@/shared/types';
 import type { SessionStore } from '@/modules/chat/hooks/useSessionStore';
 import { SESSION_MESSAGES_PAGE_SIZE } from '@/modules/chat/utils/sessionMessagePagination';
 import { createMessageHistoryRefreshCoordinator } from '@/modules/chat/utils/messageHistoryRefreshCoordinator';
@@ -84,6 +84,7 @@ type UseChatSessionStateArgs = {
   selectedSession: ProjectSession | null;
   ws: WebSocket | null;
   sendMessage: (message: unknown) => void;
+  subscribe: (listener: (event: ServerEvent) => void) => () => void;
   externalMessageUpdate?: number;
   newSessionTrigger?: number;
   processingSessions?: SessionActivityMap;
@@ -184,6 +185,7 @@ export function useChatSessionState({
   selectedSession,
   ws,
   sendMessage,
+  subscribe,
   externalMessageUpdate,
   newSessionTrigger,
   processingSessions,
@@ -235,9 +237,10 @@ export function useChatSessionState({
   const loadAllFinishedTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const loadAllOverlayTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const lastLoadedSessionKeyRef = useRef<string | null>(null);
-  // The last socket that carried this session's subscription. A new identity
-  // marks reconnect so the persisted-tail refresh can follow the subscribe.
-  const subscribedSocketRef = useRef<WebSocket | null>(null);
+  // Distinguish a lost subscription from a different session's initial load.
+  const lastSubscriptionRef = useRef<{ socket: WebSocket; sessionId: string } | null>(null);
+  // A replacement must acknowledge this session before any queued tail refresh.
+  const pendingReconnectRef = useRef<{ socket: WebSocket; sessionId: string } | null>(null);
   /**
    * Tracks the last processed value from `useProjectsState.newSessionTrigger`.
    *
@@ -326,8 +329,11 @@ export function useChatSessionState({
 
   const isActiveRef = useRef(isActive);
   const activeSessionIdRef = useRef(activeSessionId);
+  // Reject acknowledgements delivered by listeners for a replaced socket.
+  const wsRef = useRef(ws);
   isActiveRef.current = isActive;
   activeSessionIdRef.current = activeSessionId;
+  wsRef.current = ws;
 
   const latestRefreshExecutorRef = useRef<(sessionId: string) => Promise<boolean | void>>(
     async () => true,
@@ -338,6 +344,7 @@ export function useChatSessionState({
       canRequest: () => (
         isActiveRef.current
         && activeSessionIdRef.current === sessionId
+        && pendingReconnectRef.current?.sessionId !== sessionId
       ),
     });
     const slot = result.slot;
@@ -356,7 +363,11 @@ export function useChatSessionState({
   if (!refreshCoordinatorRef.current) {
     refreshCoordinatorRef.current = createMessageHistoryRefreshCoordinator(
       (sessionId) => latestRefreshExecutorRef.current(sessionId),
-      (sessionId) => isActiveRef.current && activeSessionIdRef.current === sessionId,
+      (sessionId) => (
+        isActiveRef.current
+        && activeSessionIdRef.current === sessionId
+        && pendingReconnectRef.current?.sessionId !== sessionId
+      ),
     );
   }
 
@@ -662,34 +673,55 @@ export function useChatSessionState({
     };
   }, [chatMessages.length, isActive, isLoadingSessionMessages, scrollToBottom]);
 
-  // This is the only owner of chat.subscribe. On reconnect the subscription
-  // goes first so the server attaches and replays missed seq frames before a
-  // persisted-tail refresh can merge the completed part of the turn.
+  const selectedSessionId = selectedSession?.id;
+  const selectedProjectId = selectedProject?.projectId;
+  // One owner subscribes on socket/session changes, including while hidden.
+  // The ack confirms attachment, not replay completion: replay follows the ack
+  // and can arrive while the persisted-tail request is in flight.
   useEffect(() => {
-    if (!selectedSession || !selectedProject || !ws) return;
+    if (!selectedSessionId || !selectedProjectId || !ws) return;
 
-    const isReconnect = subscribedSocketRef.current !== null
-      && subscribedSocketRef.current !== ws;
-    subscribedSocketRef.current = ws;
-    statusCheckSentAtRef.current.set(selectedSession.id, Date.now());
+    const isReconnect = lastSubscriptionRef.current?.sessionId === selectedSessionId
+      && lastSubscriptionRef.current.socket !== ws;
+    lastSubscriptionRef.current = { socket: ws, sessionId: selectedSessionId };
+    const pending = isReconnect ? lastSubscriptionRef.current : null;
+    pendingReconnectRef.current = pending;
+    // Arm the listener and pending state before send, including synchronous acks.
+    const unsubscribe = subscribe((event) => {
+      if (
+        !pending
+        || pendingReconnectRef.current !== pending
+        || wsRef.current !== pending.socket
+        || activeSessionIdRef.current !== pending.sessionId
+        || event.kind !== 'chat_subscribed'
+        || event.sessionId !== pending.sessionId
+      ) return;
+
+      pendingReconnectRef.current = null;
+      void requestLatestMessages(pending.sessionId);
+    });
+    statusCheckSentAtRef.current.set(selectedSessionId, Date.now());
     sendMessage({
       type: 'chat.subscribe',
       sessions: [{
-        sessionId: selectedSession.id,
-        lastSeq: lastSeqRef.current.get(selectedSession.id) ?? 0,
+        sessionId: selectedSessionId,
+        lastSeq: lastSeqRef.current.get(selectedSessionId) ?? 0,
       }],
     });
-    if (isReconnect) {
-      void requestLatestMessages(selectedSession.id, isActive);
-    }
+    return () => {
+      unsubscribe();
+      if (pendingReconnectRef.current === pending) {
+        pendingReconnectRef.current = null;
+      }
+    };
   }, [
-    isActive,
     lastSeqRef,
     requestLatestMessages,
-    selectedProject,
-    selectedSession,
+    selectedProjectId,
+    selectedSessionId,
     sendMessage,
     statusCheckSentAtRef,
+    subscribe,
     ws,
   ]);
 

--- a/src/modules/chat/tests/reconnectSubscription.test.tsx
+++ b/src/modules/chat/tests/reconnectSubscription.test.tsx
@@ -1,0 +1,107 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, expect, test, vi } from 'vitest';
+
+import { useChatSessionState } from '@/modules/chat/hooks/useChatSessionState';
+import type { Project, ProjectSession } from '@/shared/types';
+
+vi.mock('@/shared/api', () => ({
+  api: {
+    providers: {
+      sessionTokenUsage: () => Promise.resolve({ ok: false, json: async () => ({}) }),
+    },
+  },
+}));
+
+const SESSION_ID = 'session-a';
+const project: Project = {
+  projectId: 'project-1',
+  path: '/repo',
+  fullPath: '/repo',
+  displayName: 'Repo',
+  isStarred: false,
+};
+const session = { id: SESSION_ID } as ProjectSession;
+
+beforeEach(() => {
+  localStorage.clear();
+  vi.stubGlobal('requestAnimationFrame', () => 0);
+  vi.stubGlobal('cancelAnimationFrame', () => undefined);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+test('one owner subscribes before the reconnect history refresh', async () => {
+  const events: string[] = [];
+  const sendMessage = vi.fn((message: unknown) => {
+    events.push('subscribe');
+    return message;
+  });
+  const refreshLatestFromServer = vi.fn(async () => {
+    events.push('refresh');
+    return {
+      slot: { fetchedAt: 1, status: 'idle', total: 0, hasMore: false, offset: 0 },
+      applied: true,
+      changed: false,
+      deferred: false,
+    };
+  });
+  const sessionStore = {
+    fetchFromServer: vi.fn(async () => ({
+      fetchedAt: 1,
+      status: 'idle',
+      total: 0,
+      hasMore: false,
+      offset: 0,
+    })),
+    fetchMore: vi.fn(),
+    appendRealtime: vi.fn(),
+    refreshLatestFromServer,
+    setActiveSession: vi.fn(),
+    isStale: vi.fn(() => false),
+    updateStreaming: vi.fn(),
+    finalizeStreaming: vi.fn(),
+    getMessages: vi.fn(() => []),
+    getSessionSlot: vi.fn(() => ({
+      fetchedAt: 1,
+      status: 'idle',
+      total: 0,
+      hasMore: false,
+      offset: 0,
+    })),
+  };
+  const statusCheckSentAtRef = { current: new Map<string, number>() };
+  const lastSeqRef = { current: new Map([[SESSION_ID, 41]]) };
+  const firstSocket = {} as WebSocket;
+  const replacementSocket = {} as WebSocket;
+
+  const { rerender } = renderHook(
+    ({ ws }: { ws: WebSocket }) => useChatSessionState({
+      isActive: true,
+      selectedProject: project,
+      selectedSession: session,
+      ws,
+      sendMessage,
+      resetStreamingState: vi.fn(),
+      statusCheckSentAtRef,
+      lastSeqRef,
+      sessionStore: sessionStore as never,
+    }),
+    { initialProps: { ws: firstSocket } },
+  );
+
+  expect(sendMessage).toHaveBeenCalledTimes(1);
+  sendMessage.mockClear();
+  events.length = 0;
+
+  act(() => rerender({ ws: replacementSocket }));
+
+  await waitFor(() => expect(refreshLatestFromServer).toHaveBeenCalledTimes(1));
+  expect(sendMessage).toHaveBeenCalledTimes(1);
+  expect(sendMessage).toHaveBeenCalledWith({
+    type: 'chat.subscribe',
+    sessions: [{ sessionId: SESSION_ID, lastSeq: 41 }],
+  });
+  expect(events).toEqual(['subscribe', 'refresh']);
+});

--- a/src/modules/chat/tests/reconnectSubscription.test.tsx
+++ b/src/modules/chat/tests/reconnectSubscription.test.tsx
@@ -2,11 +2,15 @@ import { act, renderHook, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, expect, test, vi } from 'vitest';
 
 import { useChatSessionState } from '@/modules/chat/hooks/useChatSessionState';
-import type { Project, ProjectSession } from '@/shared/types';
+import { useSessionStore } from '@/modules/chat/hooks/useSessionStore';
+import { SESSION_MESSAGES_PAGE_SIZE } from '@/modules/chat/utils/sessionMessagePagination';
+import { api } from '@/shared/api';
+import type { NormalizedMessage, Project, ProjectSession, ServerEvent } from '@/shared/types';
 
 vi.mock('@/shared/api', () => ({
   api: {
     providers: {
+      sessionMessages: vi.fn(),
       sessionTokenUsage: () => Promise.resolve({ ok: false, json: async () => ({}) }),
     },
   },
@@ -20,10 +24,29 @@ const project: Project = {
   displayName: 'Repo',
   isStarred: false,
 };
-const session = { id: SESSION_ID } as ProjectSession;
+const session: ProjectSession = { id: SESSION_ID };
+const sessionMessages = vi.mocked(api.providers.sessionMessages);
+const persisted = new Map<string, string>();
+
+function historyMessage(sessionId: string): NormalizedMessage {
+  return {
+    id: `${sessionId}-answer`,
+    sessionId,
+    kind: 'text',
+    role: 'assistant',
+    provider: 'claude',
+    content: persisted.get(sessionId) ?? 'cached answer',
+    timestamp: '2026-01-01T00:00:00.000Z',
+  };
+}
 
 beforeEach(() => {
   localStorage.clear();
+  persisted.clear();
+  sessionMessages.mockReset();
+  sessionMessages.mockImplementation(async (sessionId) => new Response(JSON.stringify({
+    data: { messages: [historyMessage(sessionId)], total: 1, hasMore: false },
+  })));
   vi.stubGlobal('requestAnimationFrame', () => 0);
   vi.stubGlobal('cancelAnimationFrame', () => undefined);
 });
@@ -32,76 +55,200 @@ afterEach(() => {
   vi.unstubAllGlobals();
 });
 
-test('one owner subscribes before the reconnect history refresh', async () => {
-  const events: string[] = [];
-  const sendMessage = vi.fn((message: unknown) => {
-    events.push('subscribe');
-    return message;
-  });
-  const refreshLatestFromServer = vi.fn(async () => {
-    events.push('refresh');
-    return {
-      slot: { fetchedAt: 1, status: 'idle', total: 0, hasMore: false, offset: 0 },
-      applied: true,
-      changed: false,
-      deferred: false,
-    };
-  });
-  const sessionStore = {
-    fetchFromServer: vi.fn(async () => ({
-      fetchedAt: 1,
-      status: 'idle',
-      total: 0,
-      hasMore: false,
-      offset: 0,
-    })),
-    fetchMore: vi.fn(),
-    appendRealtime: vi.fn(),
-    refreshLatestFromServer,
-    setActiveSession: vi.fn(),
-    isStale: vi.fn(() => false),
-    updateStreaming: vi.fn(),
-    finalizeStreaming: vi.fn(),
-    getMessages: vi.fn(() => []),
-    getSessionSlot: vi.fn(() => ({
-      fetchedAt: 1,
-      status: 'idle',
-      total: 0,
-      hasMore: false,
-      offset: 0,
-    })),
+async function renderSession() {
+  const listeners = new Set<(event: ServerEvent) => void>();
+  const registeredListeners: Array<(event: ServerEvent) => void> = [];
+  const subscribe = (listener: (event: ServerEvent) => void) => {
+    listeners.add(listener);
+    registeredListeners.push(listener);
+    return () => { listeners.delete(listener); };
   };
+  const dispatch = (event: ServerEvent) => {
+    for (const listener of listeners) listener(event);
+  };
+  const sendMessage = vi.fn<(message: unknown) => void>();
+  const resetStreamingState = vi.fn();
   const statusCheckSentAtRef = { current: new Map<string, number>() };
   const lastSeqRef = { current: new Map([[SESSION_ID, 41]]) };
+  // This hook only uses socket identity; transport behavior has its own tests.
   const firstSocket = {} as WebSocket;
   const replacementSocket = {} as WebSocket;
-
-  const { rerender } = renderHook(
-    ({ ws }: { ws: WebSocket }) => useChatSessionState({
-      isActive: true,
-      selectedProject: project,
-      selectedSession: session,
-      ws,
-      sendMessage,
-      resetStreamingState: vi.fn(),
-      statusCheckSentAtRef,
-      lastSeqRef,
-      sessionStore: sessionStore as never,
-    }),
-    { initialProps: { ws: firstSocket } },
+  type Props = { ws: WebSocket | null; isActive: boolean; session: ProjectSession | null };
+  const props: Props = { ws: firstSocket, isActive: true, session };
+  const view = renderHook(
+    ({ ws, isActive, session: selectedSession }: Props) => {
+      const store = useSessionStore();
+      const chat = useChatSessionState({
+        isActive,
+        selectedProject: project,
+        selectedSession,
+        ws,
+        sendMessage,
+        subscribe,
+        resetStreamingState,
+        statusCheckSentAtRef,
+        lastSeqRef,
+        sessionStore: store,
+      });
+      return { chat, store };
+    },
+    { initialProps: props },
   );
+  await waitFor(() => expect(view.result.current.chat.chatMessages[0]?.content).toBe('cached answer'));
+  return { ...view, props, replacementSocket, sendMessage, dispatch, registeredListeners };
+}
 
-  expect(sendMessage).toHaveBeenCalledTimes(1);
-  sendMessage.mockClear();
-  events.length = 0;
+const ack = (sessionId = SESSION_ID): ServerEvent => ({ kind: 'chat_subscribed', sessionId });
 
-  act(() => rerender({ ws: replacementSocket }));
+test('initial subscription and visibility-only changes do not refresh or resubscribe', async () => {
+  const view = await renderSession();
+  await act(async () => view.dispatch(ack()));
+  expect(sessionMessages).toHaveBeenCalledTimes(1);
 
-  await waitFor(() => expect(refreshLatestFromServer).toHaveBeenCalledTimes(1));
-  expect(sendMessage).toHaveBeenCalledTimes(1);
-  expect(sendMessage).toHaveBeenCalledWith({
+  await act(async () => view.rerender({ ...view.props, isActive: false }));
+  await act(async () => view.rerender({ ...view.props, session: { ...session } }));
+  expect(view.sendMessage).toHaveBeenCalledTimes(1);
+  expect(sessionMessages).toHaveBeenCalledTimes(1);
+});
+
+test('replacement waits for its matching ack before fetching and displaying persisted history', async () => {
+  const view = await renderSession();
+  persisted.set(SESSION_ID, 'finished while disconnected');
+  await act(async () => view.rerender({ ...view.props, ws: view.replacementSocket }));
+
+  expect(view.sendMessage).toHaveBeenLastCalledWith({
     type: 'chat.subscribe',
     sessions: [{ sessionId: SESSION_ID, lastSeq: 41 }],
   });
-  expect(events).toEqual(['subscribe', 'refresh']);
+  expect(sessionMessages).toHaveBeenCalledTimes(1);
+  expect(view.result.current.chat.chatMessages[0]?.content).toBe('cached answer');
+
+  await act(async () => {
+    view.dispatch({ kind: 'chat_subscribed' });
+    view.dispatch(ack('unrelated-session'));
+  });
+  expect(sessionMessages).toHaveBeenCalledTimes(1);
+
+  await act(async () => view.dispatch(ack()));
+  await waitFor(() => expect(view.result.current.chat.chatMessages[0]?.content).toBe('finished while disconnected'));
+  expect(sessionMessages).toHaveBeenCalledTimes(2);
+  expect(sessionMessages).toHaveBeenLastCalledWith(
+    SESSION_ID,
+    { limit: SESSION_MESSAGES_PAGE_SIZE, offset: 0 },
+    expect.objectContaining({ signal: expect.any(AbortSignal) }),
+  );
+  await act(async () => view.dispatch(ack()));
+  expect(sessionMessages).toHaveBeenCalledTimes(2);
+});
+
+test('an ack delivered during send is observed because the listener is already armed', async () => {
+  const view = await renderSession();
+  persisted.set(SESSION_ID, 'caught up');
+  view.sendMessage.mockImplementation(() => view.dispatch(ack()));
+
+  await act(async () => view.rerender({ ...view.props, ws: view.replacementSocket }));
+  await waitFor(() => expect(view.result.current.chat.chatMessages[0]?.content).toBe('caught up'));
+  expect(sessionMessages).toHaveBeenCalledTimes(2);
+});
+
+test('a hidden replacement subscribes and acknowledges, but fetches only on activation', async () => {
+  const view = await renderSession();
+  const reconnected = { ...view.props, ws: view.replacementSocket };
+  persisted.set(SESSION_ID, 'hidden completion');
+
+  await act(async () => view.rerender({ ...reconnected, isActive: false }));
+  expect(view.sendMessage).toHaveBeenCalledTimes(2);
+  await act(async () => view.dispatch(ack()));
+  expect(sessionMessages).toHaveBeenCalledTimes(1);
+
+  await act(async () => view.rerender(reconnected));
+  await waitFor(() => expect(view.result.current.chat.chatMessages[0]?.content).toBe('hidden completion'));
+  expect(view.sendMessage).toHaveBeenCalledTimes(2);
+  expect(sessionMessages).toHaveBeenCalledTimes(2);
+});
+
+test('activation cannot flush queued or stale-history refreshes before the reconnect ack', async () => {
+  const view = await renderSession();
+  const reconnected = { ...view.props, ws: view.replacementSocket };
+  persisted.set(SESSION_ID, 'acknowledged completion');
+  await act(async () => view.rerender({ ...reconnected, isActive: false }));
+  // Model an existing hidden completion signal and a cache that aged while hidden.
+  await act(async () => view.result.current.chat.requestLatestMessages(SESSION_ID, false));
+  const slot = view.result.current.store.getSessionSlot(SESSION_ID);
+  if (!slot) throw new Error('Expected hydrated history');
+  slot.fetchedAt = Date.now() - 60_000;
+
+  await act(async () => view.rerender(reconnected));
+  expect(sessionMessages).toHaveBeenCalledTimes(1);
+  expect(view.result.current.chat.chatMessages[0]?.content).toBe('cached answer');
+  expect(view.sendMessage).toHaveBeenCalledTimes(2);
+
+  await act(async () => view.dispatch(ack()));
+  await waitFor(() => expect(view.result.current.chat.chatMessages[0]?.content).toBe('acknowledged completion'));
+  expect(sessionMessages).toHaveBeenCalledTimes(2);
+});
+
+test('a disconnected socket callback cannot acknowledge its replacement', async () => {
+  const view = await renderSession();
+  await act(async () => view.rerender({ ...view.props, ws: view.replacementSocket }));
+  const staleListener = view.registeredListeners[view.registeredListeners.length - 1];
+  if (!staleListener) throw new Error('Expected subscription listener');
+  await act(async () => view.rerender({ ...view.props, ws: null }));
+  const nextSocket = {} as WebSocket;
+  await act(async () => view.rerender({ ...view.props, ws: nextSocket }));
+
+  await act(async () => staleListener(ack()));
+  expect(sessionMessages).toHaveBeenCalledTimes(1);
+  persisted.set(SESSION_ID, 'current socket completion');
+  await act(async () => view.dispatch(ack()));
+  await waitFor(() => expect(view.result.current.chat.chatMessages[0]?.content).toBe('current socket completion'));
+});
+
+test('switching sessions clears the old pending ack without refreshing the new session', async () => {
+  const view = await renderSession();
+  await act(async () => view.rerender({ ...view.props, ws: view.replacementSocket }));
+  const staleListener = view.registeredListeners[view.registeredListeners.length - 1];
+  if (!staleListener) throw new Error('Expected subscription listener');
+  persisted.set('session-b', 'other conversation');
+  await act(async () => view.rerender({
+    ...view.props,
+    ws: view.replacementSocket,
+    session: { id: 'session-b' },
+  }));
+  await waitFor(() => expect(view.result.current.chat.chatMessages[0]?.content).toBe('other conversation'));
+  expect(sessionMessages).toHaveBeenCalledTimes(2);
+
+  await act(async () => {
+    staleListener(ack());
+    view.dispatch(ack());
+    view.dispatch(ack('session-b'));
+  });
+  expect(sessionMessages).toHaveBeenCalledTimes(2);
+  expect(view.result.current.chat.chatMessages[0]?.content).toBe('other conversation');
+});
+
+test('a session selected after an unselected reconnect only performs its initial history load', async () => {
+  const view = await renderSession();
+  await act(async () => view.rerender({ ...view.props, session: null }));
+  await act(async () => view.rerender({ ...view.props, session: null, ws: view.replacementSocket }));
+  persisted.set('session-b', 'new selection');
+  await act(async () => view.rerender({
+    ...view.props,
+    session: { id: 'session-b' },
+    ws: view.replacementSocket,
+  }));
+  await waitFor(() => expect(view.result.current.chat.chatMessages[0]?.content).toBe('new selection'));
+  await act(async () => view.dispatch(ack('session-b')));
+  expect(sessionMessages).toHaveBeenCalledTimes(2);
+});
+
+test('unmount clears an outstanding reconnect acknowledgement', async () => {
+  const view = await renderSession();
+  await act(async () => view.rerender({ ...view.props, ws: view.replacementSocket }));
+  const staleListener = view.registeredListeners[view.registeredListeners.length - 1];
+  if (!staleListener) throw new Error('Expected subscription listener');
+  view.unmount();
+
+  await act(async () => staleListener(ack()));
+  expect(sessionMessages).toHaveBeenCalledTimes(1);
 });

--- a/src/modules/chat/tests/reconnectSubscription.test.tsx
+++ b/src/modules/chat/tests/reconnectSubscription.test.tsx
@@ -2,6 +2,7 @@ import { act, renderHook, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, expect, test, vi } from 'vitest';
 
 import { useChatSessionState } from '@/modules/chat/hooks/useChatSessionState';
+import { useChatRealtimeHandlers } from '@/modules/chat/hooks/useChatRealtimeHandlers';
 import { useSessionStore } from '@/modules/chat/hooks/useSessionStore';
 import { SESSION_MESSAGES_PAGE_SIZE } from '@/modules/chat/utils/sessionMessagePagination';
 import { api } from '@/shared/api';
@@ -251,4 +252,40 @@ test('unmount clears an outstanding reconnect acknowledgement', async () => {
 
   await act(async () => staleListener(ack()));
   expect(sessionMessages).toHaveBeenCalledTimes(1);
+});
+
+test('reconnect notifications never become transcript rows', () => {
+  const listeners = new Set<(event: ServerEvent) => void>();
+  const subscribe = (listener: (event: ServerEvent) => void) => {
+    listeners.add(listener);
+    return () => { listeners.delete(listener); };
+  };
+  const { result } = renderHook(() => {
+    const store = useSessionStore();
+    useChatRealtimeHandlers({
+      isActive: true,
+      subscribe,
+      provider: 'claude',
+      selectedSession: session,
+      currentSessionId: SESSION_ID,
+      setTokenBudget: vi.fn(),
+      pendingPermissionRequests: [],
+      setPendingPermissionRequests: vi.fn(),
+      streamTimerRef: { current: null },
+      accumulatedStreamRef: { current: '' },
+      lastSeqRef: { current: new Map() },
+      statusCheckSentAtRef: { current: new Map() },
+      requestLatestMessages: vi.fn(async () => {}),
+      sessionStore: store,
+    });
+    return store;
+  });
+  const message = historyMessage(SESSION_ID);
+  act(() => {
+    for (const listener of listeners) {
+      listener(message);
+      listener({ kind: 'websocket_reconnected', timestamp: Date.now() });
+    }
+  });
+  expect(result.current.getMessages(SESSION_ID)).toEqual([message]);
 });

--- a/src/modules/chat/tests/transcriptScrollOwnership.test.tsx
+++ b/src/modules/chat/tests/transcriptScrollOwnership.test.tsx
@@ -107,6 +107,7 @@ async function renderChatSessionState(options: {
         selectedSession: session,
         ws: null,
         sendMessage: vi.fn(),
+        subscribe: () => () => {},
         resetStreamingState: vi.fn(),
         statusCheckSentAtRef: { current: new Map() },
         lastSeqRef: { current: new Map() },

--- a/src/shared/context/WebSocketContext.tsx
+++ b/src/shared/context/WebSocketContext.tsx
@@ -25,6 +25,9 @@ type WebSocketContextType = {
 
 const WebSocketContext = createContext<WebSocketContextType | null>(null);
 
+const RECONNECT_DELAY_MS = 3_000;
+const RESUME_PONG_TIMEOUT_MS = 3_000;
+
 export const useWebSocket = () => {
   const context = useContext(WebSocketContext);
   if (!context) {
@@ -73,6 +76,15 @@ const useWebSocketProviderState = (): WebSocketContextType => {
   const connect = useCallback(function connect() {
     if (unmountedRef.current) return; // Prevent connection if unmounted
     if (!IS_PLATFORM && (isAuthLoading || !user)) return;
+    // A reconnect timer and a resume event can race. Keep the socket already
+    // connecting or carrying traffic instead of orphaning it with a second one.
+    const existing = wsRef.current;
+    if (
+      existing
+      && (existing.readyState === WebSocket.CONNECTING || existing.readyState === WebSocket.OPEN)
+    ) {
+      return;
+    }
     try {
       // Construct WebSocket URL
       const wsUrl = buildWebSocketUrl(token);
@@ -96,6 +108,9 @@ const useWebSocketProviderState = (): WebSocketContextType => {
       websocket.onmessage = (event) => {
         try {
           const data = JSON.parse(event.data) as ServerEvent;
+          if (data.kind === 'pong') {
+            return;
+          }
           dispatch(data);
         } catch (error) {
           console.error('Error parsing WebSocket message:', error);
@@ -109,11 +124,11 @@ const useWebSocketProviderState = (): WebSocketContextType => {
         setIsConnected(false);
         wsRef.current = null;
 
-        // Attempt to reconnect after 3 seconds
         reconnectTimeoutRef.current = setTimeout(() => {
+          reconnectTimeoutRef.current = null;
           if (unmountedRef.current) return; // Prevent reconnection if unmounted
           connect();
-        }, 3000);
+        }, RECONNECT_DELAY_MS);
       };
 
       websocket.onerror = (error) => {
@@ -143,6 +158,7 @@ const useWebSocketProviderState = (): WebSocketContextType => {
       unmountedRef.current = true;
       if (reconnectTimeoutRef.current) {
         clearTimeout(reconnectTimeoutRef.current);
+        reconnectTimeoutRef.current = null;
       }
       const activeSocket = wsRef.current;
       if (activeSocket) {
@@ -157,6 +173,104 @@ const useWebSocketProviderState = (): WebSocketContextType => {
       }
     };
   }, [connect, isAuthLoading, user]); // reconnect after authentication or token refresh
+
+  // A suspended browser can retain an OPEN socket whose TCP peer is gone.
+  // Probe when the page resumes and replace the transport if no pong returns.
+  useEffect(() => {
+    let probeTimer: NodeJS.Timeout | null = null;
+    let probeSocket: WebSocket | null = null;
+    let probeListener: ((event: MessageEvent) => void) | null = null;
+
+    const clearProbe = () => {
+      if (probeTimer !== null) {
+        clearTimeout(probeTimer);
+        probeTimer = null;
+      }
+      if (probeSocket && probeListener) {
+        probeSocket.removeEventListener('message', probeListener);
+      }
+      probeSocket = null;
+      probeListener = null;
+    };
+
+    const scheduleReconnect = () => {
+      if (reconnectTimeoutRef.current) {
+        return;
+      }
+      reconnectTimeoutRef.current = setTimeout(() => {
+        reconnectTimeoutRef.current = null;
+        if (unmountedRef.current) return;
+        connect();
+      }, RECONNECT_DELAY_MS);
+    };
+
+    const replaceSocket = (socket: WebSocket) => {
+      if (wsRef.current !== socket) {
+        return;
+      }
+      clearProbe();
+      setIsConnected(false);
+      wsRef.current = null;
+      socket.close();
+      scheduleReconnect();
+    };
+
+    const handleResume = () => {
+      if (document.visibilityState !== 'visible') {
+        return;
+      }
+
+      // A bfcache restore can fire both events for one resume.
+      clearProbe();
+
+      const socket = wsRef.current;
+      if (!socket || socket.readyState === WebSocket.CLOSED) {
+        if (reconnectTimeoutRef.current) {
+          clearTimeout(reconnectTimeoutRef.current);
+          reconnectTimeoutRef.current = null;
+        }
+        connect();
+        if (!wsRef.current) {
+          scheduleReconnect();
+        }
+        return;
+      }
+      if (socket.readyState !== WebSocket.OPEN) {
+        return;
+      }
+
+      const nonce = `resume-${Date.now()}-${Math.random()}`;
+      probeSocket = socket;
+      probeListener = (event: MessageEvent) => {
+        try {
+          const frame = JSON.parse(String(event.data)) as { kind?: string; nonce?: string };
+          if (frame.kind === 'pong' && frame.nonce === nonce) {
+            clearProbe();
+          }
+        } catch {
+          // The normal message handler reports malformed frames.
+        }
+      };
+      socket.addEventListener('message', probeListener);
+
+      try {
+        socket.send(JSON.stringify({ type: 'chat.ping', nonce }));
+      } catch {
+        replaceSocket(socket);
+        return;
+      }
+
+      probeTimer = setTimeout(() => replaceSocket(socket), RESUME_PONG_TIMEOUT_MS);
+    };
+
+    document.addEventListener('visibilitychange', handleResume);
+    window.addEventListener('pageshow', handleResume);
+    return () => {
+      clearProbe();
+      document.removeEventListener('visibilitychange', handleResume);
+      window.removeEventListener('pageshow', handleResume);
+    };
+  }, [connect]);
 
   const sendMessage = useCallback((message: unknown) => {
     const socket = wsRef.current;

--- a/src/shared/context/WebSocketContext.tsx
+++ b/src/shared/context/WebSocketContext.tsx
@@ -9,6 +9,7 @@ import type { ServerEvent } from '@/shared/types';
 type ServerEventListener = (event: ServerEvent) => void;
 
 type WebSocketContextType = {
+  /** The open chat socket; null until a replacement handshake completes. */
   ws: WebSocket | null;
   sendMessage: (message: unknown) => void;
   /**
@@ -26,7 +27,9 @@ type WebSocketContextType = {
 const WebSocketContext = createContext<WebSocketContextType | null>(null);
 
 const RECONNECT_DELAY_MS = 3_000;
-const RESUME_PONG_TIMEOUT_MS = 3_000;
+const PING_INTERVAL_MS = 30_000;
+const PONG_TIMEOUT_MS = 3_000;
+const CONNECT_TIMEOUT_MS = 30_000;
 
 export const useWebSocket = () => {
   const context = useContext(WebSocketContext);
@@ -49,7 +52,8 @@ const buildWebSocketUrl = (token: string | null) => {
 
 const useWebSocketProviderState = (): WebSocketContextType => {
   const wsRef = useRef<WebSocket | null>(null);
-  const unmountedRef = useRef(false); // Track if component is unmounted
+  // Lets sendMessage retire a failed socket through the active auth effect.
+  const retireSocketRef = useRef<(socket: WebSocket) => void>(() => {});
   const hasConnectedRef = useRef(false); // Track if we've ever connected (to detect reconnects)
   /**
    * Listener registry for the subscribe API. A ref (not state) because the
@@ -58,7 +62,6 @@ const useWebSocketProviderState = (): WebSocketContextType => {
    */
   const listenersRef = useRef(new Set<ServerEventListener>());
   const [isConnected, setIsConnected] = useState(false);
-  const reconnectTimeoutRef = useRef<NodeJS.Timeout | null>(null);
   const { isLoading: isAuthLoading, token, user } = useAuth();
 
   const dispatch = useCallback((event: ServerEvent) => {
@@ -71,213 +74,158 @@ const useWebSocketProviderState = (): WebSocketContextType => {
     }
   }, []);
 
-  // Named function expression so the reconnect timer below can call itself
-  // without reading the `connect` binding while it is still initializing.
-  const connect = useCallback(function connect() {
-    if (unmountedRef.current) return; // Prevent connection if unmounted
-    if (!IS_PLATFORM && (isAuthLoading || !user)) return;
-    // A reconnect timer and a resume event can race. Keep the socket already
-    // connecting or carrying traffic instead of orphaning it with a second one.
-    const existing = wsRef.current;
-    if (
-      existing
-      && (existing.readyState === WebSocket.CONNECTING || existing.readyState === WebSocket.OPEN)
-    ) {
+  useEffect(() => {
+    if (!IS_PLATFORM && (isAuthLoading || !user)) {
       return;
     }
-    try {
-      // Construct WebSocket URL
-      const wsUrl = buildWebSocketUrl(token);
 
-      if (!wsUrl) return console.warn('No authentication token found for WebSocket connection');
+    let disposed = false;
+    // One deadline owns the handshake, next ping, pending pong, or retry.
+    let timer: number | null = null;
+    let pendingNonce: string | null = null;
 
-      const websocket = new WebSocket(wsUrl);
-      // Store connecting sockets too, so a token refresh can close them before
-      // their handshake completes with stale credentials.
-      wsRef.current = websocket;
-
-      websocket.onopen = () => {
-        setIsConnected(true);
-        if (hasConnectedRef.current) {
-          // This is a reconnect — signal so components can catch up on missed messages
-          dispatch({ kind: 'websocket_reconnected', timestamp: Date.now() });
-        }
-        hasConnectedRef.current = true;
-      };
-
-      websocket.onmessage = (event) => {
-        try {
-          const data = JSON.parse(event.data) as ServerEvent;
-          if (data.kind === 'pong') {
-            return;
-          }
-          dispatch(data);
-        } catch (error) {
-          console.error('Error parsing WebSocket message:', error);
-        }
-      };
-
-      websocket.onclose = () => {
-        if (wsRef.current !== websocket) {
-          return;
-        }
-        setIsConnected(false);
-        wsRef.current = null;
-
-        reconnectTimeoutRef.current = setTimeout(() => {
-          reconnectTimeoutRef.current = null;
-          if (unmountedRef.current) return; // Prevent reconnection if unmounted
-          connect();
-        }, RECONNECT_DELAY_MS);
-      };
-
-      websocket.onerror = (error) => {
-        console.error('WebSocket error:', error);
-      };
-
-    } catch (error) {
-      console.error('Error creating WebSocket connection:', error);
-    }
-  }, [dispatch, isAuthLoading, token, user]); // reconnect with current authentication state
-
-  // Declared after `connect` so the effect body does not reference it before
-  // initialization. `connect` is memoized on [dispatch, isAuthLoading, token,
-  // user] and `dispatch` is stable, so depending on it reconnects on exactly
-  // the same transitions as the previous [isAuthLoading, token, user] list.
-  useEffect(() => {
-    // The cleanup below sets unmountedRef = true. Without this reset, every
-    // re-run of the effect (e.g. on token refresh) would short-circuit connect()
-    // at its unmounted guard and leave the socket permanently disconnected.
-    unmountedRef.current = false;
-    if (!IS_PLATFORM && (isAuthLoading || !user)) {
-      return undefined;
-    }
-    connect();
-
-    return () => {
-      unmountedRef.current = true;
-      if (reconnectTimeoutRef.current) {
-        clearTimeout(reconnectTimeoutRef.current);
-        reconnectTimeoutRef.current = null;
-      }
-      const activeSocket = wsRef.current;
-      if (activeSocket) {
-        // Prevent the intentionally closed, old-token socket from scheduling
-        // a reconnect after the refreshed-token effect has already started.
-        activeSocket.onopen = null;
-        activeSocket.onmessage = null;
-        activeSocket.onclose = null;
-        activeSocket.onerror = null;
-        activeSocket.close();
-        wsRef.current = null;
+    const clearTimer = () => {
+      if (timer !== null) {
+        window.clearTimeout(timer);
+        timer = null;
       }
     };
-  }, [connect, isAuthLoading, user]); // reconnect after authentication or token refresh
 
-  // A suspended browser can retain an OPEN socket whose TCP peer is gone.
-  // Probe when the page resumes and replace the transport if no pong returns.
-  useEffect(() => {
-    let probeTimer: NodeJS.Timeout | null = null;
-    let probeSocket: WebSocket | null = null;
-    let probeListener: ((event: MessageEvent) => void) | null = null;
-
-    const clearProbe = () => {
-      if (probeTimer !== null) {
-        clearTimeout(probeTimer);
-        probeTimer = null;
-      }
-      if (probeSocket && probeListener) {
-        probeSocket.removeEventListener('message', probeListener);
-      }
-      probeSocket = null;
-      probeListener = null;
+    const schedule = (callback: () => void, delay: number) => {
+      clearTimer();
+      timer = window.setTimeout(() => {
+        timer = null;
+        if (!disposed) callback();
+      }, delay);
     };
 
-    const scheduleReconnect = () => {
-      if (reconnectTimeoutRef.current) {
-        return;
-      }
-      reconnectTimeoutRef.current = setTimeout(() => {
-        reconnectTimeoutRef.current = null;
-        if (unmountedRef.current) return;
-        connect();
-      }, RECONNECT_DELAY_MS);
-    };
-
-    const replaceSocket = (socket: WebSocket) => {
-      if (wsRef.current !== socket) {
-        return;
-      }
-      clearProbe();
-      setIsConnected(false);
-      wsRef.current = null;
+    const closeSocket = (socket: WebSocket) => {
+      socket.onopen = null;
+      socket.onmessage = null;
+      socket.onclose = null;
+      socket.onerror = null;
       socket.close();
-      scheduleReconnect();
     };
 
-    const handleResume = () => {
-      if (document.visibilityState !== 'visible') {
-        return;
-      }
+    const retireSocket = (socket: WebSocket) => {
+      if (disposed || wsRef.current !== socket) return;
+      pendingNonce = null;
+      wsRef.current = null;
+      setIsConnected(false);
+      closeSocket(socket);
+      schedule(connect, RECONNECT_DELAY_MS);
+    };
+    retireSocketRef.current = retireSocket;
 
-      // A bfcache restore can fire both events for one resume.
-      clearProbe();
-
+    const probe = () => {
       const socket = wsRef.current;
-      if (!socket || socket.readyState === WebSocket.CLOSED) {
-        if (reconnectTimeoutRef.current) {
-          clearTimeout(reconnectTimeoutRef.current);
-          reconnectTimeoutRef.current = null;
-        }
-        connect();
-        if (!wsRef.current) {
-          scheduleReconnect();
-        }
+      if (!socket) {
+        // Resume events must not keep restarting an already scheduled retry.
+        if (timer === null) connect();
         return;
       }
+      if (socket.readyState === WebSocket.CONNECTING || pendingNonce !== null) return;
       if (socket.readyState !== WebSocket.OPEN) {
+        retireSocket(socket);
         return;
       }
 
-      const nonce = `resume-${Date.now()}-${Math.random()}`;
-      probeSocket = socket;
-      probeListener = (event: MessageEvent) => {
-        try {
-          const frame = JSON.parse(String(event.data)) as { kind?: string; nonce?: string };
-          if (frame.kind === 'pong' && frame.nonce === nonce) {
-            clearProbe();
-          }
-        } catch {
-          // The normal message handler reports malformed frames.
-        }
-      };
-      socket.addEventListener('message', probeListener);
+      pendingNonce = `ping-${Date.now()}-${Math.random()}`;
+      schedule(() => retireSocket(socket), PONG_TIMEOUT_MS);
+      try {
+        socket.send(JSON.stringify({ type: 'chat.ping', nonce: pendingNonce }));
+      } catch {
+        retireSocket(socket);
+      }
+    };
+
+    function connect() {
+      if (disposed || wsRef.current) return;
+      const wsUrl = buildWebSocketUrl(token);
+      if (!wsUrl) return;
 
       try {
-        socket.send(JSON.stringify({ type: 'chat.ping', nonce }));
-      } catch {
-        replaceSocket(socket);
-        return;
-      }
+        const websocket = new WebSocket(wsUrl);
+        wsRef.current = websocket;
+        // A handshake can stall without either an open or a close event.
+        schedule(() => retireSocket(websocket), CONNECT_TIMEOUT_MS);
 
-      probeTimer = setTimeout(() => replaceSocket(socket), RESUME_PONG_TIMEOUT_MS);
+        websocket.onopen = () => {
+          if (disposed || wsRef.current !== websocket) return;
+          schedule(probe, PING_INTERVAL_MS);
+          setIsConnected(true);
+          if (hasConnectedRef.current) {
+            dispatch({ kind: 'websocket_reconnected', timestamp: Date.now() });
+          }
+          hasConnectedRef.current = true;
+        };
+
+        websocket.onmessage = (event) => {
+          if (disposed || wsRef.current !== websocket) return;
+          try {
+            const data = JSON.parse(event.data) as ServerEvent;
+            if (data.kind === 'pong') {
+              if (pendingNonce !== null && data.nonce === pendingNonce) {
+                pendingNonce = null;
+                schedule(probe, PING_INTERVAL_MS);
+              }
+              return;
+            }
+            dispatch(data);
+          } catch (error) {
+            console.error('Error parsing WebSocket message:', error);
+          }
+        };
+
+        websocket.onclose = () => retireSocket(websocket);
+        websocket.onerror = (error) => {
+          console.error('WebSocket error:', error);
+          retireSocket(websocket);
+        };
+      } catch (error) {
+        console.error('Error creating WebSocket connection:', error);
+        schedule(connect, RECONNECT_DELAY_MS);
+      }
+    }
+
+    const handleResume = () => {
+      if (document.visibilityState === 'visible') probe();
     };
 
+    connect();
+    // Timers also detect half-open sockets without a page event. Browsers can
+    // throttle these while suspended; resume probes do not extend a pong deadline.
     document.addEventListener('visibilitychange', handleResume);
     window.addEventListener('pageshow', handleResume);
     return () => {
-      clearProbe();
+      disposed = true;
+      clearTimer();
+      pendingNonce = null;
+      retireSocketRef.current = () => {};
       document.removeEventListener('visibilitychange', handleResume);
       window.removeEventListener('pageshow', handleResume);
+      const socket = wsRef.current;
+      wsRef.current = null;
+      if (socket) closeSocket(socket);
+      setIsConnected(false);
     };
-  }, [connect]);
+  }, [dispatch, isAuthLoading, token, user]);
 
   const sendMessage = useCallback((message: unknown) => {
     const socket = wsRef.current;
     if (socket && socket.readyState === WebSocket.OPEN) {
-      socket.send(JSON.stringify(message));
+      const payload = JSON.stringify(message);
+      try {
+        socket.send(payload);
+      } catch (error) {
+        console.error('WebSocket send error:', error);
+        retireSocketRef.current(socket);
+      }
     } else {
       console.warn('WebSocket not connected');
+      if (socket && socket.readyState !== WebSocket.CONNECTING) {
+        retireSocketRef.current(socket);
+      }
     }
   }, []);
 
@@ -290,7 +238,7 @@ const useWebSocketProviderState = (): WebSocketContextType => {
 
   const value: WebSocketContextType = useMemo(() =>
   ({
-    ws: wsRef.current,
+    ws: isConnected ? wsRef.current : null,
     sendMessage,
     subscribe,
     isConnected

--- a/src/shared/tests/webSocketContext.test.tsx
+++ b/src/shared/tests/webSocketContext.test.tsx
@@ -1,0 +1,388 @@
+import assert from 'node:assert/strict';
+
+import { act, cleanup, renderHook } from '@testing-library/react';
+import React, { useEffect } from 'react';
+import { afterEach, beforeEach, test, vi } from 'vitest';
+
+import { WebSocketProvider, useWebSocket } from '@/shared/context/WebSocketContext';
+import { AUTH_SESSION_EXPIRED_EVENT } from '@/shared/authToken';
+import type { ServerEvent } from '@/shared/types';
+
+const auth = vi.hoisted((): {
+  isLoading: boolean;
+  token: string | null;
+  user: { id: string } | null;
+} => ({ isLoading: false, token: 'first-token', user: { id: 'user' } }));
+const runtime = vi.hoisted(() => ({ platform: false }));
+vi.mock('@/modules/auth', () => ({ useAuth: () => auth }));
+vi.mock('@/shared/utils', () => ({ get IS_PLATFORM() { return runtime.platform; } }));
+
+class FakeWebSocket extends EventTarget {
+  static CONNECTING = 0;
+  static OPEN = 1;
+  static CLOSING = 2;
+  static CLOSED = 3;
+  static sockets: FakeWebSocket[] = [];
+  static constructorFailures = 0;
+
+  readyState: number = FakeWebSocket.CONNECTING;
+  onopen: ((event: Event) => void) | null = null;
+  onmessage: ((event: MessageEvent) => void) | null = null;
+  onclose: ((event: Event) => void) | null = null;
+  onerror: ((event: Event) => void) | null = null;
+  sent: Array<{ type?: string; nonce?: string }> = [];
+  sendFails = false;
+
+  constructor(readonly url: string) {
+    super();
+    if (FakeWebSocket.constructorFailures > 0) {
+      FakeWebSocket.constructorFailures -= 1;
+      throw new Error('Socket construction failed');
+    }
+    FakeWebSocket.sockets.push(this);
+  }
+
+  send(payload: string) {
+    if (this.sendFails) throw new Error('Socket send failed');
+    assert.equal(this.readyState, FakeWebSocket.OPEN);
+    this.sent.push(JSON.parse(payload));
+  }
+
+  close = vi.fn(() => {
+    this.readyState = FakeWebSocket.CLOSED;
+    this.onclose?.(new Event('close'));
+  });
+
+  open() {
+    this.readyState = FakeWebSocket.OPEN;
+    this.onopen?.(new Event('open'));
+  }
+
+  receive(frame: unknown) {
+    const event = new MessageEvent('message', { data: JSON.stringify(frame) });
+    this.onmessage?.(event);
+    this.dispatchEvent(event);
+  }
+}
+
+const wrapper = ({ children }: { children: React.ReactNode }) =>
+  React.createElement(WebSocketProvider, null, children);
+
+function mountProvider() {
+  const events: ServerEvent[] = [];
+  const hook = renderHook(() => {
+    const context = useWebSocket();
+    const { subscribe } = context;
+    useEffect(() => subscribe((event) => events.push(event)), [subscribe]);
+    return context;
+  }, { wrapper });
+  return { ...hook, events };
+}
+
+function currentSocket() {
+  const socket = FakeWebSocket.sockets.at(-1);
+  assert.ok(socket, 'the provider should construct a socket');
+  return socket;
+}
+
+function nextDeadline() {
+  act(() => { vi.advanceTimersToNextTimer(); });
+}
+
+function expectReplacement(original: FakeWebSocket) {
+  for (let attempt = 0; attempt < 4 && currentSocket() === original; attempt += 1) {
+    nextDeadline();
+  }
+  assert.notEqual(currentSocket(), original, 'the channel should recover without a page event');
+  assert.equal(FakeWebSocket.sockets.length, 2, 'recovery should create only one replacement');
+  return currentSocket();
+}
+
+function resume() {
+  act(() => {
+    document.dispatchEvent(new Event('visibilitychange'));
+    window.dispatchEvent(new Event('pageshow'));
+  });
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.stubGlobal('WebSocket', FakeWebSocket);
+  vi.spyOn(document, 'visibilityState', 'get').mockReturnValue('visible');
+  vi.spyOn(console, 'error').mockImplementation(() => {});
+  vi.spyOn(console, 'warn').mockImplementation(() => {});
+  FakeWebSocket.sockets = [];
+  FakeWebSocket.constructorFailures = 0;
+  auth.isLoading = false;
+  auth.token = 'first-token';
+  auth.user = { id: 'user' };
+  runtime.platform = false;
+  localStorage.clear();
+});
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+});
+
+test('a half-open channel recovers without resume events and delivers replacement messages', () => {
+  const { result, events } = mountProvider();
+  const original = currentSocket();
+  act(() => original.open());
+  assert.equal(result.current.isConnected, true);
+  assert.equal(events.length, 0, 'the initial connection is not a reconnect');
+
+  const replacement = expectReplacement(original);
+  assert.equal(result.current.isConnected, false);
+  const response = { kind: 'session-status', sessionId: 'session', isRunning: true };
+  act(() => {
+    replacement.open();
+    replacement.receive(response);
+    result.current.sendMessage({ type: 'chat.subscribe', sessionId: 'session' });
+  });
+  assert.equal(result.current.isConnected, true);
+  assert.equal(result.current.ws, replacement);
+  assert.equal(events[0]?.kind, 'websocket_reconnected');
+  assert.deepEqual(events.slice(1), [response]);
+  assert.deepEqual(replacement.sent, [{ type: 'chat.subscribe', sessionId: 'session' }]);
+});
+
+test('matching periodic pongs preserve the socket and never reach subscribers', () => {
+  const { events } = mountProvider();
+  const socket = currentSocket();
+  act(() => socket.open());
+
+  for (let cycle = 0; cycle < 3; cycle += 1) {
+    nextDeadline();
+    const ping = socket.sent.at(-1);
+    assert.equal(ping?.type, 'chat.ping');
+    assert.equal(typeof ping?.nonce, 'string');
+    act(() => socket.receive({ kind: 'pong', nonce: ping?.nonce }));
+    assert.equal(currentSocket(), socket);
+  }
+  assert.equal(socket.close.mock.calls.length, 0);
+  assert.deepEqual(events, []);
+});
+
+test('wrong nonces and ordinary traffic cannot satisfy a pending pong', () => {
+  const { events } = mountProvider();
+  const socket = currentSocket();
+  act(() => socket.open());
+  resume();
+  const ping = socket.sent.at(-1);
+  assert.equal(ping?.type, 'chat.ping');
+  const response = { kind: 'session-status', nonce: ping?.nonce, sessionId: 'session' };
+  act(() => {
+    socket.receive({ kind: 'pong', nonce: 'wrong-nonce' });
+    socket.receive(response);
+  });
+  expectReplacement(socket);
+  assert.deepEqual(events, [response]);
+});
+
+test('repeated page events cannot postpone a pending pong deadline', () => {
+  mountProvider();
+  const socket = currentSocket();
+  act(() => socket.open());
+  resume();
+  // Keep resuming throughout the timeout, rather than only dispatching both
+  // browser events in one tick. Restarting the deadline would never retire it.
+  for (let step = 0; step < 20 && socket.close.mock.calls.length === 0; step += 1) {
+    act(() => { vi.advanceTimersByTime(500); });
+    resume();
+  }
+  assert.equal(socket.close.mock.calls.length, 1);
+  assert.equal(socket.sent.length, 1, 'one pending probe must keep its nonce and deadline');
+  expectReplacement(socket);
+});
+
+test('closing during a probe removes its deadline and old callbacks cannot clobber the replacement', () => {
+  const { result, events } = mountProvider();
+  const socket = currentSocket();
+  act(() => socket.open());
+  resume();
+  const lateOpen = socket.onopen;
+  const lateClose = socket.onclose;
+  const lateMessage = socket.onmessage;
+  act(() => socket.close());
+  const replacement = expectReplacement(socket);
+  act(() => {
+    replacement.open();
+    lateClose?.(new Event('close'));
+    lateOpen?.(new Event('open'));
+    lateMessage?.(new MessageEvent('message', { data: JSON.stringify({ kind: 'old-frame' }) }));
+    socket.receive({ kind: 'pong', nonce: socket.sent.at(-1)?.nonce });
+  });
+  assert.equal(result.current.ws, replacement);
+  assert.equal(result.current.isConnected, true);
+  assert.deepEqual(events.map((event) => event.kind), ['websocket_reconnected']);
+  nextDeadline();
+  assert.equal(replacement.sent.at(-1)?.type, 'chat.ping');
+  assert.equal(replacement.close.mock.calls.length, 0);
+});
+
+test('ordinary close retries once and a resumed page does not create a competing connection', () => {
+  const { result } = mountProvider();
+  const socket = currentSocket();
+  act(() => socket.open());
+  act(() => socket.close());
+  assert.equal(result.current.isConnected, false);
+  resume();
+  const replacement = expectReplacement(socket);
+  resume();
+  act(() => replacement.open());
+  assert.equal(result.current.ws, replacement);
+  assert.equal(FakeWebSocket.sockets.length, 2);
+});
+
+test('constructor failure retries without a resume event using the current token', () => {
+  FakeWebSocket.constructorFailures = 1;
+  const { result, rerender } = mountProvider();
+  assert.equal(FakeWebSocket.sockets.length, 0);
+  nextDeadline();
+  const socket = currentSocket();
+  assert.equal(new URL(socket.url).searchParams.get('token'), 'first-token');
+  act(() => socket.open());
+  act(() => socket.close());
+  auth.token = 'replacement-token';
+  rerender();
+  const replacement = currentSocket();
+  assert.notEqual(replacement, socket);
+  assert.equal(new URL(replacement.url).searchParams.get('token'), 'replacement-token');
+  act(() => replacement.open());
+  assert.equal(result.current.ws, replacement);
+});
+
+test('stalled handshakes are bounded and late opens cannot publish a retired socket', () => {
+  const { result, events } = mountProvider();
+  const socket = currentSocket();
+  const lateOpen = socket.onopen;
+  resume();
+  const replacement = expectReplacement(socket);
+  act(() => lateOpen?.(new Event('open')));
+  assert.equal(result.current.isConnected, false);
+  assert.deepEqual(events, []);
+  act(() => replacement.open());
+  assert.equal(result.current.ws, replacement);
+  assert.deepEqual(events, [], 'a failed initial handshake is not a successful prior connection');
+});
+
+for (const state of [FakeWebSocket.CLOSING, FakeWebSocket.CLOSED]) {
+  test(`a socket silently entering readyState ${state} cannot block recovery`, () => {
+    mountProvider();
+    const socket = currentSocket();
+    act(() => socket.open());
+    socket.readyState = state;
+    expectReplacement(socket);
+  });
+}
+
+for (const source of ['probe', 'command']) {
+  test(`a ${source} send failure retires the socket and retries`, () => {
+    const { result } = mountProvider();
+    const socket = currentSocket();
+    act(() => socket.open());
+    socket.sendFails = true;
+    if (source === 'probe') {
+      resume();
+    } else {
+      act(() => result.current.sendMessage({ type: 'chat.subscribe', sessionId: 'session' }));
+    }
+    assert.equal(result.current.isConnected, false);
+    const replacement = expectReplacement(socket);
+    act(() => replacement.open());
+    assert.equal(result.current.ws, replacement);
+  });
+}
+
+test('token replacement, logout and unmount cancel probes and reconnect work', () => {
+  const { result, rerender, unmount } = mountProvider();
+  const socket = currentSocket();
+  act(() => socket.open());
+  resume();
+  auth.token = 'replacement-token';
+  rerender();
+  const replacement = currentSocket();
+  assert.notEqual(replacement, socket);
+  assert.equal(socket.readyState, FakeWebSocket.CLOSED);
+  assert.equal(result.current.isConnected, false);
+  assert.equal(result.current.ws, null, 'consumers must not subscribe while the replacement is connecting');
+  act(() => replacement.open());
+  assert.equal(result.current.ws, replacement, 'opening must publish the socket so chat subscribes');
+  resume();
+
+  auth.token = null;
+  auth.user = null;
+  rerender();
+  assert.equal(result.current.isConnected, false);
+  assert.equal(result.current.ws, null);
+  assert.equal(replacement.readyState, FakeWebSocket.CLOSED);
+  act(() => { vi.advanceTimersByTime(120_000); });
+  resume();
+  assert.equal(FakeWebSocket.sockets.length, 2);
+  assert.equal(vi.getTimerCount(), 0);
+
+  auth.token = 'login-token';
+  auth.user = { id: 'user' };
+  rerender();
+  const loggedIn = currentSocket();
+  act(() => loggedIn.open());
+  resume();
+  unmount();
+  act(() => { vi.advanceTimersByTime(120_000); });
+  resume();
+  assert.equal(loggedIn.readyState, FakeWebSocket.CLOSED);
+  assert.equal(FakeWebSocket.sockets.length, 3);
+  assert.equal(vi.getTimerCount(), 0);
+});
+
+test('unmount cancels a constructor retry', () => {
+  FakeWebSocket.constructorFailures = 1;
+  const { unmount } = mountProvider();
+  unmount();
+  act(() => { vi.advanceTimersByTime(120_000); });
+  resume();
+  assert.equal(FakeWebSocket.sockets.length, 0);
+  assert.equal(vi.getTimerCount(), 0);
+});
+
+test('OSS auth gates loading, missing user and missing token; platform remains tokenless', () => {
+  auth.isLoading = true;
+  const { rerender } = mountProvider();
+  resume();
+  assert.equal(FakeWebSocket.sockets.length, 0);
+  auth.isLoading = false;
+  auth.user = null;
+  rerender();
+  resume();
+  assert.equal(FakeWebSocket.sockets.length, 0);
+  auth.user = { id: 'user' };
+  auth.token = null;
+  rerender();
+  resume();
+  assert.equal(FakeWebSocket.sockets.length, 0);
+  cleanup();
+
+  runtime.platform = true;
+  auth.user = null;
+  auth.isLoading = true;
+  mountProvider();
+  assert.equal(new URL(currentSocket().url).search, '');
+});
+
+test('an expired OSS token expires the auth session without opening a channel', () => {
+  const payload = btoa(JSON.stringify({ iat: 0, exp: 1 })).replace(/=+$/, '');
+  auth.token = `header.${payload}.signature`;
+  localStorage.setItem('auth-token', auth.token);
+  const expired = vi.fn();
+  window.addEventListener(AUTH_SESSION_EXPIRED_EVENT, expired);
+  try {
+    mountProvider();
+    assert.equal(FakeWebSocket.sockets.length, 0);
+    assert.equal(localStorage.getItem('auth-token'), null);
+    assert.equal(expired.mock.calls.length, 1);
+  } finally {
+    window.removeEventListener(AUTH_SESSION_EXPIRED_EVENT, expired);
+  }
+});

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -197,7 +197,7 @@ export type SessionActivitySnapshot = {
 /**
  * One frame received from the chat websocket. The server guarantees every
  * frame carries a `kind` (provider message kinds plus gateway kinds such as
- * `chat_subscribed`, `session_upserted`, `loading_progress`,
+ * `chat_subscribed`, `pong`, `session_upserted`, `loading_progress`,
  * `protocol_error`). The synthetic `websocket_reconnected` kind is injected
  * client-side when the socket re-opens after a drop.
  */


### PR DESCRIPTION
## Purpose

Reconnect the shared `/ws` chat channel when it stops working, then catch the selected chat up on missed messages. Provider implementations, defaults, authentication modes, and the `/shell` and plugin WebSocket transports are unchanged.

Rebased onto upstream `main` at `5e73a49b`. That upstream revision still reproduces the half-open-channel failure described below.

## The failure

A dropped network path can leave the browser reporting `WebSocket.OPEN` without a close event. Upstream reconnects after close, so an apparently connected chat can stop receiving messages. Returning from suspend is one way to encounter this, but recovery must not depend on a visibility or page-show event.

The original version of this PR only probed on those page events. This revision adds periodic liveness checks and fixes the ordering of chat catch-up after reconnect.

## Changes

- Probe with `chat.ping { nonce }` 30 seconds after opening or receiving a matching pong. The gateway answers only that socket with `{ kind: "pong", nonce }`, without invoking a provider. Pong frames stay inside the transport layer.
- If no matching pong arrives within 3 seconds, retire the socket and retry after the existing 3-second reconnect delay. A handshake stuck in `CONNECTING` is retired after 30 seconds. Constructor, socket, and send failures also retire or retry the connection as appropriate.
- Use one auth-scoped timer for handshake, next ping, pong deadline, or retry. Socket identity guards and cleanup prevent retired sockets, old credentials, or pending timers from affecting a replacement. Repeated resume events cannot postpone an outstanding pong deadline.
- Keep `visibilitychange` to visible and `pageshow` as earlier probe triggers. Periodic checks do not require either event or a visibility transition.
- On socket replacement, publish the socket to chat only after it opens, send `chat.subscribe`, and wait for the matching selected-session acknowledgement before requesting the persisted tail. Arm the listener before sending; discard pending acknowledgements when the socket/session changes or the hook unmounts. Remove the obsolete duplicate reconnect subscription callback.
- Preserve hidden-chat history gating: hidden chats still subscribe, but persisted-tail HTTP waits until activation and acknowledgement. Initial connections do not gain an extra reconnect refresh. Visibility-only changes do not resubscribe.

The acknowledgement confirms subscription handling, not replay completion or provider persistence. The server sends replay after the acknowledgement, so replay and the HTTP refresh can overlap. Browser suspension or background timer throttling can delay detection; there is no wall-clock guarantee while browser timers are paused. Failed application messages are not automatically resent.

## Verification

### Native Chromium reproduction

Used an isolated browser fixture mounting the actual `WebSocketProvider`, with an authentication stub, the actual chat gateway handler, native WebSockets, and a TCP proxy. The proxy dropped both directions for existing connections without closing them, while allowing new connections through. The page stayed visible and no `visibilitychange` or `pageshow` event fired during the observation.

| Source | Replacement connections | Message emitted after blackholing |
| --- | --- | --- |
| Upstream `5e73a49b` | 0 after 51 seconds; still reported connected | Not received |
| This revision | Exactly 1 by the 40-second observation | Received by the browser consumer |

The responsive replacement remained connected through subsequent heartbeat checks. A separate token-rotation check opened one replacement and received a fresh subscription acknowledgement. The final blackhole run also received a new subscription acknowledgement before the emitted message. This was a transport fixture, not a provider-backed conversation or a physical laptop-suspend test.

### Regression and preservation checks

- The no-page-event half-open regression fails against the actual upstream transport source and passes with this revision.
- The delayed-acknowledgement regression fails against the original PR's rebased session hook because it starts HTTP before acknowledgement; it passes with this revision.
- Transport tests exercise healthy pongs, wrong nonces, repeated page events, close during a probe, stale callbacks, ordinary disconnects, failed constructors/sends, stalled handshakes, token replacement, logout, unmount, expired OSS tokens, and tokenless platform mode.
- Chat tests use the real session store to check delayed/unrelated/stale acknowledgements, displayed history, visibility changes, hidden reconnects, activation before acknowledgement, session switching, and unmount.
- A real-handler/store regression verifies that synthetic reconnect notifications never enter transcript history; it failed before restoring the explicit early return and now passes.
- A real-socket gateway test checks that pings receive the matching pong without invoking provider runtimes or broadcasting to another client.

Commands run on the rebased revision:

- `npm run test:client`: 422 passed.
- `npm test`: 416 passed, 1 skipped because the Codex rollout fixture is unavailable.
- `npm run typecheck`: passed.
- `npm run build`: passed, with CSS and bundle-size warnings.
- `npm run lint`: exited successfully with 132 warnings and no errors. Follow-up lint on all touched implementation/test files reports no warnings in the new tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added WebSocket heartbeat monitoring to detect stalled connections and automatically recover them.
  - Added `chat.ping` messages and matching `pong` responses for connection checks.
  - Chat sessions now wait for successful re-subscription before refreshing message history after reconnecting.
  - New chat turns can optionally interrupt an active provider response and complete it before starting the next turn.

- **Documentation**
  - Updated WebSocket protocol and recovery documentation with heartbeat and reconnection behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->