### PR TITLE
feat(voice): add MiniMax speech synthesis

### DIFF
--- a/docs/minimax-speech.md
+++ b/docs/minimax-speech.md
@@ -5,9 +5,18 @@ global service, or `https://api.minimaxi.com/v1` for the China service. Enter yo
 key. The full regional `t2a_v2` URL is also accepted.
 
 Leave the text-to-speech model blank to use `speech-2.8-hd` and the voice
-blank to use `English_expressive_narrator`, or supply your model and voice ID.
+blank to use `English_expressive_narrator`, or supply one of the current speech
+models: `speech-2.8-hd`, `speech-2.8-turbo`, `speech-2.6-hd`, `speech-2.6-turbo`,
+`speech-02-hd`, `speech-02-turbo`, `speech-01-hd`, or `speech-01-turbo`.
 Audio format defaults to MP3; WAV, FLAC, and PCM are also accepted. Browser playback
 depends on support for the selected format; MP3 is recommended for read-aloud.
+
+The synchronous request contains the required `model` and `text` fields. The adapter
+sets `stream: false`, requests hex audio, and maps the configured voice and audio format
+to `voice_setting` and `audio_setting`; MiniMax's other optional controls (`language_boost`,
+`pronunciation_dict`, `voice_modify`, and `subtitle_enable`) remain at their API defaults.
+Successful responses require `base_resp.status_code: 0` and `data.status: 2`; the hex
+payload in `data.audio` is decoded to the selected audio format.
 
 For server-managed credentials, leave the browser base URL blank and configure
 `VOICE_API_BASE_URL` and `VOICE_API_KEY` on the server. Optional `VOICE_TTS_MODEL`

--- a/docs/minimax-speech.md
+++ b/docs/minimax-speech.md
@@ -1,0 +1,19 @@
+# MiniMax read-aloud
+
+Enable Voice in Settings and enter `https://api.minimax.io/v1` as the base URL for the
+global service, or `https://api.minimaxi.com/v1` for the China service. Enter your MiniMax API
+key. The full regional `t2a_v2` URL is also accepted.
+
+Leave the text-to-speech model blank to use `speech-2.8-hd` and the voice
+blank to use `English_expressive_narrator`, or supply your model and voice ID.
+Audio format defaults to MP3; WAV, FLAC, and PCM are also accepted. Browser playback
+depends on support for the selected format; MP3 is recommended for read-aloud.
+
+For server-managed credentials, leave the browser base URL blank and configure
+`VOICE_API_BASE_URL` and `VOICE_API_KEY` on the server. Optional `VOICE_TTS_MODEL`
+and `VOICE_TTS_VOICE` values override the same defaults.
+
+This integration supports synchronous speech synthesis. Speech transcription
+requires a backend with a transcription API.
+
+API reference: https://platform.minimax.io/docs/api-reference/speech-t2a-http

