### PR TITLE
fix(ws): recover broken chat connections and subscriptions

### DIFF
--- a/server/modules/websocket/README.md
+++ b/server/modules/websocket/README.md
@@ -33,7 +33,7 @@ Benefits:
 |---|---|
 | `services/websocket-server.service.ts` | Creates `WebSocketServer`, binds `verifyClient`, routes connection by pathname |
 | `services/websocket-auth.service.ts` | Authenticates upgrade requests and attaches `request.user` |
-| `services/chat-websocket.service.ts` | Handles the `/ws` chat protocol (`chat.send` / `chat.abort` / `chat.subscribe` / `chat.permission-response`) |
+| `services/chat-websocket.service.ts` | Handles the `/ws` chat protocol (`chat.send` / `chat.abort` / `chat.subscribe` / `chat.permission-response` / `chat.ping`) |
 | `services/chat-run-registry.service.ts` | Tracks live provider runs per app session id: seq numbering, event replay buffer, provider-id mapping, completion state |
 | `services/chat-session-writer.service.ts` | Gateway writer handed to provider runtimes: remaps provider session ids to app ids, swallows `session_created`, assigns `seq` |
 | `services/shell-websocket.service.ts` | Handles `/shell` PTY lifecycle, reconnect buffering, auth URL detection |
@@ -108,7 +108,7 @@ When a chat socket connects:
 
 1. Add socket to `connectedClients`.
 2. Parse each incoming message with `parseIncomingJsonObject`.
-3. Dispatch by `data.type` (four message types, none provider-specific).
+3. Dispatch by `data.type`; chat commands are provider-neutral.
 4. On close, remove socket from `connectedClients`.
 
 ### Session identity model
@@ -133,15 +133,47 @@ flowchart TD
   D -->|chat.abort| F[providerRuntimeService.abort + synthetic complete]
   D -->|chat.subscribe| G[chat_subscribed ack + attach socket + replay events seq > lastSeq]
   D -->|chat.permission-response| H[providerRuntimeService.resolveToolApproval]
+  D -->|chat.ping| J[send kind:pong with matching nonce]
   D -->|other| I[send kind:protocol_error]
 ```
 
 ### Chat Notes
 
-1. **Unified envelope**: every server-to-client frame carries a `kind` — either a provider `NormalizedMessage` kind or a gateway kind (`chat_subscribed`, `session_upserted`, `loading_progress`, `protocol_error`). There is no second `type`-based protocol.
+1. **Unified envelope**: every server-to-client frame carries a `kind` — either a provider `NormalizedMessage` kind or a gateway kind (`chat_subscribed`, `pong`, `session_upserted`, `loading_progress`, `protocol_error`). There is no second `type`-based protocol.
 2. **Unified terminal lifecycle**: every provider run ends with exactly one `complete` message built by `createCompleteMessage()` (`server/shared/utils.ts`): `{ kind: "complete", sessionId, actualSessionId, exitCode, success, aborted }`. The chat handler emits a synthetic `complete` for runs that crash or get aborted, and the run registry drops duplicate completes.
 3. **Per-run event log**: every live event gets a monotonically increasing `seq`. `chat.subscribe { sessions: [{ sessionId, lastSeq }] }` re-attaches the live stream to the requesting socket (any provider, not just Claude) and replays events with `seq > lastSeq`. If the buffer no longer covers `lastSeq`, the client refreshes over REST.
 4. `chat_subscribed` includes `isProcessing` (replaces `check-session-status`) and `pendingPermissions` (replaces `get-pending-permissions`).
+
+### Broken-channel recovery
+
+The browser sends `chat.ping { nonce }` every 30 seconds after connection or a
+matching pong. The gateway replies only to that socket with `{ kind: "pong",
+nonce }`, without invoking a provider. A missing matching pong after 3 seconds
+retires the socket and schedules a new connection after the existing 3-second
+retry delay. A handshake that stays connecting for 30 seconds is also retired.
+Only one handshake, ping, pong, or retry timer is active at a time.
+
+The nonce must be a string. Missing or non-string nonces receive
+`protocol_error` with code `INVALID_NONCE`, never a `pong`. The socket remains
+available for subsequent valid requests.
+
+`visibilitychange` to visible and `pageshow` can probe earlier, but recovery does
+not require either event. Repeated page events do not extend a pending pong
+deadline. Browser suspension and background timer throttling can delay checks;
+the client cannot promise a wall-clock recovery deadline while timers are paused.
+
+On replacement, the selected chat sends `chat.subscribe` and waits for its
+matching `chat_subscribed` acknowledgement before refreshing the persisted tail.
+A separate 10-second deadline bounds that acknowledgement wait. If it expires,
+the client closes that socket so normal reconnect and resubscription can restore
+the live stream. Protocol errors and successful heartbeats do not cancel the
+deadline. History stays gated until a replacement subscription is acknowledged;
+an HTTP refresh alone would not establish live delivery. A matching acknowledgement
+or a socket/session change cancels the deadline.
+Replay follows the acknowledgement and can overlap the HTTP request. Hidden chat
+still subscribes but defers persisted-tail HTTP until activation. Initial session
+loading is unchanged, and visibility-only changes do not resubscribe.
+Failed application messages are not automatically resent.
 
 ## `/shell` Terminal Flow
 

--- a/server/modules/websocket/services/chat-websocket.service.ts
+++ b/server/modules/websocket/services/chat-websocket.service.ts
@@ -529,10 +529,11 @@ function handlePermissionResponse(data: AnyRecord, dependencies: ChatWebSocketDe
  * - `chat.abort`               { sessionId }
  * - `chat.subscribe`           { sessions: [{ sessionId, lastSeq? }] }
  * - `chat.permission-response` { requestId, allow, updatedInput?, message?, rememberEntry? }
+ * - `chat.ping`                { nonce }
  *
  * Outbound protocol (server to client): every frame is `kind`-based — either
  * a provider `NormalizedMessage` (with `seq`) or a gateway event
- * (`chat_subscribed`, `session_upserted`, `loading_progress`,
+ * (`chat_subscribed`, `pong`, `session_upserted`, `loading_progress`,
  * `protocol_error`).
  */
 /**
@@ -635,6 +636,16 @@ export function handleChatConnection(
           return;
         case 'chat.permission-response':
           handlePermissionResponse(data, dependencies);
+          return;
+        case 'chat.ping':
+          if (typeof data.nonce !== 'string') {
+            sendProtocolError(ws, 'INVALID_NONCE', 'chat.ping requires a string nonce.');
+            return;
+          }
+          sendJson(ws, {
+            kind: 'pong',
+            nonce: data.nonce,
+          });
           return;
         default:
           sendProtocolError(ws, 'UNKNOWN_MESSAGE_TYPE', `Unknown message type "${messageType}".`);

--- a/server/modules/websocket/tests/chat-ping.test.ts
+++ b/server/modules/websocket/tests/chat-ping.test.ts
@@ -1,0 +1,53 @@
+import assert from 'node:assert/strict';
+import { once } from 'node:events';
+import test from 'node:test';
+
+import { WebSocket, WebSocketServer } from 'ws';
+
+import { handleChatConnection } from '@/modules/websocket/services/chat-websocket.service.js';
+
+test('chat.ping validates its nonce and replies only to its socket without invoking providers', async (t) => {
+  const server = new WebSocketServer({ host: '127.0.0.1', port: 0 });
+  t.after(async () => {
+    for (const socket of server.clients) socket.terminate();
+    await new Promise<void>((resolve, reject) => server.close((error) => error ? reject(error) : resolve()));
+  });
+  server.on('connection', (socket, request) => handleChatConnection(socket, request, {
+    runtime: {
+      hasRuntime: () => assert.fail('ping must not inspect provider runtimes'),
+      run: async () => assert.fail('ping must not start a provider'),
+      abort: async () => assert.fail('ping must not abort a provider'),
+      resolveToolApproval: () => assert.fail('ping must not resolve approvals'),
+      getPendingApprovalsForSession: () => assert.fail('ping must not inspect approvals'),
+    },
+  }));
+  await once(server, 'listening');
+  const address = server.address();
+  assert.ok(address && typeof address === 'object');
+  const first = new WebSocket(`ws://127.0.0.1:${address.port}`);
+  const second = new WebSocket(`ws://127.0.0.1:${address.port}`);
+  t.after(() => { first.terminate(); second.terminate(); });
+  const firstFrames: unknown[] = [];
+  first.on('message', (data) => firstFrames.push(JSON.parse(data.toString())));
+  const secondFrames: unknown[] = [];
+  second.on('message', (data) => secondFrames.push(JSON.parse(data.toString())));
+  await Promise.all([once(first, 'open'), once(second, 'open')]);
+
+  const invalidReply = once(first, 'message');
+  first.send(JSON.stringify({ type: 'chat.ping', nonce: 42 }));
+  const [invalid] = await invalidReply;
+  const failure = JSON.parse(invalid.toString());
+  assert.equal(failure.kind, 'protocol_error');
+  assert.equal(failure.code, 'INVALID_NONCE');
+
+  const firstReply = once(first, 'message');
+  first.send(JSON.stringify({ type: 'chat.ping', nonce: 'first-probe' }));
+  const [reply] = await firstReply;
+  assert.deepEqual(JSON.parse(reply.toString()), { kind: 'pong', nonce: 'first-probe' });
+  assert.deepEqual(firstFrames, [failure, { kind: 'pong', nonce: 'first-probe' }]);
+
+  const secondReply = once(second, 'message');
+  second.send(JSON.stringify({ type: 'chat.ping', nonce: 'second-probe' }));
+  await secondReply;
+  assert.deepEqual(secondFrames, [{ kind: 'pong', nonce: 'second-probe' }]);
+});

