### PR TITLE
fix(auth): verify the session once per mount, not once per token refresh

### DIFF
--- a/src/modules/auth/context/AuthContext.tsx
+++ b/src/modules/auth/context/AuthContext.tsx
@@ -220,7 +220,11 @@ export function AuthProvider({ children }: AuthProviderProps) {
 
       setNeedsSetup(false);
 
-      if (!token) {
+      // Read the token from storage rather than from state. `authenticatedFetch`
+      // sends whatever storage holds, so this guard now asks exactly the question
+      // the request will answer — and, critically, keeps `token` out of this
+      // callback's dependencies. See the effect below for why that matters.
+      if (!readStoredToken()) {
         return;
       }
 
@@ -244,8 +248,26 @@ export function AuthProvider({ children }: AuthProviderProps) {
     } finally {
       setIsLoading(false);
     }
-  }, [checkOnboardingStatus, clearSession, t, token]);
+  }, [checkOnboardingStatus, clearSession, t]);
 
+  // Verifies the stored session once per mount.
+  //
+  // `checkAuthStatus` must not depend on `token`. `authenticateToken()` re-issues
+  // a token through `X-Refreshed-Token` on *every* authenticated request once the
+  // current one is past half-life, and `authenticatedFetch` feeds that straight
+  // into `storeAuthToken()`, which dispatches `AUTH_TOKEN_REFRESHED_EVENT` and so
+  // reaches `setToken()` in the listener above. If this callback were rebuilt on
+  // each token change, this effect would re-run and re-verify the session, issuing
+  // three more authenticated requests that can themselves refresh the token —
+  // a self-sustaining loop.
+  //
+  // It stays hidden while the token only moves forward: `iat` has one-second
+  // resolution, so same-second reissues are byte-identical and React's `useState`
+  // bails on an `Object.is` match without re-rendering. Once anything makes the
+  // token alternate between two values, the loop runs at request speed. Each pass
+  // also calls `setUser()` with a freshly parsed object and toggles `isLoading`,
+  // which tears down and reopens the chat WebSocket, so the visible symptom is a
+  // reconnect storm rather than the request flood underneath it.
   useEffect(() => {
     if (IS_PLATFORM) {
       setUser({ username: 'platform-user' });

--- a/src/modules/auth/tests/authVerificationReentrancy.test.tsx
+++ b/src/modules/auth/tests/authVerificationReentrancy.test.tsx
@@ -1,0 +1,146 @@
+import assert from 'node:assert/strict';
+
+import { act, cleanup, render } from '@testing-library/react';
+import { afterEach, beforeEach, test, vi } from 'vitest';
+
+import { AuthProvider } from '@/modules/auth/context/AuthContext';
+import { storeAuthToken } from '@/shared/authToken';
+
+/**
+ * Regression coverage for the auth re-entrancy loop.
+ *
+ * `authenticateToken()` attaches `X-Refreshed-Token` to *every* authenticated
+ * response once the caller's token is past half-life, and `authenticatedFetch`
+ * pipes that into `storeAuthToken()`, which dispatches `AUTH_TOKEN_REFRESHED_EVENT`
+ * and so reaches `setToken()`. `checkAuthStatus` must not be rebuilt when `token`
+ * changes: if it is, the mount effect that calls it re-runs and re-verifies the
+ * session, issuing three more authenticated requests that can refresh the token
+ * again.
+ *
+ * The loop is invisible while the token only moves forward, because `iat` has
+ * one-second resolution and React's `useState` bails on an `Object.is` match.
+ * These tests therefore drive the case where the token alternates between two
+ * values, which is what an HTTP-cached `X-Refreshed-Token` produces in the field.
+ */
+
+const AUTH_TOKEN_KEY = 'auth-token';
+
+const makeToken = (iatOffsetSeconds: number) => {
+  const encode = (value: unknown) => Buffer.from(JSON.stringify(value)).toString('base64url');
+  const iat = Math.floor(Date.now() / 1000) + iatOffsetSeconds;
+  return `${encode({ alg: 'HS256', typ: 'JWT' })}.${encode({
+    userId: 1,
+    username: 'tester',
+    iat,
+    exp: iat + 7 * 24 * 60 * 60,
+  })}.signature`;
+};
+
+/** Two valid tokens with different `iat`, so each replaces the other in state. */
+const TOKEN_A = makeToken(-6 * 24 * 60 * 60);
+const TOKEN_B = makeToken(-5 * 24 * 60 * 60);
+
+type Counts = Record<string, number>;
+
+/**
+ * The refreshed token is only offered this many times. A correct provider never
+ * uses more than the first; a re-entrant one exhausts the budget and then
+ * settles, so the assertion below fails with a count instead of hanging CI.
+ */
+const REFRESH_BUDGET = 10;
+
+/**
+ * Serves the three endpoints `checkAuthStatus` touches. `/api/auth/user`
+ * alternates the refreshed token it hands back, standing in for a server that
+ * keeps re-issuing while a cache replays an older value.
+ */
+const installFetch = (counts: Counts) => {
+  let alternate = false;
+  vi.stubGlobal('fetch', (input: unknown) => {
+    const url = String(input);
+    counts[url] = (counts[url] ?? 0) + 1;
+
+    const json = (body: unknown, headers: Record<string, string> = {}) =>
+      Promise.resolve(
+        new Response(JSON.stringify(body), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json', ...headers },
+        }),
+      );
+
+    if (url.startsWith('/api/auth/status')) {
+      return json({ needsSetup: false, isAuthenticated: true });
+    }
+    if (url.startsWith('/api/auth/user')) {
+      const body = { user: { id: 1, username: 'tester' } };
+      if (counts[url] > REFRESH_BUDGET) {
+        return json(body);
+      }
+      alternate = !alternate;
+      return json(body, { 'X-Refreshed-Token': alternate ? TOKEN_B : TOKEN_A });
+    }
+    if (url.startsWith('/api/user/onboarding-status')) {
+      return json({ hasCompletedOnboarding: true });
+    }
+    return json({});
+  });
+};
+
+const mountProvider = async () => {
+  await act(async () => {
+    render(<AuthProvider>{null}</AuthProvider>);
+  });
+  // Let any re-entrant verification run; a looping provider issues thousands of
+  // requests in this window, a correct one issues none.
+  await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 250));
+  });
+};
+
+beforeEach(() => {
+  localStorage.clear();
+  localStorage.setItem(AUTH_TOKEN_KEY, TOKEN_A);
+});
+
+afterEach(() => {
+  // Unmount before the stubbed globals go away. Vitest's default hook order is
+  // `stack`, so the `afterEach(cleanup)` registered in vitest.setup.ts runs
+  // *after* this one — a provider still mounted here would keep firing effects
+  // against a restored `fetch`. `cleanup()` is idempotent, so calling it early
+  // is safe and the setup file's call becomes a no-op.
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+test('verifies the session once per mount even while the token keeps being refreshed', async () => {
+  const counts: Counts = {};
+  installFetch(counts);
+
+  await mountProvider();
+
+  assert.equal(
+    counts['/api/auth/user'],
+    1,
+    `expected exactly one session verification, got ${counts['/api/auth/user']} — ` +
+      'checkAuthStatus is being rebuilt on every token change',
+  );
+  assert.equal(counts['/api/auth/status'], 1);
+  assert.equal(counts['/api/user/onboarding-status'], 1);
+});
+
+test('a refreshed token does not re-trigger verification', async () => {
+  const counts: Counts = {};
+  installFetch(counts);
+
+  await mountProvider();
+  const afterMount = counts['/api/auth/user'];
+
+  // A refresh arriving after mount (the `X-Refreshed-Token` path) updates the
+  // stored session but must not restart verification.
+  await act(async () => {
+    storeAuthToken(TOKEN_B);
+    await new Promise((resolve) => setTimeout(resolve, 250));
+  });
+
+  assert.equal(counts['/api/auth/user'], afterMount);
+});


### PR DESCRIPTION
Resubmission of #1177, as requested there.

## Why #1177 stopped applying

@blackmammoth was right that its diff no longer applies. The cause is a file move, not a fix: #1206 moved `src/components/**` to `src/modules/**`, so `src/components/auth/context/AuthContext.tsx` — the file #1177 patched — no longer exists at that path. It is now `src/modules/auth/context/AuthContext.tsx`.

The code shape it fixes survived the move unchanged. Verified against `main` at `5e73a49b`:

| Link in the loop | Location on current `main` |
|---|---|
| Server sets `X-Refreshed-Token` on any authenticated response past half-life | `server/modules/auth/auth.middleware.ts:78` |
| Client reads the header and pipes it into `storeAuthToken()` | `src/shared/api.ts:40-42` |
| `storeAuthToken()` dispatches `AUTH_TOKEN_REFRESHED_EVENT` | `src/shared/authToken.ts:97` |
| The listener calls `setToken(nextToken)` | `src/modules/auth/context/AuthContext.tsx:192` |
| **`checkAuthStatus` still lists `token` in its dependency array** | `src/modules/auth/context/AuthContext.tsx:247` |
| **The mount effect still depends on `checkAuthStatus`** | `src/modules/auth/context/AuthContext.tsx:260` |

Every refresh rebuilds `checkAuthStatus`, which re-runs the mount effect, which re-verifies the session — issuing three more authenticated requests, which can themselves refresh the token.

## Why it is normally invisible

`iat` has one-second resolution, so same-second reissues are byte-identical and React's `useState` bails on an `Object.is` match without re-rendering. The loop only runs once something makes the token *alternate* between two values — an HTTP-cached `X-Refreshed-Token` replaying an older value does exactly that.

The user-visible symptom is not the request flood. Each pass calls `setUser()` with a freshly parsed object and toggles `isLoading`, which tears down and reopens the chat WebSocket — so it surfaces as a reconnect storm.

## The change

Two edits, both in `AuthContext`:

- the `if (!token)` guard reads `readStoredToken()` instead. `authenticatedFetch` sends whatever storage holds, so the guard now asks exactly the question the request will answer — and `token` leaves the callback's dependencies.
- `token` is dropped from `checkAuthStatus`'s dependency array.

## Test

`src/modules/auth/tests/authVerificationReentrancy.test.tsx`, a vitest test matching the existing client suite. It mounts the provider against a stub server whose `/api/auth/user` alternates the refreshed token it returns.

Measured on this branch, not carried over from the original PR:

| `checkAuthStatus` deps | `/api/auth/user` requests per mount |
|---|---|
| with the fix | **1** |
| with `token` restored to the array | **11** |

11 rather than unbounded because the stub only offers a refreshed token 10 times and then settles — so a regression fails with a count instead of hanging CI.

Full client suite: 57 files / 398 tests pass. `typecheck` and `oxlint` clean (no new warnings on the touched file).

## Both review notes from #1177 are addressed

- *"the test-only renderer should remain out of production dependencies"* — the original PR predated `test:client`/vitest and reached for `react-test-renderer` + `node:test`. Rewriting it as a vitest test removes **both** `package.json` additions. This PR touches no dependency at all.
- *"the test setup should unmount the provider before restoring mocked browser globals"* — it now calls `cleanup()` explicitly before `vi.unstubAllGlobals()`. Vitest's default hook order is `stack`, so the `afterEach(cleanup)` in `vitest.setup.ts` runs *after* a test file's own `afterEach`; a provider left mounted would keep firing effects against a restored `fetch`.

The `src/shared/utils.ts` hunk from #1177 is also dropped — #1174 landed the same `import.meta.env?.VITE_IS_PLATFORM` guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented repeated authentication checks when session tokens refresh.
  - Improved session verification reliability during token updates.

- **Tests**
  - Added regression coverage to verify authentication checks run once per mount and are not retriggered by token refreshes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->