### PR TITLE
feat(chat): read assistant replies aloud per session

### DIFF
--- a/server/modules/database/migrations.ts
+++ b/server/modules/database/migrations.ts
@@ -457,6 +457,20 @@ const addSessionEffortColumn = (db: Database): void => {
   addColumnToTableIfNotExists(db, 'sessions', columnNames, 'effort', 'TEXT');
 };
 
+/**
+ * Adds the `auto_speak` column that records whether a session reads assistant
+ * turns aloud as they finish.
+ *
+ * Defaults to 0 so an upgrade never starts talking at an existing conversation:
+ * the feature is opt-in per session.
+ */
+const addSessionAutoSpeakColumn = (db: Database): void => {
+  const sessionsTableInfo = getTableInfo(db, 'sessions');
+  const columnNames = sessionsTableInfo.map((column) => column.name);
+
+  addColumnToTableIfNotExists(db, 'sessions', columnNames, 'auto_speak', 'BOOLEAN DEFAULT 0');
+};
+
 const ensureProjectsForSessionPaths = (db: Database): void => {
   if (!tableExists(db, 'sessions')) {
     return;
@@ -518,6 +532,7 @@ export const runMigrations = (db: Database) => {
     addProviderSessionIdMapping(db);
     addSessionModelColumn(db);
     addSessionEffortColumn(db);
+    addSessionAutoSpeakColumn(db);
     addForkedFromSessionIdColumn(db);
     ensureProjectsForSessionPaths(db);
     db.exec(SCHEDULED_MESSAGES_TABLE_SCHEMA_SQL);

--- a/server/modules/database/repositories/sessions.db.ts
+++ b/server/modules/database/repositories/sessions.db.ts
@@ -13,6 +13,8 @@ type SessionRow = {
   model: string | null;
   /** Reasoning effort this session runs with; NULL until the app records one. */
   effort: string | null;
+  /** 1 when this session reads assistant turns aloud as they complete. */
+  auto_speak: number | null;
   /** The app session this one was branched from; NULL unless it is a fork. */
   forked_from_session_id: string | null;
   isArchived: number;
@@ -26,7 +28,7 @@ type RecentSessionsPage = {
 };
 
 const SESSION_ROW_COLUMNS =
-  'session_id, provider, provider_session_id, project_path, jsonl_path, custom_name, model, effort, forked_from_session_id, isArchived, created_at, updated_at';
+  'session_id, provider, provider_session_id, project_path, jsonl_path, custom_name, model, effort, auto_speak, forked_from_session_id, isArchived, created_at, updated_at';
 
 const SQLITE_UTC_TIMESTAMP_REGEX = /^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/;
 
@@ -212,6 +214,7 @@ export const sessionsDb = {
     forkedFromSessionId: string;
     model: string | null;
     effort: string | null;
+    autoSpeak: boolean;
   }): string {
     const db = getConnection();
     const normalizedProjectPath = normalizeProjectPathForProvider(input.provider, input.projectPath);
@@ -225,8 +228,8 @@ export const sessionsDb = {
       db.prepare('DELETE FROM sessions WHERE session_id = ? AND session_id <> ?')
         .run(input.providerSessionId, input.sessionId);
       db.prepare(
-        `INSERT INTO sessions (session_id, provider, provider_session_id, custom_name, project_path, jsonl_path, model, effort, forked_from_session_id, isArchived, created_at, updated_at)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 0, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)`
+        `INSERT INTO sessions (session_id, provider, provider_session_id, custom_name, project_path, jsonl_path, model, effort, auto_speak, forked_from_session_id, isArchived, created_at, updated_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)`
       ).run(
         input.sessionId,
         input.provider,
@@ -236,6 +239,7 @@ export const sessionsDb = {
         input.jsonlPath,
         input.model,
         input.effort,
+        input.autoSpeak ? 1 : 0,
         input.forkedFromSessionId,
       );
     })();
@@ -437,6 +441,34 @@ export const sessionsDb = {
        SET effort = ?
        WHERE session_id = ?`
     ).run(effort, sessionId);
+  },
+
+  /**
+   * Records whether one session reads assistant turns aloud.
+   *
+   * Returns false when no row was updated, which means the session gateway has
+   * not allocated the row yet. The caller reports the choice back regardless so
+   * a toggle made before the first send is not silently lost from the UI.
+   */
+  setSessionAutoSpeak(sessionId: string, autoSpeak: boolean): boolean {
+    const db = getConnection();
+    const result = db.prepare(
+      `UPDATE sessions
+       SET auto_speak = ?
+       WHERE session_id = ?`
+    ).run(autoSpeak ? 1 : 0, sessionId);
+
+    return result.changes > 0;
+  },
+
+  /** Whether a session reads assistant turns aloud; false for an unknown id. */
+  getSessionAutoSpeak(sessionId: string): boolean {
+    const db = getConnection();
+    const row = db.prepare(
+      'SELECT auto_speak FROM sessions WHERE session_id = ?'
+    ).get(sessionId) as Pick<SessionRow, 'auto_speak'> | undefined;
+
+    return row?.auto_speak === 1;
   },
 
   updateSessionCustomName(sessionId: string, customName: string): void {

--- a/server/modules/database/schema.ts
+++ b/server/modules/database/schema.ts
@@ -138,6 +138,10 @@ CREATE TABLE IF NOT EXISTS sessions (
     -- restores its exact runtime configuration instead of provider defaults.
     model TEXT,
     effort TEXT,
+    -- Read every assistant turn of this session aloud as it completes. Scoped to
+    -- the session rather than the user because listening suits some
+    -- conversations and not others, and it is deleted with the session.
+    auto_speak BOOLEAN DEFAULT 0,
     -- The app session this one was branched from, NULL for sessions created
     -- normally. Informational only: a fork is a fully independent provider
     -- session, and deleting the source does not affect it.

--- a/server/modules/database/tests/sessions-auto-speak-migration.test.ts
+++ b/server/modules/database/tests/sessions-auto-speak-migration.test.ts
@@ -1,0 +1,54 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, rm } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+
+import { closeConnection, getConnection, initializeDatabase, sessionsDb } from '@/modules/database/index.js';
+
+type TableColumn = { name: string };
+
+const sessionColumns = (): string[] =>
+  (getConnection().prepare('PRAGMA table_info(sessions)').all() as TableColumn[])
+    .map((column) => column.name);
+
+/**
+ * Upgrading an install is the risky half of adding a column: a fresh database
+ * gets it from the schema, while an existing one only gets it if the migration
+ * runs. This drops the column from an initialized database to stand in for a
+ * pre-feature install, then initializes again.
+ */
+test('an existing database gains the auto_speak column on upgrade', { concurrency: false }, async () => {
+  const previousDatabasePath = process.env.DATABASE_PATH;
+  const tempDirectory = await mkdtemp(path.join(os.tmpdir(), 'auto-speak-migration-db-'));
+
+  closeConnection();
+  process.env.DATABASE_PATH = path.join(tempDirectory, 'auth.db');
+
+  try {
+    await initializeDatabase();
+    sessionsDb.createAppSession('upgraded-session', 'claude', '/tmp/auto-speak-migration');
+    sessionsDb.setSessionAutoSpeak('upgraded-session', true);
+
+    getConnection().exec('ALTER TABLE sessions DROP COLUMN auto_speak');
+    assert.ok(!sessionColumns().includes('auto_speak'), 'column removed to simulate an old install');
+
+    closeConnection();
+    await initializeDatabase();
+
+    assert.ok(sessionColumns().includes('auto_speak'), 'migration re-added the column');
+    // Pre-existing conversations must not start talking after an upgrade.
+    assert.equal(sessionsDb.getSessionAutoSpeak('upgraded-session'), false);
+    // And the column is writable afterwards, not just present.
+    assert.equal(sessionsDb.setSessionAutoSpeak('upgraded-session', true), true);
+    assert.equal(sessionsDb.getSessionAutoSpeak('upgraded-session'), true);
+  } finally {
+    closeConnection();
+    if (previousDatabasePath === undefined) {
+      delete process.env.DATABASE_PATH;
+    } else {
+      process.env.DATABASE_PATH = previousDatabasePath;
+    }
+    await rm(tempDirectory, { recursive: true, force: true });
+  }
+});

--- a/server/modules/providers/provider.routes.ts
+++ b/server/modules/providers/provider.routes.ts
@@ -445,6 +445,32 @@ const parseSessionEffortPayload = (payload: unknown): string => {
   return effort;
 };
 
+/**
+ * Reads the `autoSpeak` flag from a request body.
+ *
+ * Strict about the type rather than coercing: a missing or misspelled field
+ * would otherwise read as `false` and look like the user turning the feature
+ * off, which is indistinguishable from a real toggle in the UI.
+ */
+const parseAutoSpeakPayload = (payload: unknown): boolean => {
+  if (!payload || typeof payload !== 'object') {
+    throw new AppError('Request body must be an object.', {
+      code: 'INVALID_REQUEST_BODY',
+      statusCode: 400,
+    });
+  }
+
+  const { autoSpeak } = payload as Record<string, unknown>;
+  if (typeof autoSpeak !== 'boolean') {
+    throw new AppError('autoSpeak must be a boolean.', {
+      code: 'INVALID_AUTO_SPEAK',
+      statusCode: 400,
+    });
+  }
+
+  return autoSpeak;
+};
+
 const parseModelRecordId = (value: unknown): number => {
   const rawRecordId = readPathParam(value, 'recordId').trim();
   if (!/^\d+$/.test(rawRecordId)) {
@@ -776,6 +802,26 @@ router.get(
   asyncHandler(async (req: Request, res: Response) => {
     const sessionId = parseSessionId(req.params.sessionId);
     const result = await providerTokenUsageService.getSessionTokenUsage(sessionId);
+    res.json(createApiSuccessResponse(result));
+  }),
+);
+
+/** Whether one session reads assistant turns aloud as they complete. */
+router.get(
+  '/sessions/:sessionId/auto-speak',
+  asyncHandler(async (req: Request, res: Response) => {
+    const sessionId = parseSessionId(req.params.sessionId);
+    const result = sessionsService.getSessionAutoSpeak(sessionId);
+    res.json(createApiSuccessResponse(result));
+  }),
+);
+
+router.post(
+  '/sessions/:sessionId/auto-speak',
+  asyncHandler(async (req: Request, res: Response) => {
+    const sessionId = parseSessionId(req.params.sessionId);
+    const autoSpeak = parseAutoSpeakPayload(req.body);
+    const result = sessionsService.setSessionAutoSpeak(sessionId, autoSpeak);
     res.json(createApiSuccessResponse(result));
   }),
 );

--- a/server/modules/providers/services/sessions.service.ts
+++ b/server/modules/providers/services/sessions.service.ts
@@ -298,6 +298,9 @@ export const sessionsService = {
       // differently from the conversation it was branched from.
       model: source.model,
       effort: source.effort,
+      // A fork continues the same conversation, so it keeps reading aloud if
+      // the source did. Otherwise forking silently turns the feature off.
+      autoSpeak: source.auto_speak === 1,
     });
 
     await broadcastSessionUpserted(forkSessionId);
@@ -659,5 +662,30 @@ export const sessionsService = {
 
     sessionsDb.updateSessionCustomName(sessionId, summary);
     return { sessionId, summary };
+  },
+
+  /**
+   * Whether one session reads assistant turns aloud as they complete.
+   *
+   * Answers false for a session id the gateway has not allocated a row for yet,
+   * because the feature is opt-in: a brand-new chat has never been turned on.
+   */
+  getSessionAutoSpeak(sessionId: string): { sessionId: string; autoSpeak: boolean } {
+    return { sessionId, autoSpeak: sessionsDb.getSessionAutoSpeak(sessionId) };
+  },
+
+  /**
+   * Records whether one session reads assistant turns aloud.
+   *
+   * A row that does not exist yet is not an error: the composer can be toggled
+   * before the first send allocates the session, and the choice is echoed back
+   * so the UI keeps it. `persisted` tells the caller which of the two happened.
+   */
+  setSessionAutoSpeak(
+    sessionId: string,
+    autoSpeak: boolean,
+  ): { sessionId: string; autoSpeak: boolean; persisted: boolean } {
+    const persisted = sessionsDb.setSessionAutoSpeak(sessionId, autoSpeak);
+    return { sessionId, autoSpeak, persisted };
   },
 };

--- a/server/modules/providers/tests/provider-token-usage.service.test.ts
+++ b/server/modules/providers/tests/provider-token-usage.service.test.ts
@@ -22,6 +22,7 @@ function createSessionRow(overrides: Record<string, unknown> = {}) {
     custom_name: null,
     model: null,
     effort: null,
+    auto_speak: 0,
     forked_from_session_id: null,
     isArchived: 0,
     created_at: '2026-01-01T00:00:00.000Z',

--- a/server/modules/providers/tests/session-auto-speak.test.ts
+++ b/server/modules/providers/tests/session-auto-speak.test.ts
@@ -1,0 +1,81 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, rm } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+
+import { closeConnection, initializeDatabase, sessionsDb } from '@/modules/database/index.js';
+import { sessionsService } from '@/modules/providers/services/sessions.service.js';
+
+async function withIsolatedDatabase(runTest: () => void | Promise<void>): Promise<void> {
+  const previousDatabasePath = process.env.DATABASE_PATH;
+  const tempDirectory = await mkdtemp(path.join(os.tmpdir(), 'session-auto-speak-db-'));
+
+  closeConnection();
+  process.env.DATABASE_PATH = path.join(tempDirectory, 'auth.db');
+  await initializeDatabase();
+
+  try {
+    await runTest();
+  } finally {
+    closeConnection();
+    if (previousDatabasePath === undefined) {
+      delete process.env.DATABASE_PATH;
+    } else {
+      process.env.DATABASE_PATH = previousDatabasePath;
+    }
+    await rm(tempDirectory, { recursive: true, force: true });
+  }
+}
+
+test('auto read-aloud is off for a session that never enabled it', { concurrency: false }, async () => {
+  await withIsolatedDatabase(() => {
+    sessionsDb.createAppSession('app-session', 'claude', '/tmp/auto-speak-project');
+
+    assert.deepEqual(sessionsService.getSessionAutoSpeak('app-session'), {
+      sessionId: 'app-session',
+      autoSpeak: false,
+    });
+  });
+});
+
+test('auto read-aloud survives being turned on and off again', { concurrency: false }, async () => {
+  await withIsolatedDatabase(() => {
+    sessionsDb.createAppSession('app-session', 'claude', '/tmp/auto-speak-project');
+
+    assert.deepEqual(sessionsService.setSessionAutoSpeak('app-session', true), {
+      sessionId: 'app-session',
+      autoSpeak: true,
+      persisted: true,
+    });
+    assert.equal(sessionsService.getSessionAutoSpeak('app-session').autoSpeak, true);
+
+    sessionsService.setSessionAutoSpeak('app-session', false);
+    assert.equal(sessionsService.getSessionAutoSpeak('app-session').autoSpeak, false);
+  });
+});
+
+test('auto read-aloud is scoped to one session', { concurrency: false }, async () => {
+  await withIsolatedDatabase(() => {
+    sessionsDb.createAppSession('listening-session', 'claude', '/tmp/auto-speak-project');
+    sessionsDb.createAppSession('quiet-session', 'claude', '/tmp/auto-speak-project');
+
+    sessionsService.setSessionAutoSpeak('listening-session', true);
+
+    assert.equal(sessionsService.getSessionAutoSpeak('listening-session').autoSpeak, true);
+    assert.equal(sessionsService.getSessionAutoSpeak('quiet-session').autoSpeak, false);
+  });
+});
+
+test('setting auto read-aloud before the session row exists reports it was not stored', { concurrency: false }, async () => {
+  await withIsolatedDatabase(() => {
+    // The composer can be toggled before the first send allocates the row. The
+    // choice is echoed back so the UI keeps it, but nothing was persisted.
+    assert.deepEqual(sessionsService.setSessionAutoSpeak('never-allocated', true), {
+      sessionId: 'never-allocated',
+      autoSpeak: true,
+      persisted: false,
+    });
+    assert.equal(sessionsService.getSessionAutoSpeak('never-allocated').autoSpeak, false);
+  });
+});

--- a/src/modules/chat/ChatInterface.tsx
+++ b/src/modules/chat/ChatInterface.tsx
@@ -13,6 +13,7 @@ import type {
   SessionEstablishedContext,
   SessionNavigationOptions,
 } from '@/shared/types';
+import { useAutoSpeakArrivals } from '@/modules/chat/hooks/useAutoSpeakArrivals';
 import { useChatProviderState } from '@/modules/chat/hooks/useChatProviderState';
 import { useScheduledMessages } from '@/modules/chat/composer/useScheduledMessages';
 import { useChatSessionState } from '@/modules/chat/hooks/useChatSessionState';
@@ -168,6 +169,19 @@ function ChatInterface({
     resetStreamingState,
     statusCheckSentAtRef,
     lastSeqRef,
+    sessionStore,
+  });
+
+  // Turns that arrive without this client streaming them — another device, the
+  // provider CLI, a scheduled message — are read aloud from here rather than
+  // from the `complete` event, which only ever reaches one client per run.
+  useAutoSpeakArrivals({
+    sessionId: currentSessionId || selectedSession?.id || null,
+    provider,
+    chatMessages,
+    isProcessing,
+    isActive,
+    isLoadingSessionMessages,
     sessionStore,
   });
 
@@ -545,6 +559,7 @@ function ChatInterface({
           renderInputWithMentions={renderInputWithMentions}
           textareaRef={textareaRef}
           input={input}
+          sessionId={currentSessionId || selectedSession?.id || null}
           onVoiceTranscript={handleVoiceTranscript}
           onInputChange={handleInputChange}
           onTextareaClick={handleTextareaClick}

--- a/src/modules/chat/composer/AutoSpeakToggle.tsx
+++ b/src/modules/chat/composer/AutoSpeakToggle.tsx
@@ -1,0 +1,36 @@
+import { Volume2, VolumeX } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+
+import { PromptInputButton } from '@/modules/chat/composer/PromptInput';
+
+type Props = {
+  enabled: boolean;
+  onToggle: () => void;
+};
+
+/**
+ * Rendered by chat's ChatComposer beside the mic button.
+ *
+ * Turns auto read-aloud on or off for the current session. It sits in the
+ * composer rather than in Quick Settings because it is a per-conversation
+ * choice, and because it is the control you reach for the moment a reply starts
+ * talking when you did not want it to.
+ */
+export default function AutoSpeakToggle({ enabled, onToggle }: Props) {
+  const { t } = useTranslation('chat');
+
+  return (
+    <PromptInputButton
+      tooltip={{ content: enabled ? t('voice.autoSpeakOn') : t('voice.autoSpeakOff') }}
+      aria-label={enabled ? t('voice.autoSpeakOn') : t('voice.autoSpeakOff')}
+      aria-pressed={enabled}
+      onClick={(event: { preventDefault: () => void }) => {
+        event.preventDefault();
+        onToggle();
+      }}
+      className={enabled ? 'text-primary' : undefined}
+    >
+      {enabled ? <Volume2 /> : <VolumeX />}
+    </PromptInputButton>
+  );
+}

--- a/src/modules/chat/composer/ChatComposer.tsx
+++ b/src/modules/chat/composer/ChatComposer.tsx
@@ -29,6 +29,8 @@ import CommandMenu from '@/modules/chat/composer/CommandMenu';
 import ActivityIndicator from '@/modules/chat/composer/ActivityIndicator';
 import ComposerAttachment from '@/modules/chat/composer/ComposerAttachment';
 import VoiceInputButton from '@/modules/chat/composer/VoiceInputButton';
+import AutoSpeakToggle from '@/modules/chat/composer/AutoSpeakToggle';
+import { useAutoSpeak } from '@/modules/chat/hooks/useAutoSpeak';
 import PermissionRequestsBanner from '@/modules/chat/composer/PermissionRequestsBanner';
 import TokenUsageSummary from '@/modules/chat/composer/TokenUsageSummary';
 import QueuedMessageCard from '@/modules/chat/composer/QueuedMessageCard';
@@ -101,6 +103,8 @@ type ChatComposerProps = {
   renderInputWithMentions: (text: string) => ReactNode;
   textareaRef: RefObject<HTMLTextAreaElement>;
   input: string;
+  /** Active session, needed for the per-session auto read-aloud toggle. */
+  sessionId: string | null;
   onVoiceTranscript?: (text: string, send?: boolean) => void;
   onInputChange: (event: ChangeEvent<HTMLTextAreaElement>) => void;
   onTextareaClick: (event: MouseEvent<HTMLTextAreaElement>) => void;
@@ -174,6 +178,7 @@ export default function ChatComposer({
   renderInputWithMentions,
   textareaRef,
   input,
+  sessionId,
   onVoiceTranscript,
   onInputChange,
   onTextareaClick,
@@ -224,6 +229,7 @@ export default function ChatComposer({
   // Voice state is hosted here (not in the mic button) so the main Send button can stop
   // recording and send the transcript in one tap, the way the mic button drops it in the box.
   const voiceAvailable = useVoiceAvailable();
+  const { enabled: autoSpeakEnabled, toggle: toggleAutoSpeak } = useAutoSpeak(sessionId);
   const [voiceError, setVoiceError] = useState<string | null>(null);
   const voiceErrorTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const handleVoiceError = useCallback((msg: string) => {
@@ -441,6 +447,10 @@ export default function ChatComposer({
 
             {onVoiceTranscript && voiceAvailable && (
               <VoiceInputButton state={voiceState} onToggle={voiceToggle} errorMsg={voiceError} />
+            )}
+
+            {voiceAvailable && sessionId && (
+              <AutoSpeakToggle enabled={autoSpeakEnabled} onToggle={toggleAutoSpeak} />
             )}
 
             <TokenUsageSummary usage={tokenBudget} onClick={onShowTokenUsage} />

--- a/src/modules/chat/hooks/useAutoSpeak.ts
+++ b/src/modules/chat/hooks/useAutoSpeak.ts
@@ -1,0 +1,30 @@
+import { useCallback, useEffect, useState } from 'react';
+
+import { autoSpeakSessions } from '@/modules/chat/utils/autoSpeakSessions';
+import { voicePlayer } from '@/modules/chat/utils/voicePlayer';
+
+/**
+ * Reflects and flips one session's auto read-aloud setting. Thin adapter over the
+ * app-level store, in the same shape as useTts.
+ */
+export function useAutoSpeak(sessionId: string | null) {
+  const [enabled, setEnabled] = useState(() => autoSpeakSessions.isEnabled(sessionId));
+
+  useEffect(() => {
+    const sync = () => setEnabled(autoSpeakSessions.isEnabled(sessionId));
+    sync();
+    const unsubscribe = autoSpeakSessions.subscribe(sync);
+    if (sessionId) void autoSpeakSessions.load(sessionId);
+    return unsubscribe;
+  }, [sessionId]);
+
+  const toggle = useCallback(() => {
+    if (!sessionId) return;
+    // Inside the click, the only moment iOS grants the shared <audio> element
+    // permission to play; auto read-aloud has no gesture of its own.
+    voicePlayer.unlock();
+    autoSpeakSessions.toggle(sessionId);
+  }, [sessionId]);
+
+  return { enabled, toggle };
+}

--- a/src/modules/chat/hooks/useAutoSpeakArrivals.ts
+++ b/src/modules/chat/hooks/useAutoSpeakArrivals.ts
@@ -1,0 +1,85 @@
+import { useEffect, useRef } from 'react';
+
+import { baselineTurn, speakRefreshedTurn } from '@/modules/chat/utils/autoSpeakTurn';
+import type { SessionStore } from '@/modules/chat/hooks/useSessionStore';
+import type { ChatMessage, LLMProvider } from '@/shared/types';
+
+type UseAutoSpeakArrivalsArgs = {
+  /** The conversation on screen, or null before the first send allocates one. */
+  sessionId: string | null;
+  provider: LLMProvider;
+  /** Only a change signal; the turn is read from the store, not from this window. */
+  chatMessages: ChatMessage[];
+  /** A run this client is streaming. Its turn is spoken from `complete` instead. */
+  isProcessing: boolean;
+  /** Whether the chat tab is the visible one. */
+  isActive: boolean;
+  isLoadingSessionMessages: boolean;
+  sessionStore: SessionStore;
+};
+
+/**
+ * Speaks assistant turns that arrive from outside this client — another device or
+ * tab, the provider CLI, a scheduled message. Only one client streams a given
+ * run, so a phone that sends a message gets `complete` while a laptop showing the
+ * same conversation only gets the transcript watcher's refresh.
+ *
+ * The rest of this hook keeps it quiet whenever speaking would land as audio from
+ * nowhere.
+ */
+export function useAutoSpeakArrivals({
+  sessionId,
+  provider,
+  chatMessages,
+  isProcessing,
+  isActive,
+  isLoadingSessionMessages,
+  sessionStore,
+}: UseAutoSpeakArrivalsArgs): void {
+  const openedSessionIdRef = useRef<string | null>(null);
+  const wasActiveRef = useRef(isActive);
+  /**
+   * The transcript's fetch stamp when the chat tab became visible again, while a
+   * deferred refresh may still be on its way.
+   *
+   * Returning from the Files or Git tab does not look like opening a session —
+   * the transcript is already hydrated, so nothing sets
+   * `isLoadingSessionMessages` — but refreshes are queued while chat is hidden
+   * and flushed on return, landing a commit or two later. Waiting for the store's
+   * own stamp to move is what separates that flush from a live arrival.
+   */
+  const awaitingDeferredRefreshRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    if (!sessionId || isProcessing) return;
+
+    const wasActive = wasActiveRef.current;
+    wasActiveRef.current = isActive;
+    const fetchedAt = sessionStore.getSessionSlot(sessionId)?.fetchedAt ?? null;
+
+    if (isActive && !wasActive) {
+      awaitingDeferredRefreshRef.current = fetchedAt;
+    }
+    if (awaitingDeferredRefreshRef.current !== null) {
+      // Silent until the flush lands, and silent for that observation too, since
+      // it carries whatever arrived while away.
+      if (fetchedAt !== awaitingDeferredRefreshRef.current) {
+        awaitingDeferredRefreshRef.current = null;
+      }
+      baselineTurn({ sessionId, provider, sessionStore });
+      return;
+    }
+
+    // Still opening: re-baseline until the transcript settles, and count arrivals
+    // only from there.
+    if (isLoadingSessionMessages || openedSessionIdRef.current !== sessionId) {
+      baselineTurn({ sessionId, provider, sessionStore });
+      if (!isLoadingSessionMessages) {
+        openedSessionIdRef.current = sessionId;
+      }
+      return;
+    }
+
+    speakRefreshedTurn({ sessionId, provider, sessionStore, visible: isActive });
+  }, [chatMessages, isActive, isLoadingSessionMessages, isProcessing, provider, sessionId, sessionStore]);
+}

--- a/src/modules/chat/hooks/useChatComposerState.ts
+++ b/src/modules/chat/hooks/useChatComposerState.ts
@@ -26,6 +26,9 @@ import {
   writeQueuedMessage,
 } from '@/shared/chatDrafts';
 import { escapeRegExp } from '@/modules/chat/utils/chatFormatting';
+import { autoSpeakSessions } from '@/modules/chat/utils/autoSpeakSessions';
+import { withAutoSpeakHint } from '@/modules/chat/utils/autoSpeakPrompt';
+import { voicePlayer } from '@/modules/chat/utils/voicePlayer';
 import { useFileMentions } from '@/modules/chat/hooks/useFileMentions';
 import { useInputHistory } from '@/modules/chat/hooks/useInputHistory';
 import { useSlashCommands } from '@/modules/chat/hooks/useSlashCommands';
@@ -617,6 +620,16 @@ export function useChatComposerState({
       queuedSubmission?: QueuedDraft,
     ) => {
       event.preventDefault();
+
+      // The only gesture guaranteed on a device where auto read-aloud is already
+      // on: the setting is per session on the server, so a phone that opens a
+      // conversation the laptop enabled never clicks the toggle, and mobile
+      // browsers then refuse playback. Must stay before the await below, which is
+      // past the point where the browser still credits the gesture.
+      if (autoSpeakSessions.isEnabled(sessionKey)) {
+        voicePlayer.unlock();
+      }
+
       const currentInput = queuedSubmission?.content ?? inputValueRef.current;
       const currentAttachments = queuedSubmission?.attachments ?? attachedFiles;
       const previouslyUploadedAttachments = queuedSubmission?.uploadedAttachments ?? [];
@@ -814,10 +827,17 @@ export function useChatComposerState({
         });
       }
 
+      // The echo must show exactly what was sent: an optimistic row is matched to
+      // its persisted turn by exact text equality.
+      const sentContent = withAutoSpeakHint(
+        messageContent,
+        autoSpeakSessions.isEnabled(targetSessionId),
+      );
+
       const attachmentRecords = uploadedAttachments as ChatAttachment[];
       const userMessage: ChatMessage = {
         type: 'user',
-        content: currentInput,
+        content: sentContent,
         images: attachmentRecords.filter(isImageAttachment),
         files: attachmentRecords.filter((attachment) => !isImageAttachment(attachment)),
         timestamp: new Date(),
@@ -849,7 +869,7 @@ export function useChatComposerState({
         type: editingAnchorId ? 'chat.edit-send' : 'chat.send',
         sessionId: targetSessionId,
         ...(editingAnchorId ? { anchorId: editingAnchorId } : {}),
-        content: messageContent,
+        content: sentContent,
         options: {
           ...(queuedSubmission?.options ?? buildSendOptions(messageContent)),
           attachments: uploadedAttachments,

--- a/src/modules/chat/hooks/useChatComposerState.ts
+++ b/src/modules/chat/hooks/useChatComposerState.ts
@@ -27,7 +27,7 @@ import {
 } from '@/shared/chatDrafts';
 import { escapeRegExp } from '@/modules/chat/utils/chatFormatting';
 import { autoSpeakSessions } from '@/modules/chat/utils/autoSpeakSessions';
-import { withAutoSpeakHint } from '@/modules/chat/utils/autoSpeakPrompt';
+import { withAutoSpeakHint, withoutAutoSpeakHint } from '@/modules/chat/utils/autoSpeakPrompt';
 import { voicePlayer } from '@/modules/chat/utils/voicePlayer';
 import { useFileMentions } from '@/modules/chat/hooks/useFileMentions';
 import { useInputHistory } from '@/modules/chat/hooks/useInputHistory';
@@ -1227,8 +1227,9 @@ export function useChatComposerState({
   const beginEditMessage = useCallback((message: ChatMessage) => {
     if (!message.transcriptAnchorId) return;
     setEditingAnchorId(message.transcriptAnchorId);
-    setInput(message.content || '');
-    inputValueRef.current = message.content || '';
+    const content = withoutAutoSpeakHint(message.content || '');
+    setInput(content);
+    inputValueRef.current = content;
     textareaRef.current?.focus();
   }, [setInput]);
 

--- a/src/modules/chat/hooks/useChatRealtimeHandlers.ts
+++ b/src/modules/chat/hooks/useChatRealtimeHandlers.ts
@@ -5,6 +5,7 @@ import type { ServerEvent,MarkSessionIdle,MarkSessionProcessing,PendingPermissio
 import { showCompletionTitleIndicator } from '@/modules/chat/utils/pageTitleNotification';
 import { playChatCompletionSound, playNotificationSound } from '@/shared/utils';
 import type { SessionStore } from '@/modules/chat/hooks/useSessionStore';
+import { speakCompletedTurn } from '@/modules/chat/utils/autoSpeakTurn';
 
 const isActionablePermissionRequest = (request: { toolName?: unknown } | null | undefined): boolean => {
   return request?.toolName !== 'ExitPlanMode' && request?.toolName !== 'exit_plan_mode';
@@ -254,6 +255,21 @@ export function useChatRealtimeHandlers({
           if (sid === activeViewSessionId) {
             pendingPermissionRequestsRef.current = [];
             setPendingPermissionRequests([]);
+          }
+
+          // Before the abort and failure branches on purpose: a turn this client
+          // declines to speak still has to be recorded, or the watcher's refresh
+          // reads out the half-finished reply the user just stopped.
+          if (sid) {
+            speakCompletedTurn({
+              sessionId: sid,
+              provider,
+              sessionStore,
+              visible: !msg.aborted
+                && msg.success !== false
+                && sid === activeViewSessionId
+                && isActiveRef.current,
+            });
           }
 
           if (msg.aborted) {

--- a/src/modules/chat/tests/autoSpeakArrivals.test.tsx
+++ b/src/modules/chat/tests/autoSpeakArrivals.test.tsx
@@ -1,0 +1,210 @@
+import assert from 'node:assert/strict';
+
+import { renderHook } from '@testing-library/react';
+import { beforeEach, test, vi } from 'vitest';
+
+import type { ChatMessage, NormalizedMessage } from '@/shared/types';
+
+// Real voice playback needs an <audio> element; the per-session setting is the
+// server's, and the normalized-to-chat conversion has its own tests.
+const spoken: string[] = [];
+vi.mock('@/modules/chat/utils/voicePlayer', () => ({
+  voicePlayer: { speak: (text: string) => spoken.push(text) },
+  voiceId: (text: string) => text,
+}));
+
+vi.mock('@/modules/chat/utils/autoSpeakSessions', () => ({
+  autoSpeakSessions: { isEnabled: () => true },
+}));
+
+// Voice is off by default in stored preferences, which would silence everything.
+let voiceEnabled = true;
+vi.mock('@/shared/uiPreferences', () => ({
+  readStoredUiPreferences: () => ({ voiceEnabled }),
+}));
+
+let converted: ChatMessage[] = [];
+vi.mock('@/modules/chat/hooks/useChatMessages', () => ({
+  normalizedToChatMessages: () => converted,
+}));
+
+const { useAutoSpeakArrivals } = await import('@/modules/chat/hooks/useAutoSpeakArrivals');
+const { resetAutoSpeakTurnState } = await import('@/modules/chat/utils/autoSpeakTurn');
+
+const reply = (content: string): ChatMessage => ({
+  type: 'assistant',
+  content,
+  timestamp: new Date(),
+} as ChatMessage);
+
+// `fetchedAt` moves only when a transcript fetch completes, which is how the
+// hook tells a flushed deferred refresh from a live arrival.
+let fetchedAt = 1_000;
+
+const sessionStore = {
+  getMessages: (): NormalizedMessage[] => [],
+  getSessionSlot: () => ({ fetchedAt }),
+} as unknown as Parameters<typeof useAutoSpeakArrivals>[0]['sessionStore'];
+
+type Options = {
+  sessionId?: string | null;
+  isProcessing?: boolean;
+  isActive?: boolean;
+  isLoadingSessionMessages?: boolean;
+};
+
+/**
+ * `chatMessages` is only an identity signal, so a fresh array per render is what
+ * the real transcript does on every refresh.
+ */
+const props = (options: Options = {}) => ({
+  sessionId: options.sessionId === undefined ? 'session-1' : options.sessionId,
+  provider: 'claude' as const,
+  chatMessages: [...converted],
+  isProcessing: options.isProcessing ?? false,
+  isActive: options.isActive ?? true,
+  isLoadingSessionMessages: options.isLoadingSessionMessages ?? false,
+  sessionStore,
+});
+
+const render = (options: Options = {}) =>
+  renderHook((hookProps: ReturnType<typeof props>) => useAutoSpeakArrivals(hookProps), {
+    initialProps: props(options),
+  });
+
+beforeEach(() => {
+  spoken.length = 0;
+  converted = [];
+  fetchedAt = 1_000;
+  voiceEnabled = true;
+  resetAutoSpeakTurnState();
+});
+
+test('opening a conversation does not read out the reply already in it', () => {
+  converted = [reply('History, not news.')];
+
+  render();
+
+  assert.deepEqual(spoken, []);
+});
+
+test('a turn arriving while the conversation is open is read out', () => {
+  converted = [reply('History, not news.')];
+  const view = render();
+
+  converted = [reply('History, not news.'), reply('Arrived from the phone.')];
+  view.rerender(props());
+
+  assert.deepEqual(spoken, ['Arrived from the phone.']);
+});
+
+test('reopening a conversation that moved on elsewhere stays silent', () => {
+  // The regression this guards: session-1 is baselined, the user leaves for
+  // session-2, session-1 gains a turn on another device, and coming back loads
+  // a transcript newer than the baseline. That must not speak.
+  converted = [reply('First visit.')];
+  const view = render();
+
+  converted = [reply('Other conversation.')];
+  view.rerender(props({ sessionId: 'session-2' }));
+
+  converted = [reply('First visit.'), reply('Arrived while away.')];
+  view.rerender(props({ sessionId: 'session-1', isLoadingSessionMessages: true }));
+  view.rerender(props({ sessionId: 'session-1' }));
+
+  assert.deepEqual(spoken, []);
+
+  // ...and once open, the next arrival does speak.
+  converted = [
+    reply('First visit.'),
+    reply('Arrived while away.'),
+    reply('Arrived while watching.'),
+  ];
+  view.rerender(props({ sessionId: 'session-1' }));
+
+  assert.deepEqual(spoken, ['Arrived while watching.']);
+});
+
+test('a run this client is streaming is left to the complete event', () => {
+  converted = [reply('Baseline.')];
+  const view = render();
+
+  // Partial text mid-stream must never be spoken.
+  converted = [reply('Baseline.'), reply('Half a sen')];
+  view.rerender(props({ isProcessing: true }));
+
+  assert.deepEqual(spoken, []);
+});
+
+test('returning from another tab does not speak what arrived while away', () => {
+  // The real sequence, which an earlier version of this test got wrong: while
+  // chat is hidden the store is NOT updated — refreshes are queued — so nothing
+  // arrives until the flush completes after the tab is visible again. Returning
+  // therefore looks exactly like a live arrival unless the fetch stamp is
+  // consulted, and the session-open path does not cover it because a hydrated
+  // transcript never sets isLoadingSessionMessages.
+  converted = [reply('Baseline.')];
+  const view = render();
+
+  view.rerender(props({ isActive: false }));
+  view.rerender(props({ isActive: true }));
+
+  converted = [reply('Baseline.'), reply('Arrived while on the Files tab.')];
+  fetchedAt += 1; // the deferred refresh lands
+  view.rerender(props());
+
+  assert.deepEqual(spoken, []);
+});
+
+test('after returning, the next arrival is spoken', () => {
+  converted = [reply('Baseline.')];
+  const view = render();
+
+  view.rerender(props({ isActive: false }));
+  view.rerender(props({ isActive: true }));
+  converted = [reply('Baseline.'), reply('Arrived while away.')];
+  fetchedAt += 1;
+  view.rerender(props());
+
+  converted = [
+    reply('Baseline.'),
+    reply('Arrived while away.'),
+    reply('Arrived while watching.'),
+  ];
+  fetchedAt += 1;
+  view.rerender(props());
+
+  assert.deepEqual(spoken, ['Arrived while watching.']);
+});
+
+test('returning with nothing new does not swallow the next arrival', () => {
+  // The reason the fetch stamp is tracked rather than simply disarming on the
+  // next observation: a tab round-trip with no news must not cost a turn.
+  converted = [reply('Baseline.')];
+  const view = render();
+
+  view.rerender(props({ isActive: false }));
+  view.rerender(props({ isActive: true }));
+  fetchedAt += 1; // refresh flushed, same tail
+  view.rerender(props());
+
+  converted = [reply('Baseline.'), reply('Arrived while watching.')];
+  fetchedAt += 1;
+  view.rerender(props());
+
+  assert.deepEqual(spoken, ['Arrived while watching.']);
+});
+
+test('turning voice off in preferences silences auto read-aloud', () => {
+  // The toggle is hidden when voice is off, so speaking on would leave a
+  // session talking with no control left to stop it.
+  converted = [reply('Baseline.')];
+  const view = render();
+
+  voiceEnabled = false;
+  converted = [reply('Baseline.'), reply('Should not be spoken.')];
+  fetchedAt += 1;
+  view.rerender(props());
+
+  assert.deepEqual(spoken, []);
+});

--- a/src/modules/chat/tests/autoSpeakPrompt.test.ts
+++ b/src/modules/chat/tests/autoSpeakPrompt.test.ts
@@ -2,7 +2,7 @@ import assert from 'node:assert/strict';
 
 import { test } from 'vitest';
 
-import { withAutoSpeakHint } from '@/modules/chat/utils/autoSpeakPrompt';
+import { withAutoSpeakHint, withoutAutoSpeakHint } from '@/modules/chat/utils/autoSpeakPrompt';
 
 test('withAutoSpeakHint leaves the prompt untouched when auto read-aloud is off', () => {
   assert.equal(withAutoSpeakHint('summarize this file', false), 'summarize this file');
@@ -32,4 +32,22 @@ test('withAutoSpeakHint must be applied to raw input, not to its own output', ()
   // Re-annotating is not silently deduplicated, so the send path must apply
   // this to the raw input and never to an already-annotated string.
   assert.equal(twice.match(/read aloud automatically/g)?.length, 2);
+});
+
+test('withoutAutoSpeakHint recovers the text the user typed', () => {
+  // Editing a sent message loads its persisted text, which carries the hint.
+  // Re-sending it must not stack a second copy.
+  const sent = withAutoSpeakHint('summarize this file', true);
+  const edited = withoutAutoSpeakHint(sent);
+
+  assert.equal(edited, 'summarize this file');
+  assert.equal(withAutoSpeakHint(edited, true).match(/read aloud automatically/g)?.length, 1);
+});
+
+test('withoutAutoSpeakHint leaves an unannotated prompt alone', () => {
+  assert.equal(withoutAutoSpeakHint('summarize this file'), 'summarize this file');
+  // Only a trailing hint is the app's own suffix; the same words mid-prompt are
+  // the user's.
+  const quoted = 'Your reply will be read aloud automatically, so what?';
+  assert.equal(withoutAutoSpeakHint(quoted), quoted);
 });

--- a/src/modules/chat/tests/autoSpeakPrompt.test.ts
+++ b/src/modules/chat/tests/autoSpeakPrompt.test.ts
@@ -1,0 +1,35 @@
+import assert from 'node:assert/strict';
+
+import { test } from 'vitest';
+
+import { withAutoSpeakHint } from '@/modules/chat/utils/autoSpeakPrompt';
+
+test('withAutoSpeakHint leaves the prompt untouched when auto read-aloud is off', () => {
+  assert.equal(withAutoSpeakHint('summarize this file', false), 'summarize this file');
+});
+
+test('withAutoSpeakHint asks for a listenable reply when auto read-aloud is on', () => {
+  const result = withAutoSpeakHint('summarize this file', true);
+
+  assert.ok(result.startsWith('summarize this file\n\n'), 'keeps the prompt first and intact');
+  assert.match(result, /read aloud automatically/);
+  assert.match(result, /minimal formatting/);
+  // Addressed to the model, not written as the user describing their own message.
+  assert.match(result, /Your reply/);
+});
+
+test('withAutoSpeakHint does not annotate an empty prompt', () => {
+  // The composer refuses empty sends, so a hint on its own would be a prompt
+  // consisting only of formatting instructions.
+  assert.equal(withAutoSpeakHint('', true), '');
+  assert.equal(withAutoSpeakHint('   \n ', true), '   \n ');
+});
+
+test('withAutoSpeakHint must be applied to raw input, not to its own output', () => {
+  const once = withAutoSpeakHint('hello', true);
+  const twice = withAutoSpeakHint(once, true);
+
+  // Re-annotating is not silently deduplicated, so the send path must apply
+  // this to the raw input and never to an already-annotated string.
+  assert.equal(twice.match(/read aloud automatically/g)?.length, 2);
+});

--- a/src/modules/chat/tests/autoSpeakSessions.test.ts
+++ b/src/modules/chat/tests/autoSpeakSessions.test.ts
@@ -1,0 +1,92 @@
+import assert from 'node:assert/strict';
+
+import { beforeEach, test, vi } from 'vitest';
+
+/**
+ * The setting is optimistic locally and authoritative on the server, so what
+ * matters is that a burst of toggles leaves both in the state the user chose
+ * last.
+ */
+
+type Write = { enabled: boolean; resolve: () => void };
+
+const writes: Write[] = [];
+const settled: boolean[] = [];
+let failNextWrite = false;
+
+vi.mock('@/shared/api', () => ({
+  api: {
+    providers: {
+      sessionAutoSpeak: () => Promise.resolve({
+        ok: true,
+        json: async () => ({ success: true, data: { autoSpeak: false } }),
+      }),
+      setSessionAutoSpeak: (_sessionId: string, enabled: boolean) => {
+        const ok = !failNextWrite;
+        failNextWrite = false;
+        return new Promise((resolve) => {
+          writes.push({
+            enabled,
+            resolve: () => {
+              settled.push(enabled);
+              resolve({ ok, status: ok ? 200 : 500, json: async () => ({ success: ok }) });
+            },
+          });
+        });
+      },
+    },
+  },
+}));
+
+const { autoSpeakSessions } = await import('@/modules/chat/utils/autoSpeakSessions');
+
+/** Lets the queued write reach the api layer, which it does a microtask later. */
+const tick = () => new Promise((resolve) => { setTimeout(resolve, 0); });
+
+beforeEach(() => {
+  writes.length = 0;
+  settled.length = 0;
+  failNextWrite = false;
+});
+
+test('a second toggle waits for the first, so the server keeps the newest value', async () => {
+  const first = autoSpeakSessions.set('session-order', true);
+  const second = autoSpeakSessions.set('session-order', false);
+  await tick();
+
+  // Only one request is in flight: without this the two race and the server
+  // keeps whichever reply lands last.
+  assert.equal(writes.length, 1);
+  assert.equal(writes[0]?.enabled, true);
+
+  writes[0]?.resolve();
+  await first;
+  await tick();
+
+  assert.equal(writes.length, 2);
+  writes[1]?.resolve();
+  await second;
+
+  assert.deepEqual(settled, [true, false]);
+  assert.equal(autoSpeakSessions.isEnabled('session-order'), false);
+});
+
+test('an older failed write does not discard a newer toggle', async () => {
+  failNextWrite = true;
+  const first = autoSpeakSessions.set('session-fail', false);
+  const second = autoSpeakSessions.set('session-fail', true);
+  await tick();
+
+  writes[0]?.resolve();
+  await first;
+  await tick();
+
+  // The failure drops the cache only when it is still the latest write, so the
+  // "on" the user chose afterwards survives.
+  assert.equal(autoSpeakSessions.isEnabled('session-fail'), true);
+
+  writes[1]?.resolve();
+  await second;
+
+  assert.equal(autoSpeakSessions.isEnabled('session-fail'), true);
+});

--- a/src/modules/chat/tests/autoSpeakTurn.test.ts
+++ b/src/modules/chat/tests/autoSpeakTurn.test.ts
@@ -1,0 +1,219 @@
+import assert from 'node:assert/strict';
+
+import { beforeEach, test, vi } from 'vitest';
+
+import type { ChatMessage, NormalizedMessage } from '@/shared/types';
+
+// The turn selector is the interesting part, so the pieces around it are stubbed:
+// the voice player (a real <audio> element), the per-session setting, and the
+// normalized-to-chat conversion, which has its own tests.
+const spoken: string[] = [];
+vi.mock('@/modules/chat/utils/voicePlayer', () => ({
+  voicePlayer: { speak: (text: string) => spoken.push(text) },
+  voiceId: (text: string) => text,
+}));
+
+let autoSpeakEnabled = true;
+vi.mock('@/modules/chat/utils/autoSpeakSessions', () => ({
+  autoSpeakSessions: { isEnabled: () => autoSpeakEnabled },
+}));
+
+// Voice is off by default in stored preferences, which would silence everything.
+vi.mock('@/shared/uiPreferences', () => ({
+  readStoredUiPreferences: () => ({ voiceEnabled: true }),
+}));
+
+let converted: ChatMessage[] = [];
+vi.mock('@/modules/chat/hooks/useChatMessages', () => ({
+  normalizedToChatMessages: () => converted,
+}));
+
+const {
+  speakCompletedTurn,
+  speakRefreshedTurn,
+  resetAutoSpeakTurnState,
+} = await import('@/modules/chat/utils/autoSpeakTurn');
+
+/** Only the fields the selector reads; the conversion itself is mocked out. */
+const message = (fields: Partial<ChatMessage>): ChatMessage => ({
+  type: 'assistant',
+  content: '',
+  timestamp: new Date(),
+  ...fields,
+} as ChatMessage);
+
+const sessionStore = {
+  getMessages: (): NormalizedMessage[] => [],
+} as unknown as Parameters<typeof speakCompletedTurn>[0]['sessionStore'];
+
+const args = (overrides: { sessionId?: string; visible?: boolean } = {}) => ({
+  sessionId: overrides.sessionId ?? 'session-1',
+  provider: 'claude' as const,
+  sessionStore,
+  visible: overrides.visible ?? true,
+});
+
+const run = (overrides?: { sessionId?: string; visible?: boolean }) =>
+  speakCompletedTurn(args(overrides));
+
+beforeEach(() => {
+  spoken.length = 0;
+  autoSpeakEnabled = true;
+  converted = [];
+  resetAutoSpeakTurnState();
+});
+
+test('speakCompletedTurn reads the assistant reply that ended the turn', () => {
+  converted = [
+    message({ type: 'user', content: 'do the thing' }),
+    message({ id: 'a1', content: 'Done, here is what changed.' }),
+  ];
+
+  run();
+
+  assert.deepEqual(spoken, ['Done, here is what changed.']);
+});
+
+test('speakCompletedTurn stays silent when the session has auto read-aloud off', () => {
+  autoSpeakEnabled = false;
+  converted = [message({ id: 'a1', content: 'Should not be spoken.' })];
+
+  run();
+
+  assert.deepEqual(spoken, []);
+});
+
+test('speakCompletedTurn skips tool calls and thinking to find the spoken reply', () => {
+  converted = [
+    message({ id: 'a1', content: 'The reply worth hearing.' }),
+    message({ id: 't1', content: 'thinking out loud', isThinking: true }),
+    message({ id: 'u1', content: 'Bash: ls -la', isToolUse: true, displayText: 'Bash: ls -la' }),
+  ];
+
+  run();
+
+  assert.deepEqual(spoken, ['The reply worth hearing.']);
+});
+
+test('speakCompletedTurn says nothing for a turn that produced no assistant prose', () => {
+  // A tool-only run: stopping at the user turn is what keeps it from reaching
+  // back and re-reading the previous reply.
+  converted = [
+    message({ id: 'a0', content: 'An older reply.' }),
+    message({ type: 'user', content: 'run the tests' }),
+    message({ id: 'u1', content: 'Bash: npm test', isToolUse: true, displayText: 'Bash: npm test' }),
+  ];
+
+  run();
+
+  assert.deepEqual(spoken, []);
+});
+
+test('speakCompletedTurn ignores an empty assistant message', () => {
+  converted = [
+    message({ id: 'a1', content: 'The reply worth hearing.' }),
+    message({ id: 'a2', content: '   ' }),
+  ];
+
+  run();
+
+  assert.deepEqual(spoken, ['The reply worth hearing.']);
+});
+
+test('speakCompletedTurn stays silent when the session is not the one on screen', () => {
+  converted = [message({ id: 'a1', content: 'Finished in the background.' })];
+
+  run({ visible: false });
+
+  assert.deepEqual(spoken, []);
+});
+
+test('a turn that finished off screen is not read out on returning to it', () => {
+  // The off-screen completion still records the turn, which is what stops the
+  // transcript watcher from speaking it the moment the tab becomes visible.
+  converted = [message({ id: 'a1', content: 'Finished in the background.' })];
+  run({ visible: false });
+
+  speakRefreshedTurn(args({ visible: true }));
+
+  assert.deepEqual(spoken, []);
+});
+
+test('a stopped turn is recorded so the refresh does not read it out', () => {
+  // Aborted and failed runs pass visible=false: the half-finished reply is
+  // already in the store, and the transcript watcher refreshes moments later.
+  converted = [message({ id: 'a1', content: 'Half a sentence before the s' })];
+  run({ visible: false });
+
+  speakRefreshedTurn(args({ visible: true }));
+
+  assert.deepEqual(spoken, []);
+});
+
+test('the same turn seen twice is spoken once', () => {
+  converted = [message({ id: 'a1', content: 'Only once, please.' })];
+
+  run();
+  speakRefreshedTurn(args());
+
+  assert.deepEqual(spoken, ['Only once, please.']);
+});
+
+test('speakRefreshedTurn treats its first look at a transcript as a baseline', () => {
+  // Opening a conversation must never read out the reply already on screen.
+  converted = [message({ id: 'a1', content: 'History, not news.' })];
+
+  speakRefreshedTurn(args());
+
+  assert.deepEqual(spoken, []);
+});
+
+test('speakRefreshedTurn reads a turn that arrived from another device', () => {
+  converted = [message({ id: 'a1', content: 'History, not news.' })];
+  speakRefreshedTurn(args());
+
+  converted = [
+    message({ id: 'a1', content: 'History, not news.' }),
+    message({ id: 'a2', content: 'Sent from the phone, heard on the laptop.' }),
+  ];
+  speakRefreshedTurn(args());
+
+  assert.deepEqual(spoken, ['Sent from the phone, heard on the laptop.']);
+});
+
+test('the persisted form of a turn just spoken does not speak again', () => {
+  // What the owning client does on every turn: `complete` speaks the streamed
+  // message, then the refetch replaces it with a different object holding the
+  // same reply. Keying on the words is what makes the second one silent.
+  converted = [message({ id: 'streaming-1', content: 'Same words, new object.' })];
+  run();
+
+  converted = [message({ id: 'persisted-1', content: 'Same words, new object.' })];
+  speakRefreshedTurn(args());
+
+  assert.deepEqual(spoken, ['Same words, new object.']);
+});
+
+test('a turn whose text changed is spoken again', () => {
+  converted = [message({ id: 'a1', content: 'Partial' })];
+  speakRefreshedTurn(args());
+
+  converted = [message({ id: 'a1', content: 'Partial, then finished.' })];
+  speakRefreshedTurn(args());
+
+  converted = [message({ id: 'a1', content: 'Partial, then finished.' })];
+  speakRefreshedTurn(args());
+
+  assert.deepEqual(spoken, ['Partial, then finished.']);
+});
+
+test('turns are tracked per session', () => {
+  converted = [message({ id: 'a1', content: 'Session one reply.' })];
+  run({ sessionId: 'session-1' });
+
+  // Same text, different conversation: the other session has no baseline of
+  // its own, so a `complete` there still speaks.
+  run({ sessionId: 'session-2' });
+
+  assert.deepEqual(spoken, ['Session one reply.', 'Session one reply.']);
+});

--- a/src/modules/chat/transcript/MessageComponent.tsx
+++ b/src/modules/chat/transcript/MessageComponent.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { GitBranchIcon, PencilIcon } from 'lucide-react';
 
 import type { ChatMessage, ClaudePermissionSuggestion, PermissionGrantResult, LLMProvider,DiffLine,Project } from '@/shared/types';
-import { formatUsageLimitText, stripProposedPlanEnvelope } from '@/modules/chat/utils/chatFormatting';
+import { assistantMessageText, formattedMessageText } from '@/modules/chat/utils/chatFormatting';
 import { ToolRenderer, ToolErrorDisplay, SubagentPanel, shouldHideToolResult } from '@/modules/chat/tools';
 import { LLMProviderLogo } from '@/shared/ui';
 import { Reasoning, ReasoningContent, ReasoningTrigger } from '@/modules/chat/transcript/Reasoning';
@@ -56,17 +56,15 @@ const MessageComponent = memo(({ message, prevMessage, createDiff, onFileOpen, s
   const messageRef = useRef<HTMLDivElement | null>(null);
   const userCopyContent = String(message.content || '');
   const formattedMessageContent = useMemo(
-    () => {
-      const content = formatUsageLimitText(String(message.content || ''));
-      return provider === 'codex' && message.type === 'assistant' && !message.isThinking
-        ? stripProposedPlanEnvelope(content)
-        : content;
-    },
-    [message.content, message.isThinking, message.type, provider]
+    () => formattedMessageText(message, provider),
+    [message, provider]
   );
-  const assistantCopyContent = message.isToolUse
-    ? String(message.displayText || message.content || '')
-    : formattedMessageContent;
+  // Derived in one shared place so the auto read-aloud trigger speaks the exact
+  // same string this row's speak button would.
+  const assistantCopyContent = useMemo(
+    () => assistantMessageText(message, provider),
+    [message, provider]
+  );
   const isCommandOrFileEditToolResponse = Boolean(
     message.isToolUse && COPY_HIDDEN_TOOL_NAMES.has(String(message.toolName || ''))
   );

--- a/src/modules/chat/utils/autoSpeakPrompt.ts
+++ b/src/modules/chat/utils/autoSpeakPrompt.ts
@@ -14,3 +14,14 @@ export function withAutoSpeakHint(content: string, autoSpeakEnabled: boolean): s
   if (!autoSpeakEnabled || !content.trim()) return content;
   return `${content}\n\n${AUTO_SPEAK_PROMPT_HINT}`;
 }
+
+/**
+ * Removes a trailing hint, for loading an already-sent message back into the
+ * composer. Editing works on the persisted text, which carries the hint, so
+ * without this the resend would append a second copy.
+ */
+export function withoutAutoSpeakHint(content: string): string {
+  const suffix = `\n\n${AUTO_SPEAK_PROMPT_HINT}`;
+  if (!content.endsWith(suffix)) return content;
+  return content.slice(0, -suffix.length);
+}

--- a/src/modules/chat/utils/autoSpeakPrompt.ts
+++ b/src/modules/chat/utils/autoSpeakPrompt.ts
@@ -1,0 +1,16 @@
+// English like the rest of the prompt scaffolding: it describes output shape, not
+// language. Without it, replies written for the eye are read out as punctuation soup.
+const AUTO_SPEAK_PROMPT_HINT =
+  'Your reply will be read aloud automatically, so write it to be listened to: '
+  + 'short spoken-sounding sentences, minimal formatting.';
+
+/**
+ * The hint is visible in the transcript by necessity: the provider persists the
+ * prompt it was given, so a hidden hint reappears on reload anyway — and an echo
+ * differing from the sent text is not matched to its persisted turn, which leaves
+ * the message on screen twice.
+ */
+export function withAutoSpeakHint(content: string, autoSpeakEnabled: boolean): string {
+  if (!autoSpeakEnabled || !content.trim()) return content;
+  return `${content}\n\n${AUTO_SPEAK_PROMPT_HINT}`;
+}

--- a/src/modules/chat/utils/autoSpeakSessions.ts
+++ b/src/modules/chat/utils/autoSpeakSessions.ts
@@ -1,0 +1,93 @@
+import { api } from '@/shared/api';
+
+/**
+ * Which sessions read every assistant turn aloud as it completes.
+ *
+ * Lives outside React, next to voicePlayer, because the composer toggle, the
+ * realtime handler and the send path all need the same answer and the realtime
+ * handler is not a component. The server owns the value; this caches it so the
+ * toggle paints immediately and the completion handler can answer synchronously.
+ */
+class AutoSpeakSessions {
+  private enabledBySession = new Map<string, boolean>();
+  private inFlightLoads = new Map<string, Promise<boolean>>();
+  private listeners = new Set<() => void>();
+
+  subscribe(listener: () => void): () => void {
+    this.listeners.add(listener);
+    return () => {
+      this.listeners.delete(listener);
+    };
+  }
+
+  private emit() {
+    this.listeners.forEach((listener) => listener());
+  }
+
+  /**
+   * Synchronous answer for one session, defaulting to off — including while the
+   * first load is in flight, which errs toward silence rather than surprise.
+   */
+  isEnabled(sessionId: string | null | undefined): boolean {
+    if (!sessionId) return false;
+    return this.enabledBySession.get(sessionId) === true;
+  }
+
+  /** Fetches a session's setting once; repeat calls reuse the same request. */
+  async load(sessionId: string): Promise<boolean> {
+    const cached = this.enabledBySession.get(sessionId);
+    if (cached !== undefined) return cached;
+
+    const existingLoad = this.inFlightLoads.get(sessionId);
+    if (existingLoad) return existingLoad;
+
+    const load = (async () => {
+      try {
+        const response = await api.providers.sessionAutoSpeak(sessionId);
+        if (!response.ok) return false;
+        const body = await response.json();
+        return body?.data?.autoSpeak === true;
+      } catch {
+        // Left unset so the next mount retries rather than caching a false negative.
+        return false;
+      } finally {
+        this.inFlightLoads.delete(sessionId);
+      }
+    })();
+
+    this.inFlightLoads.set(sessionId, load);
+    const enabled = await load;
+    // Only positives are recorded: a `false` from a failed request is
+    // indistinguishable from a real "off" and would block the retry above.
+    if (enabled) {
+      this.enabledBySession.set(sessionId, true);
+      this.emit();
+    }
+    return enabled;
+  }
+
+  /**
+   * Writes optimistically, then persists. A failed write is recoverable by
+   * clicking again, so the local value is not rolled back — but the entry is
+   * dropped so the next load re-reads the server's truth.
+   */
+  async set(sessionId: string, enabled: boolean): Promise<void> {
+    this.enabledBySession.set(sessionId, enabled);
+    this.emit();
+
+    try {
+      const response = await api.providers.setSessionAutoSpeak(sessionId, enabled);
+      if (!response.ok) throw new Error(`Failed to save auto read-aloud (${response.status})`);
+    } catch (error) {
+      console.error('Failed to persist auto read-aloud setting:', error);
+      this.enabledBySession.delete(sessionId);
+      this.emit();
+    }
+  }
+
+  toggle(sessionId: string): void {
+    void this.set(sessionId, !this.isEnabled(sessionId));
+  }
+}
+
+export const autoSpeakSessions = new AutoSpeakSessions();

--- a/src/modules/chat/utils/autoSpeakSessions.ts
+++ b/src/modules/chat/utils/autoSpeakSessions.ts
@@ -12,6 +12,9 @@ class AutoSpeakSessions {
   private enabledBySession = new Map<string, boolean>();
   private inFlightLoads = new Map<string, Promise<boolean>>();
   private listeners = new Set<() => void>();
+  private inFlightWrites = new Map<string, Promise<void>>();
+  /** Increments per write, so a slow one cannot undo a newer toggle. */
+  private writeRevisionBySession = new Map<string, number>();
 
   subscribe(listener: () => void): () => void {
     this.listeners.add(listener);
@@ -70,19 +73,42 @@ class AutoSpeakSessions {
    * Writes optimistically, then persists. A failed write is recoverable by
    * clicking again, so the local value is not rolled back — but the entry is
    * dropped so the next load re-reads the server's truth.
+   *
+   * Writes for one session run one after another, because two quick toggles
+   * otherwise race and the server can keep whichever request happens to land
+   * last rather than the one the user asked for last.
    */
   async set(sessionId: string, enabled: boolean): Promise<void> {
     this.enabledBySession.set(sessionId, enabled);
     this.emit();
 
-    try {
-      const response = await api.providers.setSessionAutoSpeak(sessionId, enabled);
-      if (!response.ok) throw new Error(`Failed to save auto read-aloud (${response.status})`);
-    } catch (error) {
-      console.error('Failed to persist auto read-aloud setting:', error);
-      this.enabledBySession.delete(sessionId);
-      this.emit();
-    }
+    const revision = (this.writeRevisionBySession.get(sessionId) ?? 0) + 1;
+    this.writeRevisionBySession.set(sessionId, revision);
+
+    const previousWrite = this.inFlightWrites.get(sessionId) ?? Promise.resolve();
+    const write = previousWrite
+      .catch(() => {})
+      .then(async () => {
+        try {
+          const response = await api.providers.setSessionAutoSpeak(sessionId, enabled);
+          if (!response.ok) throw new Error(`Failed to save auto read-aloud (${response.status})`);
+        } catch (error) {
+          console.error('Failed to persist auto read-aloud setting:', error);
+          // Only the newest write may drop the cache: an older failure would
+          // otherwise discard a value the user has since chosen again.
+          if (this.writeRevisionBySession.get(sessionId) !== revision) return;
+          this.enabledBySession.delete(sessionId);
+          this.emit();
+        }
+      })
+      .finally(() => {
+        if (this.inFlightWrites.get(sessionId) === write) {
+          this.inFlightWrites.delete(sessionId);
+        }
+      });
+
+    this.inFlightWrites.set(sessionId, write);
+    return write;
   }
 
   toggle(sessionId: string): void {

--- a/src/modules/chat/utils/autoSpeakTurn.ts
+++ b/src/modules/chat/utils/autoSpeakTurn.ts
@@ -1,0 +1,109 @@
+import { autoSpeakSessions } from '@/modules/chat/utils/autoSpeakSessions';
+import { assistantMessageText } from '@/modules/chat/utils/chatFormatting';
+import { normalizedToChatMessages } from '@/modules/chat/hooks/useChatMessages';
+import { voicePlayer } from '@/modules/chat/utils/voicePlayer';
+import type { SessionStore } from '@/modules/chat/hooks/useSessionStore';
+import { readStoredUiPreferences } from '@/shared/uiPreferences';
+import type { LLMProvider } from '@/shared/types';
+
+/**
+ * The last assistant turn accounted for, per session, for the life of the page.
+ * Accounted for is not the same as spoken: an off-screen turn is recorded and
+ * never spoken, so it cannot be read out late. It also makes the entry points
+ * below idempotent, since the client that produced a turn sees it twice.
+ */
+const accountedTurnBySession = new Map<string, string>();
+
+/**
+ * By words, not id: the post-`complete` refetch returns the same reply as a new
+ * object, so keying on the id speaks every turn twice on the device that produced
+ * it. The cost is that two consecutive identical replies speak once.
+ */
+function turnKey(text: string): string {
+  return text;
+}
+
+type LatestTurn = { key: string; text: string };
+
+/** Stops at a user turn: a run is usually tool calls ending in one reply. */
+function latestTurn(
+  sessionId: string,
+  provider: LLMProvider,
+  sessionStore: SessionStore,
+): LatestTurn | null {
+  const messages = normalizedToChatMessages(sessionStore.getMessages(sessionId));
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    const message = messages[index];
+    if (message.type === 'user') return null;
+    if (message.type !== 'assistant' || message.isThinking || message.isToolUse) continue;
+
+    const text = assistantMessageText(message, provider).trim();
+    if (!text) continue;
+
+    return { key: turnKey(text), text };
+  }
+  return null;
+}
+
+type SpeakArgs = {
+  sessionId: string;
+  provider: LLMProvider;
+  sessionStore: SessionStore;
+  /** On screen, in the chat tab. False records the turn without speaking it. */
+  visible: boolean;
+};
+
+function accountFor(
+  { sessionId, provider, sessionStore, visible }: SpeakArgs,
+  { requireBaseline }: { requireBaseline: boolean },
+): void {
+  const turn = latestTurn(sessionId, provider, sessionStore);
+  if (!turn) return;
+
+  const previous = accountedTurnBySession.get(sessionId);
+  accountedTurnBySession.set(sessionId, turn.key);
+
+  if (previous === turn.key) return;
+  // A refresh cannot tell a new turn from a first look at the transcript, so its
+  // first observation only establishes the baseline. `complete` needs none: it is
+  // itself proof that a turn just finished.
+  if (requireBaseline && previous === undefined) return;
+
+  if (!visible) return;
+  if (!autoSpeakSessions.isEnabled(sessionId)) return;
+  // Voice off hides the toggle, which would leave a session speaking with no
+  // control left to stop it — and the setting is server-side, so a reload does
+  // not clear it either.
+  if (!readStoredUiPreferences().voiceEnabled) return;
+
+  // No unlock() here: it only counts inside a real gesture, and the two that
+  // matter — enabling the toggle, and sending on a device where it is already
+  // on — already do it.
+  voicePlayer.speak(turn.text);
+}
+
+/** Speaks the turn that just finished on this client, from the `complete` event. */
+export function speakCompletedTurn(args: SpeakArgs): void {
+  accountFor(args, { requireBaseline: false });
+}
+
+/**
+ * Records a session's last turn without speaking it, while a conversation opens.
+ * Otherwise opening a session that moved on elsewhere speaks as it paints.
+ */
+export function baselineTurn(args: Omit<SpeakArgs, 'visible'>): void {
+  accountFor({ ...args, visible: false }, { requireBaseline: false });
+}
+
+/**
+ * Speaks a turn that arrived from elsewhere. Only one client streams a given run,
+ * so a second device never sees `complete` — it sees the watcher's refresh.
+ */
+export function speakRefreshedTurn(args: SpeakArgs): void {
+  accountFor(args, { requireBaseline: true });
+}
+
+/** @internal Test seam: page-lifetime state would otherwise leak between cases. */
+export function resetAutoSpeakTurnState(): void {
+  accountedTurnBySession.clear();
+}

--- a/src/modules/chat/utils/chatFormatting.ts
+++ b/src/modules/chat/utils/chatFormatting.ts
@@ -1,3 +1,34 @@
+import type { ChatMessage, LLMProvider } from '@/shared/types';
+
+/**
+ * The assistant text a transcript row shows, which is also exactly what the
+ * read-aloud controls speak.
+ *
+ * Shared by MessageComponent (the copy and speak buttons) and the auto
+ * read-aloud trigger. Auto read-aloud has to produce the *same* string as the
+ * button: the voice player caches and reports playback state per text, so a
+ * different string would both miss the cache and leave the message's own speak
+ * button showing idle while its audio played.
+ */
+export function assistantMessageText(message: ChatMessage, provider: LLMProvider | string | undefined): string {
+  return message.isToolUse
+    ? String(message.displayText || message.content || '')
+    : formattedMessageText(message, provider);
+}
+
+/**
+ * One message's body text with provider-specific transport artifacts removed.
+ *
+ * Used directly by MessageComponent to render a turn, and by
+ * assistantMessageText for everything that is not a tool call.
+ */
+export function formattedMessageText(message: ChatMessage, provider: LLMProvider | string | undefined): string {
+  const content = formatUsageLimitText(String(message.content || ''));
+  return provider === 'codex' && message.type === 'assistant' && !message.isThinking
+    ? stripProposedPlanEnvelope(content)
+    : content;
+}
+
 export function normalizeInlineCodeFences(text: string) {
   if (!text || typeof text !== 'string') return text;
   try {

--- a/src/modules/chat/utils/voicePlayer.ts
+++ b/src/modules/chat/utils/voicePlayer.ts
@@ -87,6 +87,18 @@ class VoicePlayer {
     void this.play(id, content);
   }
 
+  /**
+   * Starts playback without the stop-on-second-press behaviour of `toggle`.
+   *
+   * Used by auto read-aloud, which is not a button press: a turn completing
+   * while its own audio is somehow already playing must not silence it.
+   */
+  speak(content: string) {
+    const id = voiceId(content);
+    if (this.currentId === id && (this.state === 'playing' || this.state === 'loading')) return;
+    void this.play(id, content);
+  }
+
   stop() {
     this.token++; // ignore any stale in-flight result
     this.abortActive(); // and actually cancel the network request

--- a/src/modules/i18n/locales/en/chat.json
+++ b/src/modules/i18n/locales/en/chat.json
@@ -109,7 +109,9 @@
     "transcribing": "Transcribing…",
     "speak": "Read aloud",
     "stopSpeaking": "Stop",
-    "loading": "Loading…"
+    "loading": "Loading…",
+    "autoSpeakOn": "Auto read-aloud is on",
+    "autoSpeakOff": "Auto read-aloud is off"
   },
   "input": {
     "placeholder": "Type / for commands, @ for files, or ask {{provider}} anything...",

--- a/src/modules/i18n/locales/es/chat.json
+++ b/src/modules/i18n/locales/es/chat.json
@@ -102,7 +102,9 @@
     "transcribing": "Transcribiendo…",
     "speak": "Leer en voz alta",
     "stopSpeaking": "Detener",
-    "loading": "Cargando…"
+    "loading": "Cargando…",
+    "autoSpeakOn": "Lectura automática activada",
+    "autoSpeakOff": "Lectura automática desactivada"
   },
   "input": {
     "placeholder": "Escribe / para comandos, @ para archivos, o pregúntale lo que quieras a {{provider}}...",

--- a/src/modules/i18n/locales/ko/chat.json
+++ b/src/modules/i18n/locales/ko/chat.json
@@ -102,7 +102,9 @@
     "transcribing": "받아쓰는 중…",
     "speak": "소리 내어 읽기",
     "stopSpeaking": "중지",
-    "loading": "로딩 중…"
+    "loading": "로딩 중…",
+    "autoSpeakOn": "자동 읽기 켜짐",
+    "autoSpeakOff": "자동 읽기 꺼짐"
   },
   "input": {
     "placeholder": "/를 입력하여 명령어, @를 입력하여 파일, 또는 {{provider}}에게 무엇이든 물어보세요...",

--- a/src/modules/i18n/locales/zh-CN/chat.json
+++ b/src/modules/i18n/locales/zh-CN/chat.json
@@ -102,7 +102,9 @@
     "transcribing": "转写中…",
     "speak": "朗读",
     "stopSpeaking": "停止",
-    "loading": "加载中…"
+    "loading": "加载中…",
+    "autoSpeakOn": "自动朗读已开启",
+    "autoSpeakOff": "自动朗读已关闭"
   },
   "input": {
     "placeholder": "输入 / 调用命令，@ 选择文件，或向 {{provider}} 提问...",

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -386,6 +386,14 @@ export const api = {
       post(`/api/providers/${provider}/sessions/${encodeURIComponent(sessionId)}/active-effort`, {
         effort,
       }),
+    // Auto read-aloud is a property of the conversation, not of the provider
+    // running it, so these two are not provider-scoped.
+    sessionAutoSpeak: (sessionId: string) =>
+      get(`/api/providers/sessions/${encodeURIComponent(sessionId)}/auto-speak`),
+    setSessionAutoSpeak: (sessionId: string, autoSpeak: boolean) =>
+      post(`/api/providers/sessions/${encodeURIComponent(sessionId)}/auto-speak`, {
+        autoSpeak,
+      }),
 
     mcpServers: (
       provider: string,


### PR DESCRIPTION
Closes #1298

### What this adds

A speaker toggle in the composer. While it is on, each finished assistant reply
is read aloud through the voice stack that is already in the app.

The setting is a new `auto_speak` column on the session row, next to `model` and
`effort`. So it survives a reload, it follows the conversation to another device,
a fork inherits it, and deleting the session deletes it.

### How it decides to speak

There are two triggers, because one is not enough.

- **The `complete` event** covers the client that ran the turn. No debounce is
  needed. That event already means the reply is finished.
- **The transcript refresh** covers every other client. Only one client is
  attached to a run, so a second device with the same conversation open never
  receives `complete`. It receives the watcher's `session_upserted` refresh
  instead. This trigger also covers replies produced by the provider CLI
  directly, and by scheduled messages.

### Most of the work is in staying silent

Audio that starts where no stop button is visible feels like a fault. So:

- A reply is spoken only while its session is on screen and the chat tab is
  active. In every other case the reply is recorded as already handled. It is
  never queued, so it cannot be read out later.
- Opening a conversation is silent, even if it gained replies elsewhere while it
  was closed. Loading the transcript resets the baseline instead.
- Returning from the Files, Git or Shell tab is also silent. This path needed
  care. Refreshes are held while the chat tab is hidden and flushed on return, and
  an already loaded transcript never sets `isLoadingSessionMessages`. So the flush
  otherwise looks the same as a live arrival. The store's own `fetchedAt` stamp
  tells them apart.
- Stopped and failed runs are recorded without being spoken. Otherwise the
  refresh that follows reads out the half-finished reply the user just stopped.
- Replies are deduplicated by text, not by id, because the refetch after
  `complete` returns the same reply as a new object. The cost is that two
  identical replies in a row are spoken once.

### Prompt hint

While the toggle is on, each outgoing prompt carries one extra sentence. It asks
for a reply that is written to be listened to. Without it, the model answers with
code blocks and tables, and the speech engine reads out the punctuation.

The hint is visible in the transcript. That is a consequence, not a choice. The
provider saves the prompt it receives and the app reads history back from that
file, so a hidden hint appears again after the next reload. Also, an echo that
differs from the sent text by one character is not matched to its saved message,
which shows the message twice. I am happy to drop this part if you prefer that
the feature does not touch prompts.

### Mobile autoplay

Sending a message also unlocks the shared `<audio>` element. Mobile browsers
refuse to play audio without a user gesture. Because the setting is stored on the
server, a device can inherit it from another device and never click the toggle. It
would then fail with a bare `NotAllowedError`.

### Known limits

These three need coordination between clients, which felt out of scope. I am
happy to follow up on any of them.

- A cached "on" value does not notice that another tab switched it off.
- A stopped run can still be spoken on a second device, because that device never
  learns the run was stopped.
- Editing an old message can speak an earlier reply again on other clients.

### i18n

I added keys to `en`, `es`, `ko` and `zh-CN`. Those are the four locales that
already have a `voice` block. The other seven have none and fall back to English.
Tell me if you want all eleven.

### Testing

- `npm run typecheck`, `npm run lint` and `npm run build` are clean.
- `npm run test:client`: 422 tests pass. 22 are new, covering the turn selector
  and the arrivals hook: session open, tab return, streaming, stopped run,
  arrival from another device, deduplication, and voice preference off.
- `npm run test`: 5 new server tests for the endpoint and the migration. Four
  failures in `claude-cli-path.test.ts` and one in `agent.routes.test.ts` are not
  from this change. They assume there is no `claude` binary on `PATH`, so they
  also fail on a clean checkout of `main` on this machine.
- I ran this on a real install for several hours, from a laptop and a phone,
  including the multi-device and tab-switching cases above.

### Screenshots

<img width="1070" height="831" alt="Read-aloud on" src="https://github.com/user-attachments/assets/4ee833e5-66f0-480f-8fd6-431fdec5a843" />
<img width="1070" height="831" alt="Read-aloud off" src="https://github.com/user-attachments/assets/20bfefc7-aa53-4113-bfb7-9e6086dc6264" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional per-session auto read-aloud setting with an accessible chat composer toggle.
  * Assistant replies are read aloud when enabled, including replies arriving from other tabs, devices, provider tools, or scheduled messages.
  * Settings persist per conversation and carry over when sessions are forked.
  * Added localized enabled and disabled status labels in English, Spanish, Korean, and Chinese.
* **Bug Fixes**
  * Improved transcript formatting for displayed and spoken assistant messages.
  * Prevented duplicate or stale read-aloud behavior during refreshes and rapid setting changes.
* **Tests**
  * Added coverage for persistence, isolation, streaming, visibility, and duplicate prevention.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->