### PR TITLE
feat(codex): add explicit "sync Codex model catalog" import flow

### DIFF
--- a/server/modules/database/repositories/provider-models.ts
+++ b/server/modules/database/repositories/provider-models.ts
@@ -165,4 +165,55 @@ export const providerModelsDb = {
     const row = remove();
     return row ? toCustomProviderModelRecord(row) : null;
   },
+
+  /**
+   * Replaces every custom row of one provider with `entries`, atomically.
+   *
+   * Used by the catalog-sync workflow, where the external catalog is the
+   * source of truth for the provider's custom rows. Rows the catalog no
+   * longer names are deleted and sessions that recorded one of the removed
+   * ids fall back to `fallbackModelId` (with effort cleared), mirroring the
+   * single-row delete path.
+   */
+  replaceCustomProviderModels(
+    provider: LLMProvider,
+    entries: Array<{ id: string; model: string }>,
+    fallbackModelId: string,
+  ): void {
+    const db = getConnection();
+    const replace = db.transaction(() => {
+      const existing = db.prepare(`
+        SELECT model_id
+        FROM provider_models
+        WHERE provider = ?
+      `).all(provider) as Array<{ model_id: string }>;
+
+      const nextIds = new Set(entries.map((entry) => entry.id));
+      const fallbackSessions = db.prepare(`
+        UPDATE sessions
+        SET model = ?, effort = NULL, updated_at = CURRENT_TIMESTAMP
+        WHERE provider = ? AND model = ?
+      `);
+      for (const row of existing) {
+        if (!nextIds.has(row.model_id)) {
+          fallbackSessions.run(fallbackModelId, provider, row.model_id);
+        }
+      }
+
+      db.prepare(`
+        DELETE FROM provider_models
+        WHERE provider = ?
+      `).run(provider);
+
+      const insert = db.prepare(`
+        INSERT INTO provider_models (provider, model_id, model_name, sort_order)
+        VALUES (?, ?, ?, ?)
+      `);
+      entries.forEach((entry, index) => {
+        insert.run(provider, entry.id, entry.model, index);
+      });
+    });
+
+    replace();
+  },
 };