--- a/server/modules/voice/tests/minimax-speech.service.test.ts
+++ b/server/modules/voice/tests/minimax-speech.service.test.ts
@@ -1,0 +1,124 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { createVoiceService } from '../voice.service.js';
+
+const endpoints = [
+  "https://api.minimax.io/v1/t2a_v2",
+  "https://api.minimaxi.com/v1/t2a_v2"
+];
+const defaultModel = "speech-2.8-hd";
+const defaults = {
+  baseUrl: endpoints[0],
+  apiKey: 'server-key',
+  sttModel: '',
+  ttsModel: '',
+  ttsVoice: '',
+};
+
+for (const endpoint of endpoints) {
+  test(`synthesizes MiniMax speech through ${new URL(endpoint).hostname}`, async () => {
+    let requestedUrl = '';
+    let requestedOptions: RequestInit | undefined;
+    const service = createVoiceService({
+      defaults: { ...defaults, baseUrl: endpoint.replace('/t2a_v2', '/') },
+      timeoutMs: 1_000,
+      fetchBackend: async (url, options) => {
+        requestedUrl = url;
+        requestedOptions = options;
+        return Response.json({ base_resp: { status_code: 0 }, data: { status: 2, audio: '494433ff' } });
+      },
+    });
+
+    const result = await service.synthesizeSpeech({ text: 'Read this', overrides: {} });
+
+    assert.equal(requestedUrl, endpoint);
+    assert.ok(requestedOptions);
+    assert.equal(requestedOptions.method, 'POST');
+    assert.equal(new Headers(requestedOptions.headers).get('Authorization'), 'Bearer server-key');
+    assert.deepEqual(JSON.parse(String(requestedOptions.body)), {
+      model: defaultModel,
+      text: 'Read this',
+      stream: false,
+      output_format: 'hex',
+      voice_setting: { voice_id: 'English_expressive_narrator' },
+      audio_setting: { format: 'mp3' },
+    });
+    assert.ok(result.ok);
+    assert.equal(result.value.contentType, 'audio/mpeg');
+    assert.deepEqual(new Uint8Array(await new Response(result.value.body).arrayBuffer()), new Uint8Array([73, 68, 51, 255]));
+  });
+}
+
+for (const [format, contentType] of [['wav', 'audio/wav'], ['flac', 'audio/flac'], ['pcm', 'audio/pcm']]) {
+  test(`preserves MiniMax request overrides and returns ${format} audio`, async () => {
+    let requestedOptions: RequestInit | undefined;
+    const service = createVoiceService({
+      defaults,
+      timeoutMs: 1_000,
+      fetchBackend: async (_url, options) => {
+        requestedOptions = options;
+        return Response.json({ base_resp: { status_code: 0 }, data: { status: 2, audio: '00ff' } });
+      },
+    });
+
+    const result = await service.synthesizeSpeech({
+      text: 'Custom speech',
+      overrides: { apiKey: 'request-key', ttsModel: 'custom-speech', ttsVoice: 'custom-voice', ttsFormat: ` ${format} ` },
+    });
+
+    assert.ok(requestedOptions);
+    assert.equal(new Headers(requestedOptions.headers).get('Authorization'), 'Bearer request-key');
+    const body = JSON.parse(String(requestedOptions.body));
+    assert.equal(body.model, 'custom-speech');
+    assert.deepEqual(body.voice_setting, { voice_id: 'custom-voice' });
+    assert.deepEqual(body.audio_setting, { format });
+    assert.ok(result.ok);
+    assert.equal(result.value.contentType, contentType);
+  });
+}
+
+for (const payload of [
+  { base_resp: { status_code: 1004 }, data: { status: 2, audio: '00' } },
+  { data: { status: 2, audio: '00' } },
+  { base_resp: { status_code: 0 }, data: { status: 1, audio: '00' } },
+  { base_resp: { status_code: 0 }, data: { status: 2, audio: '' } },
+  { base_resp: { status_code: 0 }, data: { status: 2, audio: 'a' } },
+  { base_resp: { status_code: 0 }, data: { status: 2, audio: 'zz' } },
+  { base_resp: { status_code: 0 }, data: { status: 2, audio: 12 } },
+  null,
+]) {
+  test(`rejects an unsuccessful or invalid MiniMax payload: ${JSON.stringify(payload)}`, async () => {
+    const service = createVoiceService({
+      defaults,
+      timeoutMs: 1_000,
+      fetchBackend: async () => Response.json(payload),
+    });
+    const result = await service.synthesizeSpeech({ text: 'Read this', overrides: {} });
+    assert.equal(result.ok, false);
+    if (!result.ok) {
+      assert.equal(result.status, 502);
+      assert.match(result.error, /MiniMax/);
+    }
+  });
+}
+
+test('rejects malformed MiniMax JSON and preserves HTTP authentication error mapping', async () => {
+  for (const response of [new Response('invalid JSON'), new Response('unauthorized', { status: 401 })]) {
+    const service = createVoiceService({ defaults, timeoutMs: 1_000, fetchBackend: async () => response });
+    const result = await service.synthesizeSpeech({ text: 'Read this', overrides: {} });
+    assert.equal(result.ok, false);
+    if (!result.ok) assert.equal(result.status, 502);
+  }
+});
+
+test('rejects unsupported MiniMax formats before sending a request', async () => {
+  const service = createVoiceService({
+    defaults,
+    timeoutMs: 1_000,
+    fetchBackend: async () => { throw new Error('fetch must not run'); },
+  });
+  const result = await service.synthesizeSpeech({ text: 'Read this', overrides: { ttsFormat: 'invalid' } });
+  assert.equal(result.ok, false);
+  if (!result.ok) assert.equal(result.status, 400);
+});

--- a/server/modules/voice/voice.module.ts
+++ b/server/modules/voice/voice.module.ts
@@ -1,5 +1,7 @@
 import multer from 'multer';
 
+import { getMiniMaxSpeechEndpoint } from '../../../shared/minimaxSpeech.js';
+
 import { createVoiceRouter } from './voice.routes.js';
 import { createVoiceService } from './voice.service.js';
 
