### PR TITLE
fix(auth): stop browser HTTP cache from replaying a stale X-Refreshed-Token

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -121,6 +121,20 @@ createWebSocketServer(server, {
 });
 
 app.use(cors({ exposedHeaders: ['X-Refreshed-Token', 'X-Auth-Error'] }));
+
+// API responses must never come out of the browser's HTTP cache. Express adds a
+// weak ETag to every JSON body by default and nothing here set Cache-Control, so
+// browsers cached /api/* responses and revalidated them. On a 304 the browser
+// replays the cached response *with its cached headers*, including a stale
+// X-Refreshed-Token minted days earlier — the client then stored that expired
+// token over the fresh one and bounced the user to login (#1308).
+app.set('etag', false);
+app.use((req, res, next) => {
+    if (req.path.startsWith('/api/')) {
+        res.setHeader('Cache-Control', 'no-store');
+    }
+    next();
+});
 app.use(express.json({
     limit: '50mb',
     type: (req) => {

--- a/src/modules/file-tree/hooks/useFileTreeUpload.ts
+++ b/src/modules/file-tree/hooks/useFileTreeUpload.ts
@@ -4,7 +4,7 @@ import type { DragEvent } from 'react';
 import { IS_PLATFORM } from '@/shared/utils';
 import type { FileTreeUploadProgressState, Project } from '@/shared/types';
 import { api } from '@/shared/api';
-import { expireAuthSession, getStoredAuthToken, storeAuthToken } from '@/shared/authToken';
+import { acceptRefreshedToken, expireAuthSession, getStoredAuthToken } from '@/shared/authToken';
 import { MAX_FILE_UPLOAD_SIZE_BYTES, MAX_FILE_UPLOAD_SIZE_LABEL } from '@/shared/constants';
 
 type UseFileTreeUploadOptions = {
@@ -123,7 +123,7 @@ const uploadFormDataWithProgress = (
     xhr.onload = () => {
       const refreshedToken = xhr.getResponseHeader('X-Refreshed-Token');
       if (refreshedToken) {
-        storeAuthToken(refreshedToken);
+        acceptRefreshedToken(refreshedToken);
       }
       if (xhr.getResponseHeader('X-Auth-Error')) {
         expireAuthSession();

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -1,7 +1,7 @@
 import {
+  acceptRefreshedToken,
   expireAuthSession,
   getStoredAuthToken,
-  storeAuthToken,
 } from '@/shared/authToken';
 import { IS_PLATFORM } from '@/shared/utils';
 import { readVoiceConfig, voiceConfigHeaders } from '@/shared/voiceConfig';
@@ -39,7 +39,7 @@ export const authenticatedFetch = (
   }).then((response) => {
     const refreshedToken = response.headers.get('X-Refreshed-Token');
     if (refreshedToken) {
-      storeAuthToken(refreshedToken);
+      acceptRefreshedToken(refreshedToken);
     }
     if (response.headers.get('X-Auth-Error')) {
       expireAuthSession();

--- a/src/shared/authToken.ts
+++ b/src/shared/authToken.ts
@@ -87,6 +87,25 @@ export const getStoredAuthToken = (): string | null => {
   return token;
 };
 
+// A refreshed token arriving on a response is only trustworthy if it is newer
+// than what we already hold. Browsers replay cached responses on a 304 together
+// with their original headers, so an X-Refreshed-Token minted days ago can show
+// up again long after it expired; storing it would overwrite a token obtained
+// seconds earlier and end the session (#1308).
+export const acceptRefreshedToken = (token: unknown): boolean => {
+  const claims = readTokenClaims(token);
+  if (!claims || isAuthTokenExpired(token)) {
+    return false;
+  }
+
+  const current = readTokenClaims(localStorage.getItem('auth-token'));
+  if (current && claims.issuedAt < current.issuedAt) {
+    return false;
+  }
+
+  return storeAuthToken(token);
+};
+
 export const storeAuthToken = (token: unknown): boolean => {
   if (!isValidRefreshedToken(token)) {
     return false;

--- a/src/shared/authToken.ts
+++ b/src/shared/authToken.ts
@@ -94,7 +94,11 @@ export const getStoredAuthToken = (): string | null => {
 // seconds earlier and end the session (#1308).
 export const acceptRefreshedToken = (token: unknown): boolean => {
   const claims = readTokenClaims(token);
-  if (!claims || isAuthTokenExpired(token)) {
+  // No clock-skew allowance here: the skew tolerance in isAuthTokenExpired only
+  // exists to avoid discarding a token we already hold. A replayed refreshed
+  // token past its exp must never replace a live one, and rejecting a
+  // borderline token is harmless because the current token stays in place.
+  if (!claims || Date.now() >= claims.expiresAt) {
     return false;
   }
 

--- a/src/shared/tests/authToken.test.ts
+++ b/src/shared/tests/authToken.test.ts
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict';
 import { test } from 'vitest';
 
 import {
+  acceptRefreshedToken,
   AUTH_SESSION_EXPIRED_EVENT,
   AUTH_TOKEN_REFRESHED_EVENT,
   getAuthTokenRefreshDelay,
@@ -131,4 +132,37 @@ test('getAuthTokenRefreshDelay: an unreadable token schedules nothing', () => {
   // null means "no refresh timer", which is distinct from 0 ("refresh now").
   assert.equal(getAuthTokenRefreshDelay('not-a-jwt'), null);
   assert.equal(getAuthTokenRefreshDelay(null), null);
+});
+
+test('acceptRefreshedToken: stores a token newer than the current one', () => {
+  const now = Math.floor(Date.now() / 1000);
+  localStorage.setItem('auth-token', makeToken({ iat: now - 100, exp: now + 500 }));
+  const newer = makeToken({ iat: now, exp: now + 600 });
+  assert.equal(acceptRefreshedToken(newer), true);
+  assert.equal(localStorage.getItem('auth-token'), newer);
+});
+
+test('acceptRefreshedToken: stores a token when nothing is stored yet', () => {
+  localStorage.removeItem('auth-token');
+  const now = Math.floor(Date.now() / 1000);
+  const token = makeToken({ iat: now, exp: now + 600 });
+  assert.equal(acceptRefreshedToken(token), true);
+  assert.equal(localStorage.getItem('auth-token'), token);
+});
+
+test('acceptRefreshedToken: rejects a token issued before the current one', () => {
+  const now = Math.floor(Date.now() / 1000);
+  const current = makeToken({ iat: now, exp: now + 600 });
+  localStorage.setItem('auth-token', current);
+  assert.equal(acceptRefreshedToken(makeToken({ iat: now - 300, exp: now + 300 })), false);
+  assert.equal(localStorage.getItem('auth-token'), current);
+});
+
+test('acceptRefreshedToken: rejects an expired or malformed token', () => {
+  const now = Math.floor(Date.now() / 1000);
+  const current = makeToken({ iat: now, exp: now + 600 });
+  localStorage.setItem('auth-token', current);
+  assert.equal(acceptRefreshedToken(makeToken({ iat: now - 7200, exp: now - 3600 })), false);
+  assert.equal(acceptRefreshedToken('not-a-jwt'), false);
+  assert.equal(localStorage.getItem('auth-token'), current);
 });

--- a/src/shared/tests/authToken.test.ts
+++ b/src/shared/tests/authToken.test.ts
@@ -158,6 +158,23 @@ test('acceptRefreshedToken: rejects a token issued before the current one', () =
   assert.equal(localStorage.getItem('auth-token'), current);
 });
 
+test('acceptRefreshedToken: rejects a token that expired within the clock-skew tolerance', () => {
+  const now = Math.floor(Date.now() / 1000);
+  const skewSeconds = TOKEN_EXPIRY_SKEW_MS / 1000;
+  const current = makeToken({ iat: now - 60, exp: now + 540 });
+  localStorage.setItem('auth-token', current);
+  // Expired 30s ago: isAuthTokenExpired() still tolerates it, but a refreshed
+  // token past its exp must never replace a live one.
+  const justExpired = makeToken({ iat: now, exp: now - Math.floor(skewSeconds / 2) });
+  assert.equal(acceptRefreshedToken(justExpired), false);
+  assert.equal(localStorage.getItem('auth-token'), current);
+
+  // Same token with nothing stored yet must not become the session either.
+  localStorage.removeItem('auth-token');
+  assert.equal(acceptRefreshedToken(justExpired), false);
+  assert.equal(localStorage.getItem('auth-token'), null);
+});
+
 test('acceptRefreshedToken: rejects an expired or malformed token', () => {
   const now = Math.floor(Date.now() / 1000);
   const current = makeToken({ iat: now, exp: now + 600 });

--- a/src/shared/tests/authenticatedFetch.test.ts
+++ b/src/shared/tests/authenticatedFetch.test.ts
@@ -179,3 +179,35 @@ test('an ordinary response leaves the stored token alone', async () => {
 
   assert.equal(localStorage.getItem('auth-token'), token);
 });
+
+test('a refreshed token older than the stored one is ignored', async () => {
+  // A 304 makes the browser replay a cached response together with its cached
+  // headers, so an X-Refreshed-Token minted before the current login can show
+  // up on a fresh request. It must not overwrite the newer token.
+  const now = Math.floor(Date.now() / 1000);
+  const current = makeToken({ iat: now, exp: now + 600 });
+  const stale = makeToken({ iat: now - 300, exp: now + 300 });
+  localStorage.setItem('auth-token', current);
+  respondWith({ 'X-Refreshed-Token': stale });
+
+  await (await loadFetch(false))('/api/projects');
+
+  assert.equal(localStorage.getItem('auth-token'), current);
+});
+
+test('an expired refreshed token never replaces a live one', async () => {
+  const current = liveToken();
+  localStorage.setItem('auth-token', current);
+  let expiries = 0;
+  const onExpired = () => {
+    expiries += 1;
+  };
+  window.addEventListener(AUTH_SESSION_EXPIRED_EVENT, onExpired);
+  respondWith({ 'X-Refreshed-Token': expiredToken() });
+
+  await (await loadFetch(false))('/api/projects');
+
+  window.removeEventListener(AUTH_SESSION_EXPIRED_EVENT, onExpired);
+  assert.equal(localStorage.getItem('auth-token'), current);
+  assert.equal(expiries, 0);
+});


### PR DESCRIPTION
Fixes #1308

## Problem

`/api/*` JSON responses go out with Express's default weak `ETag` and **no `Cache-Control`**, so browsers cache them and revalidate on the next request. When the server answers `304 Not Modified`, the browser hands the app the cached body **together with the cached headers**. If that cached response was captured while the JWT was past its half-life, it carries an `X-Refreshed-Token` from days ago. `authenticatedFetch` stored any `X-Refreshed-Token` unconditionally, so a token obtained seconds earlier at login was overwritten by an already-expired one, `getStoredAuthToken()` dropped it and the user was bounced to the login screen with *"Your session expired"* immediately after a successful login. The same browser profile fails forever (the cache entry never goes away); incognito works.

## Reproduce

1. Log in from Chrome over plain `http://<host>:3001`; use the UI for a few days so some API response (e.g. `GET /api/user/onboarding-status`) is served while the token is past half-life and carries `X-Refreshed-Token`.
2. Wait until that refreshed token expires (>7 days).
3. Log in again with valid credentials → `POST /api/auth/login` 200, then `GET /api/user/onboarding-status` **304**, then every following request goes out without `Authorization` and 401s.

Packet capture and full analysis in #1308.

## Fix

- **Server** (`server/index.ts`): `app.set('etag', false)` and `Cache-Control: no-store` on `/api/*`. `index.html` and hashed assets already had explicit cache headers; the API was the only cacheable thing left.
- **Client** (`src/shared/authToken.ts`): new `acceptRefreshedToken()` that stores a refreshed token only if it is well-formed, not expired, and its `iat` is not older than the stored token's. Used by `authenticatedFetch` and by the XHR upload path in `useFileTreeUpload`. `storeAuthToken()` is unchanged for login/register, where the token is authoritative.

Either layer alone stops the bounce; both together also protect users behind caching proxies and older cached entries.

## Tests

- `authenticatedFetch.test.ts`: a refreshed token older than the stored one is ignored; an expired refreshed token never replaces a live one.
- `authToken.test.ts`: `acceptRefreshedToken` accepts newer / first token, rejects older, expired and malformed.
- `npm run lint`, `npm run test:client` (402 passed), `npm test` (416 server tests, 0 failed) and `npm run build:server` all green locally.

Verified in production on a 1.37.2 install with the server-side change applied: the affected Android Chrome profile logs in normally again without clearing its cache.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - API responses are no longer cached by browsers, helping ensure users receive current data and response headers.
  - Refreshed authentication tokens are accepted only when valid and newer than the token already in use.
  - Prevents expired, outdated, or replayed tokens from replacing an active session or triggering unnecessary session-expiration behavior.
- **Tests**
  - Added coverage for refreshed-token validation, including older, expired, malformed, and replayed tokens.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->