--- a/server/modules/providers/list/codex/codex-models.provider.ts
+++ b/server/modules/providers/list/codex/codex-models.provider.ts
@@ -7,6 +7,7 @@ import TOML from '@iarna/toml';
 import type { IProviderModels } from '@/shared/interfaces.js';
 import type {
   ProviderCurrentActiveModel,
+  ProviderModelOption,
   ProviderModelsDefinition,
 } from '@/shared/types.js';
 import {
@@ -96,28 +97,182 @@ export const CODEX_PREDEFINED_MODELS: ProviderModelsDefinition = {
   DEFAULT: 'gpt-5.6-sol',
 };
 
-const CODEX_CONFIG_PATH = path.join(os.homedir(), '.codex', 'config.toml');
+/**
+ * Maps one entry of a Codex `model_catalog_json` file onto a selectable model.
+ *
+ * Only entries Codex itself lists in `/model` are imported: the picker sets
+ * `show_in_picker` for `visibility: "list"` alone, so `hide`, `none` and
+ * missing visibility are all excluded, mirroring the TUI's model list.
+ */
+const toCatalogModelOption = (rawEntry: unknown): ProviderModelOption | null => {
+  const entry = readObjectRecord(rawEntry);
+  if (!entry) {
+    return null;
+  }
 
-/** Provider registry model adapter for Codex predefined models and active config. */
+  const visibility = readOptionalString(entry.visibility)?.toLowerCase();
+  if (visibility !== 'list') {
+    return null;
+  }
+
+  const slug = readOptionalString(entry.slug);
+  if (!slug) {
+    return null;
+  }
+
+  const effortValues = readCatalogEffortValues(entry.supported_reasoning_levels);
+  const defaultEffort = readOptionalString(entry.default_reasoning_level);
+  const description = readOptionalString(entry.description);
+
+  return {
+    value: slug,
+    label: readOptionalString(entry.display_name) ?? slug,
+    ...(description ? { description } : {}),
+    ...(effortValues.length > 0
+      ? { effort: { ...(defaultEffort ? { default: defaultEffort } : {}), values: effortValues } }
+      : {}),
+  };
+};
+
+const readCatalogEffortValues = (rawLevels: unknown): { value: string; description?: string }[] => {
+  if (!Array.isArray(rawLevels)) {
+    return [];
+  }
+
+  return rawLevels.flatMap((rawLevel) => {
+    const level = readObjectRecord(rawLevel);
+    const effort = readOptionalString(level?.effort);
+    if (!effort) {
+      return [];
+    }
+
+    const description = readOptionalString(level?.description);
+    return [{
+      value: effort,
+      ...(description ? { description } : {}),
+    }];
+  });
+};
+
+/**
+ * Parses a Codex `model_catalog_json` document into ordered model options.
+ *
+ * Returns null when the document is unusable — invalid JSON, no `models`
+ * array, or no selectable entries — so callers can surface "no usable
+ * catalog" instead of an empty import.
+ */
+const parseCodexCatalogContent = (rawContent: string): ProviderModelOption[] | null => {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(rawContent);
+  } catch {
+    return null;
+  }
+
+  const root = readObjectRecord(parsed);
+  if (!root || !Array.isArray(root.models)) {
+    return null;
+  }
+
+  const seen = new Set<string>();
+  const options: ProviderModelOption[] = [];
+  for (const rawEntry of root.models) {
+    const option = toCatalogModelOption(rawEntry);
+    if (!option || seen.has(option.value)) {
+      continue;
+    }
+    seen.add(option.value);
+    options.push(option);
+  }
+
+  return options.length > 0 ? options : null;
+};
+
+const expandHomePath = (rawPath: string): string => (
+  rawPath === '~' || rawPath.startsWith('~/')
+    ? path.join(os.homedir(), rawPath.slice(1))
+    : rawPath
+);
+
+/**
+ * Provider registry model adapter for the Codex predefined catalog and active
+ * config.
+ *
+ * The supported-model list stays curated and immutable; Codex's own
+ * `model_catalog_json` is only exposed through `readExternalCatalog()` so the
+ * catalog-sync workflow can import its entries as user-editable custom rows.
+ */
 export class CodexProviderModels implements IProviderModels {
+  /** Resolved per instance so tests can point the adapter at a throwaway home. */
+  private readonly configPath: string;
+
+  constructor(options: { configPath?: string } = {}) {
+    this.configPath = options.configPath ?? path.join(os.homedir(), '.codex', 'config.toml');
+  }
+
   async getSupportedModels(): Promise<ProviderModelsDefinition> {
     return CODEX_PREDEFINED_MODELS;
   }
 
-  async getCurrentActiveModel(): Promise<ProviderCurrentActiveModel> {
+  /**
+   * Reads the models defined by the `model_catalog_json` named in
+   * `~/.codex/config.toml`, or null when the config or catalog is missing or
+   * unusable.
+   */
+  async readExternalCatalog(): Promise<ProviderModelsDefinition | null> {
+    const config = await this.readCodexConfig();
+    if (!config) {
+      return null;
+    }
+
+    const catalogPath = readOptionalString(config.model_catalog_json);
+    if (!catalogPath) {
+      return null;
+    }
+
     try {
-      const raw = await readFile(CODEX_CONFIG_PATH, 'utf8');
-      const parsed = readObjectRecord(TOML.parse(raw));
-      const model = readOptionalString(parsed?.model);
-      if (!model) {
-        return buildDefaultProviderCurrentActiveModel(await this.getSupportedModels());
+      const raw = await readFile(expandHomePath(catalogPath), 'utf8');
+      const options = parseCodexCatalogContent(raw);
+      if (!options) {
+        return null;
       }
 
+      const configuredModel = readOptionalString(config.model);
+      if (configuredModel && !options.some((option) => option.value === configuredModel)) {
+        // Keep the configured default selectable even when the catalog omits it.
+        options.push({ value: configuredModel, label: configuredModel });
+      }
+
+      const defaultModel = configuredModel
+        ?? (options.some((option) => option.value === CODEX_PREDEFINED_MODELS.DEFAULT)
+          ? CODEX_PREDEFINED_MODELS.DEFAULT
+          : options[0].value);
+
       return {
-        model,
+        OPTIONS: options,
+        DEFAULT: defaultModel,
       };
     } catch {
-      return buildDefaultProviderCurrentActiveModel(await this.getSupportedModels());
+      return null;
     }
+  }
+
+  private async readCodexConfig(): Promise<Record<string, unknown> | null> {
+    try {
+      const raw = await readFile(this.configPath, 'utf8');
+      return readObjectRecord(TOML.parse(raw));
+    } catch {
+      return null;
+    }
+  }
+
+  async getCurrentActiveModel(): Promise<ProviderCurrentActiveModel> {
+    const config = await this.readCodexConfig();
+    const model = readOptionalString(config?.model);
+    if (model) {
+      return { model };
+    }
+
+    return buildDefaultProviderCurrentActiveModel(await this.getSupportedModels());
   }
 }

--- a/server/modules/providers/list/codex/codex-models.provider.ts
+++ b/server/modules/providers/list/codex/codex-models.provider.ts
@@ -238,11 +238,9 @@ export class CodexProviderModels implements IProviderModels {
       }
 
       const configuredModel = readOptionalString(config.model);
-      if (configuredModel && !options.some((option) => option.value === configuredModel)) {
-        // Keep the configured default selectable even when the catalog omits it.
-        options.push({ value: configuredModel, label: configuredModel });
-      }
-
+      // Only picker-visible entries are importable. A configured default that
+      // the catalog hides or does not declare stays the DEFAULT value but must
+      // never become a selectable custom row through catalog sync.
       const defaultModel = configuredModel
         ?? (options.some((option) => option.value === CODEX_PREDEFINED_MODELS.DEFAULT)
           ? CODEX_PREDEFINED_MODELS.DEFAULT

--- a/server/modules/providers/provider.routes.ts
+++ b/server/modules/providers/provider.routes.ts
@@ -566,7 +566,15 @@ router.post(
   '/:provider/models/catalog-sync',
   asyncHandler(async (req: Request, res: Response) => {
     const provider = parseProvider(req.params.provider);
-    const result = await providerModelsService.applyCatalogSync(provider);
+    const body = (req.body ?? {}) as { fingerprint?: unknown };
+    const fingerprint = typeof body.fingerprint === 'string' ? body.fingerprint.trim() : '';
+    if (!fingerprint) {
+      throw new AppError('A catalog-sync preview fingerprint is required.', {
+        code: 'CATALOG_SYNC_FINGERPRINT_REQUIRED',
+        statusCode: 400,
+      });
+    }
+    const result = await providerModelsService.applyCatalogSync(provider, fingerprint);
     res.json(createApiSuccessResponse({ provider, ...result }));
   }),
 );

--- a/server/modules/providers/provider.routes.ts
+++ b/server/modules/providers/provider.routes.ts
@@ -553,6 +553,24 @@ router.delete(
   }),
 );
 
+router.get(
+  '/:provider/models/catalog-sync/preview',
+  asyncHandler(async (req: Request, res: Response) => {
+    const provider = parseProvider(req.params.provider);
+    const plan = await providerModelsService.previewCatalogSync(provider);
+    res.json(createApiSuccessResponse({ provider, plan }));
+  }),
+);
+
+router.post(
+  '/:provider/models/catalog-sync',
+  asyncHandler(async (req: Request, res: Response) => {
+    const provider = parseProvider(req.params.provider);
+    const result = await providerModelsService.applyCatalogSync(provider);
+    res.json(createApiSuccessResponse({ provider, ...result }));
+  }),
+);
+
 /**
  * Reports which model one session is using. `requestedModel` lets the client
  * pass the default it would otherwise send, so a session that has not been

--- a/server/modules/providers/services/provider-models.service.ts
+++ b/server/modules/providers/services/provider-models.service.ts
@@ -8,6 +8,7 @@ import type {
   ProviderCurrentActiveModel,
   ProviderModelOption,
   ProviderModelsDefinition,
+  ProviderCatalogSyncPlan,
   ProviderSessionModel,
 } from '@/shared/types.js';
 import { AppError } from '@/shared/utils.js';
@@ -28,6 +29,7 @@ type ProviderModelsCatalogStore = Pick<
   | 'createCustomProviderModel'
   | 'updateCustomProviderModel'
   | 'deleteCustomProviderModel'
+  | 'replaceCustomProviderModels'
 >;
 
 type ProviderModelsServiceDependencies = {
@@ -211,6 +213,119 @@ export const createProviderModelsService = (dependencies: ProviderModelsServiceD
     };
   };
 
+  /**
+   * Loads the external model catalog a provider CLI reads from a
+   * user-configured file, or throws when the provider has no such source or
+   * the configured file is unusable.
+   */
+  const readExternalCatalogOrThrow = async (
+    provider: LLMProvider,
+  ): Promise<ProviderModelsDefinition> => {
+    const models = resolveProvider(provider).models;
+    if (!models.readExternalCatalog) {
+      throw new AppError(`${provider} does not support syncing an external model catalog.`, {
+        code: 'CATALOG_SYNC_UNSUPPORTED',
+        statusCode: 404,
+      });
+    }
+
+    const definition = await models.readExternalCatalog();
+    if (!definition || definition.OPTIONS.length === 0) {
+      throw new AppError(
+        'No usable Codex model catalog is configured. Set model_catalog_json in ~/.codex/config.toml first.',
+        {
+          code: 'CODEX_CATALOG_UNAVAILABLE',
+          statusCode: 400,
+        },
+      );
+    }
+
+    return definition;
+  };
+
+  /**
+   * Diffs stored custom rows against the provider's external catalog.
+   *
+   * Catalog entries whose id the curated predefined list already offers are
+   * skipped instead of stored, matching the single-row create path that
+   * rejects such ids. Everything else is added, renamed when the display name
+   * changed, or removed when the catalog no longer lists it.
+   */
+  const buildCatalogSyncPlan = (
+    provider: LLMProvider,
+    predefined: ProviderModelsDefinition,
+    external: ProviderModelsDefinition,
+  ): ProviderCatalogSyncPlan => {
+    const existingById = new Map(
+      catalog.listCustomProviderModels(provider).map((record) => [record.modelId, record]),
+    );
+    const predefinedIds = new Set(predefined.OPTIONS.map((option) => option.value));
+    const additions: ProviderCatalogSyncPlan['additions'] = [];
+    const updates: ProviderCatalogSyncPlan['updates'] = [];
+    const skipped: ProviderCatalogSyncPlan['skipped'] = [];
+
+    for (const option of external.OPTIONS) {
+      if (predefinedIds.has(option.value)) {
+        skipped.push({ id: option.value, model: option.label, reason: 'builtin' });
+        continue;
+      }
+
+      const existing = existingById.get(option.value);
+      const entry = {
+        id: option.value,
+        model: option.label,
+        ...(existing && existing.model !== option.label ? { previousModel: existing.model } : {}),
+      };
+      if (!existing) {
+        additions.push(entry);
+      } else if (existing.model !== option.label) {
+        updates.push(entry);
+      }
+    }
+
+    const keptIds = new Set(external.OPTIONS.map((option) => option.value));
+    const removals = [...existingById.values()]
+      .filter((record) => !keptIds.has(record.modelId))
+      .map((record) => ({ id: record.modelId, model: record.model }));
+
+    return { provider, additions, updates, removals, skipped };
+  };
+
+  /**
+   * Returns the diff a catalog sync would apply, without touching the store.
+   */
+  const previewCatalogSync = async (provider: LLMProvider): Promise<ProviderCatalogSyncPlan> => {
+    const [predefined, external] = await Promise.all([
+      resolveProvider(provider).models.getSupportedModels(),
+      readExternalCatalogOrThrow(provider),
+    ]);
+    return buildCatalogSyncPlan(provider, predefined, external);
+  };
+
+  /**
+   * Replaces the provider's custom rows with the external catalog entries and
+   * returns the applied plan plus the refreshed merged catalog.
+   */
+  const applyCatalogSync = async (
+    provider: LLMProvider,
+  ): Promise<{ plan: ProviderCatalogSyncPlan; models: ProviderModelsDefinition }> => {
+    const models = resolveProvider(provider).models;
+    const predefined = await models.getSupportedModels();
+    const external = await readExternalCatalogOrThrow(provider);
+    const plan = buildCatalogSyncPlan(provider, predefined, external);
+    const skippedIds = new Set(plan.skipped.map((entry) => entry.id));
+    const finalEntries = external.OPTIONS
+      .filter((option) => !skippedIds.has(option.value))
+      .map((option) => ({ id: option.value, model: option.label }));
+
+    catalog.replaceCustomProviderModels(provider, finalEntries, predefined.DEFAULT);
+
+    return {
+      plan,
+      models: mergeProviderModels(predefined, catalog.listCustomProviderModels(provider)),
+    };
+  };
+
   const readRecordedSessionSelection = (
     sessionId: string,
   ): { model: string | null; effort: string | null } | null => {
@@ -390,6 +505,8 @@ export const createProviderModelsService = (dependencies: ProviderModelsServiceD
     createCustomModel,
     updateCustomModel,
     deleteCustomModel,
+    previewCatalogSync,
+    applyCatalogSync,
     setSessionModel,
     setSessionEffort,
     resolveSessionModel,

--- a/server/modules/providers/services/provider-models.service.ts
+++ b/server/modules/providers/services/provider-models.service.ts
@@ -256,9 +256,8 @@ export const createProviderModelsService = (dependencies: ProviderModelsServiceD
     predefined: ProviderModelsDefinition,
     external: ProviderModelsDefinition,
   ): ProviderCatalogSyncPlan => {
-    const existingById = new Map(
-      catalog.listCustomProviderModels(provider).map((record) => [record.modelId, record]),
-    );
+    const currentRows = catalog.listCustomProviderModels(provider);
+    const existingById = new Map(currentRows.map((record) => [record.modelId, record]));
     const predefinedIds = new Set(predefined.OPTIONS.map((option) => option.value));
     const additions: ProviderCatalogSyncPlan['additions'] = [];
     const updates: ProviderCatalogSyncPlan['updates'] = [];
@@ -283,12 +282,29 @@ export const createProviderModelsService = (dependencies: ProviderModelsServiceD
       }
     }
 
-    const keptIds = new Set(external.OPTIONS.map((option) => option.value));
+    // A stored row whose id the curated list now owns cannot survive apply
+    // (apply only stores non-built-in entries), so such rows must surface as
+    // removals here or the preview would claim the library already matches.
+    const keptIds = new Set(
+      external.OPTIONS
+        .filter((option) => !predefinedIds.has(option.value))
+        .map((option) => option.value),
+    );
     const removals = [...existingById.values()]
       .filter((record) => !keptIds.has(record.modelId))
       .map((record) => ({ id: record.modelId, model: record.model }));
 
-    return { provider, additions, updates, removals, skipped };
+    return {
+      provider,
+      additions,
+      updates,
+      removals,
+      skipped,
+      fingerprint: JSON.stringify({
+        catalog: external.OPTIONS.map((option) => [option.value, option.label]),
+        rows: currentRows.map((record) => [record.modelId, record.model]),
+      }),
+    };
   };
 
   /**
@@ -308,11 +324,27 @@ export const createProviderModelsService = (dependencies: ProviderModelsServiceD
    */
   const applyCatalogSync = async (
     provider: LLMProvider,
+    fingerprint?: string,
   ): Promise<{ plan: ProviderCatalogSyncPlan; models: ProviderModelsDefinition }> => {
+    if (typeof fingerprint !== 'string' || !fingerprint.trim()) {
+      throw new AppError('A catalog-sync preview fingerprint is required.', {
+        code: 'CATALOG_SYNC_FINGERPRINT_REQUIRED',
+        statusCode: 400,
+      });
+    }
     const models = resolveProvider(provider).models;
     const predefined = await models.getSupportedModels();
     const external = await readExternalCatalogOrThrow(provider);
     const plan = buildCatalogSyncPlan(provider, predefined, external);
+    if (plan.fingerprint !== fingerprint) {
+      throw new AppError(
+        'The Codex catalog or your custom models changed since the preview. Preview again and confirm.',
+        {
+          code: 'CATALOG_SYNC_CONFLICT',
+          statusCode: 409,
+        },
+      );
+    }
     const skippedIds = new Set(plan.skipped.map((entry) => entry.id));
     const finalEntries = external.OPTIONS
       .filter((option) => !skippedIds.has(option.value))

--- a/server/modules/providers/tests/codex-catalog-source.test.ts
+++ b/server/modules/providers/tests/codex-catalog-source.test.ts
@@ -99,18 +99,21 @@ test('Codex external catalog lists only picker-visible entries with metadata', a
   }
 });
 
-test('Codex external catalog appends and defaults to the configured model', async () => {
+test('Codex external catalog keeps a configured default out of OPTIONS when it is not list-visible', async () => {
   const { adapter, homeDir } = await makeAdapter(null);
   try {
-    const catalogPath = await catalogLine(homeDir, [{ slug: 'vendor/alpha', visibility: 'list' }]);
-    await writeConfig(
-      path.join(homeDir, 'config.toml'),
-      'model = "vendor/custom-default"\nmodel_catalog_json = "' + catalogPath + '"\n',
-    );
+    const catalogPath = await catalogLine(homeDir, [
+      { slug: 'vendor/alpha', visibility: 'list' },
+      { slug: 'vendor/hidden-default', visibility: 'hide' },
+    ]);
+    const config = 'model = "vendor/hidden-default"'
+      + String.fromCharCode(10)
+      + 'model_catalog_json = "' + catalogPath + '"';
+    await writeConfig(path.join(homeDir, 'config.toml'), config);
 
     const models = await adapter.readExternalCatalog();
-    assert.deepEqual(models?.OPTIONS.map((option) => option.value), ['vendor/alpha', 'vendor/custom-default']);
-    assert.equal(models?.DEFAULT, 'vendor/custom-default');
+    assert.deepEqual(models?.OPTIONS.map((option) => option.value), ['vendor/alpha']);
+    assert.equal(models?.DEFAULT, 'vendor/hidden-default');
   } finally {
     await rm(homeDir, { recursive: true, force: true });
   }

--- a/server/modules/providers/tests/codex-catalog-source.test.ts
+++ b/server/modules/providers/tests/codex-catalog-source.test.ts
@@ -1,0 +1,117 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+
+import { CodexProviderModels } from '@/modules/providers/list/codex/codex-models.provider.js';
+
+const writeConfig = async (configPath: string, config: string): Promise<void> => {
+  await writeFile(configPath, config, 'utf8');
+};
+
+const catalogLine = (homeDir: string, models: unknown[]): Promise<string> => {
+  const catalogPath = path.join(homeDir, 'models-catalog.json');
+  return writeFile(catalogPath, JSON.stringify({ models }), 'utf8').then(() => catalogPath);
+};
+
+const makeAdapter = async (config: string | null) => {
+  const homeDir = await mkdtemp(path.join(os.tmpdir(), 'codex-catalog-source-'));
+  const configPath = path.join(homeDir, 'config.toml');
+  if (config !== null) {
+    await writeConfig(configPath, config);
+  }
+  return { adapter: new CodexProviderModels({ configPath }), homeDir };
+};
+
+test('Codex external catalog is null when config or catalog is unusable', async () => {
+  const cases: Array<{ name: string; config: string | null; setup?: string }> = [
+    { name: 'no config file', config: null },
+    { name: 'no model_catalog_json key', config: 'model = "gpt-5.6-sol"\n' },
+    { name: 'catalog file missing', config: 'model_catalog_json = "/no/such/catalog.json"\n' },
+    { name: 'catalog is not valid JSON', config: '' },
+    { name: 'catalog has no models array', config: '' },
+    { name: 'catalog lists no visible models', config: '' },
+  ];
+  for (const entry of cases) {
+    await test(entry.name, async () => {
+      const { adapter, homeDir } = await makeAdapter(entry.config);
+      try {
+        if (entry.name === 'catalog is not valid JSON') {
+          await writeFile(path.join(homeDir, 'catalog.json'), 'not json {', 'utf8');
+          await writeConfig(path.join(homeDir, 'config.toml'), 'model_catalog_json = "' + path.join(homeDir, 'catalog.json') + '"\n');
+        } else if (entry.name === 'catalog has no models array') {
+          const catalogPath = path.join(homeDir, 'catalog.json');
+          await writeFile(catalogPath, JSON.stringify({ versions: [] }), 'utf8');
+          await writeConfig(path.join(homeDir, 'config.toml'), 'model_catalog_json = "' + catalogPath + '"\n');
+        } else if (entry.name === 'catalog lists no visible models') {
+          const catalogPath = await catalogLine(homeDir, [
+            { slug: 'vendor/hidden', visibility: 'hide' },
+            { slug: 'vendor/none', visibility: 'none' },
+            { slug: 'vendor/missing-visibility' },
+          ]);
+          await writeConfig(path.join(homeDir, 'config.toml'), 'model_catalog_json = "' + catalogPath + '"\n');
+        }
+        assert.equal(await adapter.readExternalCatalog(), null);
+      } finally {
+        await rm(homeDir, { recursive: true, force: true });
+      }
+    });
+  }
+});
+
+test('Codex external catalog lists only picker-visible entries with metadata', async () => {
+  const { adapter, homeDir } = await makeAdapter(null);
+  try {
+    const catalogPath = await catalogLine(homeDir, [
+      {
+        slug: 'vendor/alpha',
+        display_name: 'Alpha Model',
+        description: 'A listed model',
+        default_reasoning_level: 'medium',
+        supported_reasoning_levels: [{ effort: 'low' }, { effort: 'medium', description: 'Default' }],
+        visibility: 'list',
+      },
+      { slug: 'vendor/dup', visibility: 'list' },
+      { slug: 'vendor/dup', visibility: 'list' },
+      { slug: 'vendor/hidden', visibility: 'hide' },
+      { slug: 'vendor/none', visibility: 'none' },
+      { slug: 'vendor/undeclared' },
+    ]);
+    await writeConfig(path.join(homeDir, 'config.toml'), 'model_catalog_json = "' + catalogPath + '"\n');
+
+    const models = await adapter.readExternalCatalog();
+    assert.deepEqual(models?.OPTIONS, [
+      {
+        value: 'vendor/alpha',
+        label: 'Alpha Model',
+        description: 'A listed model',
+        effort: {
+          default: 'medium',
+          values: [{ value: 'low' }, { value: 'medium', description: 'Default' }],
+        },
+      },
+      { value: 'vendor/dup', label: 'vendor/dup' },
+    ]);
+    assert.equal(models?.DEFAULT, 'vendor/alpha');
+  } finally {
+    await rm(homeDir, { recursive: true, force: true });
+  }
+});
+
+test('Codex external catalog appends and defaults to the configured model', async () => {
+  const { adapter, homeDir } = await makeAdapter(null);
+  try {
+    const catalogPath = await catalogLine(homeDir, [{ slug: 'vendor/alpha', visibility: 'list' }]);
+    await writeConfig(
+      path.join(homeDir, 'config.toml'),
+      'model = "vendor/custom-default"\nmodel_catalog_json = "' + catalogPath + '"\n',
+    );
+
+    const models = await adapter.readExternalCatalog();
+    assert.deepEqual(models?.OPTIONS.map((option) => option.value), ['vendor/alpha', 'vendor/custom-default']);
+    assert.equal(models?.DEFAULT, 'vendor/custom-default');
+  } finally {
+    await rm(homeDir, { recursive: true, force: true });
+  }
+});

--- a/server/modules/providers/tests/provider-models.service.test.ts
+++ b/server/modules/providers/tests/provider-models.service.test.ts
@@ -416,10 +416,20 @@ test('catalog sync apply replaces custom rows and returns the merged catalog', a
   });
   await service.createCustomModel('codex', { model: 'Vendor A old', id: 'vendor/a' });
   await service.createCustomModel('codex', { model: 'Gone model', id: 'vendor/old' });
+  // A row that predates its id becoming curated: the service cannot create it
+  // anymore, but apply must still report and remove it.
+  catalog.rows.set('codex', [
+    ...(catalog.rows.get('codex') ?? []),
+    { recordId: 99, provider: 'codex', modelId: 'codex-default', model: 'Old curated clash', sortOrder: 9 },
+  ]);
 
-  const result = await service.applyCatalogSync('codex');
+  const previewed = await service.previewCatalogSync('codex');
+  const result = await service.applyCatalogSync('codex', previewed.fingerprint);
 
-  assert.deepEqual(result.plan.removals, [{ id: 'vendor/old', model: 'Gone model' }]);
+  assert.deepEqual(result.plan.removals, [
+    { id: 'vendor/old', model: 'Gone model' },
+    { id: 'codex-default', model: 'Old curated clash' },
+  ]);
   assert.deepEqual(result.plan.skipped.map((entry) => entry.id), ['codex-default']);
   assert.deepEqual(
     catalog.rows.get('codex')?.map((row) => [row.modelId, row.model]),
@@ -440,5 +450,29 @@ test('catalog sync is rejected when unsupported or no usable catalog exists', as
   await assert.rejects(
     () => unconfigured.service.previewCatalogSync('codex'),
     (error) => error instanceof AppError && error.code === 'CODEX_CATALOG_UNAVAILABLE',
+  );
+});
+
+
+test('catalog sync apply rejects a missing or stale fingerprint', async () => {
+  const { service } = createTestService({
+    externalCatalog: () => ({
+      OPTIONS: [{ value: 'vendor/a', label: 'Vendor A' }],
+      DEFAULT: 'vendor/a',
+    }),
+  });
+  await service.createCustomModel('codex', { model: 'Vendor A', id: 'vendor/a' });
+
+  await assert.rejects(
+    () => service.applyCatalogSync('codex'),
+    (error) => error instanceof AppError && error.code === 'CATALOG_SYNC_FINGERPRINT_REQUIRED',
+  );
+
+  const previewed = await service.previewCatalogSync('codex');
+  await service.createCustomModel('codex', { model: 'Late addition', id: 'vendor/late' });
+
+  await assert.rejects(
+    () => service.applyCatalogSync('codex', previewed.fingerprint),
+    (error) => error instanceof AppError && error.code === 'CATALOG_SYNC_CONFLICT',
   );
 });

--- a/server/modules/providers/tests/provider-models.service.test.ts
+++ b/server/modules/providers/tests/provider-models.service.test.ts
@@ -96,6 +96,18 @@ const createCatalogStore = () => {
       rows.set(provider, readRows(provider).filter((record) => record.recordId !== recordId));
       return existing;
     },
+    replaceCustomProviderModels(
+      provider: LLMProvider,
+      entries: Array<{ id: string; model: string }>,
+    ) {
+      rows.set(provider, entries.map((entry, index) => ({
+        recordId: nextRecordId++,
+        provider,
+        modelId: entry.id,
+        model: entry.model,
+        sortOrder: index,
+      })));
+    },
   };
 };
 
@@ -104,6 +116,7 @@ const createTestService = (options: {
   sessions?: ReturnType<typeof createSessionStore>;
   activeModel?: (provider: LLMProvider, sessionId?: string) => string;
   onCatalogRead?: (provider: LLMProvider) => void;
+  externalCatalog?: (provider: LLMProvider) => ProviderModelsDefinition | null;
 } = {}) => {
   const catalog = options.catalog ?? createCatalogStore();
   const sessions = options.sessions ?? createSessionStore();
@@ -119,6 +132,9 @@ const createTestService = (options: {
         getCurrentActiveModel: async (sessionId) => createCurrentActiveModel(
           options.activeModel?.(provider, sessionId) ?? `${provider}-default`,
         ),
+        ...(options.externalCatalog
+          ? { readExternalCatalog: async () => options.externalCatalog?.(provider) ?? null }
+          : {}),
       },
     }),
   });
