### PR TITLE
fix(server): allow workspace paths under a Windows drive root WORKSPACES_ROOT

### DIFF
--- a/server/shared/tests/workspace-path.test.ts
+++ b/server/shared/tests/workspace-path.test.ts
@@ -1,0 +1,44 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { isPathWithinRoot, normalizeProjectPath } from '@/shared/utils.js';
+
+test('isPathWithinRoot accepts paths under a Windows drive root (issue #746)', () => {
+  const root = normalizeProjectPath('D:\\');
+  assert.equal(root, 'D:\\');
+  assert.equal(isPathWithinRoot(normalizeProjectPath('D:\\Claude code'), root), true);
+  assert.equal(isPathWithinRoot(normalizeProjectPath('D:\\work\\project'), root), true);
+});
+
+test('isPathWithinRoot also accepts the bare drive form for a drive root', () => {
+  const root = normalizeProjectPath('D:');
+  assert.equal(isPathWithinRoot(normalizeProjectPath('D:\\Claude code'), root), true);
+});
+
+test('isPathWithinRoot matches the drive root itself', () => {
+  const root = normalizeProjectPath('D:\\');
+  assert.equal(isPathWithinRoot('D:\\', root), true);
+});
+
+test('isPathWithinRoot rejects paths on a different drive', () => {
+  const root = normalizeProjectPath('D:\\');
+  assert.equal(isPathWithinRoot(normalizeProjectPath('C:\\Users\\someone'), root), false);
+});
+
+test('isPathWithinRoot compares Windows paths case-insensitively', () => {
+  const root = normalizeProjectPath('C:\\Users\\lihong');
+  assert.equal(isPathWithinRoot(normalizeProjectPath('c:\\users\\LIHONG\\proj'), root), true);
+});
+
+test('isPathWithinRoot does not match on partial path segments', () => {
+  const root = normalizeProjectPath('C:\\Users');
+  assert.equal(isPathWithinRoot(normalizeProjectPath('C:\\UsersOther'), root), false);
+});
+
+test('isPathWithinRoot keeps POSIX containment behavior', () => {
+  const root = normalizeProjectPath('/home/user');
+  assert.equal(isPathWithinRoot(normalizeProjectPath('/home/user/project'), root), true);
+  assert.equal(isPathWithinRoot(normalizeProjectPath('/home/user'), root), true);
+  assert.equal(isPathWithinRoot(normalizeProjectPath('/etc/passwd'), root), false);
+  assert.equal(isPathWithinRoot(normalizeProjectPath('/home/username/project'), root), false);
+});

