### PR TITLE
feat(chat): render workspace image paths in markdown

### DIFF
--- a/src/modules/chat/ChatInterface.tsx
+++ b/src/modules/chat/ChatInterface.tsx
@@ -5,6 +5,7 @@ import { ArrowDownIcon } from 'lucide-react';
 import { useTasksSettings } from '@/modules/task-master';
 import { useWebSocket } from '@/shared/context/WebSocketContext';
 import PermissionContext from '@/modules/chat/context/PermissionContext';
+import { MarkdownWorkspaceContext } from '@/modules/chat/context/MarkdownWorkspaceContext';
 import { api } from '@/shared/api';
 import type {
   ChatMessage,
@@ -367,6 +368,11 @@ function ChatInterface({
     handlePermissionDecision,
   }), [pendingPermissionRequests, handlePermissionDecision]);
 
+  // Lets markdown image paths in the transcript resolve against this project.
+  const markdownWorkspaceValue = useMemo(() => ({
+    projectId: selectedProject?.projectId ?? null,
+  }), [selectedProject?.projectId]);
+
   // A composer pick becomes the default for new chats and, when a session is
   // open, is recorded against that session so reopening it restores this model.
   const handleSelectComposerModel = useCallback(async (model: string) => {
@@ -418,59 +424,61 @@ function ChatInterface({
   return (
     <PermissionContext.Provider value={permissionContextValue}>
       <div className="flex h-full min-h-0 flex-col">
-        <ChatMessagesPane
-          scrollContainerRef={scrollContainerRef}
-          // Not redundant with the `scroll` listener. A first page is 20 rows,
-          // tool results fold into their calls, and the "load earlier" link is
-          // hidden while more pages exist — so a short transcript is often not
-          // scrollable at all and never emits `scroll`. Wheel and touch are
-          // then the only way to reach the top pager or the "load all" overlay.
-          onWheel={handleScroll}
-          onTouchMove={handleScroll}
-          isLoadingSessionMessages={isLoadingSessionMessages}
-          isProcessing={isProcessing}
-          hasActivityIndicator={hasActivityIndicator}
-          chatMessages={chatMessages}
-          selectedSession={selectedSession}
-          currentSessionId={currentSessionId}
-          provider={provider}
-          setProvider={setProvider}
-          textareaRef={textareaRef}
-          providerModels={providerModels}
-          setProviderModel={setStoredProviderModel}
-          providerModelCatalog={providerModelCatalog}
-          providerModelActions={providerModelActions}
-          providerModelsLoading={providerModelsLoading}
-          tasksEnabled={tasksEnabled}
-          isTaskMasterInstalled={isTaskMasterInstalled}
-          onShowAllTasks={onShowAllTasks}
-          setInput={setInput}
-          isLoadingMoreMessages={isLoadingMoreMessages}
-          hasMoreMessages={hasMoreMessages}
-          totalMessages={totalMessages}
-          sessionMessagesCount={chatMessages.length}
-          visibleMessageCount={visibleMessageCount}
-          visibleMessages={visibleMessages}
-          loadEarlierMessages={loadEarlierMessages}
-          loadAllMessages={loadAllMessages}
-          allMessagesLoaded={allMessagesLoaded}
-          isLoadingAllMessages={isLoadingAllMessages}
-          loadAllJustFinished={loadAllJustFinished}
-          showLoadAllOverlay={showLoadAllOverlay}
-          createDiff={createDiff}
-          onFileOpen={onFileOpen}
-          onShowSettings={onShowSettings}
-          onGrantToolPermission={handleGrantToolPermission}
-          showRawParameters={showRawParameters}
-          showThinking={showThinking}
-          selectedProject={selectedProject}
-          // Editing replaces the turn and everything after it, so it is only
-          // offered when the session is idle — a half-truncated transcript with
-          // a live stream writing into it is not recoverable.
-          onEditMessage={supportsMessageEditing && !isProcessing ? beginEditMessage : undefined}
-          onForkFromMessage={supportsSessionForking ? handleForkFromMessage : undefined}
-          onLoadFullTranscript={loadFullTranscript}
-        />
+        <MarkdownWorkspaceContext.Provider value={markdownWorkspaceValue}>
+          <ChatMessagesPane
+            scrollContainerRef={scrollContainerRef}
+            // Not redundant with the `scroll` listener. A first page is 20 rows,
+            // tool results fold into their calls, and the "load earlier" link is
+            // hidden while more pages exist — so a short transcript is often not
+            // scrollable at all and never emits `scroll`. Wheel and touch are
+            // then the only way to reach the top pager or the "load all" overlay.
+            onWheel={handleScroll}
+            onTouchMove={handleScroll}
+            isLoadingSessionMessages={isLoadingSessionMessages}
+            isProcessing={isProcessing}
+            hasActivityIndicator={hasActivityIndicator}
+            chatMessages={chatMessages}
+            selectedSession={selectedSession}
+            currentSessionId={currentSessionId}
+            provider={provider}
+            setProvider={setProvider}
+            textareaRef={textareaRef}
+            providerModels={providerModels}
+            setProviderModel={setStoredProviderModel}
+            providerModelCatalog={providerModelCatalog}
+            providerModelActions={providerModelActions}
+            providerModelsLoading={providerModelsLoading}
+            tasksEnabled={tasksEnabled}
+            isTaskMasterInstalled={isTaskMasterInstalled}
+            onShowAllTasks={onShowAllTasks}
+            setInput={setInput}
+            isLoadingMoreMessages={isLoadingMoreMessages}
+            hasMoreMessages={hasMoreMessages}
+            totalMessages={totalMessages}
+            sessionMessagesCount={chatMessages.length}
+            visibleMessageCount={visibleMessageCount}
+            visibleMessages={visibleMessages}
+            loadEarlierMessages={loadEarlierMessages}
+            loadAllMessages={loadAllMessages}
+            allMessagesLoaded={allMessagesLoaded}
+            isLoadingAllMessages={isLoadingAllMessages}
+            loadAllJustFinished={loadAllJustFinished}
+            showLoadAllOverlay={showLoadAllOverlay}
+            createDiff={createDiff}
+            onFileOpen={onFileOpen}
+            onShowSettings={onShowSettings}
+            onGrantToolPermission={handleGrantToolPermission}
+            showRawParameters={showRawParameters}
+            showThinking={showThinking}
+            selectedProject={selectedProject}
+            // Editing replaces the turn and everything after it, so it is only
+            // offered when the session is idle — a half-truncated transcript with
+            // a live stream writing into it is not recoverable.
+            onEditMessage={supportsMessageEditing && !isProcessing ? beginEditMessage : undefined}
+            onForkFromMessage={supportsSessionForking ? handleForkFromMessage : undefined}
+            onLoadFullTranscript={loadFullTranscript}
+          />
+        </MarkdownWorkspaceContext.Provider>
 
         <div className="relative flex-shrink-0">
           {isUserScrolledUp && chatMessages.length > 0 && (

--- a/src/modules/chat/context/MarkdownWorkspaceContext.ts
+++ b/src/modules/chat/context/MarkdownWorkspaceContext.ts
@@ -1,0 +1,18 @@
+import { createContext, useContext } from 'react';
+
+/**
+ * The project that relative file references in model-authored markdown
+ * resolve against.
+ *
+ * Markdown is rendered deep inside the transcript (messages, tool results,
+ * streaming halves) and none of those call sites know the selected project.
+ * ChatInterface provides it once so `![alt](imagenes/foto.png)` can be fetched
+ * through the authenticated project files route instead of failing as a bare
+ * `<img src>` against the web origin.
+ */
+export const MarkdownWorkspaceContext = createContext<{ projectId: string | null }>({ projectId: null });
+
+/** DB `projectId` of the project the transcript belongs to, or null outside a project. */
+export function useMarkdownWorkspaceProjectId(): string | null {
+  return useContext(MarkdownWorkspaceContext).projectId;
+}

--- a/src/modules/chat/tests/markdownImage.test.tsx
+++ b/src/modules/chat/tests/markdownImage.test.tsx
@@ -1,0 +1,97 @@
+import assert from 'node:assert/strict';
+
+import { render, waitFor } from '@testing-library/react';
+import { beforeEach, test, vi } from 'vitest';
+
+import { Markdown } from '@/modules/chat/transcript/Markdown';
+import { MarkdownWorkspaceContext } from '@/modules/chat/context/MarkdownWorkspaceContext';
+
+const readFileBlob = vi.fn();
+vi.mock('@/shared/api', () => ({
+  api: {
+    readFileBlob: (...args: unknown[]) => readFileBlob(...args),
+  },
+}));
+
+/**
+ * Chat markdown that references an image by workspace path has to be fetched
+ * through the authenticated files route: a bare <img src="imagenes/x.png">
+ * resolves against the web origin and 404s. Web URLs keep loading directly.
+ */
+
+const OBJECT_URL = 'blob:mock-image';
+// jsdom has no object URLs at all, so these are stubbed for the whole file
+// rather than restored per test: React's unmount cleanup, which revokes the
+// URL, runs from the setup file's afterEach after this file's hooks.
+const createObjectURL = vi.fn(() => OBJECT_URL);
+const revokeObjectURL = vi.fn();
+URL.createObjectURL = createObjectURL;
+URL.revokeObjectURL = revokeObjectURL;
+
+beforeEach(() => {
+  readFileBlob.mockReset();
+  createObjectURL.mockClear();
+  revokeObjectURL.mockClear();
+});
+
+const renderInProject = (markdown: string, projectId: string | null = 'project-1') =>
+  render(
+    <MarkdownWorkspaceContext.Provider value={{ projectId }}>
+      <Markdown>{markdown}</Markdown>
+    </MarkdownWorkspaceContext.Provider>,
+  );
+
+test('a workspace image path is fetched through the project files route and shown as a blob', async () => {
+  readFileBlob.mockResolvedValue({ ok: true, blob: async () => new Blob(['png']) });
+
+  const { findByRole } = renderInProject('Aquí la tienes:\n\n![gato naranja](imagenes/gato.png)\n');
+
+  const img = (await findByRole('img')) as HTMLImageElement;
+  assert.equal(img.getAttribute('src'), OBJECT_URL);
+  assert.equal(img.alt, 'gato naranja');
+  assert.equal(readFileBlob.mock.calls.length, 1);
+  assert.deepEqual(readFileBlob.mock.calls[0].slice(0, 2), ['project-1', 'imagenes/gato.png']);
+});
+
+test('a leading ./ is dropped before asking the server', async () => {
+  readFileBlob.mockResolvedValue({ ok: true, blob: async () => new Blob(['png']) });
+
+  const { findByRole } = renderInProject('![captura](./out/captura.png)');
+
+  await findByRole('img');
+  assert.equal(readFileBlob.mock.calls[0][1], 'out/captura.png');
+});
+
+test('web URLs are left to the browser', () => {
+  const { getByRole } = renderInProject('![logo](https://example.com/logo.png)');
+
+  const img = getByRole('img') as HTMLImageElement;
+  assert.equal(img.getAttribute('src'), 'https://example.com/logo.png');
+  assert.equal(readFileBlob.mock.calls.length, 0);
+});
+
+test('a missing file falls back to the alt text instead of a broken image', async () => {
+  readFileBlob.mockResolvedValue({ ok: false, blob: async () => new Blob() });
+
+  const { findByText, queryByRole } = renderInProject('![gato](imagenes/nada.png)');
+
+  await findByText('gato');
+  assert.equal(queryByRole('img'), null);
+});
+
+test('without a project the path cannot be resolved and the alt text is shown', async () => {
+  const { findByText } = renderInProject('![gato](imagenes/gato.png)', null);
+
+  await findByText('gato');
+  assert.equal(readFileBlob.mock.calls.length, 0);
+});
+
+test('the image is revoked when the markdown unmounts', async () => {
+  readFileBlob.mockResolvedValue({ ok: true, blob: async () => new Blob(['png']) });
+
+  const { findByRole, unmount } = renderInProject('![gato](imagenes/gato.png)');
+  await findByRole('img');
+  unmount();
+
+  await waitFor(() => assert.equal(revokeObjectURL.mock.calls[0]?.[0], OBJECT_URL));
+});

--- a/src/modules/chat/transcript/Markdown.tsx
+++ b/src/modules/chat/transcript/Markdown.tsx
@@ -8,6 +8,7 @@ import { oneDark, oneLight } from 'react-syntax-highlighter/dist/esm/styles/pris
 import { useTranslation } from 'react-i18next';
 
 import { MermaidDiagram } from '@/modules/code-editor';
+import { MarkdownImage } from '@/modules/chat/transcript/MarkdownImage';
 import { normalizeInlineCodeFences } from '@/modules/chat/utils/chatFormatting';
 import { copyTextToClipboard } from '@/shared/utils';
 import { SyntaxHighlighter } from '@/shared/syntaxHighlighter';
@@ -195,6 +196,9 @@ if (!document.getElementById(SYNTAX_THEME_STYLE_ELEMENT_ID)) {
 
 const markdownComponents = {
   code: CodeBlock,
+  // Workspace image paths are fetched through the authenticated files route;
+  // a bare <img src> would resolve against the web origin and 404.
+  img: MarkdownImage,
   // Fenced/indented code arrives as <pre><code>. Re-render the child CodeBlock
   // with `forceBlock` so it always gets the block treatment (react-markdown v9+
   // no longer passes an `inline` flag), and skip the outer <pre> so Tailwind

--- a/src/modules/chat/transcript/MarkdownImage.tsx
+++ b/src/modules/chat/transcript/MarkdownImage.tsx
@@ -1,0 +1,153 @@
+import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { ImageOff } from 'lucide-react';
+
+import { api } from '@/shared/api';
+import { useMarkdownWorkspaceProjectId } from '@/modules/chat/context/MarkdownWorkspaceContext';
+import { ImageLightbox } from '@/modules/chat/transcript/ChatMessageImages';
+
+type MarkdownImageProps = {
+  node?: unknown;
+  src?: string;
+  alt?: string;
+  title?: string;
+};
+
+// Sources the browser can load on its own. Anything else is a workspace file
+// reference and has to go through the authenticated project files route.
+const isBrowserLoadableSrc = (src: string): boolean => /^(https?:|data:|blob:)/i.test(src);
+
+// Turn the markdown src into the path the file-tree route expects. Relative
+// paths are resolved against the project root server-side; absolute paths are
+// accepted as long as they stay inside it.
+const toWorkspacePath = (src: string): string => {
+  let workspacePath = src.trim();
+  if (workspacePath.startsWith('file://')) {
+    workspacePath = workspacePath.slice('file://'.length);
+  }
+  if (workspacePath.startsWith('./')) {
+    workspacePath = workspacePath.slice(2);
+  }
+  try {
+    workspacePath = decodeURI(workspacePath);
+  } catch {
+    // Keep the raw value when it is not valid percent-encoding.
+  }
+  return workspacePath;
+};
+
+type LoadedImage = { key: string; url: string | null; failed: boolean };
+
+/**
+ * Resolves a markdown image src to something an <img> can display. Web, data
+ * and blob URLs pass through untouched; workspace paths are fetched as blobs
+ * (a bare <img src> cannot carry the auth header) and exposed as object URLs.
+ */
+function useMarkdownImageSrc(src: string, projectId: string | null): { src: string | null; failed: boolean } {
+  const passthrough = isBrowserLoadableSrc(src);
+  // Keyed by what was requested so a src change reads as "loading" until the
+  // new fetch settles, without resetting state synchronously in the effect.
+  const key = `${projectId ?? ''}:${src}`;
+  const [loaded, setLoaded] = useState<LoadedImage | null>(null);
+
+  useEffect(() => {
+    if (passthrough || !projectId) {
+      return;
+    }
+
+    let objectUrl: string | null = null;
+    const controller = new AbortController();
+
+    const load = async () => {
+      try {
+        const response = await api.readFileBlob(projectId, toWorkspacePath(src), { signal: controller.signal });
+        if (!response.ok) {
+          setLoaded({ key, url: null, failed: true });
+          return;
+        }
+        const blob = await response.blob();
+        objectUrl = URL.createObjectURL(blob);
+        setLoaded({ key, url: objectUrl, failed: false });
+      } catch (error) {
+        if (error instanceof Error && error.name === 'AbortError') {
+          return;
+        }
+        setLoaded({ key, url: null, failed: true });
+      }
+    };
+
+    void load();
+
+    return () => {
+      controller.abort();
+      if (objectUrl) {
+        URL.revokeObjectURL(objectUrl);
+      }
+    };
+  }, [key, passthrough, projectId, src]);
+
+  if (passthrough) {
+    return { src, failed: false };
+  }
+  if (!projectId) {
+    return { src: null, failed: true };
+  }
+  const current = loaded && loaded.key === key ? loaded : null;
+  return { src: current?.url ?? null, failed: current?.failed ?? false };
+}
+
+/**
+ * `img` renderer for chat markdown. Shows images the model references by
+ * workspace path (screenshots it took, files it generated) inline, with the
+ * same click-to-expand lightbox as user attachments. Used by the shared
+ * Markdown component overrides.
+ */
+export function MarkdownImage({ node: _node, src, alt, title }: MarkdownImageProps) {
+  const { t } = useTranslation();
+  const projectId = useMarkdownWorkspaceProjectId();
+  const source = src ?? '';
+  const { src: resolved, failed } = useMarkdownImageSrc(source, projectId);
+  const [expanded, setExpanded] = useState(false);
+
+  if (!source) {
+    return null;
+  }
+
+  const label = alt || title || source;
+
+  if (failed) {
+    return (
+      <span
+        className="my-1 inline-flex max-w-full items-center gap-1.5 rounded-md border border-border/60 bg-muted px-2 py-1 text-xs text-muted-foreground"
+        title={source}
+      >
+        <ImageOff className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+        <span className="truncate">{label}</span>
+      </span>
+    );
+  }
+
+  if (!resolved) {
+    return <span className="my-2 block h-40 max-w-md animate-pulse rounded-xl border border-border/50 bg-muted" />;
+  }
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setExpanded(true)}
+        aria-label={t('chat:misc.expandImage', { name: label })}
+        className="my-2 block max-w-full overflow-hidden rounded-xl border border-border/50 bg-muted/30 shadow-sm focus:outline-none focus:ring-2 focus:ring-primary/60"
+      >
+        <img
+          src={resolved}
+          alt={alt ?? ''}
+          title={title}
+          loading="lazy"
+          className="block max-h-96 max-w-full cursor-zoom-in object-contain"
+        />
+      </button>
+      {expanded && <ImageLightbox src={resolved} alt={label} onClose={() => setExpanded(false)} />}
+    </>
+  );
+}


### PR DESCRIPTION
## What

Chat markdown that references an image by workspace path, e.g. `![cat](out/cat.png)` after the model generated or screenshotted a file, currently renders as a broken image: react-markdown emits a bare `<img src>` that the browser resolves against the web origin, and `/api/file-tree/projects/:id/files/content` needs the auth header anyway.

This adds an `img` override for chat markdown:

- Workspace paths are fetched through `api.readFileBlob` (the same authenticated route the file tree and attachment thumbnails already use), shown inline and expanded in the existing `ImageLightbox` on click.
- `http(s):`, `data:` and `blob:` sources pass through untouched.
- A missing file falls back to the alt text with an icon instead of a broken image; loading shows a placeholder.
- A leading `./` and `file://` are stripped before asking the server; the server keeps enforcing that the path stays inside the project root.

`ChatInterface` provides the selected `projectId` through a small `MarkdownWorkspaceContext` around `ChatMessagesPane`, so every `Markdown` call site in the transcript (messages, tool results, streaming halves) resolves paths against the right project without threading a prop through each of them.

## Files

- `src/modules/chat/transcript/MarkdownImage.tsx` (new)
- `src/modules/chat/context/MarkdownWorkspaceContext.ts` (new)
- `src/modules/chat/tests/markdownImage.test.tsx` (new, 6 tests)
- `src/modules/chat/transcript/Markdown.tsx`: registers `img: MarkdownImage`
- `src/modules/chat/ChatInterface.tsx`: provider around `ChatMessagesPane`

## Checks

- `npm run test:client -- src/modules/chat/tests/markdownImage.test.tsx` and the existing markdown tests pass.
- `npm run typecheck`, `npm run lint` clean for the touched files (no new warnings).
- Verified end to end on a self-hosted instance: a reply with `![...](imagenes/x.png)` now shows the PNG inline and opens the lightbox.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Markdown images in chat transcripts now support project-relative file paths.
  - Workspace images are securely loaded from the active project and displayed with loading and error states.
  - Images can be opened in an expanded lightbox view.
  - Direct web image URLs continue to load normally.

- **Bug Fixes**
  - Improved handling of missing projects, unavailable files, and relative path formats.
  - Added cleanup for temporary image resources when images are removed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->