@@ -350,4 +366,79 @@ test('resolveResumeModel never consults provider-global state', async () => {
 
   assert.equal(model, 'gpt-5.5');
   assert.equal(providerLookups, 0);
+});
+
+test('catalog sync preview diffs additions, renames, removals and builtin skips', async () => {
+  const { service, catalog } = createTestService({
+    externalCatalog: () => ({
+      OPTIONS: [
+        { value: 'codex-default', label: 'Builtin duplicate' },
+        { value: 'vendor/a', label: 'Vendor A renamed' },
+        { value: 'vendor/b', label: 'Vendor B kept' },
+        { value: 'vendor/c', label: 'Vendor C fresh' },
+      ],
+      DEFAULT: 'vendor/a',
+    }),
+  });
+  await service.createCustomModel('codex', { model: 'Vendor A', id: 'vendor/a' });
+  await service.createCustomModel('codex', { model: 'Vendor B kept', id: 'vendor/b' });
+  await service.createCustomModel('codex', { model: 'Gone model', id: 'vendor/old' });
+
+  const plan = await service.previewCatalogSync('codex');
+
+  assert.deepEqual(plan.provider, 'codex');
+  assert.deepEqual(plan.additions, [{ id: 'vendor/c', model: 'Vendor C fresh' }]);
+  assert.deepEqual(plan.updates, [{
+    id: 'vendor/a',
+    model: 'Vendor A renamed',
+    previousModel: 'Vendor A',
+  }]);
+  assert.deepEqual(plan.removals, [{ id: 'vendor/old', model: 'Gone model' }]);
+  assert.deepEqual(plan.skipped, [{
+    id: 'codex-default',
+    model: 'Builtin duplicate',
+    reason: 'builtin',
+  }]);
+  // The preview must not touch the store.
+  assert.equal(catalog.rows.get('codex')?.length, 3);
+});
+
+test('catalog sync apply replaces custom rows and returns the merged catalog', async () => {
+  const { service, catalog } = createTestService({
+    externalCatalog: () => ({
+      OPTIONS: [
+        { value: 'codex-default', label: 'Builtin duplicate' },
+        { value: 'vendor/a', label: 'Vendor A' },
+        { value: 'vendor/b', label: 'Vendor B fresh' },
+      ],
+      DEFAULT: 'vendor/a',
+    }),
+  });
+  await service.createCustomModel('codex', { model: 'Vendor A old', id: 'vendor/a' });
+  await service.createCustomModel('codex', { model: 'Gone model', id: 'vendor/old' });
+
+  const result = await service.applyCatalogSync('codex');
+
+  assert.deepEqual(result.plan.removals, [{ id: 'vendor/old', model: 'Gone model' }]);
+  assert.deepEqual(result.plan.skipped.map((entry) => entry.id), ['codex-default']);
+  assert.deepEqual(
+    catalog.rows.get('codex')?.map((row) => [row.modelId, row.model]),
+    [['vendor/a', 'Vendor A'], ['vendor/b', 'Vendor B fresh']],
+  );
+  assert.equal(result.models.OPTIONS.filter((option) => option.value === 'codex-default').length, 1);
+  assert.equal(result.models.OPTIONS.some((option) => option.value === 'vendor/b'), true);
+});
+
+test('catalog sync is rejected when unsupported or no usable catalog exists', async () => {
+  const unsupported = createTestService();
+  await assert.rejects(
+    () => unsupported.service.previewCatalogSync('claude'),
+    (error) => error instanceof AppError && error.code === 'CATALOG_SYNC_UNSUPPORTED',
+  );
+
+  const unconfigured = createTestService({ externalCatalog: () => null });
+  await assert.rejects(
+    () => unconfigured.service.previewCatalogSync('codex'),
+    (error) => error instanceof AppError && error.code === 'CODEX_CATALOG_UNAVAILABLE',
+  );
 });

