### PR TITLE
fix(auth): render the message of a structured error envelope, not the object

### DIFF
--- a/src/modules/auth/context/AuthContext.tsx
+++ b/src/modules/auth/context/AuthContext.tsx
@@ -7,6 +7,7 @@ import { api } from '@/shared/api';
 import { AUTH_SESSION_EXPIRED_EVENT, AUTH_TOKEN_REFRESHED_EVENT, getAuthTokenRefreshDelay, isValidRefreshedToken, storeAuthToken } from '@/shared/authToken';
 import { hydrateChatDrafts, resetChatDrafts } from '@/shared/chatDrafts';
 import { hydrateUserPreferences, resetUserPreferences } from '@/shared/userSettings';
+import { resolveApiErrorMessage, type ApiErrorPayload } from '@/modules/auth/context/apiErrorMessage';
 /** The signed-in account held by AuthContext - a required `username` plus an optional id and any additional fields the auth API returns - and should be read through `useAuth()` rather than re-derived from raw auth responses. */
 type AuthUser = {
   id?: number | string;
@@ -45,10 +46,6 @@ type OnboardingStatusPayload = {
   hasCompletedOnboarding?: boolean;
 };
 
-type ApiErrorPayload = {
-  error?: string;
-  message?: string;
-};
 
 type AuthContextValue = {
   user: AuthUser | null;
@@ -73,14 +70,6 @@ async function parseJsonSafely<T>(response: Response): Promise<T | null> {
   } catch {
     return null;
   }
-}
-
-function resolveApiErrorMessage(payload: ApiErrorPayload | null, fallback: string): string {
-  if (!payload) {
-    return fallback;
-  }
-
-  return payload.error ?? payload.message ?? fallback;
 }
 
 const AuthContext = createContext<AuthContextValue | null>(null);

--- a/src/modules/auth/context/apiErrorMessage.ts
+++ b/src/modules/auth/context/apiErrorMessage.ts
@@ -1,0 +1,34 @@
+/**
+ * Error bodies the auth endpoints produce. The auth middleware answers with a
+ * bare `{ error: 'string' }`, while the global error middleware serialises an
+ * `AppError` as `{ success: false, error: { code, message, details } }`.
+ */
+export type ApiErrorPayload = {
+  error?: string | { code?: string; message?: string; details?: unknown };
+  message?: string;
+};
+
+/**
+ * Picks the human-readable message out of an auth error body, whatever its
+ * shape. Returning the structured `error` object itself sent it into
+ * `AuthErrorAlert` as a React child, which throws and unmounts the login
+ * screen.
+ */
+export function resolveApiErrorMessage(payload: ApiErrorPayload | null, fallback: string): string {
+  if (!payload) {
+    return fallback;
+  }
+
+  const { error, message } = payload;
+  if (typeof error === 'string' && error) {
+    return error;
+  }
+  if (error && typeof error === 'object' && typeof error.message === 'string' && error.message) {
+    return error.message;
+  }
+  if (typeof message === 'string' && message) {
+    return message;
+  }
+
+  return fallback;
+}

--- a/src/modules/auth/context/apiErrorMessage.ts
+++ b/src/modules/auth/context/apiErrorMessage.ts
@@ -20,14 +20,17 @@ export function resolveApiErrorMessage(payload: ApiErrorPayload | null, fallback
   }
 
   const { error, message } = payload;
-  if (typeof error === 'string' && error) {
-    return error;
-  }
-  if (error && typeof error === 'object' && typeof error.message === 'string' && error.message) {
-    return error.message;
-  }
-  if (typeof message === 'string' && message) {
-    return message;
+  // A blank or whitespace-only message would render an empty alert, so it
+  // counts as absent and the fallback is used instead.
+  const candidates = [
+    error,
+    error && typeof error === 'object' ? error.message : undefined,
+    message,
+  ];
+  for (const candidate of candidates) {
+    if (typeof candidate === 'string' && candidate.trim()) {
+      return candidate.trim();
+    }
   }
 
   return fallback;

--- a/src/modules/auth/tests/resolveApiErrorMessage.test.ts
+++ b/src/modules/auth/tests/resolveApiErrorMessage.test.ts
@@ -33,3 +33,11 @@ test('resolveApiErrorMessage: never returns anything but a string', () => {
   assert.equal(resolveApiErrorMessage({ error: { code: 'INTERNAL_ERROR' } }, FALLBACK), FALLBACK);
   assert.equal(resolveApiErrorMessage({ error: { message: '' } }, FALLBACK), FALLBACK);
 });
+
+test('resolveApiErrorMessage: treats blank and whitespace-only messages as absent', () => {
+  expect(resolveApiErrorMessage({ error: '   ' }, 'fallback')).toBe('fallback');
+  expect(resolveApiErrorMessage({ error: { message: '\n\t' } }, 'fallback')).toBe('fallback');
+  expect(resolveApiErrorMessage({ error: '  ', message: '   ' }, 'fallback')).toBe('fallback');
+  expect(resolveApiErrorMessage({ error: '  Invalid credentials  ' }, 'fallback')).toBe('Invalid credentials');
+});
+

--- a/src/modules/auth/tests/resolveApiErrorMessage.test.ts
+++ b/src/modules/auth/tests/resolveApiErrorMessage.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 
-import { test } from 'vitest';
+import { expect, test } from 'vitest';
 
 import { resolveApiErrorMessage } from '@/modules/auth/context/apiErrorMessage';
 

--- a/src/modules/auth/tests/resolveApiErrorMessage.test.ts
+++ b/src/modules/auth/tests/resolveApiErrorMessage.test.ts
@@ -1,0 +1,35 @@
+import assert from 'node:assert/strict';
+
+import { test } from 'vitest';
+
+import { resolveApiErrorMessage } from '@/modules/auth/context/apiErrorMessage';
+
+const FALLBACK = 'Login failed';
+
+// The global error middleware wraps every AppError (invalid credentials,
+// missing fields, password too short, ...) in a structured envelope. Handing
+// that object to the alert as a React child threw and blanked the login screen.
+test('resolveApiErrorMessage: reads the message out of the structured error envelope', () => {
+  const payload = {
+    success: false,
+    error: { code: 'AUTH_INVALID_CREDENTIALS', message: 'Invalid username or password' },
+  };
+  const resolved: string = resolveApiErrorMessage(payload, FALLBACK);
+  assert.equal(resolved, 'Invalid username or password');
+});
+
+test('resolveApiErrorMessage: keeps the bare string shape the auth middleware sends', () => {
+  assert.equal(resolveApiErrorMessage({ error: 'Invalid API key' }, FALLBACK), 'Invalid API key');
+});
+
+test('resolveApiErrorMessage: falls back to a top-level message', () => {
+  assert.equal(resolveApiErrorMessage({ message: 'Too many attempts' }, FALLBACK), 'Too many attempts');
+});
+
+test('resolveApiErrorMessage: never returns anything but a string', () => {
+  assert.equal(resolveApiErrorMessage(null, FALLBACK), FALLBACK);
+  assert.equal(resolveApiErrorMessage({}, FALLBACK), FALLBACK);
+  assert.equal(resolveApiErrorMessage({ error: '' }, FALLBACK), FALLBACK);
+  assert.equal(resolveApiErrorMessage({ error: { code: 'INTERNAL_ERROR' } }, FALLBACK), FALLBACK);
+  assert.equal(resolveApiErrorMessage({ error: { message: '' } }, FALLBACK), FALLBACK);
+});


### PR DESCRIPTION
## Summary

Fixes #1300.

Entering a wrong password blanked the login screen. The auth routes hand failures to the global error middleware, which serialises an `AppError` as `{ success: false, error: { code, message } }`, but `resolveApiErrorMessage` returned `payload.error` as-is. The envelope **object** travelled through `login()` into `LoginForm` and reached `AuthErrorAlert` as a React child, React threw while rendering `<p>{errorMessage}</p>`, and with no error boundary above `ProtectedRoute` the whole tree unmounted. The auth middleware's bare `{ error: 'string' }` responses rendered fine, which is why only some auth errors blanked the screen.

## Change

- `src/modules/auth/context/apiErrorMessage.ts` (new): `resolveApiErrorMessage` now understands both shapes: a string `error`, an `error.message` inside the envelope, or a top-level `message`, and always returns a string (empty strings and envelopes without a message fall back to the caller's default). `ApiErrorPayload` documents both shapes.
- `AuthContext.tsx` imports the helper instead of defining it; behaviour of `login` / `register` is otherwise unchanged. Moving the pure helper out of the provider file keeps the component file free of non-component exports (the fast-refresh lint rule) and makes it testable without React.

## Tests

`src/modules/auth/tests/resolveApiErrorMessage.test.ts` (vitest): the structured envelope (`AUTH_INVALID_CREDENTIALS`), the bare string shape, a top-level message, and the always-a-string guarantee (`null`, `{}`, empty strings, an envelope without `message`). Two cases fail on `main`.

`npx vitest run …/resolveApiErrorMessage.test.ts` → 4 passed; `oxlint src/modules/auth/` reports nothing for the changed files; `tsc --noEmit` clean for the auth module.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved authentication error-message handling for structured responses, plain-text errors, empty values, and incomplete responses.
  - Whitespace-only messages are now ignored, while valid messages are trimmed for clearer display.
  - Login and registration continue to show an appropriate fallback message when no usable error details are available.

- **Tests**
  - Added coverage for supported authentication error formats, whitespace handling, message trimming, and fallback scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->