@@ -18,6 +20,11 @@ const voiceService = createVoiceService({
     sttModel: process.env.VOICE_STT_MODEL || 'whisper-1',
     ttsModel: process.env.VOICE_TTS_MODEL || 'tts-1',
     ttsVoice: process.env.VOICE_TTS_VOICE || 'alloy',
+    // Let the native adapter supply its own defaults for MiniMax endpoints.
+    ...(getMiniMaxSpeechEndpoint(process.env.VOICE_API_BASE_URL || '') ? {
+      ttsModel: process.env.VOICE_TTS_MODEL || '',
+      ttsVoice: process.env.VOICE_TTS_VOICE || '',
+    } : {}),
   },
   timeoutMs: voiceTimeoutMs,
   fetchBackend: async (url, options) => {

--- a/server/modules/voice/voice.service.ts
+++ b/server/modules/voice/voice.service.ts
@@ -6,6 +6,8 @@ import type {
   VoiceSpeechPayload,
 } from '@/shared/types.js';
 
+import { getMiniMaxSpeechEndpoint, synthesizeMiniMaxSpeech } from '../../../shared/minimaxSpeech.js';
+
 type VoiceServiceDependencies = {
   defaults: {
     baseUrl: string;
@@ -160,7 +162,10 @@ export function createVoiceService(dependencies: VoiceServiceDependencies): Voic
       }
 
       try {
-        const response = await dependencies.fetchBackend(`${config.baseUrl}/audio/speech`, {
+        const miniMaxEndpoint = getMiniMaxSpeechEndpoint(config.baseUrl);
+        const response = miniMaxEndpoint
+          ? await synthesizeMiniMaxSpeech(miniMaxEndpoint, input.text, config, dependencies.fetchBackend)
+          : await dependencies.fetchBackend(`${config.baseUrl}/audio/speech`, {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',

--- a/shared/minimaxSpeech.ts
+++ b/shared/minimaxSpeech.ts
@@ -1,0 +1,96 @@
+const MINIMAX_SPEECH_ENDPOINTS = [
+  "https://api.minimax.io/v1/t2a_v2",
+  "https://api.minimaxi.com/v1/t2a_v2"
+];
+const MINIMAX_SPEECH_MODEL = "speech-2.8-hd";
+const MINIMAX_AUDIO_TYPES: Record<string, string> = {
+  mp3: 'audio/mpeg',
+  wav: 'audio/wav',
+  flac: 'audio/flac',
+  pcm: 'audio/pcm',
+};
+
+type MiniMaxSpeechSettings = {
+  apiKey: string;
+  ttsModel: string;
+  ttsVoice: string;
+  ttsFormat: string;
+};
+
+/** Used by the browser voice API and server Voice module to select a regional TTS endpoint. */
+export function getMiniMaxSpeechEndpoint(baseUrl: string): string | undefined {
+  const normalizedUrl = baseUrl.trim().replace(/\/+$/, '');
+  return MINIMAX_SPEECH_ENDPOINTS.find((endpoint) =>
+    normalizedUrl === endpoint || normalizedUrl === endpoint.slice(0, endpoint.lastIndexOf('/')),
+  );
+}
+
+function speechFailure(error: string, status = 502): Response {
+  return Response.json({ error }, { status });
+}
+
+/**
+ * Used by the browser voice API and server Voice service to turn MiniMax's
+ * synchronous JSON/hex response into playable audio without a second download.
+ * The caller supplies the fetch adapter, including its timeout or abort signal.
+ */
+export async function synthesizeMiniMaxSpeech(
+  endpoint: string,
+  text: string,
+  settings: MiniMaxSpeechSettings,
+  fetchBackend: (url: string, options: RequestInit) => Promise<Response>,
+  signal?: AbortSignal,
+): Promise<Response> {
+  const format = settings.ttsFormat.trim() || 'mp3';
+  if (!Object.prototype.hasOwnProperty.call(MINIMAX_AUDIO_TYPES, format)) {
+    return speechFailure('Unsupported MiniMax audio format. Use mp3, wav, flac, or pcm.', 400);
+  }
+
+  const response = await fetchBackend(endpoint, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      ...(settings.apiKey ? { Authorization: `Bearer ${settings.apiKey}` } : {}),
+    },
+    body: JSON.stringify({
+      model: settings.ttsModel.trim() || MINIMAX_SPEECH_MODEL,
+      text,
+      stream: false,
+      output_format: 'hex',
+      voice_setting: { voice_id: settings.ttsVoice.trim() || 'English_expressive_narrator' },
+      audio_setting: { format },
+    }),
+    ...(signal ? { signal } : {}),
+  });
+
+  if (!response.ok) {
+    return response;
+  }
+
+  let payload: {
+    base_resp?: { status_code?: number };
+    data?: { audio?: unknown; status?: number };
+  } | null;
+  try {
+    payload = await response.json() as typeof payload;
+  } catch {
+    return speechFailure('MiniMax returned an invalid speech response.');
+  }
+  if (!payload || payload.base_resp?.status_code !== 0) {
+    const code = payload?.base_resp?.status_code;
+    return speechFailure(
+      typeof code !== 'number' ? 'MiniMax returned an invalid speech response.' : `MiniMax speech failed (code ${code}).`,
+    );
+  }
+
+  const audio = payload.data?.audio;
+  if (payload.data?.status !== 2 || typeof audio !== 'string' || !/^(?:[\da-f]{2})+$/i.test(audio)) {
+    return speechFailure('MiniMax returned incomplete or invalid speech audio.');
+  }
+
+  const bytes = new Uint8Array(audio.length / 2);
+  for (let index = 0; index < bytes.length; index += 1) {
+    bytes[index] = Number.parseInt(audio.slice(index * 2, index * 2 + 2), 16);
+  }
+  return new Response(bytes, { headers: { 'Content-Type': MINIMAX_AUDIO_TYPES[format] } });
+}

--- a/shared/minimaxSpeech.ts
+++ b/shared/minimaxSpeech.ts
@@ -1,8 +1,18 @@
 const MINIMAX_SPEECH_ENDPOINTS = [
-  "https://api.minimax.io/v1/t2a_v2",
-  "https://api.minimaxi.com/v1/t2a_v2"
+  'https://api.minimax.io/v1/t2a_v2',
+  'https://api.minimaxi.com/v1/t2a_v2',
 ];
-const MINIMAX_SPEECH_MODEL = "speech-2.8-hd";
+const MINIMAX_SPEECH_MODELS = [
+  'speech-2.8-hd',
+  'speech-2.8-turbo',
+  'speech-2.6-hd',
+  'speech-2.6-turbo',
+  'speech-02-hd',
+  'speech-02-turbo',
+  'speech-01-hd',
+  'speech-01-turbo',
+] as const;
+const MINIMAX_SPEECH_MODEL = MINIMAX_SPEECH_MODELS[0];
 const MINIMAX_AUDIO_TYPES: Record<string, string> = {
   mp3: 'audio/mpeg',
   wav: 'audio/wav',

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -1,3 +1,4 @@
+import { getMiniMaxSpeechEndpoint, synthesizeMiniMaxSpeech } from '@shared/minimaxSpeech';
 import {
   expireAuthSession,
   getStoredAuthToken,
@@ -563,11 +564,16 @@ export function transcribeVoice(blob: Blob, filename: string): Promise<Response>
 }
 
 /**
- * Synthesizes speech for the given text, using the user's configured OpenAI-compatible
+ * Synthesizes speech for the chat module using the user's configured voice
  * endpoint when one is set and otherwise the CloudCLI voice proxy.
  */
 export function synthesizeVoice(text: string, signal: AbortSignal): Promise<Response> {
   const config = readVoiceConfig();
+  const miniMaxEndpoint = getMiniMaxSpeechEndpoint(config.baseUrl);
+
+  if (miniMaxEndpoint) {
+    return synthesizeMiniMaxSpeech(miniMaxEndpoint, text, config, fetch, signal);
+  }
 
   if (config.baseUrl.trim()) {
     return fetch(voiceDirectUrl(config.baseUrl.trim(), '/audio/speech'), {

--- a/src/shared/tests/minimaxSpeech.test.ts
+++ b/src/shared/tests/minimaxSpeech.test.ts
@@ -1,0 +1,62 @@
+import assert from 'node:assert/strict';
+
+import { afterEach, beforeEach, test, vi } from 'vitest';
+
+import { synthesizeVoice } from '@/shared/api';
+import { VOICE_CONFIG_STORAGE_KEY } from '@/shared/voiceConfig';
+
+const endpoints = [
+  "https://api.minimax.io/v1/t2a_v2",
+  "https://api.minimaxi.com/v1/t2a_v2"
+];
+const defaultModel = "speech-2.8-hd";
+
+beforeEach(() => { localStorage.clear(); });
+afterEach(() => { vi.unstubAllGlobals(); });
+
+for (const endpoint of endpoints) {
+  test(`plays MiniMax speech directly from ${new URL(endpoint).hostname}`, async () => {
+    localStorage.setItem(VOICE_CONFIG_STORAGE_KEY, JSON.stringify({ baseUrl: endpoint, apiKey: 'voice-key' }));
+    localStorage.setItem('auth-token', 'application-token');
+    const controller = new AbortController();
+    const fetchMock = vi.fn(async (_url: string, _options?: RequestInit) =>
+      Response.json({ base_resp: { status_code: 0 }, data: { status: 2, audio: '494433' } }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const response = await synthesizeVoice('Read this', controller.signal);
+
+    assert.equal(fetchMock.mock.calls.length, 1);
+    const [url, options] = fetchMock.mock.calls[0];
+    assert.equal(url, endpoint);
+    assert.equal(options?.signal, controller.signal);
+    assert.equal(new Headers(options?.headers).get('Authorization'), 'Bearer voice-key');
+    assert.equal(JSON.parse(String(options?.body)).model, defaultModel);
+    assert.equal(response.headers.get('Content-Type'), 'audio/mpeg');
+    assert.deepEqual(new Uint8Array(await response.arrayBuffer()), new Uint8Array([73, 68, 51]));
+  });
+}
+
+test('surfaces MiniMax application errors instead of playing the JSON response', async () => {
+  localStorage.setItem(VOICE_CONFIG_STORAGE_KEY, JSON.stringify({ baseUrl: endpoints[0] }));
+  vi.stubGlobal('fetch', vi.fn(async () => Response.json({ base_resp: { status_code: 1004 } })));
+
+  const response = await synthesizeVoice('Read this', new AbortController().signal);
+
+  assert.equal(response.status, 502);
+  assert.deepEqual(await response.json(), { error: 'MiniMax speech failed (code 1004).' });
+});
+
+test('keeps unrelated voice endpoints on their existing speech contract', async () => {
+  localStorage.setItem(VOICE_CONFIG_STORAGE_KEY, JSON.stringify({
+    baseUrl: 'https://voice.example/v1', ttsModel: 'custom-speech', ttsVoice: 'custom-voice',
+  }));
+  const fetchMock = vi.fn(async (_url: string, _options?: RequestInit) => new Response('audio'));
+  vi.stubGlobal('fetch', fetchMock);
+
+  await synthesizeVoice('Read this', new AbortController().signal);
+
+  const [url, options] = fetchMock.mock.calls[0];
+  assert.equal(url, 'https://voice.example/v1/audio/speech');
+  assert.deepEqual(JSON.parse(String(options?.body)), { model: 'custom-speech', voice: 'custom-voice', input: 'Read this' });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,8 @@
       // The frontend keeps "@" mapped to /src.
       // The backend gets its own "@" mapping in server/tsconfig.json so both sides can use
       // the same alias name without sharing one compiler configuration.
-      "@/*": ["src/*"]
+      "@/*": ["src/*"],
+      "@shared/*": ["shared/*"]
     },
     "skipLibCheck": true,
     "moduleResolution": "Bundler",

--- a/vite.config.js
+++ b/vite.config.js
@@ -31,7 +31,8 @@ export default defineConfig(({ mode }) => {
     },
     resolve: {
       alias: {
-        '@': fileURLToPath(new URL('./src', import.meta.url))
+        '@': fileURLToPath(new URL('./src', import.meta.url)),
+        '@shared': fileURLToPath(new URL('./shared', import.meta.url))
       }
     },
     server: {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,6 +8,7 @@ export default defineConfig({
   resolve: {
     alias: {
       '@': fileURLToPath(new URL('./src', import.meta.url)),
+      '@shared': fileURLToPath(new URL('./shared', import.meta.url)),
     },
   },
   define: {


### PR DESCRIPTION
Reason: Add MiniMax global and China text-to-speech support to the existing voice pipeline.

Implemented the synchronous MiniMax `t2a_v2` adapter for both regional endpoints, including the current speech model catalog, required `model` and `text` fields, voice and audio settings, supported audio formats, and validated hex audio response parsing. Existing OpenAI-compatible voice backends remain unchanged.

Checks:
- `npx tsx --tsconfig server/tsconfig.json --test server/modules/voice/tests/minimax-speech.service.test.ts`
- `npx vitest run src/shared/tests/minimaxSpeech.test.ts`
- `npm run typecheck`
- `npm run lint`
- `npm run build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added MiniMax text-to-speech support for global and China regional endpoints.
  - Added configurable API credentials, models, voices, and audio formats.
  - Added validation and playback support for generated MP3, WAV, FLAC, and PCM audio.
- **Documentation**
  - Documented MiniMax Voice configuration, supported models, response handling, and server-managed settings.
- **Tests**
  - Added coverage for successful synthesis, regional endpoints, configuration overrides, invalid formats, and error responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->