--- a/server/shared/interfaces.ts
+++ b/server/shared/interfaces.ts
@@ -101,6 +101,18 @@ export interface IProviderModels {
   getSupportedModels(): Promise<ProviderModelsDefinition>;
 
   /**
+   * Returns the models the provider CLI itself loads from a user-configured
+   * external file (Codex's `model_catalog_json`), or null when no usable file
+   * is configured.
+   *
+   * Only providers whose runtime reads such a file implement this. The
+   * provider-models service calls it from the catalog-sync workflow so users
+   * can import those entries as editable custom-model rows instead of the app
+   * silently reading the file on every catalog request.
+   */
+  readExternalCatalog?(): Promise<ProviderModelsDefinition | null>;
+
+  /**
    * Reads the model the provider itself believes one session is running with.
    *
    * Only consulted for sessions the app has never recorded a model for — a

--- a/server/shared/types.ts
+++ b/server/shared/types.ts
@@ -152,6 +152,12 @@ export type ProviderCatalogSyncPlan = {
   updates: ProviderCatalogSyncEntry[];
   removals: ProviderCatalogSyncEntry[];
   skipped: ProviderCatalogSyncSkip[];
+  /**
+   * Opaque fingerprint of the catalog and custom rows the preview reviewed.
+   * Apply requests must echo it so a changed store or catalog cannot be
+   * overwritten without a fresh confirmation.
+   */
+  fingerprint: string;
 };
 
 // ---------------------------

