### PR TITLE
fix(claude): hold the CLI open for backgrounded agents and workflows

### DIFF
--- a/server/modules/providers/list/claude/claude-runtime.provider.js
+++ b/server/modules/providers/list/claude/claude-runtime.provider.js
@@ -552,10 +552,14 @@ const DEFERRED_WORK_TOOLS = new Set(['Monitor', 'ScheduleWakeup', 'CronCreate', 
  * Only turns that start background work need their CLI process held open; every
  * other turn can let it exit immediately, as it did before the hold existed.
  *
+ * Used by the providers module's tests, which pin the tool matching directly:
+ * the alternative is driving a whole SDK run to observe whether stdin was held,
+ * and the cost of getting this wrong is silently killed background work.
+ *
  * @param {Object} sdkMessage - SDK stream message
  * @returns {boolean} True when the message launches work that outlives the turn
  */
-function startsBackgroundWork(sdkMessage) {
+export function startsBackgroundWork(sdkMessage) {
   const content = sdkMessage?.message?.content;
   if (!Array.isArray(content)) {
     return false;
@@ -1225,6 +1229,5 @@ export {
   getPendingApprovalsForSession,
   reconnectSessionWriter,
   extractTokenBudget,
-  extractCumulativeTokenBudget,
-  startsBackgroundWork
+  extractCumulativeTokenBudget
 };

--- a/server/modules/providers/list/claude/claude-runtime.provider.js
+++ b/server/modules/providers/list/claude/claude-runtime.provider.js
@@ -539,9 +539,12 @@ function extractCumulativeTokenBudget(sdkMessage) {
   };
 }
 
-// Tool calls that leave work running past the end of a turn. Bash only counts
-// when it is explicitly backgrounded; the rest defer or watch work by nature.
-const DEFERRED_WORK_TOOLS = new Set(['Monitor', 'ScheduleWakeup', 'CronCreate', 'TaskCreate']);
+// Tool calls that leave work running past the end of a turn. Bash and Agent only
+// count when they are backgrounded; the rest defer or watch work by nature.
+// Workflow belongs here rather than in a branch of its own: its input schema has
+// no foreground option at all, so every call returns a task id immediately and
+// reports back in a later turn.
+const DEFERRED_WORK_TOOLS = new Set(['Monitor', 'ScheduleWakeup', 'CronCreate', 'TaskCreate', 'Workflow']);
 
 /**
  * Detects tool calls that keep working after the turn's `result` arrives.
@@ -564,6 +567,15 @@ function startsBackgroundWork(sdkMessage) {
     }
     if (block.name === 'Bash') {
       return block.input?.run_in_background === true;
+    }
+    // A backgrounded subagent outlives the turn exactly like a backgrounded
+    // Bash does, so the process has to be held open for it to report back.
+    // Agents background by default — `run_in_background` is optional and only
+    // an explicit `false` opts out — hence `!== false` rather than `=== true`.
+    // A foreground agent must stay out of DEFERRED_WORK_TOOLS: it never pushes
+    // a follow-up turn, so it would pin the process for the full ceiling.
+    if (block.name === 'Agent') {
+      return block.input?.run_in_background !== false;
     }
     return DEFERRED_WORK_TOOLS.has(block.name);
   });
@@ -1213,5 +1225,6 @@ export {
   getPendingApprovalsForSession,
   reconnectSessionWriter,
   extractTokenBudget,
-  extractCumulativeTokenBudget
+  extractCumulativeTokenBudget,
+  startsBackgroundWork
 };

--- a/server/modules/providers/tests/claude-background-work.test.ts
+++ b/server/modules/providers/tests/claude-background-work.test.ts
@@ -1,0 +1,71 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { startsBackgroundWork } from '@/modules/providers/list/claude/claude-runtime.provider.js';
+
+// Only turns that start work outliving the turn hold their CLI process open. A
+// turn scored `false` here has its stdin released the moment `result` arrives,
+// and the CLI reads that EOF as print wind-down — so anything still running dies.
+const turn = (...blocks: Array<{ name: string; input?: Record<string, unknown> }>) => ({
+  type: 'assistant',
+  message: { content: blocks.map((block) => ({ type: 'tool_use', input: {}, ...block })) },
+});
+
+test('a backgrounded Bash holds the process open', () => {
+  assert.equal(startsBackgroundWork(turn({ name: 'Bash', input: { run_in_background: true } })), true);
+});
+
+test('a foreground Bash does not', () => {
+  assert.equal(startsBackgroundWork(turn({ name: 'Bash', input: { run_in_background: false } })), false);
+});
+
+test('a backgrounded Agent holds the process open', () => {
+  // The gap this suite exists for: a background agent used to be scored as
+  // nothing outstanding, so the CLI wound down and killed it mid-run.
+  assert.equal(startsBackgroundWork(turn({ name: 'Agent', input: { run_in_background: true } })), true);
+});
+
+test('an Agent with no run_in_background holds the process open', () => {
+  // `run_in_background` is optional on AgentInput and agents background by
+  // default, so an omitted field means background, not foreground.
+  assert.equal(startsBackgroundWork(turn({ name: 'Agent', input: { prompt: 'Investigate' } })), true);
+});
+
+test('a foreground Agent does not', () => {
+  // It never pushes a follow-up turn, so holding for it would pin the process
+  // for the full BG_WAIT_CEILING_MS.
+  assert.equal(startsBackgroundWork(turn({ name: 'Agent', input: { run_in_background: false } })), false);
+});
+
+test('a Workflow holds the process open', () => {
+  // WorkflowInput has no foreground option: every call returns a task id
+  // immediately and reports back in a later turn.
+  assert.equal(startsBackgroundWork(turn({ name: 'Workflow', input: { script: 'export const meta = {}' } })), true);
+});
+
+test('a deferred-work tool holds the process open', () => {
+  assert.equal(startsBackgroundWork(turn({ name: 'Monitor' })), true);
+});
+
+test('a turn that starts nothing lasting does not', () => {
+  assert.equal(startsBackgroundWork(turn({ name: 'Read' })), false);
+});
+
+test('one backgrounded agent among foreground calls is enough', () => {
+  assert.equal(
+    startsBackgroundWork(
+      turn(
+        { name: 'Read' },
+        { name: 'Agent', input: { run_in_background: false } },
+        { name: 'Agent', input: { run_in_background: true } },
+      ),
+    ),
+    true,
+  );
+});
+
+test('a message carrying no tool calls does not', () => {
+  assert.equal(startsBackgroundWork({ type: 'result', message: { content: 'done' } }), false);
+  assert.equal(startsBackgroundWork({ type: 'assistant', message: { content: [] } }), false);
+  assert.equal(startsBackgroundWork({}), false);
+});


### PR DESCRIPTION
Fixes #1268.

## The bug

`startsBackgroundWork()` decides whether a turn's CLI process is held open past its `result`. It matches `Bash` and the `DEFERRED_WORK_TOOLS` set, but nothing matches `Agent` — so a turn whose only outstanding work is a background subagent is scored as having nothing pending. `releasePromptStream()` runs immediately, the SDK closes stdin, the CLI reads that EOF as print wind-down, and the agent is killed mid-run.

The Node server never restarts and the browser stays on the same transcript, so the only visible trace is on the next message:

```
No completion record was found for background agent "<name>" from the previous session.
```

As #1268 notes, this is a gap in the fix that shipped for #1113 rather than a regression: that work predates background agents, and its own notes list subagents as finishing inside a turn, which was true at the time.

## Reproduce

1. Ask Claude to spawn a background agent that runs for a minute or two.
2. Wait for the turn to end — the agent is still running.
3. Send any follow-up message.
4. The follow-up opens with the missing-completion-record warning, and the agent produced no result.

## The change

`Agent` gets its own arm rather than a place in `DEFERRED_WORK_TOOLS`, for the reason given in the issue: that set would also match *foreground* agents, which never push a follow-up turn and would therefore pin a CLI process for the full 30-minute `BG_WAIT_CEILING_MS`.

The test is `!== false` rather than `=== true` because `run_in_background` is optional on `AgentInput` and agents background by default — an omitted field means background, so `=== true` would still drop the common case.

`Workflow` **is** added to `DEFERRED_WORK_TOOLS`, and that is deliberate: `WorkflowInput` has no foreground option at all, so every call returns a task id immediately and reports back in a later turn. It has the identical failure mode in the identical function. Happy to split it out if you would rather keep this PR to the letter of the issue.

## Tests

New `server/modules/providers/tests/claude-background-work.test.ts`, following the existing `claude-subagent-echo.test.ts` pattern; `startsBackgroundWork` is exported for it the same way `isSubagentPromptEcho` is.

Ten cases, including guards against the two ways this could be got wrong — a foreground `Agent` must **not** hold (or it pins the process for the ceiling), and the existing `Bash`/`Monitor` behaviour must not shift.

Verified the tests fail without the fix rather than assuming it: reverting just the two logic changes fails exactly the 4 fix-dependent cases and leaves the other 6 green.

## Checks

- `npm test` — 421 pass / 4 fail. The 4 failures are `claude-cli-path.test.ts` and are **pre-existing on unmodified `main`**: this machine has a native `/usr/bin/claude`, which those tests assume absent. Confirmed by stashing and re-running.
- `npm run build` — passes.
- `oxlint` — clean on both changed files.
- No lockfile or unrelated changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Agent tasks now run in the background by default unless explicitly configured for foreground execution.
  * Workflow actions are recognized as deferred background work.
  * Messages containing multiple tool calls are now supported for background processing.

* **Bug Fixes**
  * Improved classification of background and foreground work across supported tools, including Bash, Agent, and Workflow actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->