### PR TITLE
feat(sidebar): pin expanded project header while sessions scroll

### DIFF
--- a/src/modules/sidebar/SidebarProjectItem.tsx
+++ b/src/modules/sidebar/SidebarProjectItem.tsx
@@ -143,9 +143,9 @@ function SidebarProjectItem({
 
   return (
     <div className={cn('md:space-y-1', isDeleting && 'opacity-50 pointer-events-none')}>
-      <div className="md:group group">
+      <div className="sticky top-0 z-10 md:group group">
         {isCompact && (
-        <div>
+        <div className="bg-background">
           <div
             className={cn(
               'p-3 mx-3 my-1 rounded-lg bg-card border border-border/50 active:scale-[0.98] transition-all duration-150',
@@ -289,8 +289,12 @@ function SidebarProjectItem({
         <Button
           variant="ghost"
           className={cn(
-            'flex w-full justify-between p-2 h-auto font-normal hover:bg-accent/50',
-            isSelected && 'bg-accent text-accent-foreground',
+            'sticky top-0 z-10 flex w-full justify-between p-2 h-auto font-normal hover:bg-accent/50',
+            isSelected
+              ? 'bg-accent text-accent-foreground'
+              : isStarred
+                ? 'bg-background hover:bg-accent/50'
+                : 'bg-background',
             isStarred &&
               !isSelected &&
               'bg-yellow-50/50 dark:bg-yellow-900/10 hover:bg-yellow-100/50 dark:hover:bg-yellow-900/20',


### PR DESCRIPTION
Make the project header sticky at the top of the scroll area when a project is expanded, so the header and its session list are visually isolated: the header stays fixed below the search bar and only the sessions scroll beneath it.

- Wrap the project header in a sticky top-0 z-10 container
- Give the sticky header a solid bg-background so scrolling sessions do not show through
- Restructure desktop Button background logic so the selected, starred and default states each provide a solid background for sticky mode

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Improved sidebar project row visibility by keeping project entries fixed during scrolling.
  - Added consistent background styling for compact and non-compact project entries.
  - Preserved hover styling for starred and unselected projects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->