--- a/server/shared/types.ts
+++ b/server/shared/types.ts
@@ -124,6 +124,36 @@ export type CustomProviderModelInput = {
   model: string;
 };
 
+/** One provider model a catalog sync will add, rename or remove. */
+export type ProviderCatalogSyncEntry = {
+  /** Provider-facing identifier, stored as `model_id`. */
+  id: string;
+  /** Display name, stored as `model_name`. */
+  model: string;
+  /** Current display name when the sync renames an existing row. */
+  previousModel?: string;
+};
+
+/** One external catalog entry a sync skips, and why. */
+export type ProviderCatalogSyncSkip = {
+  id: string;
+  model: string;
+  /** The curated predefined list already offers this id, so it cannot be stored. */
+  reason: 'builtin';
+};
+
+/**
+ * Diff between one provider's stored custom rows and the provider CLI's
+ * external model catalog, produced by a catalog-sync preview.
+ */
+export type ProviderCatalogSyncPlan = {
+  provider: LLMProvider;
+  additions: ProviderCatalogSyncEntry[];
+  updates: ProviderCatalogSyncEntry[];
+  removals: ProviderCatalogSyncEntry[];
+  skipped: ProviderCatalogSyncSkip[];
+};
+
 // ---------------------------
 //----------------- PROVIDER ACTIVE MODEL TYPES ------------
 /**

--- a/src/modules/chat/hooks/useChatProviderState.ts
+++ b/src/modules/chat/hooks/useChatProviderState.ts
@@ -7,6 +7,8 @@ import type { PendingPermissionRequest, PermissionMode,
   Project,
   CustomProviderModelInput,
   ProviderModelActions,
+  ProviderCatalogSyncActions,
+  ProviderCatalogSyncPlan,
   ProviderModelOption,
   ProviderModelsDefinition } from '@/shared/types';
 import { DEFAULT_EFFORT_VALUE } from '@/shared/constants';
@@ -112,6 +114,15 @@ type SessionSelectionApiResponse = {
     source?: 'session' | 'provider' | 'default';
   };
 };
+
+type CatalogSyncApiResponse = {
+   success?: boolean;
+   data?: {
+     plan?: ProviderCatalogSyncPlan;
+     models?: ProviderModelsDefinition;
+   };
+   error?: { message?: string };
+ };
 
 type SessionProviderSelection = {
   provider: LLMProvider;
@@ -801,11 +812,44 @@ export function useChatProviderState({ selectedSession, selectedProject: _select
     setStoredProviderModel,
   ]);
 
+  /**
+   * Fetches the diff between the provider's stored custom rows and its
+   * external model catalog; the library panel shows it before any write.
+   */
+  const previewCatalogSync = useCallback<ProviderCatalogSyncActions['preview']>(async (targetProvider) => {
+    const response = await api.providers.previewCatalogSync(targetProvider);
+    const body = (await response.json()) as CatalogSyncApiResponse;
+    if (!response.ok || !body.success || !body.data?.plan) {
+      throw new Error(body.error?.message || 'Unable to preview the model catalog sync.');
+    }
+    return body.data.plan;
+  }, []);
+
+  /**
+   * Replaces the provider's custom rows with the external catalog after the
+   * user confirmed the preview, then refreshes the in-memory catalog.
+   */
+  const applyCatalogSync = useCallback<ProviderCatalogSyncActions['apply']>(async (targetProvider) => {
+    const response = await api.providers.applyCatalogSync(targetProvider);
+    const body = (await response.json()) as CatalogSyncApiResponse;
+    if (!response.ok || !body.success || !body.data?.plan) {
+      throw new Error(body.error?.message || 'Unable to apply the model catalog sync.');
+    }
+    if (body.data.models) {
+      applyProviderCatalog(targetProvider, body.data.models);
+    }
+    return body.data.plan;
+  }, [applyProviderCatalog]);
+
   const providerModelActions = useMemo<ProviderModelActions>(() => ({
     create: createCustomModel,
     update: updateCustomModel,
     remove: removeCustomModel,
-  }), [createCustomModel, removeCustomModel, updateCustomModel]);
+    catalogSync: {
+      preview: previewCatalogSync,
+      apply: applyCatalogSync,
+    },
+  }), [applyCatalogSync, createCustomModel, previewCatalogSync, removeCustomModel, updateCustomModel]);
 
   return {
     provider,

--- a/src/modules/chat/hooks/useChatProviderState.ts
+++ b/src/modules/chat/hooks/useChatProviderState.ts
@@ -843,17 +843,26 @@ export function useChatProviderState({ selectedSession, selectedProject: _select
       if (removedIds.has(providerModels[targetProvider])) {
         setStoredProviderModel(targetProvider, models.DEFAULT);
       }
-      if (provider === targetProvider && sessionModel && removedIds.has(sessionModel)) {
+      // Guard inside the updater: the request may resolve after the user
+      // switched sessions or picked another model, and that newer selection
+      // must not be reset to the fallback.
+      setSessionSelection((current) => {
+        if (
+          !current
+          || current.provider !== targetProvider
+          || !current.model
+          || !removedIds.has(current.model)
+        ) {
+          return current;
+        }
         // The server already reset the session row to the fallback model and
         // cleared its effort; mirror that in the in-memory selection so the
         // composer never keeps offering a removed model id.
-        setSessionSelection((current) => (current
-          ? { ...current, model: models.DEFAULT, effort: null }
-          : current));
-      }
+        return { ...current, model: models.DEFAULT, effort: null };
+      });
     }
     return data.plan;
-  }, [applyProviderCatalog, provider, providerModels, sessionModel, setStoredProviderModel]);
+  }, [applyProviderCatalog, providerModels, setStoredProviderModel]);
 
   const providerModelActions = useMemo<ProviderModelActions>(() => ({
     create: createCustomModel,

--- a/src/modules/chat/hooks/useChatProviderState.ts
+++ b/src/modules/chat/hooks/useChatProviderState.ts
@@ -829,17 +829,31 @@ export function useChatProviderState({ selectedSession, selectedProject: _select
    * Replaces the provider's custom rows with the external catalog after the
    * user confirmed the preview, then refreshes the in-memory catalog.
    */
-  const applyCatalogSync = useCallback<ProviderCatalogSyncActions['apply']>(async (targetProvider) => {
-    const response = await api.providers.applyCatalogSync(targetProvider);
+  const applyCatalogSync = useCallback<ProviderCatalogSyncActions['apply']>(async (targetProvider, fingerprint) => {
+    const response = await api.providers.applyCatalogSync(targetProvider, fingerprint);
     const body = (await response.json()) as CatalogSyncApiResponse;
-    if (!response.ok || !body.success || !body.data?.plan) {
+    const data = body.data;
+    if (!response.ok || !body.success || !data?.plan) {
       throw new Error(body.error?.message || 'Unable to apply the model catalog sync.');
     }
-    if (body.data.models) {
-      applyProviderCatalog(targetProvider, body.data.models);
+    if (data.models) {
+      const models = data.models;
+      applyProviderCatalog(targetProvider, models);
+      const removedIds = new Set(data.plan.removals.map((entry) => entry.id));
+      if (removedIds.has(providerModels[targetProvider])) {
+        setStoredProviderModel(targetProvider, models.DEFAULT);
+      }
+      if (provider === targetProvider && sessionModel && removedIds.has(sessionModel)) {
+        // The server already reset the session row to the fallback model and
+        // cleared its effort; mirror that in the in-memory selection so the
+        // composer never keeps offering a removed model id.
+        setSessionSelection((current) => (current
+          ? { ...current, model: models.DEFAULT, effort: null }
+          : current));
+      }
     }
-    return body.data.plan;
-  }, [applyProviderCatalog]);
+    return data.plan;
+  }, [applyProviderCatalog, provider, providerModels, sessionModel, setStoredProviderModel]);
 
   const providerModelActions = useMemo<ProviderModelActions>(() => ({
     create: createCustomModel,

--- a/src/modules/chat/modals/ModelLibraryPanel.tsx
+++ b/src/modules/chat/modals/ModelLibraryPanel.tsx
@@ -7,6 +7,7 @@ import {
   LockKeyhole,
   Pencil,
   Plus,
+  RefreshCw,
   Trash2,
   X,
 } from 'lucide-react';
@@ -16,6 +17,7 @@ import type {
   LLMProvider,
   ProviderModelActions,
   ProviderModelOption,
+  ProviderCatalogSyncPlan,
   ProviderModelsDefinition,
 } from '@/shared/types';
 
@@ -57,6 +59,13 @@ export default function ModelLibraryPanel({
   const [confirmDeleteRecordId, setConfirmDeleteRecordId] = useState<number | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [notice, setNotice] = useState<string | null>(null);
+  // Holds the catalog-sync diff shown for confirmation before any write.
+  const [catalogSyncPlan, setCatalogSyncPlan] = useState<ProviderCatalogSyncPlan | null>(null);
+  // True while a catalog-sync preview or apply request is in flight.
+  const [catalogSyncing, setCatalogSyncing] = useState(false);
+  // Explains why a catalog sync could not start or finish (for example when no
+  // model_catalog_json is configured on this machine).
+  const [catalogSyncError, setCatalogSyncError] = useState<string | null>(null);
 
   useEffect(() => {
     setSelectedProvider(initialProvider);
@@ -75,6 +84,8 @@ export default function ModelLibraryPanel({
     [options],
   );
 
+  const supportsCatalogSync = actions.catalogSync !== undefined && selectedProvider === 'codex';
+
   const resetForm = () => {
     setEditing(null);
     setModel('');
@@ -86,6 +97,8 @@ export default function ModelLibraryPanel({
     setSelectedProvider(provider);
     setConfirmDeleteRecordId(null);
     setNotice(null);
+    setCatalogSyncPlan(null);
+    setCatalogSyncError(null);
     resetForm();
   };
 
@@ -155,6 +168,55 @@ export default function ModelLibraryPanel({
       setError(caughtError instanceof Error ? caughtError.message : t('chat:misc.modelDeleteFailed'));
     } finally {
       setDeletingRecordId(null);
+    }
+  };
+
+  const previewCatalogSync = async () => {
+    if (!actions.catalogSync) {
+      return;
+    }
+    setCatalogSyncing(true);
+    setCatalogSyncError(null);
+    setNotice(null);
+    try {
+      const plan = await actions.catalogSync.preview(selectedProvider);
+      if (plan.additions.length === 0 && plan.updates.length === 0 && plan.removals.length === 0) {
+        setNotice('Your Codex models already match the catalog.');
+      } else {
+        setCatalogSyncPlan(plan);
+      }
+    } catch (caughtError) {
+      setCatalogSyncError(
+        caughtError instanceof Error ? caughtError.message : 'Unable to preview the Codex catalog.',
+      );
+    } finally {
+      setCatalogSyncing(false);
+    }
+  };
+
+  const applyCatalogSync = async () => {
+    if (!actions.catalogSync || !catalogSyncPlan) {
+      return;
+    }
+    setCatalogSyncing(true);
+    setCatalogSyncError(null);
+    setNotice(null);
+    try {
+      const plan = await actions.catalogSync.apply(selectedProvider);
+      setCatalogSyncPlan(null);
+      const changes = plan.additions.length + plan.updates.length;
+      const removals = plan.removals.length;
+      setNotice(
+        removals > 0
+          ? `Synced ${changes} model(s) from the Codex catalog and removed ${removals}.`
+          : `Synced ${changes} model(s) from the Codex catalog.`,
+      );
+    } catch (caughtError) {
+      setCatalogSyncError(
+        caughtError instanceof Error ? caughtError.message : 'Unable to sync the Codex catalog.',
+      );
+    } finally {
+      setCatalogSyncing(false);
     }
   };
 
@@ -281,6 +343,105 @@ export default function ModelLibraryPanel({
         </form>
 
         <div className="min-h-0 space-y-4">
+          {supportsCatalogSync && (
+            <section className="rounded-2xl border border-border/70 bg-muted/20 p-3">
+              <div className="flex flex-wrap items-center justify-between gap-2">
+                <div>
+                  <p className="text-xs font-semibold text-foreground">Sync from Codex catalog</p>
+                  <p className="mt-0.5 text-[11px] text-muted-foreground">
+                    Replace your Codex models with the entries Codex lists in model_catalog_json.
+                  </p>
+                </div>
+                {!catalogSyncPlan && (
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    disabled={catalogSyncing}
+                    onClick={() => void previewCatalogSync()}
+                    className="h-8 rounded-lg"
+                  >
+                    {catalogSyncing ? (
+                      <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                    ) : (
+                      <RefreshCw className="h-3.5 w-3.5" />
+                    )}
+                    Preview sync
+                  </Button>
+                )}
+              </div>
+
+              {catalogSyncError && !catalogSyncPlan && (
+                <div role="alert" className="mt-3 rounded-xl border border-destructive/30 bg-destructive/10 px-3 py-2 text-xs text-destructive">
+                  {catalogSyncError}
+                </div>
+              )}
+
+              {catalogSyncPlan && (
+                <div className="mt-3 space-y-2 border-t border-border/60 pt-3">
+                  <p className="text-xs font-medium text-foreground">This sync will:</p>
+                  {(catalogSyncPlan.additions.length > 0
+                    || catalogSyncPlan.updates.length > 0
+                    || catalogSyncPlan.removals.length > 0) ? (
+                    <ul className="space-y-1 text-[11px] text-muted-foreground">
+                      {catalogSyncPlan.additions.map((entry) => (
+                        <li key={`add-${entry.id}`}>
+                          Add {entry.model} (<span className="font-mono text-foreground">{entry.id}</span>)
+                        </li>
+                      ))}
+                      {catalogSyncPlan.updates.map((entry) => (
+                        <li key={`update-${entry.id}`}>
+                          Rename {entry.previousModel ?? entry.id} to {entry.model}
+                        </li>
+                      ))}
+                      {catalogSyncPlan.removals.map((entry) => (
+                        <li key={`remove-${entry.id}`}>
+                          Remove {entry.model} (<span className="font-mono text-foreground">{entry.id}</span>)
+                        </li>
+                      ))}
+                    </ul>
+                  ) : (
+                    <p className="text-[11px] text-muted-foreground">Make no changes.</p>
+                  )}
+                  {catalogSyncPlan.skipped.length > 0 && (
+                    <p className="text-[11px] text-muted-foreground">
+                      Skipping {catalogSyncPlan.skipped.length} catalog id(s) already offered as built-in models.
+                    </p>
+                  )}
+                  {catalogSyncError && (
+                    <div role="alert" className="rounded-xl border border-destructive/30 bg-destructive/10 px-3 py-2 text-xs text-destructive">
+                      {catalogSyncError}
+                    </div>
+                  )}
+                  <div className="flex items-center gap-2 pt-1">
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="sm"
+                      disabled={catalogSyncing}
+                      onClick={() => {
+                        setCatalogSyncPlan(null);
+                        setCatalogSyncError(null);
+                      }}
+                      className="h-8 rounded-lg"
+                    >
+                      Cancel
+                    </Button>
+                    <Button
+                      type="button"
+                      size="sm"
+                      disabled={catalogSyncing}
+                      onClick={() => void applyCatalogSync()}
+                      className="h-8 rounded-lg"
+                    >
+                      {catalogSyncing && <Loader2 className="h-3.5 w-3.5 animate-spin" />}
+                      Apply sync
+                    </Button>
+                  </div>
+                </div>
+              )}
+            </section>
+          )}
           <section>
             <div className="mb-2 flex items-center justify-between gap-3 px-1">
               <div>

--- a/src/modules/chat/modals/ModelLibraryPanel.tsx
+++ b/src/modules/chat/modals/ModelLibraryPanel.tsx
@@ -180,7 +180,10 @@ export default function ModelLibraryPanel({
     setNotice(null);
     try {
       const plan = await actions.catalogSync.preview(selectedProvider);
-      if (plan.additions.length === 0 && plan.updates.length === 0 && plan.removals.length === 0) {
+      if (plan.additions.length === 0
+        && plan.updates.length === 0
+        && plan.removals.length === 0
+        && plan.skipped.length === 0) {
         setNotice('Your Codex models already match the catalog.');
       } else {
         setCatalogSyncPlan(plan);
@@ -202,7 +205,7 @@ export default function ModelLibraryPanel({
     setCatalogSyncError(null);
     setNotice(null);
     try {
-      const plan = await actions.catalogSync.apply(selectedProvider);
+      const plan = await actions.catalogSync.apply(selectedProvider, catalogSyncPlan.fingerprint);
       setCatalogSyncPlan(null);
       const changes = plan.additions.length + plan.updates.length;
       const removals = plan.removals.length;

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -366,8 +366,8 @@ export const api = {
 
     previewCatalogSync: (provider: string) =>
       get(`/api/providers/${provider}/models/catalog-sync/preview`),
-    applyCatalogSync: (provider: string) =>
-      post(`/api/providers/${provider}/models/catalog-sync`),
+    applyCatalogSync: (provider: string, fingerprint: string) =>
+      post(`/api/providers/${provider}/models/catalog-sync`, { fingerprint }),
 
     createSession: (payload: {
       provider: string;

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -364,6 +364,11 @@ export const api = {
     deleteModel: (provider: string, recordId: string | number) =>
       del(`/api/providers/${provider}/models/${recordId}`),
 
+    previewCatalogSync: (provider: string) =>
+      get(`/api/providers/${provider}/models/catalog-sync/preview`),
+    applyCatalogSync: (provider: string) =>
+      post(`/api/providers/${provider}/models/catalog-sync`),
+
     createSession: (payload: {
       provider: string;
       projectPath: string;

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -44,6 +44,46 @@ export type ProviderModelActions = {
     input: CustomProviderModelInput,
   ): Promise<void>;
   remove(provider: LLMProvider, existing: ProviderModelOption): Promise<void>;
+  /** Catalog-sync entry point, present only when the provider exposes one. */
+  catalogSync?: ProviderCatalogSyncActions;
+};
+
+/** One provider model a catalog sync will add, rename or remove. */
+export type ProviderCatalogSyncEntry = {
+  id: string;
+  model: string;
+  /** Current display name when the sync renames an existing row. */
+  previousModel?: string;
+};
+
+/** One external catalog entry a sync skips, and why. */
+export type ProviderCatalogSyncSkip = {
+  id: string;
+  model: string;
+  /** The curated predefined list already offers this id, so it cannot be stored. */
+  reason: 'builtin';
+};
+
+/**
+ * Diff between one provider's stored custom rows and the provider CLI's
+ * external model catalog, produced by a catalog-sync preview.
+ */
+export type ProviderCatalogSyncPlan = {
+  provider: LLMProvider;
+  additions: ProviderCatalogSyncEntry[];
+  updates: ProviderCatalogSyncEntry[];
+  removals: ProviderCatalogSyncEntry[];
+  skipped: ProviderCatalogSyncSkip[];
+};
+
+/**
+ * Opt-in catalog sync callbacks. Only providers whose CLI reads an external
+ * model catalog (Codex model_catalog_json) provide these; preview shows the
+ * diff and apply replaces the provider's custom rows after user confirmation.
+ */
+export type ProviderCatalogSyncActions = {
+  preview(provider: LLMProvider): Promise<ProviderCatalogSyncPlan>;
+  apply(provider: LLMProvider): Promise<ProviderCatalogSyncPlan>;
 };
 
 // ---------------------------

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -74,6 +74,8 @@ export type ProviderCatalogSyncPlan = {
   updates: ProviderCatalogSyncEntry[];
   removals: ProviderCatalogSyncEntry[];
   skipped: ProviderCatalogSyncSkip[];
+  /** Fingerprint of the catalog and rows the preview reviewed; apply must echo it. */
+  fingerprint: string;
 };
 
 /**
@@ -83,7 +85,7 @@ export type ProviderCatalogSyncPlan = {
  */
 export type ProviderCatalogSyncActions = {
   preview(provider: LLMProvider): Promise<ProviderCatalogSyncPlan>;
-  apply(provider: LLMProvider): Promise<ProviderCatalogSyncPlan>;
+  apply(provider: LLMProvider, fingerprint: string): Promise<ProviderCatalogSyncPlan>;
 };
 
 // ---------------------------


### PR DESCRIPTION
## Summary

Aims to address #901

Adds an explicit, confirm-first "Sync from Codex catalog" flow to the model library's Codex tab. The user clicks **Preview sync**, sees exactly which models will be added, renamed and removed, and only then applies the change. Nothing reads `~/.codex/config.toml` on ordinary model requests — the manual model library remains the only store, and the catalog file is consulted only when the user asks for it.

## What changed

- `CodexProviderModels.readExternalCatalog()` parses the `model_catalog_json` named in `~/.codex/config.toml`, importing only entries Codex itself lists in `/model` (`visibility: "list"` — `hide`, `none` and undeclared visibility stay out, mirroring the Codex picker).
- The provider-models service builds a preview diff: additions, renames, removals, and entries skipped because the curated predefined list already offers that id (matching the existing single-row uniqueness rule).
- Apply atomically replaces the provider's custom rows in one transaction; sessions that recorded a removed model id fall back to the provider default with effort cleared, same as the per-row delete path.
- Routes: `GET /api/providers/:provider/models/catalog-sync/preview` and `POST /api/providers/:provider/models/catalog-sync` (only Codex implements the catalog source; other providers get a clear error).
- Model library UI: Codex tab shows a sync card with preview, per-row change list, skipped-builtin notice, cancel and apply; the in-memory catalog refreshes after apply.

## Validation

- Adapter unit tests: missing/unusable config and catalog, visibility filtering, dedupe, metadata mapping, configured-model default.
- Service unit tests: preview diff categories, apply replacement + merged catalog result, unsupported-provider and unconfigured-catalog errors.
- Existing provider models, provider routes and frontend provider-model tests still pass; client and server typechecks plus oxlint are clean.
- Smoke-tested against a real `model_catalog_json`: all 8 picker-visible entries parse and import.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Codex model discovery from the configured external catalog.
  - Added model library controls to preview and apply catalog changes, including additions, renames, and removals.
  - Skipped entries already available as built-in models and refreshed the model list after synchronization.
  - Added synchronization endpoints with confirmation of the reviewed catalog state.

- **Bug Fixes**
  - Improved handling of missing, invalid, or unusable catalog files.
  - Reset sessions using removed models to the selected fallback model.
  - Prevented applying changes when the reviewed catalog state is outdated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->