--- a/server/shared/types.ts
+++ b/server/shared/types.ts
@@ -203,6 +203,7 @@ export type MessageKind =
  */
 export type GatewayEventKind =
   | 'chat_subscribed'
+  | 'pong'
   | 'session_upserted'
   | 'loading_progress'
   | 'protocol_error';

--- a/src/modules/chat/ChatInterface.tsx
+++ b/src/modules/chat/ChatInterface.tsx
@@ -161,6 +161,7 @@ function ChatInterface({
     selectedSession,
     ws,
     sendMessage,
+    subscribe,
     externalMessageUpdate,
     newSessionTrigger,
     processingSessions,
@@ -256,23 +257,6 @@ function ChatInterface({
     resolvePermissionModeForProvider,
   });
 
-  // On WebSocket reconnect, request a bounded persisted-tail sync (deferred
-  // while Chat is hidden), then re-subscribe — the
-  // `chat_subscribed` ack restores or clears the activity indicator, replays
-  // missed live events, and re-attaches a still-running stream to this socket.
-  const handleWebSocketReconnect = useCallback(async () => {
-    if (!selectedProject || !selectedSession) return;
-    await requestLatestMessages(selectedSession.id, isActive);
-    statusCheckSentAtRef.current.set(selectedSession.id, Date.now());
-    sendMessage({
-      type: 'chat.subscribe',
-      sessions: [{
-        sessionId: selectedSession.id,
-        lastSeq: lastSeqRef.current.get(selectedSession.id) ?? 0,
-      }],
-    });
-  }, [isActive, requestLatestMessages, selectedProject, selectedSession, sendMessage]);
-
   useChatRealtimeHandlers({
     isActive,
     subscribe,
@@ -288,7 +272,6 @@ function ChatInterface({
     statusCheckSentAtRef,
     onSessionProcessing,
     onSessionIdle,
-    onWebSocketReconnect: handleWebSocketReconnect,
     requestLatestMessages,
     sessionStore,
   });

--- a/src/modules/chat/hooks/useChatRealtimeHandlers.ts
+++ b/src/modules/chat/hooks/useChatRealtimeHandlers.ts
@@ -36,7 +36,6 @@ type UseChatRealtimeHandlersArgs = {
   statusCheckSentAtRef: MutableRefObject<Map<string, number>>;
   onSessionProcessing?: MarkSessionProcessing;
   onSessionIdle?: MarkSessionIdle;
-  onWebSocketReconnect?: () => void;
   requestLatestMessages: (sessionId: string, allowNetwork?: boolean) => Promise<void>;
   sessionStore: SessionStore;
 };
@@ -69,7 +68,6 @@ export function useChatRealtimeHandlers({
   statusCheckSentAtRef,
   onSessionProcessing,
   onSessionIdle,
-  onWebSocketReconnect,
   requestLatestMessages,
   sessionStore,
 }: UseChatRealtimeHandlersArgs) {
@@ -109,10 +107,6 @@ export function useChatRealtimeHandlers({
       }
 
       switch (msg.kind) {
-        case 'websocket_reconnected':
-          onWebSocketReconnect?.();
-          return;
-
         case 'history_truncated': {
           // An already-sent message was replaced. Every client watching this
           // session drops the superseded turns before the replacement streams
@@ -171,6 +165,10 @@ export function useChatRealtimeHandlers({
           }
           return;
         }
+
+        // useChatSessionState owns reconnect catch-up; this is not a transcript row.
+        case 'websocket_reconnected':
+          return;
 
         // Sidebar/global events — owned by useProjectsState.
         case 'session_upserted':
@@ -364,7 +362,6 @@ export function useChatRealtimeHandlers({
     statusCheckSentAtRef,
     onSessionProcessing,
     onSessionIdle,
-    onWebSocketReconnect,
     requestLatestMessages,
     sessionStore,
   ]);

--- a/src/modules/chat/hooks/useChatSessionState.ts
+++ b/src/modules/chat/hooks/useChatSessionState.ts
@@ -2,7 +2,17 @@ import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } fr
 import type { MutableRefObject } from 'react';
 
 import { api } from '@/shared/api';
-import type { MarkSessionIdle, SessionActivityMap,Project,ProjectSession,LLMProvider,NormalizedMessage,ChatMessage,DiffCalculator } from '@/shared/types';
+import type {
+  MarkSessionIdle,
+  SessionActivityMap,
+  Project,
+  ProjectSession,
+  LLMProvider,
+  NormalizedMessage,
+  ChatMessage,
+  DiffCalculator,
+  ServerEvent,
+} from '@/shared/types';
 import type { SessionStore } from '@/modules/chat/hooks/useSessionStore';
 import { SESSION_MESSAGES_PAGE_SIZE } from '@/modules/chat/utils/sessionMessagePagination';
 import { createMessageHistoryRefreshCoordinator } from '@/modules/chat/utils/messageHistoryRefreshCoordinator';
@@ -13,6 +23,9 @@ import { readSelectedProvider } from '@/shared/selectedProvider';
 import type { SearchTarget } from '@/modules/chat/utils/searchTargetLocator';
 
 const INITIAL_VISIBLE_MESSAGES = 100;
+
+/** A live transport must still acknowledge reattachment before history can refresh. */
+const RECONNECT_ACK_TIMEOUT_MS = 10_000;
 
 /** Messages kept below a search hit so it lands mid-viewport rather than at the edge. */
 const SEARCH_TARGET_CONTEXT_MESSAGES = 20;
@@ -84,6 +97,7 @@ type UseChatSessionStateArgs = {
   selectedSession: ProjectSession | null;
   ws: WebSocket | null;
   sendMessage: (message: unknown) => void;
+  subscribe: (listener: (event: ServerEvent) => void) => () => void;
   externalMessageUpdate?: number;
   newSessionTrigger?: number;
   processingSessions?: SessionActivityMap;
@@ -184,6 +198,7 @@ export function useChatSessionState({
   selectedSession,
   ws,
   sendMessage,
+  subscribe,
   externalMessageUpdate,
   newSessionTrigger,
   processingSessions,
@@ -235,6 +250,10 @@ export function useChatSessionState({
   const loadAllFinishedTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const loadAllOverlayTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const lastLoadedSessionKeyRef = useRef<string | null>(null);
+  // Distinguish a lost subscription from a different session's initial load.
+  const lastSubscriptionRef = useRef<{ socket: WebSocket; sessionId: string } | null>(null);
+  // A replacement must acknowledge this session before any queued tail refresh.
+  const pendingReconnectRef = useRef<{ socket: WebSocket; sessionId: string } | null>(null);
   /**
    * Tracks the last processed value from `useProjectsState.newSessionTrigger`.
    *
@@ -323,8 +342,11 @@ export function useChatSessionState({
 
   const isActiveRef = useRef(isActive);
   const activeSessionIdRef = useRef(activeSessionId);
+  // Reject acknowledgements delivered by listeners for a replaced socket.
+  const wsRef = useRef(ws);
   isActiveRef.current = isActive;
   activeSessionIdRef.current = activeSessionId;
+  wsRef.current = ws;
 
   const latestRefreshExecutorRef = useRef<(sessionId: string) => Promise<boolean | void>>(
     async () => true,
@@ -335,6 +357,7 @@ export function useChatSessionState({
       canRequest: () => (
         isActiveRef.current
         && activeSessionIdRef.current === sessionId
+        && pendingReconnectRef.current?.sessionId !== sessionId
       ),
     });
     const slot = result.slot;
@@ -353,7 +376,11 @@ export function useChatSessionState({
   if (!refreshCoordinatorRef.current) {
     refreshCoordinatorRef.current = createMessageHistoryRefreshCoordinator(
       (sessionId) => latestRefreshExecutorRef.current(sessionId),
-      (sessionId) => isActiveRef.current && activeSessionIdRef.current === sessionId,
+      (sessionId) => (
+        isActiveRef.current
+        && activeSessionIdRef.current === sessionId
+        && pendingReconnectRef.current?.sessionId !== sessionId
+      ),
     );
   }
 
@@ -659,20 +686,70 @@ export function useChatSessionState({
     };
   }, [chatMessages.length, isActive, isLoadingSessionMessages, scrollToBottom]);
 
-  // Session replay/subscription remains active regardless of which main tab is
-  // visible. Only persisted-history HTTP traffic is visibility-gated below.
+  const selectedSessionId = selectedSession?.id;
+  const selectedProjectId = selectedProject?.projectId;
+  // One owner subscribes on socket/session changes, including while hidden.
+  // The ack confirms attachment, not replay completion: replay follows the ack
+  // and can arrive while the persisted-tail request is in flight.
   useEffect(() => {
-    if (!selectedSession || !selectedProject || !ws) return;
+    if (!selectedSessionId || !selectedProjectId || !ws) return;
 
-    statusCheckSentAtRef.current.set(selectedSession.id, Date.now());
+    const isReconnect = lastSubscriptionRef.current?.sessionId === selectedSessionId
+      && lastSubscriptionRef.current.socket !== ws;
+    lastSubscriptionRef.current = { socket: ws, sessionId: selectedSessionId };
+    const pending = isReconnect ? lastSubscriptionRef.current : null;
+    pendingReconnectRef.current = pending;
+    // Recover through the transport's existing reconnect lifecycle, not an
+    // unattached HTTP refresh. Cleanup or the next subscription owns pending.
+    const ackTimeout = pending ? setTimeout(() => {
+      if (
+        pendingReconnectRef.current === pending
+        && wsRef.current === pending.socket
+        && activeSessionIdRef.current === pending.sessionId
+      ) {
+        pending.socket.close();
+      }
+    }, RECONNECT_ACK_TIMEOUT_MS) : undefined;
+    // Arm the listener and pending state before send, including synchronous acks.
+    const unsubscribe = subscribe((event) => {
+      if (
+        !pending
+        || pendingReconnectRef.current !== pending
+        || wsRef.current !== pending.socket
+        || activeSessionIdRef.current !== pending.sessionId
+        || event.kind !== 'chat_subscribed'
+        || event.sessionId !== pending.sessionId
+      ) return;
+
+      clearTimeout(ackTimeout);
+      pendingReconnectRef.current = null;
+      void requestLatestMessages(pending.sessionId);
+    });
+    statusCheckSentAtRef.current.set(selectedSessionId, Date.now());
     sendMessage({
       type: 'chat.subscribe',
       sessions: [{
-        sessionId: selectedSession.id,
-        lastSeq: lastSeqRef.current.get(selectedSession.id) ?? 0,
+        sessionId: selectedSessionId,
+        lastSeq: lastSeqRef.current.get(selectedSessionId) ?? 0,
       }],
     });
-  }, [lastSeqRef, selectedProject, selectedSession, sendMessage, statusCheckSentAtRef, ws]);
+    return () => {
+      clearTimeout(ackTimeout);
+      unsubscribe();
+      if (pendingReconnectRef.current === pending) {
+        pendingReconnectRef.current = null;
+      }
+    };
+  }, [
+    lastSeqRef,
+    requestLatestMessages,
+    selectedProjectId,
+    selectedSessionId,
+    sendMessage,
+    statusCheckSentAtRef,
+    subscribe,
+    ws,
+  ]);
 
   // Main session loading effect — store-based.
   //

--- a/src/modules/chat/tests/reconnectSubscription.test.tsx
+++ b/src/modules/chat/tests/reconnectSubscription.test.tsx
@@ -1,0 +1,415 @@
+import { act, cleanup, renderHook, waitFor } from '@testing-library/react';
+import { useLayoutEffect } from 'react';
+import { afterEach, beforeEach, expect, test, vi } from 'vitest';
+
+import { useChatSessionState } from '@/modules/chat/hooks/useChatSessionState';
+import { useChatRealtimeHandlers } from '@/modules/chat/hooks/useChatRealtimeHandlers';
+import { useSessionStore } from '@/modules/chat/hooks/useSessionStore';
+import { SESSION_MESSAGES_PAGE_SIZE } from '@/modules/chat/utils/sessionMessagePagination';
+import { api } from '@/shared/api';
+import type { NormalizedMessage, Project, ProjectSession, ServerEvent } from '@/shared/types';
+
+vi.mock('@/shared/api', () => ({
+  api: {
+    providers: {
+      sessionMessages: vi.fn(),
+      sessionTokenUsage: () => Promise.resolve({ ok: false, json: async () => ({}) }),
+    },
+  },
+}));
+
+const SESSION_ID = 'session-a';
+const project: Project = {
+  projectId: 'project-1',
+  path: '/repo',
+  fullPath: '/repo',
+  displayName: 'Repo',
+  isStarred: false,
+};
+const session: ProjectSession = { id: SESSION_ID };
+const sessionMessages = vi.mocked(api.providers.sessionMessages);
+const persisted = new Map<string, string>();
+
+function historyMessage(sessionId: string): NormalizedMessage {
+  return {
+    id: `${sessionId}-answer`,
+    sessionId,
+    kind: 'text',
+    role: 'assistant',
+    provider: 'claude',
+    content: persisted.get(sessionId) ?? 'cached answer',
+    timestamp: '2026-01-01T00:00:00.000Z',
+  };
+}
+
+beforeEach(() => {
+  localStorage.clear();
+  persisted.clear();
+  sessionMessages.mockReset();
+  sessionMessages.mockImplementation(async (sessionId) => new Response(JSON.stringify({
+    data: { messages: [historyMessage(sessionId)], total: 1, hasMore: false },
+  })));
+  vi.stubGlobal('requestAnimationFrame', () => 0);
+  vi.stubGlobal('cancelAnimationFrame', () => undefined);
+});
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+});
+
+// Only socket identity and close are consumed here; transport reconnection is
+// exercised separately by webSocketContext.test.tsx.
+class FakeWebSocket extends EventTarget implements WebSocket {
+  readonly CONNECTING = 0;
+  readonly OPEN = 1;
+  readonly CLOSING = 2;
+  readonly CLOSED = 3;
+  readonly bufferedAmount = 0;
+  readonly extensions = '';
+  readonly protocol = '';
+  readonly url = 'ws://localhost/ws';
+  binaryType: BinaryType = 'blob';
+  readyState: number = this.OPEN;
+  onopen: WebSocket['onopen'] = null;
+  onmessage: WebSocket['onmessage'] = null;
+  onerror: WebSocket['onerror'] = null;
+  onclose: WebSocket['onclose'] = null;
+  send = vi.fn<WebSocket['send']>();
+  close = vi.fn<WebSocket['close']>(() => {
+    this.readyState = this.CLOSED;
+    const event = new CloseEvent('close');
+    this.onclose?.call(this, event);
+    this.dispatchEvent(event);
+  });
+}
+
+async function renderSession() {
+  const listeners = new Set<(event: ServerEvent) => void>();
+  const registeredListeners: Array<(event: ServerEvent) => void> = [];
+  const subscribe = (listener: (event: ServerEvent) => void) => {
+    listeners.add(listener);
+    registeredListeners.push(listener);
+    return () => { listeners.delete(listener); };
+  };
+  const dispatch = (event: ServerEvent) => {
+    for (const listener of listeners) listener(event);
+  };
+  const sendMessage = vi.fn<(message: unknown) => void>();
+  const resetStreamingState = vi.fn();
+  const statusCheckSentAtRef = { current: new Map<string, number>() };
+  const lastSeqRef = { current: new Map([[SESSION_ID, 41]]) };
+  const firstSocket = new FakeWebSocket();
+  const replacementSocket = new FakeWebSocket();
+  type Props = {
+    ws: WebSocket | null;
+    isActive: boolean;
+    session: ProjectSession | null;
+    beforePassiveCleanup?: () => void;
+  };
+  const props: Props = { ws: firstSocket, isActive: true, session };
+  const view = renderHook(
+    ({ ws, isActive, session: selectedSession, beforePassiveCleanup }: Props) => {
+      const store = useSessionStore();
+      const chat = useChatSessionState({
+        isActive,
+        selectedProject: project,
+        selectedSession,
+        ws,
+        sendMessage,
+        subscribe,
+        resetStreamingState,
+        statusCheckSentAtRef,
+        lastSeqRef,
+        sessionStore: store,
+      });
+      useLayoutEffect(() => { beforePassiveCleanup?.(); }, [beforePassiveCleanup]);
+      return { chat, store };
+    },
+    { initialProps: props },
+  );
+  await waitFor(() => expect(view.result.current.chat.chatMessages[0]?.content).toBe('cached answer'));
+  return { ...view, props, firstSocket, replacementSocket, sendMessage, dispatch, registeredListeners };
+}
+
+const ack = (sessionId = SESSION_ID): ServerEvent => ({ kind: 'chat_subscribed', sessionId });
+
+test('initial subscription and visibility-only changes do not refresh or resubscribe', async () => {
+  const view = await renderSession();
+  vi.useFakeTimers();
+  await act(async () => view.dispatch(ack()));
+  expect(sessionMessages).toHaveBeenCalledTimes(1);
+
+  await act(async () => view.rerender({ ...view.props, isActive: false }));
+  await act(async () => view.rerender({ ...view.props, session: { ...session } }));
+  expect(view.sendMessage).toHaveBeenCalledTimes(1);
+  expect(sessionMessages).toHaveBeenCalledTimes(1);
+  await act(async () => vi.advanceTimersByTimeAsync(10_000));
+  expect(view.firstSocket.close).not.toHaveBeenCalled();
+});
+
+test('replacement waits for its matching ack before fetching and displaying persisted history', async () => {
+  const view = await renderSession();
+  persisted.set(SESSION_ID, 'finished while disconnected');
+  await act(async () => view.rerender({ ...view.props, ws: view.replacementSocket }));
+
+  expect(view.sendMessage).toHaveBeenLastCalledWith({
+    type: 'chat.subscribe',
+    sessions: [{ sessionId: SESSION_ID, lastSeq: 41 }],
+  });
+  expect(sessionMessages).toHaveBeenCalledTimes(1);
+  expect(view.result.current.chat.chatMessages[0]?.content).toBe('cached answer');
+
+  await act(async () => {
+    view.dispatch({ kind: 'chat_subscribed' });
+    view.dispatch(ack('unrelated-session'));
+  });
+  expect(sessionMessages).toHaveBeenCalledTimes(1);
+
+  await act(async () => view.dispatch(ack()));
+  await waitFor(() => expect(view.result.current.chat.chatMessages[0]?.content).toBe('finished while disconnected'));
+  expect(sessionMessages).toHaveBeenCalledTimes(2);
+  expect(sessionMessages).toHaveBeenLastCalledWith(
+    SESSION_ID,
+    { limit: SESSION_MESSAGES_PAGE_SIZE, offset: 0 },
+    expect.objectContaining({ signal: expect.any(AbortSignal) }),
+  );
+  await act(async () => view.dispatch(ack()));
+  expect(sessionMessages).toHaveBeenCalledTimes(2);
+});
+
+test('a missing reconnect ack closes the socket despite protocol errors and pongs, then catches up after reattachment', async () => {
+  const view = await renderSession();
+  vi.useFakeTimers();
+  persisted.set(SESSION_ID, 'finished during failed attachment');
+  await act(async () => view.rerender({ ...view.props, ws: view.replacementSocket }));
+  const staleListener = view.registeredListeners.at(-1);
+  if (!staleListener) throw new Error('Expected subscription listener');
+
+  await act(async () => {
+    view.dispatch({ kind: 'protocol_error', message: 'Unrelated request failed' });
+    view.dispatch({ kind: 'chat_subscribed' });
+    view.dispatch(ack('unrelated-session'));
+    view.dispatch({ kind: 'pong', nonce: 'successful-heartbeat' });
+    view.registeredListeners[0]?.(ack());
+    await vi.advanceTimersByTimeAsync(9_999);
+  });
+  expect(view.replacementSocket.close).not.toHaveBeenCalled();
+  expect(sessionMessages).toHaveBeenCalledTimes(1);
+
+  await act(async () => vi.advanceTimersByTimeAsync(1));
+  expect(view.replacementSocket.close).toHaveBeenCalledTimes(1);
+  expect(sessionMessages).toHaveBeenCalledTimes(1);
+  expect(view.result.current.chat.chatMessages[0]?.content).toBe('cached answer');
+
+  // Model the provider's close -> disconnected -> replacement-open lifecycle.
+  await act(async () => view.rerender({ ...view.props, ws: null }));
+  const nextSocket = new FakeWebSocket();
+  await act(async () => view.rerender({ ...view.props, ws: nextSocket }));
+  expect(view.sendMessage).toHaveBeenCalledTimes(3);
+  expect(view.sendMessage).toHaveBeenLastCalledWith({
+    type: 'chat.subscribe',
+    sessions: [{ sessionId: SESSION_ID, lastSeq: 41 }],
+  });
+  await act(async () => staleListener(ack()));
+  expect(sessionMessages).toHaveBeenCalledTimes(1);
+
+  persisted.set(SESSION_ID, 'latest completion after reattachment');
+  await act(async () => view.dispatch(ack()));
+  expect(view.result.current.chat.chatMessages[0]?.content).toBe('latest completion after reattachment');
+  expect(sessionMessages).toHaveBeenCalledTimes(2);
+  await act(async () => vi.advanceTimersByTimeAsync(10_000));
+  expect(nextSocket.close).not.toHaveBeenCalled();
+});
+
+test('an ack delivered during send is observed because the listener is already armed', async () => {
+  const view = await renderSession();
+  vi.useFakeTimers();
+  persisted.set(SESSION_ID, 'caught up');
+  view.sendMessage.mockImplementation(() => view.dispatch(ack()));
+
+  await act(async () => view.rerender({ ...view.props, ws: view.replacementSocket }));
+  expect(view.result.current.chat.chatMessages[0]?.content).toBe('caught up');
+  expect(sessionMessages).toHaveBeenCalledTimes(2);
+  await act(async () => vi.advanceTimersByTimeAsync(10_000));
+  expect(view.replacementSocket.close).not.toHaveBeenCalled();
+});
+
+test('a hidden replacement subscribes and acknowledges, but fetches only on activation', async () => {
+  const view = await renderSession();
+  const reconnected = { ...view.props, ws: view.replacementSocket };
+  persisted.set(SESSION_ID, 'hidden completion');
+
+  await act(async () => view.rerender({ ...reconnected, isActive: false }));
+  expect(view.sendMessage).toHaveBeenCalledTimes(2);
+  await act(async () => view.dispatch(ack()));
+  expect(sessionMessages).toHaveBeenCalledTimes(1);
+
+  await act(async () => view.rerender(reconnected));
+  await waitFor(() => expect(view.result.current.chat.chatMessages[0]?.content).toBe('hidden completion'));
+  expect(view.sendMessage).toHaveBeenCalledTimes(2);
+  expect(sessionMessages).toHaveBeenCalledTimes(2);
+});
+
+test('a hidden missing-ack timeout reattaches without fetching until activation', async () => {
+  const view = await renderSession();
+  vi.useFakeTimers();
+  const hidden = { ...view.props, isActive: false };
+  persisted.set(SESSION_ID, 'completed while hidden');
+  await act(async () => view.rerender({ ...hidden, ws: view.replacementSocket }));
+  await act(async () => vi.advanceTimersByTimeAsync(10_000));
+  expect(view.replacementSocket.close).toHaveBeenCalledTimes(1);
+  expect(sessionMessages).toHaveBeenCalledTimes(1);
+
+  await act(async () => view.rerender({ ...hidden, ws: null }));
+  const nextSocket = new FakeWebSocket();
+  await act(async () => view.rerender({ ...hidden, ws: nextSocket }));
+  await act(async () => view.dispatch(ack()));
+  await act(async () => vi.advanceTimersByTimeAsync(10_000));
+  expect(nextSocket.close).not.toHaveBeenCalled();
+  expect(sessionMessages).toHaveBeenCalledTimes(1);
+  expect(view.result.current.chat.chatMessages[0]?.content).toBe('cached answer');
+  expect(view.sendMessage).toHaveBeenCalledTimes(3);
+
+  await act(async () => view.rerender({ ...view.props, ws: nextSocket }));
+  expect(view.result.current.chat.chatMessages[0]?.content).toBe('completed while hidden');
+  expect(sessionMessages).toHaveBeenCalledTimes(2);
+  expect(view.sendMessage).toHaveBeenCalledTimes(3);
+});
+
+test('activation cannot flush queued or stale-history refreshes before the reconnect ack', async () => {
+  const view = await renderSession();
+  const reconnected = { ...view.props, ws: view.replacementSocket };
+  persisted.set(SESSION_ID, 'acknowledged completion');
+  await act(async () => view.rerender({ ...reconnected, isActive: false }));
+  // Model an existing hidden completion signal and a cache that aged while hidden.
+  await act(async () => view.result.current.chat.requestLatestMessages(SESSION_ID, false));
+  const slot = view.result.current.store.getSessionSlot(SESSION_ID);
+  if (!slot) throw new Error('Expected hydrated history');
+  slot.fetchedAt = Date.now() - 60_000;
+
+  await act(async () => view.rerender(reconnected));
+  expect(sessionMessages).toHaveBeenCalledTimes(1);
+  expect(view.result.current.chat.chatMessages[0]?.content).toBe('cached answer');
+  expect(view.sendMessage).toHaveBeenCalledTimes(2);
+
+  await act(async () => view.dispatch(ack()));
+  await waitFor(() => expect(view.result.current.chat.chatMessages[0]?.content).toBe('acknowledged completion'));
+  expect(sessionMessages).toHaveBeenCalledTimes(2);
+});
+
+test('a disconnected socket callback cannot acknowledge its replacement', async () => {
+  const view = await renderSession();
+  vi.useFakeTimers();
+  await act(async () => view.rerender({ ...view.props, ws: view.replacementSocket }));
+  const staleListener = view.registeredListeners[view.registeredListeners.length - 1];
+  if (!staleListener) throw new Error('Expected subscription listener');
+  await act(async () => vi.advanceTimersByTimeAsync(5_000));
+  await act(async () => view.rerender({ ...view.props, ws: null }));
+  const nextSocket = new FakeWebSocket();
+  await act(async () => view.rerender({ ...view.props, ws: nextSocket }));
+
+  await act(async () => staleListener(ack()));
+  expect(sessionMessages).toHaveBeenCalledTimes(1);
+  await act(async () => vi.advanceTimersByTimeAsync(5_000));
+  expect(view.replacementSocket.close).not.toHaveBeenCalled();
+  expect(nextSocket.close).not.toHaveBeenCalled();
+  persisted.set(SESSION_ID, 'current socket completion');
+  await act(async () => view.dispatch(ack()));
+  expect(view.result.current.chat.chatMessages[0]?.content).toBe('current socket completion');
+});
+
+test('switching sessions at the ack deadline keeps the socket open and loads the new session', async () => {
+  const view = await renderSession();
+  vi.useFakeTimers();
+  await act(async () => view.rerender({ ...view.props, ws: view.replacementSocket }));
+  const staleListener = view.registeredListeners[view.registeredListeners.length - 1];
+  if (!staleListener) throw new Error('Expected subscription listener');
+  persisted.set('session-b', 'other conversation');
+  await act(async () => view.rerender({
+    ...view.props,
+    ws: view.replacementSocket,
+    session: { id: 'session-b' },
+    // The old deadline can run after render updates the session ref but before
+    // the subscription effect has cleaned up its previous timer.
+    beforePassiveCleanup: () => { vi.advanceTimersByTime(10_000); },
+  }));
+  expect(view.result.current.chat.chatMessages[0]?.content).toBe('other conversation');
+  expect(sessionMessages).toHaveBeenCalledTimes(2);
+
+  await act(async () => {
+    staleListener(ack());
+    view.dispatch(ack());
+    view.dispatch(ack('session-b'));
+  });
+  await act(async () => vi.advanceTimersByTimeAsync(10_000));
+  expect(view.replacementSocket.close).not.toHaveBeenCalled();
+  expect(sessionMessages).toHaveBeenCalledTimes(2);
+  expect(view.result.current.chat.chatMessages[0]?.content).toBe('other conversation');
+});
+
+test('a session selected after an unselected reconnect only performs its initial history load', async () => {
+  const view = await renderSession();
+  await act(async () => view.rerender({ ...view.props, session: null }));
+  await act(async () => view.rerender({ ...view.props, session: null, ws: view.replacementSocket }));
+  persisted.set('session-b', 'new selection');
+  await act(async () => view.rerender({
+    ...view.props,
+    session: { id: 'session-b' },
+    ws: view.replacementSocket,
+  }));
+  await waitFor(() => expect(view.result.current.chat.chatMessages[0]?.content).toBe('new selection'));
+  await act(async () => view.dispatch(ack('session-b')));
+  expect(sessionMessages).toHaveBeenCalledTimes(2);
+});
+
+test('unmount clears an outstanding reconnect acknowledgement', async () => {
+  const view = await renderSession();
+  vi.useFakeTimers();
+  await act(async () => view.rerender({ ...view.props, ws: view.replacementSocket }));
+  const staleListener = view.registeredListeners[view.registeredListeners.length - 1];
+  if (!staleListener) throw new Error('Expected subscription listener');
+  view.unmount();
+
+  await act(async () => staleListener(ack()));
+  await act(async () => vi.advanceTimersByTimeAsync(10_000));
+  expect(view.replacementSocket.close).not.toHaveBeenCalled();
+  expect(sessionMessages).toHaveBeenCalledTimes(1);
+});
+
+test('reconnect notifications never become transcript rows', () => {
+  const listeners = new Set<(event: ServerEvent) => void>();
+  const subscribe = (listener: (event: ServerEvent) => void) => {
+    listeners.add(listener);
+    return () => { listeners.delete(listener); };
+  };
+  const { result } = renderHook(() => {
+    const store = useSessionStore();
+    useChatRealtimeHandlers({
+      isActive: true,
+      subscribe,
+      provider: 'claude',
+      selectedSession: session,
+      currentSessionId: SESSION_ID,
+      setTokenBudget: vi.fn(),
+      pendingPermissionRequests: [],
+      setPendingPermissionRequests: vi.fn(),
+      streamTimerRef: { current: null },
+      accumulatedStreamRef: { current: '' },
+      lastSeqRef: { current: new Map() },
+      statusCheckSentAtRef: { current: new Map() },
+      requestLatestMessages: vi.fn(async () => {}),
+      sessionStore: store,
+    });
+    return store;
+  });
+  const message = historyMessage(SESSION_ID);
+  act(() => {
+    for (const listener of listeners) {
+      listener(message);
+      listener({ kind: 'websocket_reconnected', timestamp: Date.now() });
+    }
+  });
+  expect(result.current.getMessages(SESSION_ID)).toEqual([message]);
+});

--- a/src/modules/chat/tests/transcriptScrollOwnership.test.tsx
+++ b/src/modules/chat/tests/transcriptScrollOwnership.test.tsx
@@ -107,6 +107,7 @@ async function renderChatSessionState(options: {
         selectedSession: session,
         ws: null,
         sendMessage: vi.fn(),
+        subscribe: () => () => {},
         resetStreamingState: vi.fn(),
         statusCheckSentAtRef: { current: new Map() },
         lastSeqRef: { current: new Map() },

--- a/src/shared/context/WebSocketContext.tsx
+++ b/src/shared/context/WebSocketContext.tsx
@@ -9,6 +9,7 @@ import type { ServerEvent } from '@/shared/types';
 type ServerEventListener = (event: ServerEvent) => void;
 
 type WebSocketContextType = {
+  /** The open chat socket; null until a replacement handshake completes. */
   ws: WebSocket | null;
   sendMessage: (message: unknown) => void;
   /**
@@ -24,6 +25,11 @@ type WebSocketContextType = {
 };
 
 const WebSocketContext = createContext<WebSocketContextType | null>(null);
+
+const RECONNECT_DELAY_MS = 3_000;
+const PING_INTERVAL_MS = 30_000;
+const PONG_TIMEOUT_MS = 3_000;
+const CONNECT_TIMEOUT_MS = 30_000;
 
 export const useWebSocket = () => {
   const context = useContext(WebSocketContext);
@@ -46,7 +52,8 @@ const buildWebSocketUrl = (token: string | null) => {
 
 const useWebSocketProviderState = (): WebSocketContextType => {
   const wsRef = useRef<WebSocket | null>(null);
-  const unmountedRef = useRef(false); // Track if component is unmounted
+  // Lets sendMessage retire a failed socket through the active auth effect.
+  const retireSocketRef = useRef<(socket: WebSocket) => void>(() => {});
   const hasConnectedRef = useRef(false); // Track if we've ever connected (to detect reconnects)
   /**
    * Listener registry for the subscribe API. A ref (not state) because the
@@ -55,7 +62,6 @@ const useWebSocketProviderState = (): WebSocketContextType => {
    */
   const listenersRef = useRef(new Set<ServerEventListener>());
   const [isConnected, setIsConnected] = useState(false);
-  const reconnectTimeoutRef = useRef<NodeJS.Timeout | null>(null);
   const { isLoading: isAuthLoading, token, user } = useAuth();
 
   const dispatch = useCallback((event: ServerEvent) => {
@@ -68,102 +74,158 @@ const useWebSocketProviderState = (): WebSocketContextType => {
     }
   }, []);
 
-  // Named function expression so the reconnect timer below can call itself
-  // without reading the `connect` binding while it is still initializing.
-  const connect = useCallback(function connect() {
-    if (unmountedRef.current) return; // Prevent connection if unmounted
-    if (!IS_PLATFORM && (isAuthLoading || !user)) return;
-    try {
-      // Construct WebSocket URL
-      const wsUrl = buildWebSocketUrl(token);
-
-      if (!wsUrl) return console.warn('No authentication token found for WebSocket connection');
-
-      const websocket = new WebSocket(wsUrl);
-      // Store connecting sockets too, so a token refresh can close them before
-      // their handshake completes with stale credentials.
-      wsRef.current = websocket;
-
-      websocket.onopen = () => {
-        setIsConnected(true);
-        if (hasConnectedRef.current) {
-          // This is a reconnect — signal so components can catch up on missed messages
-          dispatch({ kind: 'websocket_reconnected', timestamp: Date.now() });
-        }
-        hasConnectedRef.current = true;
-      };
-
-      websocket.onmessage = (event) => {
-        try {
-          const data = JSON.parse(event.data) as ServerEvent;
-          dispatch(data);
-        } catch (error) {
-          console.error('Error parsing WebSocket message:', error);
-        }
-      };
-
-      websocket.onclose = () => {
-        if (wsRef.current !== websocket) {
-          return;
-        }
-        setIsConnected(false);
-        wsRef.current = null;
-
-        // Attempt to reconnect after 3 seconds
-        reconnectTimeoutRef.current = setTimeout(() => {
-          if (unmountedRef.current) return; // Prevent reconnection if unmounted
-          connect();
-        }, 3000);
-      };
-
-      websocket.onerror = (error) => {
-        console.error('WebSocket error:', error);
-      };
-
-    } catch (error) {
-      console.error('Error creating WebSocket connection:', error);
-    }
-  }, [dispatch, isAuthLoading, token, user]); // reconnect with current authentication state
-
-  // Declared after `connect` so the effect body does not reference it before
-  // initialization. `connect` is memoized on [dispatch, isAuthLoading, token,
-  // user] and `dispatch` is stable, so depending on it reconnects on exactly
-  // the same transitions as the previous [isAuthLoading, token, user] list.
   useEffect(() => {
-    // The cleanup below sets unmountedRef = true. Without this reset, every
-    // re-run of the effect (e.g. on token refresh) would short-circuit connect()
-    // at its unmounted guard and leave the socket permanently disconnected.
-    unmountedRef.current = false;
     if (!IS_PLATFORM && (isAuthLoading || !user)) {
-      return undefined;
+      return;
     }
-    connect();
 
-    return () => {
-      unmountedRef.current = true;
-      if (reconnectTimeoutRef.current) {
-        clearTimeout(reconnectTimeoutRef.current);
-      }
-      const activeSocket = wsRef.current;
-      if (activeSocket) {
-        // Prevent the intentionally closed, old-token socket from scheduling
-        // a reconnect after the refreshed-token effect has already started.
-        activeSocket.onopen = null;
-        activeSocket.onmessage = null;
-        activeSocket.onclose = null;
-        activeSocket.onerror = null;
-        activeSocket.close();
-        wsRef.current = null;
+    let disposed = false;
+    // One deadline owns the handshake, next ping, pending pong, or retry.
+    let timer: number | null = null;
+    let pendingNonce: string | null = null;
+
+    const clearTimer = () => {
+      if (timer !== null) {
+        window.clearTimeout(timer);
+        timer = null;
       }
     };
-  }, [connect, isAuthLoading, user]); // reconnect after authentication or token refresh
+
+    const schedule = (callback: () => void, delay: number) => {
+      clearTimer();
+      timer = window.setTimeout(() => {
+        timer = null;
+        if (!disposed) callback();
+      }, delay);
+    };
+
+    const closeSocket = (socket: WebSocket) => {
+      socket.onopen = null;
+      socket.onmessage = null;
+      socket.onclose = null;
+      socket.onerror = null;
+      socket.close();
+    };
+
+    const retireSocket = (socket: WebSocket) => {
+      if (disposed || wsRef.current !== socket) return;
+      pendingNonce = null;
+      wsRef.current = null;
+      setIsConnected(false);
+      closeSocket(socket);
+      schedule(connect, RECONNECT_DELAY_MS);
+    };
+    retireSocketRef.current = retireSocket;
+
+    const probe = () => {
+      const socket = wsRef.current;
+      if (!socket) {
+        // Resume events must not keep restarting an already scheduled retry.
+        if (timer === null) connect();
+        return;
+      }
+      if (socket.readyState === WebSocket.CONNECTING || pendingNonce !== null) return;
+      if (socket.readyState !== WebSocket.OPEN) {
+        retireSocket(socket);
+        return;
+      }
+
+      pendingNonce = `ping-${Date.now()}-${Math.random()}`;
+      schedule(() => retireSocket(socket), PONG_TIMEOUT_MS);
+      try {
+        socket.send(JSON.stringify({ type: 'chat.ping', nonce: pendingNonce }));
+      } catch {
+        retireSocket(socket);
+      }
+    };
+
+    function connect() {
+      if (disposed || wsRef.current) return;
+      const wsUrl = buildWebSocketUrl(token);
+      if (!wsUrl) return;
+
+      try {
+        const websocket = new WebSocket(wsUrl);
+        wsRef.current = websocket;
+        // A handshake can stall without either an open or a close event.
+        schedule(() => retireSocket(websocket), CONNECT_TIMEOUT_MS);
+
+        websocket.onopen = () => {
+          if (disposed || wsRef.current !== websocket) return;
+          schedule(probe, PING_INTERVAL_MS);
+          setIsConnected(true);
+          if (hasConnectedRef.current) {
+            dispatch({ kind: 'websocket_reconnected', timestamp: Date.now() });
+          }
+          hasConnectedRef.current = true;
+        };
+
+        websocket.onmessage = (event) => {
+          if (disposed || wsRef.current !== websocket) return;
+          try {
+            const data = JSON.parse(event.data) as ServerEvent;
+            if (data.kind === 'pong') {
+              if (pendingNonce !== null && data.nonce === pendingNonce) {
+                pendingNonce = null;
+                schedule(probe, PING_INTERVAL_MS);
+              }
+              return;
+            }
+            dispatch(data);
+          } catch (error) {
+            console.error('Error parsing WebSocket message:', error);
+          }
+        };
+
+        websocket.onclose = () => retireSocket(websocket);
+        websocket.onerror = (error) => {
+          console.error('WebSocket error:', error);
+          retireSocket(websocket);
+        };
+      } catch (error) {
+        console.error('Error creating WebSocket connection:', error);
+        schedule(connect, RECONNECT_DELAY_MS);
+      }
+    }
+
+    const handleResume = () => {
+      if (document.visibilityState === 'visible') probe();
+    };
+
+    connect();
+    // Timers also detect half-open sockets without a page event. Browsers can
+    // throttle these while suspended; resume probes do not extend a pong deadline.
+    document.addEventListener('visibilitychange', handleResume);
+    window.addEventListener('pageshow', handleResume);
+    return () => {
+      disposed = true;
+      clearTimer();
+      pendingNonce = null;
+      retireSocketRef.current = () => {};
+      document.removeEventListener('visibilitychange', handleResume);
+      window.removeEventListener('pageshow', handleResume);
+      const socket = wsRef.current;
+      wsRef.current = null;
+      if (socket) closeSocket(socket);
+      setIsConnected(false);
+    };
+  }, [dispatch, isAuthLoading, token, user]);
 
   const sendMessage = useCallback((message: unknown) => {
     const socket = wsRef.current;
     if (socket && socket.readyState === WebSocket.OPEN) {
-      socket.send(JSON.stringify(message));
+      const payload = JSON.stringify(message);
+      try {
+        socket.send(payload);
+      } catch (error) {
+        console.error('WebSocket send error:', error);
+        retireSocketRef.current(socket);
+      }
     } else {
       console.warn('WebSocket not connected');
+      if (socket && socket.readyState !== WebSocket.CONNECTING) {
+        retireSocketRef.current(socket);
+      }
     }
   }, []);
 
@@ -176,7 +238,7 @@ const useWebSocketProviderState = (): WebSocketContextType => {
 
   const value: WebSocketContextType = useMemo(() =>
   ({
-    ws: wsRef.current,
+    ws: isConnected ? wsRef.current : null,
     sendMessage,
     subscribe,
     isConnected

--- a/src/shared/tests/webSocketContext.test.tsx
+++ b/src/shared/tests/webSocketContext.test.tsx
@@ -1,0 +1,388 @@
+import assert from 'node:assert/strict';
+
+import { act, cleanup, renderHook } from '@testing-library/react';
+import React, { useEffect } from 'react';
+import { afterEach, beforeEach, test, vi } from 'vitest';
+
+import { WebSocketProvider, useWebSocket } from '@/shared/context/WebSocketContext';
+import { AUTH_SESSION_EXPIRED_EVENT } from '@/shared/authToken';
+import type { ServerEvent } from '@/shared/types';
+
+const auth = vi.hoisted((): {
+  isLoading: boolean;
+  token: string | null;
+  user: { id: string } | null;
+} => ({ isLoading: false, token: 'first-token', user: { id: 'user' } }));
+const runtime = vi.hoisted(() => ({ platform: false }));
+vi.mock('@/modules/auth', () => ({ useAuth: () => auth }));
+vi.mock('@/shared/utils', () => ({ get IS_PLATFORM() { return runtime.platform; } }));
+
+class FakeWebSocket extends EventTarget {
+  static CONNECTING = 0;
+  static OPEN = 1;
+  static CLOSING = 2;
+  static CLOSED = 3;
+  static sockets: FakeWebSocket[] = [];
+  static constructorFailures = 0;
+
+  readyState: number = FakeWebSocket.CONNECTING;
+  onopen: ((event: Event) => void) | null = null;
+  onmessage: ((event: MessageEvent) => void) | null = null;
+  onclose: ((event: Event) => void) | null = null;
+  onerror: ((event: Event) => void) | null = null;
+  sent: Array<{ type?: string; nonce?: string }> = [];
+  sendFails = false;
+
+  constructor(readonly url: string) {
+    super();
+    if (FakeWebSocket.constructorFailures > 0) {
+      FakeWebSocket.constructorFailures -= 1;
+      throw new Error('Socket construction failed');
+    }
+    FakeWebSocket.sockets.push(this);
+  }
+
+  send(payload: string) {
+    if (this.sendFails) throw new Error('Socket send failed');
+    assert.equal(this.readyState, FakeWebSocket.OPEN);
+    this.sent.push(JSON.parse(payload));
+  }
+
+  close = vi.fn(() => {
+    this.readyState = FakeWebSocket.CLOSED;
+    this.onclose?.(new Event('close'));
+  });
+
+  open() {
+    this.readyState = FakeWebSocket.OPEN;
+    this.onopen?.(new Event('open'));
+  }
+
+  receive(frame: unknown) {
+    const event = new MessageEvent('message', { data: JSON.stringify(frame) });
+    this.onmessage?.(event);
+    this.dispatchEvent(event);
+  }
+}
+
+const wrapper = ({ children }: { children: React.ReactNode }) =>
+  React.createElement(WebSocketProvider, null, children);
+
+function mountProvider() {
+  const events: ServerEvent[] = [];
+  const hook = renderHook(() => {
+    const context = useWebSocket();
+    const { subscribe } = context;
+    useEffect(() => subscribe((event) => events.push(event)), [subscribe]);
+    return context;
+  }, { wrapper });
+  return { ...hook, events };
+}
+
+function currentSocket() {
+  const socket = FakeWebSocket.sockets.at(-1);
+  assert.ok(socket, 'the provider should construct a socket');
+  return socket;
+}
+
+function nextDeadline() {
+  act(() => { vi.advanceTimersToNextTimer(); });
+}
+
+function expectReplacement(original: FakeWebSocket) {
+  for (let attempt = 0; attempt < 4 && currentSocket() === original; attempt += 1) {
+    nextDeadline();
+  }
+  assert.notEqual(currentSocket(), original, 'the channel should recover without a page event');
+  assert.equal(FakeWebSocket.sockets.length, 2, 'recovery should create only one replacement');
+  return currentSocket();
+}
+
+function resume() {
+  act(() => {
+    document.dispatchEvent(new Event('visibilitychange'));
+    window.dispatchEvent(new Event('pageshow'));
+  });
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.stubGlobal('WebSocket', FakeWebSocket);
+  vi.spyOn(document, 'visibilityState', 'get').mockReturnValue('visible');
+  vi.spyOn(console, 'error').mockImplementation(() => {});
+  vi.spyOn(console, 'warn').mockImplementation(() => {});
+  FakeWebSocket.sockets = [];
+  FakeWebSocket.constructorFailures = 0;
+  auth.isLoading = false;
+  auth.token = 'first-token';
+  auth.user = { id: 'user' };
+  runtime.platform = false;
+  localStorage.clear();
+});
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+});
+
+test('a half-open channel recovers without resume events and delivers replacement messages', () => {
+  const { result, events } = mountProvider();
+  const original = currentSocket();
+  act(() => original.open());
+  assert.equal(result.current.isConnected, true);
+  assert.equal(events.length, 0, 'the initial connection is not a reconnect');
+
+  const replacement = expectReplacement(original);
+  assert.equal(result.current.isConnected, false);
+  const response = { kind: 'session-status', sessionId: 'session', isRunning: true };
+  act(() => {
+    replacement.open();
+    replacement.receive(response);
+    result.current.sendMessage({ type: 'chat.subscribe', sessionId: 'session' });
+  });
+  assert.equal(result.current.isConnected, true);
+  assert.equal(result.current.ws, replacement);
+  assert.equal(events[0]?.kind, 'websocket_reconnected');
+  assert.deepEqual(events.slice(1), [response]);
+  assert.deepEqual(replacement.sent, [{ type: 'chat.subscribe', sessionId: 'session' }]);
+});
+
+test('matching periodic pongs preserve the socket and never reach subscribers', () => {
+  const { events } = mountProvider();
+  const socket = currentSocket();
+  act(() => socket.open());
+
+  for (let cycle = 0; cycle < 3; cycle += 1) {
+    nextDeadline();
+    const ping = socket.sent.at(-1);
+    assert.equal(ping?.type, 'chat.ping');
+    assert.equal(typeof ping?.nonce, 'string');
+    act(() => socket.receive({ kind: 'pong', nonce: ping?.nonce }));
+    assert.equal(currentSocket(), socket);
+  }
+  assert.equal(socket.close.mock.calls.length, 0);
+  assert.deepEqual(events, []);
+});
+
+test('wrong nonces and ordinary traffic cannot satisfy a pending pong', () => {
+  const { events } = mountProvider();
+  const socket = currentSocket();
+  act(() => socket.open());
+  resume();
+  const ping = socket.sent.at(-1);
+  assert.equal(ping?.type, 'chat.ping');
+  const response = { kind: 'session-status', nonce: ping?.nonce, sessionId: 'session' };
+  act(() => {
+    socket.receive({ kind: 'pong', nonce: 'wrong-nonce' });
+    socket.receive(response);
+  });
+  expectReplacement(socket);
+  assert.deepEqual(events, [response]);
+});
+
+test('repeated page events cannot postpone a pending pong deadline', () => {
+  mountProvider();
+  const socket = currentSocket();
+  act(() => socket.open());
+  resume();
+  // Keep resuming throughout the timeout, rather than only dispatching both
+  // browser events in one tick. Restarting the deadline would never retire it.
+  for (let step = 0; step < 20 && socket.close.mock.calls.length === 0; step += 1) {
+    act(() => { vi.advanceTimersByTime(500); });
+    resume();
+  }
+  assert.equal(socket.close.mock.calls.length, 1);
+  assert.equal(socket.sent.length, 1, 'one pending probe must keep its nonce and deadline');
+  expectReplacement(socket);
+});
+
+test('closing during a probe removes its deadline and old callbacks cannot clobber the replacement', () => {
+  const { result, events } = mountProvider();
+  const socket = currentSocket();
+  act(() => socket.open());
+  resume();
+  const lateOpen = socket.onopen;
+  const lateClose = socket.onclose;
+  const lateMessage = socket.onmessage;
+  act(() => socket.close());
+  const replacement = expectReplacement(socket);
+  act(() => {
+    replacement.open();
+    lateClose?.(new Event('close'));
+    lateOpen?.(new Event('open'));
+    lateMessage?.(new MessageEvent('message', { data: JSON.stringify({ kind: 'old-frame' }) }));
+    socket.receive({ kind: 'pong', nonce: socket.sent.at(-1)?.nonce });
+  });
+  assert.equal(result.current.ws, replacement);
+  assert.equal(result.current.isConnected, true);
+  assert.deepEqual(events.map((event) => event.kind), ['websocket_reconnected']);
+  nextDeadline();
+  assert.equal(replacement.sent.at(-1)?.type, 'chat.ping');
+  assert.equal(replacement.close.mock.calls.length, 0);
+});
+
+test('ordinary close retries once and a resumed page does not create a competing connection', () => {
+  const { result } = mountProvider();
+  const socket = currentSocket();
+  act(() => socket.open());
+  act(() => socket.close());
+  assert.equal(result.current.isConnected, false);
+  resume();
+  const replacement = expectReplacement(socket);
+  resume();
+  act(() => replacement.open());
+  assert.equal(result.current.ws, replacement);
+  assert.equal(FakeWebSocket.sockets.length, 2);
+});
+
+test('constructor failure retries without a resume event using the current token', () => {
+  FakeWebSocket.constructorFailures = 1;
+  const { result, rerender } = mountProvider();
+  assert.equal(FakeWebSocket.sockets.length, 0);
+  nextDeadline();
+  const socket = currentSocket();
+  assert.equal(new URL(socket.url).searchParams.get('token'), 'first-token');
+  act(() => socket.open());
+  act(() => socket.close());
+  auth.token = 'replacement-token';
+  rerender();
+  const replacement = currentSocket();
+  assert.notEqual(replacement, socket);
+  assert.equal(new URL(replacement.url).searchParams.get('token'), 'replacement-token');
+  act(() => replacement.open());
+  assert.equal(result.current.ws, replacement);
+});
+
+test('stalled handshakes are bounded and late opens cannot publish a retired socket', () => {
+  const { result, events } = mountProvider();
+  const socket = currentSocket();
+  const lateOpen = socket.onopen;
+  resume();
+  const replacement = expectReplacement(socket);
+  act(() => lateOpen?.(new Event('open')));
+  assert.equal(result.current.isConnected, false);
+  assert.deepEqual(events, []);
+  act(() => replacement.open());
+  assert.equal(result.current.ws, replacement);
+  assert.deepEqual(events, [], 'a failed initial handshake is not a successful prior connection');
+});
+
+for (const state of [FakeWebSocket.CLOSING, FakeWebSocket.CLOSED]) {
+  test(`a socket silently entering readyState ${state} cannot block recovery`, () => {
+    mountProvider();
+    const socket = currentSocket();
+    act(() => socket.open());
+    socket.readyState = state;
+    expectReplacement(socket);
+  });
+}
+
+for (const source of ['probe', 'command']) {
+  test(`a ${source} send failure retires the socket and retries`, () => {
+    const { result } = mountProvider();
+    const socket = currentSocket();
+    act(() => socket.open());
+    socket.sendFails = true;
+    if (source === 'probe') {
+      resume();
+    } else {
+      act(() => result.current.sendMessage({ type: 'chat.subscribe', sessionId: 'session' }));
+    }
+    assert.equal(result.current.isConnected, false);
+    const replacement = expectReplacement(socket);
+    act(() => replacement.open());
+    assert.equal(result.current.ws, replacement);
+  });
+}
+
+test('token replacement, logout and unmount cancel probes and reconnect work', () => {
+  const { result, rerender, unmount } = mountProvider();
+  const socket = currentSocket();
+  act(() => socket.open());
+  resume();
+  auth.token = 'replacement-token';
+  rerender();
+  const replacement = currentSocket();
+  assert.notEqual(replacement, socket);
+  assert.equal(socket.readyState, FakeWebSocket.CLOSED);
+  assert.equal(result.current.isConnected, false);
+  assert.equal(result.current.ws, null, 'consumers must not subscribe while the replacement is connecting');
+  act(() => replacement.open());
+  assert.equal(result.current.ws, replacement, 'opening must publish the socket so chat subscribes');
+  resume();
+
+  auth.token = null;
+  auth.user = null;
+  rerender();
+  assert.equal(result.current.isConnected, false);
+  assert.equal(result.current.ws, null);
+  assert.equal(replacement.readyState, FakeWebSocket.CLOSED);
+  act(() => { vi.advanceTimersByTime(120_000); });
+  resume();
+  assert.equal(FakeWebSocket.sockets.length, 2);
+  assert.equal(vi.getTimerCount(), 0);
+
+  auth.token = 'login-token';
+  auth.user = { id: 'user' };
+  rerender();
+  const loggedIn = currentSocket();
+  act(() => loggedIn.open());
+  resume();
+  unmount();
+  act(() => { vi.advanceTimersByTime(120_000); });
+  resume();
+  assert.equal(loggedIn.readyState, FakeWebSocket.CLOSED);
+  assert.equal(FakeWebSocket.sockets.length, 3);
+  assert.equal(vi.getTimerCount(), 0);
+});
+
+test('unmount cancels a constructor retry', () => {
+  FakeWebSocket.constructorFailures = 1;
+  const { unmount } = mountProvider();
+  unmount();
+  act(() => { vi.advanceTimersByTime(120_000); });
+  resume();
+  assert.equal(FakeWebSocket.sockets.length, 0);
+  assert.equal(vi.getTimerCount(), 0);
+});
+
+test('OSS auth gates loading, missing user and missing token; platform remains tokenless', () => {
+  auth.isLoading = true;
+  const { rerender } = mountProvider();
+  resume();
+  assert.equal(FakeWebSocket.sockets.length, 0);
+  auth.isLoading = false;
+  auth.user = null;
+  rerender();
+  resume();
+  assert.equal(FakeWebSocket.sockets.length, 0);
+  auth.user = { id: 'user' };
+  auth.token = null;
+  rerender();
+  resume();
+  assert.equal(FakeWebSocket.sockets.length, 0);
+  cleanup();
+
+  runtime.platform = true;
+  auth.user = null;
+  auth.isLoading = true;
+  mountProvider();
+  assert.equal(new URL(currentSocket().url).search, '');
+});
+
+test('an expired OSS token expires the auth session without opening a channel', () => {
+  const payload = btoa(JSON.stringify({ iat: 0, exp: 1 })).replace(/=+$/, '');
+  auth.token = `header.${payload}.signature`;
+  localStorage.setItem('auth-token', auth.token);
+  const expired = vi.fn();
+  window.addEventListener(AUTH_SESSION_EXPIRED_EVENT, expired);
+  try {
+    mountProvider();
+    assert.equal(FakeWebSocket.sockets.length, 0);
+    assert.equal(localStorage.getItem('auth-token'), null);
+    assert.equal(expired.mock.calls.length, 1);
+  } finally {
+    window.removeEventListener(AUTH_SESSION_EXPIRED_EVENT, expired);
+  }
+});

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -197,7 +197,7 @@ export type SessionActivitySnapshot = {
 /**
  * One frame received from the chat websocket. The server guarantees every
  * frame carries a `kind` (provider message kinds plus gateway kinds such as
- * `chat_subscribed`, `session_upserted`, `loading_progress`,
+ * `chat_subscribed`, `pong`, `session_upserted`, `loading_progress`,
  * `protocol_error`). The synthetic `websocket_reconnected` kind is injected
  * client-side when the socket re-opens after a drop.
  */


### PR DESCRIPTION
## Purpose

Supersedes #1283 with one commit based on upstream `main` at `5e73a49b`. This carries the reviewed reconnect fix and adds recovery when a replacement socket never acknowledges its chat subscription.

Restore the shared `/ws` chat connection when it stops working, then restore the selected chat's subscription and persisted history. Provider startup, abort behavior, defaults, authentication modes, `/shell`, and plugin WebSockets are unchanged.

## Behavior

- Send a nonce-bearing `chat.ping` 30 seconds after connection or a matching pong. If no matching pong arrives within 3 seconds, retire the socket and retry after the existing 3-second delay. A handshake stuck for 30 seconds also retries. The gateway rejects missing or non-string nonces with `protocol_error` / `INVALID_NONCE`, without emitting a pong or closing the socket.
- Keep visible-page and `pageshow` probes as faster triggers, but do not depend on those events. Use one transport timer and reject stale socket callbacks; token changes, logout, and unmount clean up the old connection.
- Publish only open sockets to chat. After replacement, subscribe first and wait for the matching `chat_subscribed` acknowledgement before refreshing history. Synthetic reconnect notifications never enter transcript storage.
- Bound the reconnect acknowledgement wait to 10 seconds. If it expires, close that socket and let the existing transport reconnect and resubscribe, even when heartbeats remain healthy. A timer-only HTTP fallback would not restore live subscription, so history still waits for a successful acknowledgement. Persistent server errors keep retrying rather than being treated as success.
- Cancel the acknowledgement deadline on acknowledgement, socket/session change, or unmount. Preserve initial history loading and hidden-chat HTTP gating; visibility-only changes do not resubscribe.

The server sends replay after the acknowledgement, so replay and the history request may overlap. Browser timer suspension/throttling can delay recovery. Failed application messages are not automatically resent. Retry backoff and provider-run interruption changes are outside this PR.

## Verification

**Native Chromium fixtures, using actual client hooks and gateway code:**

- A TCP-blackholed socket on upstream `5e73a49b` stayed apparently connected with no replacement or new message after 51 seconds. The carried transport fix made exactly one replacement by the 40-second observation and received the message, without visibility/page-show events.
- For the new failure path, forced the gateway's pending-approval lookup to throw during reconnect subscription while heartbeats continued working. The previous PR left history blocked. This revision closed the unacknowledged socket, received a fresh subscription acknowledgement, refreshed persisted history, and received a live message through the run registry.
- The new visible/hidden missing-ack regressions fail against the original PR hook and pass with this revision. Tests also cover acknowledgement/deadline cleanup, auth/token rotation, stale callbacks, healthy sockets, initial loading, and hidden-session activation. The session-switch test also fires the old deadline after the new session renders but before passive-effect cleanup; it fails without the session-identity guard and passes with it.

These are isolated fixtures with stubbed authentication/provider execution, not a physical laptop-suspend test or a provider-backed conversation.

The real-socket gateway regression rejects a malformed nonce without a pong, then confirms valid pings still work on the same socket without provider calls or broadcasts. It fails before nonce validation and passes afterward.

**Commands on this branch:**

- `npm run test:client`: 424 passed.
- `npm test`: 416 passed, one Codex fixture-dependent skip.
- `npm run typecheck`: passed.
- `npm run build`: passed, with CSS/bundle-size warnings.
- `npm run lint`: successful exit, 132 warnings and no errors.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added WebSocket health checks to detect unavailable connections and recover automatically.
  - Added support for resuming chat sessions after reconnecting, including subscription confirmation and message catch-up.
  - Added reconnection handling when returning to an active browser tab or window.
  - Added support for `chat.ping` requests with corresponding `pong` responses.

- **Bug Fixes**
  - Improved handling of connection timeouts, failed sends, interrupted handshakes, and stale connections.
  - Prevented reconnect notifications from appearing as chat messages.
  - Improved authentication and logout handling during WebSocket recovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->