--- a/server/shared/utils.ts
+++ b/server/shared/utils.ts
@@ -213,6 +213,44 @@ export function normalizeProjectPath(inputPath: string): string {
 }
 
 /**
+ * Checks whether an already-normalized path equals or is nested inside a
+ * normalized workspace root.
+ *
+ * The naive `startsWith(root + sep)` comparison breaks for Windows drive
+ * roots: `normalizeProjectPath` keeps the trailing separator for filesystem
+ * roots (`D:\`), so appending another separator never matches paths like
+ * `D:\Claude code`. Windows paths are also case-insensitive, so drive letters
+ * and path segments are compared without regard to case.
+ */
+export function isPathWithinRoot(candidatePath: string, normalizedRoot: string): boolean {
+  if (!candidatePath || !normalizedRoot) {
+    return false;
+  }
+
+  const useWindowsRules = shouldUseWindowsPathNormalization(normalizedRoot);
+  const parser = useWindowsRules ? path.win32 : path.posix;
+
+  if (candidatePath === normalizedRoot) {
+    return true;
+  }
+
+  // A Windows drive root ("D:" / "D:." / "D:\") contains every path on the same
+  // drive, so compare drive letters instead of doing a string prefix check.
+  if (useWindowsRules && /^[a-zA-Z]:(\\?|\.)$/.test(normalizedRoot)) {
+    const rootDrive = normalizedRoot.slice(0, 2).toLowerCase();
+    const candidateRoot = parser.parse(candidatePath).root.toLowerCase();
+    return candidateRoot === `${rootDrive}\\`;
+  }
+
+  const prefix = normalizedRoot.endsWith(parser.sep) ? normalizedRoot : `${normalizedRoot}${parser.sep}`;
+  if (!useWindowsRules) {
+    return candidatePath.startsWith(prefix);
+  }
+
+  return candidatePath.toLowerCase().startsWith(prefix.toLowerCase());
+}
+
+/**
  * Validates that a user-supplied workspace path is safe to use.
  *
  * Call this before any filesystem mutation that creates or registers projects.
@@ -282,11 +320,21 @@ export async function validateWorkspacePath(requestedPath: string): Promise<Work
       }
     }
 
-    const resolvedWorkspaceRoot = normalizeProjectPath(await realpath(WORKSPACES_ROOT));
-    if (
-      !resolvedPath.startsWith(`${resolvedWorkspaceRoot}${path.sep}`)
-      && resolvedPath !== resolvedWorkspaceRoot
-    ) {
+    let resolvedWorkspaceRoot: string;
+    try {
+      resolvedWorkspaceRoot = normalizeProjectPath(await realpath(path.resolve(WORKSPACES_ROOT)));
+    } catch (error) {
+      const fileError = error as NodeJS.ErrnoException;
+      if (fileError.code !== 'ENOENT') {
+        throw fileError;
+      }
+
+      // The configured root does not exist yet (e.g. a fresh drive root);
+      // fall back to its absolute normalized form.
+      resolvedWorkspaceRoot = normalizeProjectPath(path.resolve(WORKSPACES_ROOT));
+    }
+
+    if (!isPathWithinRoot(resolvedPath, resolvedWorkspaceRoot)) {
       return {
         valid: false,
         error: `Workspace path must be within the allowed workspace root: ${WORKSPACES_ROOT}`,
@@ -300,10 +348,7 @@ export async function validateWorkspacePath(requestedPath: string): Promise<Work
         const symlinkTarget = await readlink(absolutePath);
         const resolvedSymlinkPath = path.resolve(path.dirname(absolutePath), symlinkTarget);
         const realSymlinkPath = await realpath(resolvedSymlinkPath);
-        if (
-          !realSymlinkPath.startsWith(`${resolvedWorkspaceRoot}${path.sep}`)
-          && realSymlinkPath !== resolvedWorkspaceRoot
-        ) {
+        if (!isPathWithinRoot(normalizeProjectPath(realSymlinkPath), resolvedWorkspaceRoot)) {
           return {
             valid: false,
             error: 'Symlink target is outside the allowed workspace root',


### PR DESCRIPTION
## Problem

Fixes #746

On Windows, setting `WORKSPACES_ROOT=D:` (or `D:`) made `validateWorkspacePath` reject every path on that drive with:

> Workspace path must be within the allowed workspace root: D:
Two root causes:

1. `normalizeProjectPath` keeps the trailing separator for filesystem roots (`normalizeProjectPath('D:\') === 'D:\'`), so the containment check built the prefix `"D:\\\\"` (double separator) and `resolvedPath.startsWith(root + path.sep)` never matched paths like `D:\Claude code`.
2. `await realpath(WORKSPACES_ROOT)` was unguarded — `realpath` on a drive root can fail, aborting validation entirely.

## Fix

Added `isPathWithinRoot(candidatePath, normalizedRoot)` and used it for both the workspace-root containment check and the symlink containment check:

- Recognizes Windows drive roots (`D:` / `D:.` / `D:\`) and compares drive letters instead of doing a string prefix check.
- Compares Windows paths case-insensitively (drive letters and path segments).
- Keeps the original POSIX containment semantics unchanged (no partial-segment matches, e.g. `/home/user` vs `/home/username`).
- `realpath` on a not-yet-existing `WORKSPACES_ROOT` now falls back to the normalized absolute path instead of throwing.

## Verification

- New unit tests in `server/shared/tests/workspace-path.test.ts` (drive-root accept, cross-drive reject, case-insensitivity, partial-segment, POSIX behavior): 7/7 pass, full `server/shared` suite green.
- `tsc --noEmit` passes.
- End-to-end on Windows with `WORKSPACES_ROOT=D:`: `D:\Claude code`, `D:\Claude code\sub`, `D:\` all validate; with `WORKSPACES_ROOT=D:\workspaces`, `D:\Claude code` and `C:\Users` are still correctly rejected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workspace path validation across Windows and POSIX environments.
  * Correctly handles drive roots, drive-letter casing, path boundaries, symlink targets, and workspaces that do not yet exist.
  * Prevents incorrectly accepting paths from different drives or with only partially matching directory names.

* **Tests**
  * Added coverage for Windows drive-root behavior, case-insensitive comparisons, path containment, and POSIX compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->