### PR TITLE
fix(providers): strip ANSI escapes from OpenCode and Cursor stderr

### DIFF
--- a/server/modules/providers/list/claude/claude-models.provider.ts
+++ b/server/modules/providers/list/claude/claude-models.provider.ts
@@ -7,7 +7,7 @@ import type {
   ProviderModelOption,
   ProviderModelsDefinition,
 } from '@/shared/types.js';
-import { buildDefaultProviderCurrentActiveModel } from '@/shared/utils.js';
+import { buildDefaultProviderCurrentActiveModel, stripAnsiSequences } from '@/shared/utils.js';
 
 /**
  * Ultracode is not one of the SDK's reasoning-effort levels. Selecting it runs the turn at
@@ -179,13 +179,6 @@ type ClaudeInitEvent = {
   };
 };
 
-const ANSI_PATTERN = new RegExp(
-  '[\\u001B\\u009B][[\\]()#;?]*(?:'
-  + '(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-ORZcf-nqry=><]'
-  + '|(?:[\\dA-PR-TZcf-ntqry=><~]))',
-  'g',
-);
-
 /**
  * Claude Code stamps locally-synthesized rows (API-error placeholders and the
  * like) with `model: "<synthetic>"`. Angle-bracketed values are placeholders,
@@ -214,8 +207,6 @@ export const extractClaudeEventModel = (event: ClaudeInitEvent, sessionId: strin
   return messageModel && !isPlaceholderModel(messageModel) ? messageModel : null;
 };
 
-const stripAnsi = (value: string): string => value.replace(ANSI_PATTERN, '');
-
 const extractTaggedContent = (content: string, tagName: string): string | null => {
   const escapedTagName = tagName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
   const match = new RegExp(`<${escapedTagName}>([\\s\\S]*?)<\\/${escapedTagName}>`).exec(content);
@@ -225,7 +216,7 @@ const extractTaggedContent = (content: string, tagName: string): string | null =
 const extractClaudeModelFromTextContent = (content: string): string | null => {
   const localCommandStdout = extractTaggedContent(content, 'local-command-stdout');
   if (localCommandStdout !== null) {
-    const cleanedStdout = stripAnsi(localCommandStdout).replace(/\s+/g, ' ').trim();
+    const cleanedStdout = stripAnsiSequences(localCommandStdout).replace(/\s+/g, ' ').trim();
     const changedModel = /(?:set|changed|switched)\s+model\s+to\s+(.+?)\.?$/i.exec(cleanedStdout);
     const stdoutModel = changedModel?.[1]?.trim();
     // A placeholder stdout hit must not shadow a real <model> tag further down.

--- a/server/modules/providers/list/claude/claude-sessions.provider.ts
+++ b/server/modules/providers/list/claude/claude-sessions.provider.ts
@@ -19,6 +19,7 @@ import {
   generateMessageId,
   readObjectRecord,
   sliceTailPage,
+  stripAnsiSequences,
   truncateSubagentActivity,
 } from '@/shared/utils.js';
 import { sessionsDb } from '@/modules/database/index.js';
@@ -638,14 +639,6 @@ function buildLocalCommandDisplayText(payload: ClaudeLocalCommandPayload): strin
   return commandArgs ? `${baseCommand} ${commandArgs}` : baseCommand;
 }
 
-/**
- * Claude local-command stdout may contain ANSI styling codes because it was
- * captured from the terminal. The web chat should receive readable plain text.
- */
-function stripAnsiFormatting(text: string): string {
-  return text.replace(/\u001B\[[0-9;?]*[ -/]*[@-~]/g, '');
-}
-
 export class ClaudeSessionsProvider implements IProviderSessions {
   /**
    * Normalizes one Claude JSONL entry or live SDK stream event into the shared
@@ -840,7 +833,7 @@ export class ClaudeSessionsProvider implements IProviderSessions {
          */
         const localCommandStdout = extractTaggedContent(text, 'local-command-stdout');
         if (localCommandStdout !== null) {
-          const stdoutText = stripAnsiFormatting(localCommandStdout).trim();
+          const stdoutText = stripAnsiSequences(localCommandStdout).trim();
           if (stdoutText) {
             messages.push(createNormalizedMessage({
               id: baseId,

--- a/server/modules/providers/list/cursor/cursor-runtime.provider.js
+++ b/server/modules/providers/list/cursor/cursor-runtime.provider.js
@@ -6,7 +6,7 @@ import {
   normalizeAttachmentDescriptors
 } from '@/shared/image-attachments.js';
 import { notifyRunFailed, notifyRunStopped } from '@/modules/notifications/index.js';
-import { createCompleteMessage, createNormalizedMessage, flattenPromptForWindowsShell } from '@/shared/utils.js';
+import { createCompleteMessage, createNormalizedMessage, flattenPromptForWindowsShell, stripAnsiSequences } from '@/shared/utils.js';
 
 // cross-spawn resolves .cmd shims/PATHEXT on Windows and delegates to
 // child_process.spawn everywhere else.
@@ -277,7 +277,14 @@ async function spawnCursor(command, options = {}, ws, context) {
           return;
         }
 
-        ws.send(createNormalizedMessage({ kind: 'error', content: stderrText, sessionId: capturedSessionId || sessionId || null, provider: 'cursor' }));
+        // The CLI styles its stderr for a terminal; the chat renders plain
+        // text, so the escapes have to go before the text is surfaced.
+        const cleanedStderrText = stripAnsiSequences(stderrText);
+        if (!cleanedStderrText.trim()) {
+          return;
+        }
+
+        ws.send(createNormalizedMessage({ kind: 'error', content: cleanedStderrText, sessionId: capturedSessionId || sessionId || null, provider: 'cursor' }));
       });
 
       // Handle process completion

--- a/server/modules/providers/list/opencode/opencode-runtime.provider.js
+++ b/server/modules/providers/list/opencode/opencode-runtime.provider.js
@@ -9,7 +9,7 @@ import {
   normalizeAttachmentDescriptors
 } from '@/shared/image-attachments.js';
 import { notifyRunFailed, notifyRunStopped } from '@/modules/notifications/index.js';
-import { createCompleteMessage, createNormalizedMessage, flattenPromptForWindowsShell, getOpenCodeDatabasePath } from '@/shared/utils.js';
+import { createCompleteMessage, createNormalizedMessage, flattenPromptForWindowsShell, getOpenCodeDatabasePath, stripAnsiSequences } from '@/shared/utils.js';
 
 // cross-spawn resolves .cmd shims/PATHEXT on Windows and delegates to
 // child_process.spawn everywhere else.
@@ -308,7 +308,10 @@ async function spawnOpenCode(command, options = {}, ws, context) {
       });
 
       opencodeProcess.stderr.on('data', (data) => {
-        const stderrText = data.toString();
+        // opencode styles its stderr for a terminal; the chat renders plain
+        // text, so the escapes have to go before the text is surfaced. A chunk
+        // that was styling only cleans down to nothing and is not an error.
+        const stderrText = stripAnsiSequences(data.toString());
         if (!stderrText.trim()) {
           return;
         }

--- a/server/modules/providers/services/session-conversations-search.service.ts
+++ b/server/modules/providers/services/session-conversations-search.service.ts
@@ -5,6 +5,7 @@ import readline from 'node:readline';
 import { spawn } from 'cross-spawn';
 import { rgPath } from '@vscode/ripgrep';
 
+import { stripAnsiSequences } from '@/shared/utils.js';
 import { projectsDb, sessionsDb } from '@/modules/database/index.js';
 
 type AnyRecord = Record<string, any>;
@@ -409,10 +410,6 @@ function buildClaudeLocalCommandDisplayText(payload: ClaudeLocalCommandPayload):
   return commandArgs ? `${baseCommand} ${commandArgs}` : baseCommand;
 }
 
-function stripAnsiFormatting(text: string): string {
-  return text.replace(/\u001B\[[0-9;?]*[ -/]*[@-~]/g, '');
-}
-
 type ClaudeSearchableMessage = {
   text: string;
   role: 'user' | 'assistant';
@@ -456,7 +453,7 @@ function extractClaudeSearchableMessage(entry: AnyRecord): ClaudeSearchableMessa
 
     const localCommandStdout = extractTaggedContent(content, 'local-command-stdout');
     if (localCommandStdout !== null) {
-      const stdoutText = stripAnsiFormatting(localCommandStdout).trim();
+      const stdoutText = stripAnsiSequences(localCommandStdout).trim();
       return stdoutText
         ? {
             text: stdoutText,

--- a/server/modules/websocket/services/shell-websocket.service.ts
+++ b/server/modules/websocket/services/shell-websocket.service.ts
@@ -5,7 +5,7 @@ import path from 'node:path';
 import pty, { type IPty } from 'node-pty';
 import { WebSocket, type RawData } from 'ws';
 
-import { parseIncomingJsonObject } from '@/shared/utils.js';
+import { parseIncomingJsonObject, stripAnsiSequences } from '@/shared/utils.js';
 
 type ShellIncomingMessage = {
   type?: string;
@@ -34,12 +34,7 @@ type PtySessionEntry = {
 const ptySessionsMap = new Map<string, PtySessionEntry>();
 const PTY_SESSION_TIMEOUT = 30 * 60 * 1000;
 const SHELL_URL_PARSE_BUFFER_LIMIT = 32768;
-const ANSI_ESCAPE_SEQUENCE_REGEX = /\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~]|\][^\x07]*(?:\x07|\x1B\\))/g;
 const TRAILING_URL_PUNCTUATION_REGEX = /[)\]}>.,;:!?]+$/;
-
-function stripAnsiSequences(value: string): string {
-  return value.replace(ANSI_ESCAPE_SEQUENCE_REGEX, '');
-}
 
 function normalizeDetectedUrl(url: string): string | null {
   const cleanedUrl = url.trim().replace(TRAILING_URL_PUNCTUATION_REGEX, '');

--- a/server/shared/tests/strip-ansi-sequences.test.ts
+++ b/server/shared/tests/strip-ansi-sequences.test.ts
@@ -1,0 +1,42 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { stripAnsiSequences } from '@/shared/utils.js';
+
+test('strips the SGR colors a CLI writes around its own warnings', () => {
+  const styled = '\u001B[93m\u001B[1m! \u001B[0m\u001B[0mpermission requested: external_directory';
+  assert.equal(stripAnsiSequences(styled), '! permission requested: external_directory');
+});
+
+test('strips CSI cursor control, including the 8-bit introducer', () => {
+  assert.equal(stripAnsiSequences('a\u001B[2Kb\u001B[?25lc'), 'abc');
+  assert.equal(stripAnsiSequences('a\u009B31mb'), 'ab');
+});
+
+test('strips an OSC sequence with either terminator, without eating the rest', () => {
+  assert.equal(stripAnsiSequences('\u001B]0;title\u0007done'), 'done');
+  assert.equal(stripAnsiSequences('\u001B]8;;https://example.com\u001B\\link'), 'link');
+});
+
+test('strips other ECMA-48 escape sequences such as charset selection', () => {
+  assert.equal(stripAnsiSequences('\u001B(Bplain'), 'plain');
+});
+
+test('leaves text without escape sequences untouched', () => {
+  assert.equal(stripAnsiSequences('plain [93m-looking text'), 'plain [93m-looking text');
+});
+
+test('strips a CSI sequence that carries a private parameter byte', () => {
+  assert.equal(stripAnsiSequences('a\u001B[>cb'), 'ab');
+});
+
+test('stops an unterminated OSC at the next escape, so later styling still strips', () => {
+  assert.equal(
+    stripAnsiSequences('\u001B]0;unterminated\u001B[31mred\u001B[0m'),
+    '0;unterminatedred',
+  );
+});
+
+test('reduces a styling-only chunk to an empty string', () => {
+  assert.equal(stripAnsiSequences('\u001B[0m\u001B[2K'), '');
+});

--- a/server/shared/utils.ts
+++ b/server/shared/utils.ts
@@ -1127,6 +1127,35 @@ export function flattenPromptForWindowsShell(prompt: string): string {
 
 // ---------------------------
 //----------------- TERMINAL OUTPUT UTILITIES ------------
+/**
+ * Matches the escape sequences a CLI emits when it believes it is writing to a
+ * terminal, in the three shapes those tools actually produce:
+ * - OSC (`ESC ]` … terminated by BEL or ST), used for titles and hyperlinks.
+ * - CSI (`ESC [`, or the 8-bit `\u009B` introducer that stands in for both
+ *   bytes), used for SGR colors and cursor control.
+ * - any other ECMA-48 escape sequence: `ESC`, optional intermediate bytes
+ *   (`0x20`-`0x2F`), one final byte (`0x30`-`0x7E`), such as `ESC ( B`.
+ *
+ * OSC and CSI are listed first so their terminators are consumed by the
+ * specific alternative rather than by the generic one.
+ */
+const ANSI_ESCAPE_SEQUENCE_REGEX =
+  /\u001B\][^\u0007\u001B]*(?:\u0007|\u001B\\)|(?:\u001B\[|\u009B)[0-?]*[ -/]*[@-~]|\u001B[ -/]*[0-~]/g;
+
+/**
+ * Removes ANSI escape sequences from text captured off a CLI's stdout or
+ * stderr. Provider runtimes, session readers, and the shell WebSocket share
+ * this because every one of them forwards captured process output to a web
+ * client that renders plain text: left in, the escapes show up verbatim
+ * (`[93m[1m!`) instead of as styling.
+ *
+ * The result can be empty when the input was styling only, so callers that
+ * forward the text should re-check for emptiness after cleaning.
+ */
+export function stripAnsiSequences(value: string): string {
+  return value.replace(ANSI_ESCAPE_SEQUENCE_REGEX, '');
+}
+
 const ANSI_TERMINAL_STYLES = {
   reset: '\x1b[0m',
   bright: '\x1b[1m',


### PR DESCRIPTION
## The bug

When an OpenCode run writes to stderr, `opencode-runtime.provider.js` forwards the chunk to the chat verbatim as a `kind: 'error'` message. OpenCode styles that output for a terminal, so the ANSI escapes are rendered as literal text in the UI:

```
!  Error
^[[93m^[[1m! ^[[0m^[[0mpermission requested: external_directory (/etc/*); auto-rejecting
```

`cursor-runtime.provider.js` surfaces its stderr the same way, so it has the same problem.

### Reproduce

1. Pick OpenCode as the provider and send a prompt that makes the CLI print a warning on stderr — e.g. anything that trips a permission prompt, such as asking it to read a path outside the project.
2. The error bubble in the chat shows the raw escape sequences instead of styled or plain text.

## The fix

- Strip the escapes in both runtimes before the text is sent to the client. A chunk that turns out to have been styling only now cleans down to nothing and is dropped, instead of producing an empty error bubble.
- Four private ANSI strippers had already grown in `server/`, each with a different regex and none of them exported:
  - `websocket/services/shell-websocket.service.ts` (`stripAnsiSequences`)
  - `providers/list/claude/claude-sessions.provider.ts` (`stripAnsiFormatting`)
  - `providers/services/session-conversations-search.service.ts` (`stripAnsiFormatting`)
  - `providers/list/claude/claude-models.provider.ts` (`stripAnsi`)

  One implementation now lives in `server/shared/utils.ts` next to `ANSI_TERMINAL_STYLES`, and every caller uses it. The shared pattern is the union of what those four covered, so no caller loses coverage: OSC (BEL or ST terminated), CSI in both the `ESC [` and 8-bit introducer forms, and the remaining ECMA-48 escape sequences such as `ESC ( B`.

No behavior change for the Claude session/search readers — they get a strictly wider pattern on the same inputs.

## Verification

- `npm test` — 422 tests, 0 failures (the 1 skip is the pre-existing Codex-fixture skip).
- New unit tests in `server/shared/tests/strip-ansi-sequences.test.ts`, including the exact string from the report.
- `npm run typecheck`, `npm run lint` (no new warnings), `npm run build` all clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of terminal formatting codes across Claude, Cursor, OpenCode, and shell output.
  * Chat errors now display clean, readable text without ANSI escape sequences.
  * Empty or formatting-only error output is no longer shown.
  * Claude session and search results consistently remove terminal styling from command output.

* **Tests**
  * Added coverage for terminal color, cursor-control, hyperlink, and styling sequences.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Notes for review

Three things worth flagging rather than leaving for you to find:

- **One observable behaviour change in the shell WebSocket.** The previous
  alternation order there left `8;;http://example.com` behind when stripping an
  OSC 8 hyperlink (`ESC ] 8 ; ; <url> ST`). That is now removed properly. It is a
  fix, but it means a URL announced *only* through an OSC 8 hyperlink is no longer
  picked up by the terminal's URL detector, since the text is gone along with the
  sequence.
- **The two runtime providers stay as `.js`.** The backend module standards ask for
  a TypeScript migration of files you touch, but they also warn against migrations
  outside the scope of a change, and both files are large. Happy to split that into
  its own PR if you prefer it the other way.
- **Known limitation, unchanged by this PR.** stderr arrives in chunks, so a
  sequence split across two `data` events (`ESC [9` then `3m`) still leaks its tail
  into the UI. Fixing that needs buffering at the transport level, which felt out
  of scope here.

The OSC alternative is bounded on `ESC` as well as `BEL`, so an unterminated OSC
cannot scan to the end of a large chunk (a 40 KB chunk of unterminated OSC
introducers went from ~750 ms to 0 ms) and no longer swallows whatever CSI follows
it. `ST` still matches, since it begins with `ESC`.
