### PR TITLE
fix(pwa): prevent white startup chrome and use a dark splash default

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,33 @@
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <link rel="icon" type="image/png" href="/favicon.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0, user-scalable=no, viewport-fit=cover, interactive-widget=resizes-content" />
+    <!-- Set the saved theme before the PWA shell paints. -->
+    <meta name="theme-color" content="#141414" />
+    <meta name="msapplication-TileColor" content="#141414" />
+    <script>
+      {
+        let savedTheme;
+        try {
+          const mirroredTheme = JSON.parse(localStorage.getItem('user-preferences') || 'null')?.theme;
+          savedTheme = mirroredTheme === 'system' || mirroredTheme === 'light' || mirroredTheme === 'dark'
+            ? mirroredTheme
+            : localStorage.getItem('theme');
+        } catch {
+          try {
+            savedTheme = localStorage.getItem('theme');
+          } catch {
+            // System preference remains available when storage is unavailable.
+          }
+        }
+        const isDark = savedTheme === 'dark'
+          || (savedTheme !== 'light' && window.matchMedia('(prefers-color-scheme: dark)').matches);
+        const themeColor = isDark ? '#141414' : '#f6f4ef';
+        document.documentElement.classList.toggle('dark', isDark);
+        document.querySelectorAll('meta[name="theme-color"], meta[name="msapplication-TileColor"]').forEach(meta => {
+          meta.setAttribute('content', themeColor);
+        });
+      }
+    </script>
     <title>CloudCLI UI</title>
 
     <!-- Fonts: Encode Sans (UI) + Merriweather (chat) -->
@@ -26,10 +53,6 @@
     <!-- iOS Safari Icons -->
     <link rel="apple-touch-icon" sizes="152x152" href="/icons/icon-152x152.png" />
     <link rel="apple-touch-icon" sizes="180x180" href="/icons/icon-192x192.png" />
-    
-    <!-- Theme Color -->
-    <meta name="theme-color" content="#ffffff" />
-    <meta name="msapplication-TileColor" content="#ffffff" />
     
     <!-- Prevent zoom on iOS -->
     <meta name="format-detection" content="telephone=no" />

--- a/index.html
+++ b/index.html
@@ -13,9 +13,8 @@
         let savedTheme;
         try {
           const mirroredTheme = JSON.parse(localStorage.getItem('user-preferences') || 'null')?.theme;
-          savedTheme = mirroredTheme === 'system' || mirroredTheme === 'light' || mirroredTheme === 'dark'
-            ? mirroredTheme
-            : localStorage.getItem('theme');
+          // A present but unsupported value follows the system, rather than reviving a legacy theme.
+          savedTheme = mirroredTheme !== undefined ? mirroredTheme : localStorage.getItem('theme');
         } catch {
           try {
             savedTheme = localStorage.getItem('theme');
@@ -24,7 +23,7 @@
           }
         }
         const isDark = savedTheme === 'dark'
-          || (savedTheme !== 'light' && window.matchMedia('(prefers-color-scheme: dark)').matches);
+          || (savedTheme !== 'light' && window.matchMedia?.('(prefers-color-scheme: dark)').matches === true);
         const themeColor = isDark ? '#141414' : '#f6f4ef';
         document.documentElement.classList.toggle('dark', isDark);
         document.querySelectorAll('meta[name="theme-color"], meta[name="msapplication-TileColor"]').forEach(meta => {

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -4,8 +4,8 @@
   "description": "CloudCLI UI web application",
   "start_url": "/",
   "display": "standalone",
-  "background_color": "#ffffff",
-  "theme_color": "#ffffff",
+  "background_color": "#141414",
+  "theme_color": "#141414",
   "orientation": "portrait-primary",
   "scope": "/",
   "icons": [

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,7 +1,7 @@
 // Service Worker for CloudCLI PWA
 // Cache only manifest (needed for PWA install). HTML and JS are never pre-cached
 // so a rebuild + refresh always picks up the latest assets.
-const CACHE_NAME = 'claude-ui-v2';
+const CACHE_NAME = 'claude-ui-v3';
 const urlsToCache = [
   '/manifest.json'
 ];
@@ -51,9 +51,18 @@ self.addEventListener('fetch', event => {
     return;
   }
 
-  // Everything else — network-first
+  // Keep the installable manifest cache synchronized with the network copy.
+  const shouldRefreshCache = new URL(url).pathname.endsWith('/manifest.json');
   event.respondWith(
-    fetch(event.request).catch(() => caches.match(event.request))
+    fetch(event.request)
+      .then(async response => {
+        if (shouldRefreshCache && response.ok) {
+          const cache = await caches.open(CACHE_NAME);
+          await cache.put(event.request, response.clone());
+        }
+        return response;
+      })
+      .catch(() => caches.match(event.request))
   );
 });
 

--- a/public/sw.js
+++ b/public/sw.js
@@ -57,8 +57,12 @@ self.addEventListener('fetch', event => {
     fetch(event.request)
       .then(async response => {
         if (shouldRefreshCache && response.ok) {
-          const cache = await caches.open(CACHE_NAME);
-          await cache.put(event.request, response.clone());
+          try {
+            const cache = await caches.open(CACHE_NAME);
+            await cache.put(event.request, response.clone());
+          } catch {
+            // Cache refresh is best-effort; keep the successful network response.
+          }
         }
         return response;
       })

--- a/src/index.css
+++ b/src/index.css
@@ -126,6 +126,10 @@
     transition: none;
   }
   
+  html {
+    @apply bg-background;
+  }
+
   body {
     @apply bg-background text-foreground;
 

--- a/src/shared/context/ThemeContext.tsx
+++ b/src/shared/context/ThemeContext.tsx
@@ -14,6 +14,12 @@ type ThemeContextValue = {
 
 const ThemeContext = createContext<ThemeContextValue | null>(null);
 
+function readIsDarkMode(): boolean {
+  const savedTheme = readUserPreference<unknown>('theme', null);
+  return savedTheme === 'dark'
+    || (savedTheme !== 'light' && window.matchMedia?.('(prefers-color-scheme: dark)').matches === true);
+}
+
 export const useTheme = () => {
   const context = useContext(ThemeContext);
   if (!context) {
@@ -24,30 +30,13 @@ export const useTheme = () => {
 
 /** Mounted once by App so every module can read and switch the colour theme through useTheme. */
 export const ThemeProvider = ({ children }: { children: ReactNode }) => {
-  // Check for saved theme preference or default to system preference. The
-  // stored theme is read synchronously from the preference mirror so the very
-  // first paint is already the right colour.
-  const [isDarkMode, setIsDarkMode] = useState(() => {
-    const savedTheme = readUserPreference<string | null>('theme', null);
-    if (savedTheme) {
-      return savedTheme === 'dark';
-    }
-
-    // Check system preference
-    if (window.matchMedia) {
-      return window.matchMedia('(prefers-color-scheme: dark)').matches;
-    }
-
-    return false;
-  });
+  // Read the startup mirror, including its legacy theme seed, before the first render.
+  const [isDarkMode, setIsDarkMode] = useState(readIsDarkMode);
 
   // The theme now lives in auth.db, so a change made on another device (or in
   // another tab) arrives through the preference store rather than a re-render.
   useEffect(() => subscribeToUserPreferences(() => {
-    const savedTheme = readUserPreference<string | null>('theme', null);
-    if (savedTheme) {
-      setIsDarkMode(savedTheme === 'dark');
-    }
+    setIsDarkMode(readIsDarkMode());
   }), []);
 
   // Applying the theme to the document and persisting it are deliberately
@@ -55,33 +44,17 @@ export const ThemeProvider = ({ children }: { children: ReactNode }) => {
   // theme had been fetched — writing this device's system default over the
   // theme the user actually chose on another one.
   useEffect(() => {
-    if (isDarkMode) {
-      document.documentElement.classList.add('dark');
+    document.documentElement.classList.toggle('dark', isDarkMode);
 
-      // Update iOS status bar style and theme color for dark mode
-      const statusBarMeta = document.querySelector('meta[name="apple-mobile-web-app-status-bar-style"]');
-      if (statusBarMeta) {
-        statusBarMeta.setAttribute('content', 'black-translucent');
-      }
-
-      const themeColorMeta = document.querySelector('meta[name="theme-color"]');
-      if (themeColorMeta) {
-        themeColorMeta.setAttribute('content', '#141414'); // Dark background color (hsl(0 0% 8%))
-      }
-    } else {
-      document.documentElement.classList.remove('dark');
-
-      // Update iOS status bar style and theme color for light mode
-      const statusBarMeta = document.querySelector('meta[name="apple-mobile-web-app-status-bar-style"]');
-      if (statusBarMeta) {
-        statusBarMeta.setAttribute('content', 'default');
-      }
-
-      const themeColorMeta = document.querySelector('meta[name="theme-color"]');
-      if (themeColorMeta) {
-        themeColorMeta.setAttribute('content', '#f6f4ef'); // Light background color (warm cream)
-      }
+    const statusBarMeta = document.querySelector('meta[name="apple-mobile-web-app-status-bar-style"]');
+    if (statusBarMeta) {
+      statusBarMeta.setAttribute('content', isDarkMode ? 'black-translucent' : 'default');
     }
+
+    const themeColor = isDarkMode ? '#141414' : '#f6f4ef';
+    document.querySelectorAll('meta[name="theme-color"], meta[name="msapplication-TileColor"]').forEach(meta => {
+      meta.setAttribute('content', themeColor);
+    });
   }, [isDarkMode]);
 
   // Listen for system theme changes
@@ -90,9 +63,9 @@ export const ThemeProvider = ({ children }: { children: ReactNode }) => {
 
     const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
     const handleChange = (e: MediaQueryListEvent) => {
-      // Only update if user hasn't manually set a preference
-      const savedTheme = readUserPreference<string | null>('theme', null);
-      if (!savedTheme) {
+      // Only supported explicit preferences stop following the system.
+      const savedTheme = readUserPreference<unknown>('theme', null);
+      if (savedTheme !== 'light' && savedTheme !== 'dark') {
         setIsDarkMode(e.matches);
       }
     };

--- a/src/shared/tests/serviceWorker.test.ts
+++ b/src/shared/tests/serviceWorker.test.ts
@@ -1,0 +1,85 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { URL } from 'node:url';
+import { runInNewContext } from 'node:vm';
+
+import { test } from 'vitest';
+
+const SERVICE_WORKER_SOURCE = readFileSync('public/sw.js', 'utf8');
+
+type ManifestFetchEvent = {
+  request: Request;
+  respondWith: (response: Promise<Response | undefined>) => void;
+};
+
+type WorkerDependencies = {
+  fetch: () => Promise<Response>;
+  caches: {
+    open: () => Promise<{ put: () => Promise<void> }>;
+    match: () => Promise<Response | undefined>;
+  };
+};
+
+async function fetchManifest(dependencies: WorkerDependencies) {
+  const listeners = new Map<string, (event: ManifestFetchEvent) => void>();
+  runInNewContext(SERVICE_WORKER_SOURCE, {
+    ...dependencies,
+    URL,
+    Response,
+    self: {
+      addEventListener: (name: string, listener: (event: ManifestFetchEvent) => void) => {
+        listeners.set(name, listener);
+      },
+    },
+  });
+
+  const onFetch = listeners.get('fetch');
+  assert.ok(onFetch, 'service worker must register a fetch handler');
+  return new Promise<Response | undefined>((resolve) => {
+    onFetch({
+      request: new Request('https://cloudcli.example/manifest.json'),
+      respondWith: resolve,
+    });
+  });
+}
+
+test('manifest fetch returns fresh content when opening the cache fails', async () => {
+  const fresh = new Response('{"name":"Fresh manifest"}');
+  const response = await fetchManifest({
+    fetch: async () => fresh,
+    caches: {
+      open: async () => { throw new Error('Cache storage unavailable'); },
+      match: async () => new Response('{"name":"Stale manifest"}'),
+    },
+  });
+
+  assert.equal(await response?.text(), '{"name":"Fresh manifest"}');
+});
+
+test('manifest fetch returns fresh content when writing the cache fails', async () => {
+  const fresh = new Response('{"name":"Fresh manifest"}');
+  const response = await fetchManifest({
+    fetch: async () => fresh,
+    caches: {
+      open: async () => ({
+        put: async () => { throw new Error('Cache quota exceeded'); },
+      }),
+      match: async () => new Response('{"name":"Stale manifest"}'),
+    },
+  });
+
+  assert.equal(await response?.text(), '{"name":"Fresh manifest"}');
+});
+
+test('manifest fetch falls back to cached content when the network fails', async () => {
+  const cached = new Response('{"name":"Offline manifest"}');
+  const response = await fetchManifest({
+    fetch: async () => { throw new TypeError('Network unavailable'); },
+    caches: {
+      open: async () => ({ put: async () => {} }),
+      match: async () => cached,
+    },
+  });
+
+  assert.equal(await response?.text(), '{"name":"Offline manifest"}');
+});

--- a/src/shared/tests/themeStartup.test.tsx
+++ b/src/shared/tests/themeStartup.test.tsx
@@ -1,0 +1,214 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+import { act, renderHook } from '@testing-library/react';
+import React from 'react';
+import { afterEach, beforeEach, test, vi } from 'vitest';
+
+const html = readFileSync('index.html', 'utf8');
+let serverPreferences: Record<string, unknown> = {};
+let preferencesStatus = 200;
+const saved: Record<string, unknown>[] = [];
+let systemIsDark = false;
+let systemChanges = new EventTarget();
+
+vi.mock('@/shared/api', () => ({
+  api: {
+    user: {
+      preferences: async () => new Response(JSON.stringify({ preferences: serverPreferences }), { status: preferencesStatus }),
+      savePreferences: async (updates: Record<string, unknown>) => {
+        saved.push(updates);
+        return new Response('{}');
+      },
+    },
+  },
+}));
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  localStorage.clear();
+  serverPreferences = {};
+  preferencesStatus = 200;
+  saved.length = 0;
+  systemIsDark = false;
+  systemChanges = new EventTarget();
+  vi.spyOn(window, 'matchMedia').mockImplementation((query) => ({
+    get matches() { return systemIsDark; },
+    media: query,
+    onchange: null,
+    addEventListener: systemChanges.addEventListener.bind(systemChanges),
+    removeEventListener: systemChanges.removeEventListener.bind(systemChanges),
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    dispatchEvent: systemChanges.dispatchEvent.bind(systemChanges),
+  }));
+});
+
+afterEach(() => {
+  vi.clearAllTimers();
+  vi.useRealTimers();
+  document.head.innerHTML = '';
+  document.documentElement.classList.remove('dark');
+});
+
+function boot() {
+  const documentFromHtml = new DOMParser().parseFromString(html, 'text/html');
+  document.head.innerHTML = documentFromHtml.head.innerHTML;
+  const script = documentFromHtml.querySelector('script:not([src])')?.textContent;
+  assert.ok(script, 'index.html must include the pre-paint theme script');
+  window.eval(script);
+}
+
+async function mountTheme() {
+  // Static imports cannot exercise the store's module-load read on each simulated reload.
+  vi.resetModules();
+  const store = await import('@/shared/userSettings');
+  const { ThemeProvider, useTheme } = await import('@/shared/context/ThemeContext');
+  const hook = renderHook(() => useTheme(), {
+    wrapper: ({ children }) => React.createElement(ThemeProvider, null, children),
+  });
+  return { ...hook, store };
+}
+
+function assertTheme(isDark: boolean) {
+  assert.equal(document.documentElement.classList.contains('dark'), isDark);
+  for (const name of ['theme-color', 'msapplication-TileColor']) {
+    assert.equal(document.querySelector(`meta[name="${name}"]`)?.getAttribute('content'),
+      isDark ? '#141414' : '#f6f4ef');
+  }
+}
+
+function changeSystemTheme(isDark: boolean) {
+  act(() => {
+    systemIsDark = isDark;
+    systemChanges.dispatchEvent(Object.assign(new Event('change'), { matches: isDark }));
+  });
+}
+
+test('legacy-only startup agrees with boot, then yields to server changes and resets across reloads', async () => {
+  localStorage.setItem('theme', 'dark');
+  boot();
+  assertTheme(true);
+  const { result, store, unmount } = await mountTheme();
+  assert.equal(result.current.isDarkMode, true);
+  assertTheme(true);
+
+  serverPreferences = { theme: 'light' };
+  await act(() => store.hydrateUserPreferences());
+  assert.equal(result.current.isDarkMode, false);
+  assertTheme(false);
+
+  serverPreferences = {};
+  await act(() => store.hydrateUserPreferences());
+  changeSystemTheme(true);
+  assert.equal(result.current.isDarkMode, true);
+  await vi.advanceTimersByTimeAsync(500);
+  assert.deepEqual(saved, [], 'stale legacy theme must not be migrated over the server again');
+
+  unmount();
+  systemIsDark = false;
+  boot();
+  assertTheme(false);
+  const reloaded = await mountTheme();
+  assert.equal(reloaded.result.current.isDarkMode, false);
+});
+
+test('unsupported mirrored theme follows system instead of stale legacy, while explicit toggles update both colors', async () => {
+  localStorage.setItem('user-preferences', JSON.stringify({ theme: 'system' }));
+  localStorage.setItem('theme', 'dark');
+  boot();
+  assertTheme(false);
+  const { result, store } = await mountTheme();
+  assert.equal(result.current.isDarkMode, false);
+  changeSystemTheme(true);
+  assert.equal(result.current.isDarkMode, true);
+  assertTheme(true);
+
+  act(() => result.current.toggleDarkMode());
+  assertTheme(false);
+  assert.equal(store.readUserPreference('theme', null), 'light');
+  changeSystemTheme(false);
+  changeSystemTheme(true);
+  assert.equal(result.current.isDarkMode, false);
+  act(() => result.current.toggleDarkMode());
+  assertTheme(true);
+});
+
+test('an auth reset preserves unmigrated theme, but a server-owned theme never revives after reset', async () => {
+  localStorage.setItem('theme', 'dark');
+  boot();
+  const { result, store, unmount } = await mountTheme();
+  assert.equal(result.current.isDarkMode, true);
+  act(() => store.resetUserPreferences());
+  assert.equal(result.current.isDarkMode, false);
+  assertTheme(false);
+
+  // An expired token can reset the store before the first authenticated migration.
+  await act(() => store.hydrateUserPreferences());
+  assert.equal(result.current.isDarkMode, true);
+  await vi.advanceTimersByTimeAsync(500);
+  assert.deepEqual(saved, [{ theme: 'dark' }]);
+
+  serverPreferences = { theme: 'dark' };
+  await act(() => store.hydrateUserPreferences());
+  act(() => store.resetUserPreferences());
+  assertTheme(false);
+  unmount();
+
+  boot();
+  assertTheme(false);
+  const reloaded = await mountTheme();
+  assert.equal(reloaded.result.current.isDarkMode, false);
+});
+
+test('malformed mirror uses legacy, and blocked storage leaves boot and runtime following system', async () => {
+  localStorage.setItem('user-preferences', '{broken');
+  localStorage.setItem('theme', 'dark');
+  boot();
+  assertTheme(true);
+  const legacy = await mountTheme();
+  assert.equal(legacy.result.current.isDarkMode, true);
+  legacy.unmount();
+
+  vi.spyOn(window, 'localStorage', 'get').mockImplementation(() => {
+    throw new DOMException('Storage blocked', 'SecurityError');
+  });
+  boot();
+  assertTheme(false);
+  const blocked = await mountTheme();
+  assert.equal(blocked.result.current.isDarkMode, false);
+  changeSystemTheme(true);
+  assert.equal(blocked.result.current.isDarkMode, true);
+  assertTheme(true);
+});
+
+test('HTTP errors preserve the current theme while a successful server reset follows system', async () => {
+  localStorage.setItem('user-preferences', JSON.stringify({ theme: 'dark' }));
+  boot();
+  const { result, store } = await mountTheme();
+
+  preferencesStatus = 503;
+  await act(() => store.hydrateUserPreferences());
+  assert.equal(result.current.isDarkMode, true);
+  assertTheme(true);
+  assert.equal(store.hasHydratedUserPreferences(), false);
+
+  preferencesStatus = 200;
+  serverPreferences = { theme: null };
+  await act(() => store.hydrateUserPreferences());
+  assertTheme(false);
+});
+
+test('a queued theme choice survives hydration without a server value and supersedes legacy migration', async () => {
+  systemIsDark = true;
+  localStorage.setItem('theme', 'dark');
+  boot();
+  const { result, store } = await mountTheme();
+  act(() => result.current.toggleDarkMode());
+
+  await act(() => store.hydrateUserPreferences());
+  assert.equal(result.current.isDarkMode, false);
+  assertTheme(false);
+  await vi.advanceTimersByTimeAsync(500);
+  assert.deepEqual(saved, [{ theme: 'light' }]);
+});

--- a/src/shared/userSettings.ts
+++ b/src/shared/userSettings.ts
@@ -214,7 +214,11 @@ function readLegacyPreference(key: UserPreferenceKey): unknown {
     return undefined;
   }
 
-  if (key === 'theme' || key === 'userLanguage' || key === 'selectedProvider') {
+  if (key === 'theme') {
+    return raw === 'light' || raw === 'dark' ? raw : undefined;
+  }
+
+  if (key === 'userLanguage' || key === 'selectedProvider') {
     return raw;
   }
 
@@ -282,11 +286,13 @@ export async function hydrateUserPreferences(): Promise<void> {
 
   try {
     const response = await api.user.preferences();
-    if (response.ok) {
-      const payload = (await response.json()) as { preferences?: unknown };
-      if (isRecord(payload.preferences)) {
-        serverPreferences = payload.preferences as PreferenceRecord;
-      }
+    // HTTP errors are failed reads, not authoritative preference resets.
+    if (!response.ok) {
+      return;
+    }
+    const payload = (await response.json()) as { preferences?: unknown };
+    if (isRecord(payload.preferences)) {
+      serverPreferences = payload.preferences as PreferenceRecord;
     }
   } catch (error) {
     // Keep whatever the mirror holds; an offline load must still render the
@@ -297,7 +303,7 @@ export async function hydrateUserPreferences(): Promise<void> {
 
   const migrated: PreferenceRecord = {};
   for (const key of PREFERENCE_KEYS) {
-    if (serverPreferences[key] !== undefined) {
+    if (serverPreferences[key] !== undefined || pendingServerWrites[key] !== undefined) {
       continue;
     }
 
@@ -318,9 +324,18 @@ export async function hydrateUserPreferences(): Promise<void> {
     delete pendingServerWrites[key];
   }
 
-  preferences = { ...serverPreferences, ...migrated };
+  // Keep queued choices for keys the server did not supply; legacy values cannot replace them.
+  preferences = { ...serverPreferences, ...migrated, ...pendingServerWrites };
   hasHydrated = true;
   writeMirror();
+  if (serverPreferences.theme !== undefined) {
+    try {
+      // Retire legacy only once the server owns the theme, not while migration is still queued.
+      localStorage.removeItem(LEGACY_STORAGE_KEYS.theme);
+    } catch {
+      // The adopted in-memory preferences remain authoritative without storage.
+    }
+  }
 
   if (Object.keys(migrated).length > 0) {
     queueServerWrite(migrated);
@@ -357,6 +372,8 @@ export function resetUserPreferences(): void {
 // The mirror is read at module load rather than on first use because the theme
 // and language readers run during module initialization, before any component
 // has mounted.
-if (typeof localStorage !== 'undefined') {
-  preferences = readMirror();
+preferences = readMirror();
+// Seed legacy theme only at startup. Later reads must respect server hydration and resets.
+if (preferences.theme === undefined) {
+  preferences.theme = readLegacyPreference('theme');
 }


### PR DESCRIPTION
Installed on Android in dark mode, the PWA's system chrome is white: white status bar above a dark app, a white splash on launch, and a white band when the transcript rubber-bands past its end.

Three separate sources, none of which follow the theme.

## Reproduction

Install the app on Android, set the app to dark, then relaunch it from the home screen. The status bar and splash are white. On desktop the same causes are directly observable:

1. Load the app, set dark mode, reload.
2. Read the shell values the OS uses.

```js
const meta = (n) => document.querySelector(`meta[name="${n}"]`)?.getAttribute('content');
console.log({
  themeColor: meta('theme-color'),
  tileColor: meta('msapplication-TileColor'),
  html: getComputedStyle(document.documentElement).backgroundColor,
  body: getComputedStyle(document.body).backgroundColor,
});
fetch('/manifest.json').then(r => r.json()).then(m => console.log(m.theme_color, m.background_color));
```

Chromium, dark saved:

| | `main` | this PR |
|---|---|---|
| `index.html` as served | `theme-color` `#ffffff` | `#141414`, corrected pre-paint from the saved theme |
| `msapplication-TileColor` | `#ffffff` (never updated) | `#141414` |
| `<html>` background | `rgba(0, 0, 0, 0)` | `rgb(20, 20, 20)` |
| `<body>` background | `rgb(20, 20, 20)` | `rgb(20, 20, 20)` |
| `manifest.json` `theme_color` / `background_color` | `#ffffff` / `#ffffff` | `#141414` / `#141414` |

On `main`, `ThemeContext` updates `theme-color` once React has mounted, which is why the runtime value looks right in a settled tab, but the document ships `#ffffff`, so the browser chrome can initially paint white. Android launch splash colors come from the manifest, not this runtime update. `ThemeContext` never touches `msapplication-TileColor`, and it cannot help the manifest at all.

The transparent `<html>` is the rubber-band band: only `body` was painted, so over-scroll exposes the canvas underneath.

## The change

- `index.html` sets the document theme and shell meta colors before first paint. It reads the mirrored `user-preferences.theme` first, with the legacy `theme` key only when the mirror has no theme. Only `light` and `dark` are explicit choices; absent or unsupported values follow `prefers-color-scheme`. Blocked or malformed storage is handled without aborting boot.
- `manifest.json` `theme_color` and `background_color` are fixed at `#141414`, matching the app's dark background. They do not switch with the app theme.
- `html` gets `@apply bg-background`, so over-scroll paints the app background rather than white.
- `sw.js` cache bumped to `claude-ui-v3`. Manifest requests remain network-first and refresh the cached copy on success. Cache-open/write failures are best effort and cannot discard the network response; genuine network failures retain cached fallback. This does not force Android to refresh installed metadata immediately.

The light-mode page keeps `theme-color` at `#f6f4ef` and both document backgrounds at `rgb(247, 246, 243)`. The installed-app manifest colors change from white to dark even for light-mode users. Both `theme-color` and `msapplication-TileColor` now follow runtime theme changes.

## Review follow-up

- Runtime startup now reads the same legacy theme fallback as the pre-paint script. Unsupported stored values follow the system at startup and on system-theme changes; this does not introduce a persisted `system` mode.
- The legacy theme is retired only after a server response supplies a theme. Auth resets preserve unmigrated legacy input, so an expired token cannot erase the preference before sign-in.
- Failed HTTP preference reads preserve the current theme. Queued choices for keys the server has not supplied survive hydration and are not overwritten by legacy migration. An explicit server theme still takes precedence.
- The static dark manifest remains a deliberate dark-splash default for every installation, including light-mode users. The title now states that limitation rather than promising a theme-aware installed splash.

## Verification

- `npm run test:client`: 54 files, 383 tests passed.
- `npm run build:client`, `npm run typecheck`, and `npm run lint` passed. Lint reports 128 warnings.
- New regression tests fail against the original code; the auth-reset, HTTP-error and queued-choice cases also reproduced before their corrections.
- Chromium: nine startup cases agreed before React loaded and after mount, covering mirrored light/dark, legacy-only values, missing/unsupported/null preferences and malformed storage. Runtime checks covered both meta colors, legacy migration, auth reset, server authority, HTTP 503 preservation and a queued choice during hydration. Storage denial is covered by the component/boot regression test.
- This verifies the browser behavior, not Android installed-splash rendering or metadata-refresh timing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The app now applies your saved or system theme before the interface appears, reducing flashes of the wrong theme.
  * Browser and installed-app colors now update consistently for light and dark modes.
  * Existing theme preferences are migrated and synchronized more reliably across sessions.

* **Bug Fixes**
  * Improved handling of unavailable storage, invalid preferences, and failed settings requests.
  * Updated app metadata and offline caching so fresh manifest data is used when available, with cached fallback during network failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->