### PR TITLE
feat(providers): source claude, codex, and opencode model catalogs from the CLIs

### DIFF
--- a/server/modules/providers/list/claude/claude-models.provider.ts
+++ b/server/modules/providers/list/claude/claude-models.provider.ts
@@ -1,5 +1,7 @@
 import { readFile } from 'node:fs/promises';
 
+import { query } from '@anthropic-ai/claude-agent-sdk';
+
 import { sessionsDb } from '@/modules/database/index.js';
 import type { IProviderModels } from '@/shared/interfaces.js';
 import type {
@@ -7,7 +9,7 @@ import type {
   ProviderModelOption,
   ProviderModelsDefinition,
 } from '@/shared/types.js';
-import { buildDefaultProviderCurrentActiveModel } from '@/shared/utils.js';
+import { AppError, buildDefaultProviderCurrentActiveModel } from '@/shared/utils.js';
 
 /**
  * Ultracode is not one of the SDK's reasoning-effort levels. Selecting it runs the turn at
@@ -22,151 +24,6 @@ const ULTRACODE_EFFORT_OPTION = {
   description: 'Highest effort plus standing workflow orchestration.',
 };
 
-export const CLAUDE_PREDEFINED_MODELS: ProviderModelsDefinition = {
-  OPTIONS: [
-    {
-      value: 'default',
-      label: 'Default (recommended)',
-      description: 'Use the recommended model for your Claude account and deployment.',
-      effort: {
-        default: 'high',
-        values: [
-          { value: 'low' },
-          { value: 'medium' },
-          { value: 'high' },
-          { value: 'max' },
-        ],
-      },
-    },
-    {
-      value: 'best',
-      label: 'Best available',
-      description: 'Use Fable 5 when available, otherwise the latest Opus model.',
-      effort: {
-        default: 'high',
-        values: [
-          { value: 'low' },
-          { value: 'medium' },
-          { value: 'high' },
-          { value: 'xhigh' },
-          { value: 'max' },
-          ULTRACODE_EFFORT_OPTION,
-        ],
-      },
-    },
-    {
-      value: 'fable',
-      label: 'Fable 5',
-      description: 'Most capable Claude model for the hardest, longest-running tasks.',
-      effort: {
-        default: 'high',
-        values: [
-          { value: 'low' },
-          { value: 'medium' },
-          { value: 'high' },
-          { value: 'xhigh' },
-          { value: 'max' },
-          ULTRACODE_EFFORT_OPTION,
-        ],
-      },
-    },
-    {
-      value: 'sonnet',
-      label: 'Sonnet',
-      description: 'Latest Sonnet model for everyday coding tasks.',
-      effort: {
-        default: 'high',
-        values: [
-          { value: 'low' },
-          { value: 'medium' },
-          { value: 'high' },
-          { value: 'xhigh' },
-          { value: 'max' },
-          ULTRACODE_EFFORT_OPTION,
-        ],
-      },
-    },
-    {
-      value: 'sonnet[1m]',
-      label: 'Sonnet (1M context)',
-      description: 'Latest Sonnet model with a 1M context window.',
-      effort: {
-        default: 'high',
-        values: [
-          { value: 'low' },
-          { value: 'medium' },
-          { value: 'high' },
-          { value: 'xhigh' },
-          { value: 'max' },
-          ULTRACODE_EFFORT_OPTION,
-        ],
-      },
-    },
-    {
-      value: 'opus',
-      label: 'Opus',
-      description: 'Latest Opus model for complex reasoning and coding tasks.',
-      effort: {
-        default: 'high',
-        values: [
-          { value: 'low' },
-          { value: 'medium' },
-          { value: 'high' },
-          { value: 'xhigh' },
-          { value: 'max' },
-          ULTRACODE_EFFORT_OPTION,
-        ],
-      },
-    },
-    {
-      value: 'opus[1m]',
-      label: 'Opus (1M context)',
-      description: 'Latest Opus model with a 1M context window.',
-      effort: {
-        default: 'high',
-        values: [
-          { value: 'low' },
-          { value: 'medium' },
-          { value: 'high' },
-          { value: 'xhigh' },
-          { value: 'max' },
-          ULTRACODE_EFFORT_OPTION,
-        ],
-      },
-    },
-    {
-      value: 'haiku',
-      label: 'Haiku',
-      description: 'Fast and efficient Claude model for simple tasks.',
-    },
-    {
-      value: 'opusplan',
-      label: 'Opus Plan',
-      description: 'Use Opus while planning, then switch to Sonnet for execution.',
-      effort: {
-        default: 'high',
-        values: [
-          { value: 'low' },
-          { value: 'medium' },
-          { value: 'high' },
-          { value: 'xhigh' },
-          { value: 'max' },
-          ULTRACODE_EFFORT_OPTION,
-        ],
-      },
-    },
-  ],
-  DEFAULT: 'default',
-};
-
-export const findClaudeModelOption = (model: string | undefined | null): ProviderModelOption | null => {
-  const normalizedModel = typeof model === 'string' ? model.trim() : '';
-  if (!normalizedModel) {
-    return null;
-  }
-
-  return CLAUDE_PREDEFINED_MODELS.OPTIONS.find((option) => option.value === normalizedModel) ?? null;
-};
 type ClaudeInitEvent = {
   sessionId?: string;
   session_id?: string;
@@ -288,20 +145,130 @@ const readClaudeSessionModelFromJsonl = async (
   return null;
 };
 
+/** One entry of the SDK's `supportedModels()` answer, narrowed to the picker's fields. */
+type ClaudeSdkModelInfo = {
+  value: string;
+  displayName?: string;
+  description?: string;
+  supportsEffort?: boolean;
+  supportedEffortLevels?: string[];
+};
+
+/** How long a successful `supportedModels()` answer stays fresh. */
+const LIVE_CATALOG_TTL_MS = 60_000;
+
+/** Test seam: replaces the SDK round-trip with a fixture-backed reader. */
+export type ClaudeProviderModelsDependencies = {
+  readSupportedModels?: () => Promise<ClaudeSdkModelInfo[]>;
+};
+
+/**
+ * Asks the Claude CLI which models this install can actually run.
+ *
+ * `supportedModels()` reads the initialize handshake the SDK already performs
+ * when a query starts; it does not run a model turn. The original attempt at
+ * this was disabled because the throwaway query left a session jsonl behind
+ * (and listed the server's workspace as a project). `persistSession: false`
+ * is exactly that fix, and an empty prompt generator makes the child exit as
+ * soon as the handshake answer is in.
+ */
+const readClaudeCliModels = async (): Promise<ClaudeSdkModelInfo[]> => {
+  // The SDK types the prompt loosely; the generator never yields, so nothing
+  // reaches the model even if the CLI's stdin stays open past the handshake.
+  const queryInstance = query({
+    prompt: (async function* emptyPrompt() { /* yields nothing */ })(),
+    options: { persistSession: false, maxTurns: 1 },
+  } as Parameters<typeof query>[0]);
+  try {
+    return await queryInstance.supportedModels();
+  } finally {
+    try {
+      await queryInstance.close();
+    } catch {
+      // A child that already exited on its own makes close() reject; the
+      // catalog answer is in hand either way.
+    }
+  }
+};
+
+/**
+ * Builds the picker catalog from the CLI answer.
+ *
+ * There is deliberately no curated fallback list behind this: a hardcoded
+ * catalog goes stale against every CLI upgrade and account change, and the
+ * picker surfacing the CLI failure beats quietly offering models this install
+ * may not run. Ultracode stays a CloudCLI-side addition - the SDK has never
+ * heard of it - and keeps its xhigh-only precondition.
+ */
+const buildCatalogFromCli = (models: ClaudeSdkModelInfo[]): ProviderModelsDefinition => {
+  const options: ProviderModelOption[] = models
+    .filter((model) => typeof model?.value === 'string' && model.value.trim())
+    .map((model) => {
+      const effortValues = model.supportsEffort === false
+        ? []
+        : [...new Set(model.supportedEffortLevels ?? [])];
+      const effortOptions = effortValues.map((value) => ({ value }));
+      return {
+        value: model.value,
+        label: model.displayName?.trim() || model.value,
+        ...(model.description?.trim() ? { description: model.description.trim() } : {}),
+        ...(effortOptions.length > 0
+          ? {
+            effort: {
+              values: effortValues.includes('xhigh')
+                ? [...effortOptions, ULTRACODE_EFFORT_OPTION]
+                : effortOptions,
+            },
+          }
+          : {}),
+      };
+    });
+
+  if (options.length === 0) {
+    throw new AppError('Claude reported no usable models.', {
+      code: 'CLAUDE_MODELS_UNAVAILABLE',
+      statusCode: 502,
+    });
+  }
+
+  return {
+    OPTIONS: options,
+    DEFAULT: options.find((option) => option.value === 'default')?.value ?? options[0].value,
+  };
+};
+
 export class ClaudeProviderModels implements IProviderModels {
+  private readonly readSupportedModels: () => Promise<ClaudeSdkModelInfo[]>;
+  private liveCatalog: Promise<ProviderModelsDefinition> | null = null;
+  private liveCatalogExpiresAt = 0;
+
+  constructor(dependencies: ClaudeProviderModelsDependencies = {}) {
+    this.readSupportedModels = dependencies.readSupportedModels ?? readClaudeCliModels;
+  }
+
+  /**
+   * Reports the picker catalog from the Claude CLI's initialize handshake.
+   *
+   * Spawning the CLI costs about a second, so a successful answer is cached
+   * briefly and concurrent callers share one in-flight run (the picker, the
+   * active-model lookup, and effort validation all resolve the catalog within
+   * the same page load). A failed run is not cached; the next caller retries
+   * rather than waiting out the TTL on an error.
+   */
   async getSupportedModels(): Promise<ProviderModelsDefinition> {
-    // claude creates a new jsonl file as a separate session for this request.
-    // As a result, it lists the workspace where this is invoked when it shouldn't.
-    //
-    // Disabled for now:
-    // const queryInstance = query({
-    //   prompt: 'Get supported models',
-    //   options: buildClaudeQueryOptions(),
-    // });
-    // const supportedModels = await queryInstance.supportedModels();
-    // queryInstance.close();
-    // return buildClaudeModelsDefinition(supportedModels);
-    return CLAUDE_PREDEFINED_MODELS;
+    if (!this.liveCatalog || Date.now() >= this.liveCatalogExpiresAt) {
+      const run = (async () => buildCatalogFromCli(await this.readSupportedModels()))();
+      this.liveCatalog = run;
+      this.liveCatalogExpiresAt = Date.now() + LIVE_CATALOG_TTL_MS;
+      void run.catch(() => {
+        if (this.liveCatalog === run) {
+          this.liveCatalog = null;
+          this.liveCatalogExpiresAt = 0;
+        }
+      });
+    }
+
+    return this.liveCatalog;
   }
 
   async getCurrentActiveModel(sessionId?: string): Promise<ProviderCurrentActiveModel> {

--- a/server/modules/providers/list/claude/claude-runtime.provider.js
+++ b/server/modules/providers/list/claude/claude-runtime.provider.js
@@ -25,7 +25,6 @@ import {
   normalizeImageDescriptors
 } from '@/shared/image-attachments.js';
 import {
-  CLAUDE_PREDEFINED_MODELS,
   CLAUDE_ULTRACODE_EFFORT
 } from '@/modules/providers/list/claude/claude-models.provider.js';
 import { resolveClaudeCodeExecutablePath } from '@/shared/claude-cli-path.js';
@@ -78,7 +77,7 @@ const TOOLS_REQUIRING_INTERACTION = new Set(['AskUserQuestion', 'ExitPlanMode'])
 // selection is translated back into the two options the SDK actually understands here.
 const ULTRACODE_SDK_EFFORT = 'xhigh';
 
-function resolveClaudeEffort(model, effort, modelsDefinition = CLAUDE_PREDEFINED_MODELS) {
+function resolveClaudeEffort(model, effort, modelsDefinition) {
   const selectedModel = modelsDefinition?.OPTIONS?.find((option) => option.value === model) || null;
   const allowedEfforts = selectedModel?.effort?.values
     ?.map((value) => value.value) || [];
@@ -271,12 +270,18 @@ function mapCliOptionsToSDK(options = {}) {
 
   sdkOptions.disallowedTools = settings.disallowedTools || [];
 
-  sdkOptions.model = options.model || CLAUDE_PREDEFINED_MODELS.DEFAULT;
+  // No curated fallback: an absent model is left unset so the CLI runs the
+  // account's own default rather than a source-controlled alias. The websocket
+  // send path records a model on every turn, so this only covers callers that
+  // deliberately omit it.
+  if (options.model) {
+    sdkOptions.model = options.model;
+  }
 
   applyClaudeEffort(sdkOptions, resolveClaudeEffort(
     sdkOptions.model,
     effort,
-    options.effortModels || CLAUDE_PREDEFINED_MODELS,
+    options.effortModels,
   ));
 
   sdkOptions.systemPrompt = {
@@ -757,12 +762,10 @@ async function queryClaudeSDK(command, options = {}, ws, context) {
 
   try {
     const resolvedModel = await context.resolveResumeModel(sessionId, options.model);
-    let effortModels = CLAUDE_PREDEFINED_MODELS;
-    try {
-      effortModels = await context.getProviderModels();
-    } catch (error) {
-      console.warn('[Claude SDK] Unable to load provider models for effort validation:', error);
-    }
+    // No curated fallback: effort choices are validated against the live CLI
+    // catalog, and a catalog that cannot load fails the turn with the CLI's
+    // own error rather than silently validating against stale defaults.
+    const effortModels = await context.getProviderModels();
 
     const sdkOptions = mapCliOptionsToSDK({
       ...options,

--- a/server/modules/providers/list/codex/codex-app-server.client.ts
+++ b/server/modules/providers/list/codex/codex-app-server.client.ts
@@ -3,7 +3,7 @@ import { stat } from 'node:fs/promises';
 import { createRequire } from 'node:module';
 import readline from 'node:readline';
 
-import { AppError } from '@/shared/utils.js';
+import { AppError, readObjectRecord, readOptionalString } from '@/shared/utils.js';
 
 /**
  * Minimal JSON-RPC client for `codex app-server`.
@@ -74,9 +74,12 @@ async function withAppServer<T>(
   run: (call: (method: string, params: unknown) => Promise<unknown>) => Promise<T>,
 ): Promise<T> {
   const launcher = resolveCodexLauncher();
+  // windowsHide keeps Windows from allocating a console for the child; without
+  // it every fork flashes a cmd window when the server runs without one.
   const child = spawn(process.execPath, [launcher, 'app-server'], {
     env: process.env,
     stdio: ['pipe', 'pipe', 'pipe'],
+    windowsHide: true,
   });
 
   // The server logs sandbox and skill warnings to stderr on every start. They
@@ -191,7 +194,47 @@ async function withAppServer<T>(
   }
 }
 
+/**
+ * One model entry from the app-server's `model/list`.
+ *
+ * Only the fields the picker needs are typed; the server also sends service
+ * tiers, modalities, and marketing copy this app does not surface.
+ */
+export type CodexServerModel = {
+  id: string;
+  displayName?: string | null;
+  description?: string | null;
+  hidden?: boolean;
+  isDefault?: boolean;
+  supportedReasoningEfforts?: { reasoningEffort: string }[] | null;
+  defaultReasoningEffort?: string | null;
+};
+
 export const codexAppServer = {
+  /**
+   * Asks the CLI which models this install can actually run.
+   *
+   * This is the same catalog `codex` itself shows its model picker, so it
+   * follows logins, feature flags, and CLI upgrades without a curated list
+   * going stale. Retired entries come back flagged `hidden` and are dropped
+   * here - offering one would hand the picker a model the CLI refuses to run.
+   */
+  async listModels(): Promise<CodexServerModel[]> {
+    return withAppServer(async (call) => {
+      const result = await call('model/list', {}) as { data?: unknown } | undefined;
+      if (!Array.isArray(result?.data)) {
+        throw new AppError('Codex reported no models.', {
+          code: 'CODEX_MODELS_UNAVAILABLE',
+          statusCode: 502,
+        });
+      }
+
+      return result.data.filter((entry): entry is CodexServerModel => {
+        const record = readObjectRecord(entry);
+        return Boolean(readOptionalString(record?.id)) && record?.hidden !== true;
+      });
+    });
+  },
   /**
    * Copies a thread into a new one that ends at `lastTurnId`, or copies the
    * whole thread when it is omitted.

--- a/server/modules/providers/list/codex/codex-models.provider.ts
+++ b/server/modules/providers/list/codex/codex-models.provider.ts
@@ -4,136 +4,138 @@ import path from 'node:path';
 
 import TOML from '@iarna/toml';
 
+import { codexAppServer, type CodexServerModel } from '@/modules/providers/list/codex/codex-app-server.client.js';
 import type { IProviderModels } from '@/shared/interfaces.js';
 import type {
   ProviderCurrentActiveModel,
+  ProviderModelOption,
   ProviderModelsDefinition,
 } from '@/shared/types.js';
 import {
+  AppError,
   buildDefaultProviderCurrentActiveModel,
   readObjectRecord,
   readOptionalString,
 } from '@/shared/utils.js';
 
-/** Curated Codex catalog shipped as immutable CloudCLI defaults. */
-export const CODEX_PREDEFINED_MODELS: ProviderModelsDefinition = {
-  OPTIONS: [
-    {
-      value: 'gpt-6-astra',
-      label: 'GPT-6 Astra',
-      description: 'Our most capable model for complex, demanding work.',
-      effort: {
-        default: 'low',
-        values: [
-          { value: 'low' },
-          { value: 'medium' },
-          { value: 'high' },
-          { value: 'xhigh' },
-          { value: 'max' },
-          { value: 'ultra' },
-        ],
-      },
-    },
-    {
-      value: 'gpt-5.6-sol',
-      label: 'GPT-5.6 Sol',
-      description: 'Latest frontier agentic coding model.',
-      effort: {
-        default: 'low',
-        values: [
-          { value: 'low' },
-          { value: 'medium' },
-          { value: 'high' },
-          { value: 'xhigh' },
-          { value: 'max' },
-          { value: 'ultra' },
-        ],
-      },
-    },
-    {
-      value: 'gpt-5.6-terra',
-      label: 'GPT-5.6 Terra',
-      description: 'Balanced agentic coding model for everyday work.',
-      effort: {
-        default: 'medium',
-        values: [
-          { value: 'low' },
-          { value: 'medium' },
-          { value: 'high' },
-          { value: 'xhigh' },
-          { value: 'max' },
-          { value: 'ultra' },
-        ],
-      },
-    },
-    {
-      value: 'gpt-5.6-luna',
-      label: 'GPT-5.6 Luna',
-      description: 'Fast and affordable agentic coding model.',
-      effort: {
-        default: 'medium',
-        values: [
-          { value: 'low' },
-          { value: 'medium' },
-          { value: 'high' },
-          { value: 'xhigh' },
-          { value: 'max' },
-        ],
-      },
-    },
-    {
-      value: 'gpt-5.5',
-      label: 'GPT-5.5',
-      description: 'Frontier model for complex coding, research, and real-world work.',
-      effort: {
-        default: 'medium',
-        values: [{ value: 'low' }, { value: 'medium' }, { value: 'high' }, { value: 'xhigh' }],
-      },
-    },
-    {
-      value: 'gpt-5.4',
-      label: 'GPT-5.4',
-      description: 'Strong model for everyday coding.',
-      effort: {
-        default: 'medium',
-        values: [{ value: 'low' }, { value: 'medium' }, { value: 'high' }, { value: 'xhigh' }],
-      },
-    },
-    {
-      value: 'gpt-5.4-mini',
-      label: 'GPT-5.4 Mini',
-      description: 'Small, fast, and cost-efficient model for simpler coding tasks.',
-      effort: {
-        default: 'medium',
-        values: [{ value: 'low' }, { value: 'medium' }, { value: 'high' }, { value: 'xhigh' }],
-      },
-    },
-  ],
-  DEFAULT: 'gpt-5.6-sol',
+/** How long a successful `model/list` answer stays fresh. */
+const LIVE_CATALOG_TTL_MS = 60_000;
+
+/** Test seam: replaces the app-server round-trip with a fixture-backed reader. */
+export type CodexProviderModelsDependencies = {
+  listModels?: () => Promise<CodexServerModel[]>;
+};
+
+/**
+ * Maps one app-server catalog entry onto the picker's option shape.
+ *
+ * `supportedReasoningEfforts` is the CLI's own answer for which effort levels
+ * the model accepts, so the effort picker can no longer drift from what the
+ * pinned CLI actually supports. The curated list had curated defaults on top;
+ * the CLI's `defaultReasoningEffort` takes that role here, and a default the
+ * server reports outside its own supported list is dropped rather than shown.
+ */
+const toCodexModelOption = (model: CodexServerModel): ProviderModelOption => {
+  const effortValues = (model.supportedReasoningEfforts ?? [])
+    .map((entry) => readOptionalString(entry?.reasoningEffort))
+    .filter((value, index, values): value is string => Boolean(value) && values.indexOf(value) === index);
+
+  const defaultEffort = readOptionalString(model.defaultReasoningEffort);
+  return {
+    value: model.id,
+    label: readOptionalString(model.displayName) ?? model.id,
+    ...(readOptionalString(model.description) ? { description: readOptionalString(model.description) as string } : {}),
+    ...(effortValues.length > 0
+      ? {
+        effort: {
+          values: effortValues.map((value) => ({ value })),
+          ...(defaultEffort && effortValues.includes(defaultEffort) ? { default: defaultEffort } : {}),
+        },
+      }
+      : {}),
+  };
+};
+
+/**
+ * Builds the picker catalog from the CLI answer.
+ *
+ * There is deliberately no curated fallback list behind this: a hardcoded
+ * catalog goes stale against every CLI upgrade and login change, and offering
+ * models the install cannot run is worse than the picker surfacing the CLI
+ * failure. An empty answer is treated as the same failure.
+ */
+const buildCatalogFromServer = (models: CodexServerModel[]): ProviderModelsDefinition => {
+  // Hidden is already dropped in the client; filtering again here keeps a
+  // stubbed listModels from smuggling a retired model into the picker.
+  const options = models
+    .filter((model) => model.hidden !== true)
+    .map(toCodexModelOption);
+  if (options.length === 0) {
+    throw new AppError('Codex reported no usable models.', {
+      code: 'CODEX_MODELS_UNAVAILABLE',
+      statusCode: 502,
+    });
+  }
+
+  const defaultOption = options[models.findIndex((model) => model.isDefault === true)] ?? options[0];
+  return {
+    OPTIONS: options,
+    DEFAULT: defaultOption.value,
+  };
 };
 
 const CODEX_CONFIG_PATH = path.join(os.homedir(), '.codex', 'config.toml');
 
-/** Provider registry model adapter for Codex predefined models and active config. */
+/** Provider registry model adapter for the live Codex catalog and active config. */
 export class CodexProviderModels implements IProviderModels {
+  private readonly listModels: () => Promise<CodexServerModel[]>;
+  private liveCatalog: Promise<ProviderModelsDefinition> | null = null;
+  private liveCatalogExpiresAt = 0;
+
+  constructor(dependencies: CodexProviderModelsDependencies = {}) {
+    this.listModels = dependencies.listModels ?? (() => codexAppServer.listModels());
+  }
+
+  /**
+   * Reports the picker catalog from `codex app-server`'s `model/list`.
+   *
+   * The round-trip spawns a short-lived app-server child, so a successful
+   * answer is cached briefly and concurrent callers share one in-flight run
+   * (the picker, the active-model lookup, and effort validation all resolve
+   * the catalog within the same page load). A failed run is not cached; the
+   * next caller retries rather than waiting out the TTL on an error.
+   */
   async getSupportedModels(): Promise<ProviderModelsDefinition> {
-    return CODEX_PREDEFINED_MODELS;
+    if (!this.liveCatalog || Date.now() >= this.liveCatalogExpiresAt) {
+      const run = (async () => buildCatalogFromServer(await this.listModels()))();
+      this.liveCatalog = run;
+      this.liveCatalogExpiresAt = Date.now() + LIVE_CATALOG_TTL_MS;
+      void run.catch(() => {
+        if (this.liveCatalog === run) {
+          this.liveCatalog = null;
+          this.liveCatalogExpiresAt = 0;
+        }
+      });
+    }
+
+    return this.liveCatalog;
   }
 
   async getCurrentActiveModel(): Promise<ProviderCurrentActiveModel> {
+    // The fallback here is the CLI catalog's own default, not a curated one,
+    // so an unreadable config still yields a model this install can run.
     try {
       const raw = await readFile(CODEX_CONFIG_PATH, 'utf8');
       const parsed = readObjectRecord(TOML.parse(raw));
       const model = readOptionalString(parsed?.model);
-      if (!model) {
-        return buildDefaultProviderCurrentActiveModel(await this.getSupportedModels());
+      if (model) {
+        return { model };
       }
-
-      return {
-        model,
-      };
     } catch {
-      return buildDefaultProviderCurrentActiveModel(await this.getSupportedModels());
+      // Fall through to the CLI catalog's default when the config is missing
+      // or unreadable.
     }
+
+    return buildDefaultProviderCurrentActiveModel(await this.getSupportedModels());
   }
 }

--- a/server/modules/providers/list/opencode/opencode-models.provider.ts
+++ b/server/modules/providers/list/opencode/opencode-models.provider.ts
@@ -519,22 +519,31 @@ const runOpenCodeModelsCli = async (): Promise<string | null> =>
     let child: ReturnType<typeof crossSpawn>;
     try {
       child = crossSpawn('opencode', ['models', '--verbose'], {
-        stdio: ['ignore', 'pipe', 'ignore'],
+        stdio: ['ignore', 'pipe', 'pipe'],
         shell: false,
       });
-    } catch {
+    } catch (error) {
+      console.warn('[OpenCode] `opencode models --verbose` failed to start:', error);
       resolve(null);
       return;
     }
 
     let stdout = '';
+    let stderr = '';
     let settled = false;
-    const finish = (value: string | null) => {
+    const finish = (value: string | null, reason?: string) => {
       if (settled) {
         return;
       }
       settled = true;
       clearTimeout(timer);
+      if (value === null) {
+        console.warn(
+          '[OpenCode] `opencode models --verbose` unusable (%s). stderr: %s',
+          reason ?? 'unknown',
+          stderr.trim().slice(0, 400) || '(empty)',
+        );
+      }
       resolve(value);
     };
 
@@ -544,14 +553,22 @@ const runOpenCodeModelsCli = async (): Promise<string | null> =>
       } catch {
         // A dead child is exactly what the timeout wants anyway.
       }
-      finish(null);
+      finish(null, 'timeout');
     }, OPENCODE_MODELS_CLI_TIMEOUT_MS);
 
     child.stdout?.on('data', (chunk: Buffer) => {
       stdout += chunk.toString();
     });
-    child.on('error', () => finish(null));
-    child.on('close', (code) => finish(code === 0 && stdout.trim() ? stdout : null));
+    child.stderr?.on('data', (chunk: Buffer) => {
+      stderr += chunk.toString();
+    });
+    child.on('error', (error) => {
+      console.warn('[OpenCode] `opencode models --verbose` spawn error:', error);
+      finish(null, 'spawn-error');
+    });
+    child.on('close', (code) => {
+      finish(code === 0 && stdout.trim() ? stdout : null, `exit=${code} stdout=${stdout.length}B`);
+    });
   });
 
 /**

--- a/server/modules/providers/list/opencode/opencode-models.provider.ts
+++ b/server/modules/providers/list/opencode/opencode-models.provider.ts
@@ -1,7 +1,3 @@
-import { readFile } from 'node:fs/promises';
-import os from 'node:os';
-import path from 'node:path';
-
 // cross-spawn: drop-in spawn with Windows .cmd/PATHEXT resolution, matching
 // the choice made in the OpenCode runtime adapter.
 import crossSpawn from 'cross-spawn';
@@ -21,354 +17,14 @@ import {
   readOptionalString,
 } from '@/shared/utils.js';
 
-/**
- * Curated OpenCode catalog shipped as immutable CloudCLI defaults.
- *
- * The live catalog comes from `opencode models --verbose`, so this list is now
- * metadata rather than the source of truth: it upgrades the bare ids the CLI
- * reports for the four built-in gateways (OpenCode Zen, OpenCode Go, and the
- * Anthropic and OpenAI providers OpenCode addresses with the user's own
- * credentials) into curated labels, groupings, and verified effort variants,
- * and it keeps the picker populated when the CLI cannot run at all.
- */
-export const OPENCODE_PREDEFINED_MODELS: ProviderModelsDefinition = {
-  OPTIONS: [
-    { value: 'opencode/gpt-5.6-sol', label: 'GPT 5.6 Sol', description: 'OpenCode Zen' },
-    { value: 'opencode/gpt-5.6-terra', label: 'GPT 5.6 Terra', description: 'OpenCode Zen' },
-    { value: 'opencode/gpt-5.6-luna', label: 'GPT 5.6 Luna', description: 'OpenCode Zen' },
-    { value: 'opencode/gpt-5.5', label: 'GPT 5.5', description: 'OpenCode Zen' },
-    { value: 'opencode/gpt-5.5-pro', label: 'GPT 5.5 Pro', description: 'OpenCode Zen' },
-    { value: 'opencode/gpt-5.4', label: 'GPT 5.4', description: 'OpenCode Zen' },
-    { value: 'opencode/gpt-5.4-pro', label: 'GPT 5.4 Pro', description: 'OpenCode Zen' },
-    { value: 'opencode/gpt-5.4-mini', label: 'GPT 5.4 Mini', description: 'OpenCode Zen' },
-    { value: 'opencode/gpt-5.4-nano', label: 'GPT 5.4 Nano', description: 'OpenCode Zen' },
-    { value: 'opencode/gpt-5.3-codex', label: 'GPT 5.3 Codex', description: 'OpenCode Zen' },
-    { value: 'opencode/gpt-5.3-codex-spark', label: 'GPT 5.3 Codex Spark', description: 'OpenCode Zen' },
-    { value: 'opencode/gpt-5.2', label: 'GPT 5.2', description: 'OpenCode Zen' },
-    { value: 'opencode/gpt-5.1', label: 'GPT 5.1', description: 'OpenCode Zen' },
-    { value: 'opencode/gpt-5', label: 'GPT 5', description: 'OpenCode Zen' },
-    { value: 'opencode/gpt-5-nano', label: 'GPT 5 Nano', description: 'OpenCode Zen' },
-    { value: 'opencode/claude-fable-5', label: 'Claude Fable 5', description: 'OpenCode Zen' },
-    { value: 'opencode/claude-opus-5', label: 'Claude Opus 5', description: 'OpenCode Zen' },
-    { value: 'opencode/claude-opus-4-8', label: 'Claude Opus 4.8', description: 'OpenCode Zen' },
-    { value: 'opencode/claude-opus-4-7', label: 'Claude Opus 4.7', description: 'OpenCode Zen' },
-    { value: 'opencode/claude-opus-4-6', label: 'Claude Opus 4.6', description: 'OpenCode Zen' },
-    { value: 'opencode/claude-opus-4-5', label: 'Claude Opus 4.5', description: 'OpenCode Zen' },
-    { value: 'opencode/claude-sonnet-5', label: 'Claude Sonnet 5', description: 'OpenCode Zen' },
-    { value: 'opencode/claude-sonnet-4-6', label: 'Claude Sonnet 4.6', description: 'OpenCode Zen' },
-    { value: 'opencode/claude-sonnet-4-5', label: 'Claude Sonnet 4.5', description: 'OpenCode Zen' },
-    { value: 'opencode/claude-haiku-4-5', label: 'Claude Haiku 4.5', description: 'OpenCode Zen' },
-    { value: 'opencode/gemini-3.6-flash', label: 'Gemini 3.6 Flash', description: 'OpenCode Zen' },
-    { value: 'opencode/gemini-3.5-flash', label: 'Gemini 3.5 Flash', description: 'OpenCode Zen' },
-    { value: 'opencode/gemini-3.5-flash-lite', label: 'Gemini 3.5 Flash Lite', description: 'OpenCode Zen' },
-    { value: 'opencode/gemini-3.1-pro', label: 'Gemini 3.1 Pro', description: 'OpenCode Zen' },
-    { value: 'opencode/gemini-3-flash', label: 'Gemini 3 Flash', description: 'OpenCode Zen' },
-    { value: 'opencode/grok-4.5', label: 'Grok 4.5', description: 'OpenCode Zen' },
-    { value: 'opencode/grok-build-0.1', label: 'Grok Build 0.1', description: 'OpenCode Zen' },
-    { value: 'opencode/qwen3.7-max', label: 'Qwen3.7 Max', description: 'OpenCode Zen' },
-    { value: 'opencode/qwen3.7-plus', label: 'Qwen3.7 Plus', description: 'OpenCode Zen' },
-    { value: 'opencode/qwen3.6-plus', label: 'Qwen3.6 Plus', description: 'OpenCode Zen' },
-    { value: 'opencode/qwen3.5-plus', label: 'Qwen3.5 Plus', description: 'OpenCode Zen' },
-    { value: 'opencode/deepseek-v4-pro', label: 'DeepSeek V4 Pro', description: 'OpenCode Zen' },
-    { value: 'opencode/deepseek-v4-flash', label: 'DeepSeek V4 Flash', description: 'OpenCode Zen' },
-    { value: 'opencode/minimax-m3', label: 'MiniMax M3', description: 'OpenCode Zen' },
-    { value: 'opencode/minimax-m2.7', label: 'MiniMax M2.7', description: 'OpenCode Zen' },
-    { value: 'opencode/minimax-m2.5', label: 'MiniMax M2.5', description: 'OpenCode Zen' },
-    { value: 'opencode/glm-5.2', label: 'GLM 5.2', description: 'OpenCode Zen' },
-    { value: 'opencode/glm-5.1', label: 'GLM 5.1', description: 'OpenCode Zen' },
-    { value: 'opencode/kimi-k2.5', label: 'Kimi K2.5', description: 'OpenCode Zen' },
-    { value: 'opencode/kimi-k2.6', label: 'Kimi K2.6', description: 'OpenCode Zen' },
-    { value: 'opencode/kimi-k2.7-code', label: 'Kimi K2.7 Code', description: 'OpenCode Zen' },
-    { value: 'opencode/kimi-k3', label: 'Kimi K3', description: 'OpenCode Zen' },
-    { value: 'opencode/big-pickle', label: 'Big Pickle', description: 'OpenCode Zen · Free' },
-    { value: 'opencode/mimo-v2.5-free', label: 'MiMo-V2.5 Free', description: 'OpenCode Zen · Free' },
-    { value: 'opencode/laguna-s-2.1-free', label: 'Laguna S 2.1 Free', description: 'OpenCode Zen · Free' },
-    { value: 'opencode/ling-3.0-flash-free', label: 'Ling-3.0-flash Free', description: 'OpenCode Zen · Free' },
-    { value: 'opencode/north-mini-code-free', label: 'North Mini Code Free', description: 'OpenCode Zen · Free' },
-    { value: 'opencode/nemotron-3-ultra-free', label: 'Nemotron 3 Ultra Free', description: 'OpenCode Zen · Free' },
-    { value: 'opencode/deepseek-v4-flash-free', label: 'DeepSeek V4 Flash Free', description: 'OpenCode Zen · Free' },
-    {
-      value: 'opencode-go/grok-4.6',
-      label: 'Grok 4.6',
-      description: 'OpenCode Go',
-      effort: {
-        values: [{ value: 'low' }, { value: 'medium' }, { value: 'high' }, { value: 'xhigh' }],
-      },
-    },
-    {
-      value: 'opencode-go/glm-5.3-flash',
-      label: 'GLM 5.3 Flash',
-      description: 'OpenCode Go',
-      effort: {
-        values: [{ value: 'low' }, { value: 'high' }, { value: 'max' }],
-      },
-    },
-    {
-      value: 'opencode-go/glm-5.3',
-      label: 'GLM 5.3',
-      description: 'OpenCode Go',
-      effort: {
-        values: [{ value: 'low' }, { value: 'high' }, { value: 'max' }],
-      },
-    },
-    {
-      value: 'opencode-go/glm-5.2',
-      label: 'GLM 5.2',
-      description: 'OpenCode Go',
-      effort: {
-        values: [{ value: 'high' }, { value: 'max' }],
-      },
-    },
-    { value: 'opencode-go/glm-5.1', label: 'GLM 5.1', description: 'OpenCode Go' },
-    {
-      value: 'opencode-go/gpt-5.6-luna',
-      label: 'GPT 5.6 Luna',
-      description: 'OpenCode Go',
-      effort: {
-        values: [
-          { value: 'none' },
-          { value: 'low' },
-          { value: 'medium' },
-          { value: 'high' },
-          { value: 'xhigh' },
-          { value: 'max' },
-        ],
-      },
-    },
-    {
-      value: 'opencode-go/kimi-k3',
-      label: 'Kimi K3',
-      description: 'OpenCode Go',
-      effort: {
-        values: [{ value: 'max' }],
-      },
-    },
-    { value: 'opencode-go/kimi-k2.7-code', label: 'Kimi K2.7 Code', description: 'OpenCode Go' },
-    { value: 'opencode-go/kimi-k2.6', label: 'Kimi K2.6', description: 'OpenCode Go' },
-    {
-      value: 'opencode-go/longcat-2.0',
-      label: 'LongCat 2.0',
-      description: 'OpenCode Go',
-      effort: {
-        values: [{ value: 'low' }, { value: 'medium' }, { value: 'high' }],
-      },
-    },
-    { value: 'opencode-go/mimo-v2.5', label: 'MiMo V2.5', description: 'OpenCode Go' },
-    { value: 'opencode-go/mimo-v2.5-pro', label: 'MiMo V2.5 Pro', description: 'OpenCode Go' },
-    {
-      value: 'opencode-go/minimax-m3',
-      label: 'MiniMax M3',
-      description: 'OpenCode Go',
-      effort: {
-        values: [{ value: 'none' }, { value: 'thinking' }],
-      },
-    },
-    { value: 'opencode-go/minimax-m2.7', label: 'MiniMax M2.7', description: 'OpenCode Go' },
-    {
-      value: 'opencode-go/muse-spark-1.3-contributor',
-      label: 'Muse Spark 1.3 Contributor',
-      description: 'OpenCode Go',
-      effort: {
-        values: [
-          { value: 'minimal' },
-          { value: 'low' },
-          { value: 'medium' },
-          { value: 'high' },
-          { value: 'xhigh' },
-        ],
-      },
-    },
-    {
-      value: 'opencode-go/muse-spark-1.2-contributor',
-      label: 'Muse Spark 1.2 Contributor',
-      description: 'OpenCode Go',
-      effort: {
-        values: [
-          { value: 'minimal' },
-          { value: 'low' },
-          { value: 'medium' },
-          { value: 'high' },
-          { value: 'xhigh' },
-        ],
-      },
-    },
-    {
-      value: 'opencode-go/qwen3.8-max',
-      label: 'Qwen3.8 Max',
-      description: 'OpenCode Go',
-      effort: {
-        values: [{ value: 'low' }, { value: 'medium' }, { value: 'xhigh' }],
-      },
-    },
-    {
-      value: 'opencode-go/qwen3.8-flash',
-      label: 'Qwen3.8 Flash',
-      description: 'OpenCode Go',
-      effort: {
-        values: [{ value: 'low' }, { value: 'medium' }, { value: 'xhigh' }],
-      },
-    },
-    { value: 'opencode-go/qwen3.7-max', label: 'Qwen3.7 Max', description: 'OpenCode Go' },
-    { value: 'opencode-go/qwen3.7-plus', label: 'Qwen3.7 Plus', description: 'OpenCode Go' },
-    { value: 'opencode-go/qwen3.6-plus', label: 'Qwen3.6 Plus', description: 'OpenCode Go' },
-    {
-      value: 'opencode-go/deepseek-v4-pro',
-      label: 'DeepSeek V4 Pro',
-      description: 'OpenCode Go',
-      effort: {
-        values: [{ value: 'high' }, { value: 'max' }],
-      },
-    },
-    {
-      value: 'opencode-go/deepseek-v4-flash',
-      label: 'DeepSeek V4 Flash',
-      description: 'OpenCode Go',
-      effort: {
-        values: [{ value: 'low' }, { value: 'high' }, { value: 'max' }],
-      },
-    },
-    {
-      value: 'opencode-go/deepseek-v4-flash-vision-exp',
-      label: 'DeepSeek V4 Flash Vision Exp',
-      description: 'OpenCode Go',
-      effort: {
-        values: [{ value: 'low' }, { value: 'high' }, { value: 'max' }],
-      },
-    },
-    {
-      value: 'opencode-go/hy4-preview',
-      label: 'Hy4 Preview',
-      description: 'OpenCode Go',
-      effort: {
-        values: [{ value: 'none' }, { value: 'high' }],
-      },
-    },
-    {
-      value: 'opencode-go/hy3',
-      label: 'Hy3',
-      description: 'OpenCode Go',
-      effort: {
-        values: [{ value: 'none' }, { value: 'low' }, { value: 'high' }],
-      },
-    },
-    {
-      value: 'opencode-go/omen-alpha',
-      label: 'Omen Alpha',
-      description: 'OpenCode Go',
-      effort: {
-        values: [{ value: 'low' }, { value: 'high' }],
-      },
-    },
-    { value: 'anthropic/claude-opus-5', label: 'Claude Opus 5', description: 'Anthropic' },
-    { value: 'anthropic/claude-opus-5-fast', label: 'Claude Opus 5 Fast', description: 'Anthropic' },
-    { value: 'anthropic/claude-fable-5', label: 'Claude Fable 5', description: 'Anthropic' },
-    { value: 'anthropic/claude-sonnet-5', label: 'Claude Sonnet 5', description: 'Anthropic' },
-    { value: 'anthropic/claude-opus-4-8', label: 'Claude Opus 4.8', description: 'Anthropic' },
-    { value: 'anthropic/claude-opus-4-8-fast', label: 'Claude Opus 4.8 Fast', description: 'Anthropic' },
-    { value: 'anthropic/claude-opus-4-7', label: 'Claude Opus 4.7', description: 'Anthropic' },
-    { value: 'anthropic/claude-opus-4-7-fast', label: 'Claude Opus 4.7 Fast', description: 'Anthropic' },
-    { value: 'anthropic/claude-opus-4-6', label: 'Claude Opus 4.6', description: 'Anthropic' },
-    { value: 'anthropic/claude-opus-4-6-fast', label: 'Claude Opus 4.6 Fast', description: 'Anthropic' },
-    { value: 'anthropic/claude-opus-4-5', label: 'Claude Opus 4.5 (latest)', description: 'Anthropic' },
-    { value: 'anthropic/claude-opus-4-5-20251101', label: 'Claude Opus 4.5', description: 'Anthropic' },
-    { value: 'anthropic/claude-sonnet-4-6', label: 'Claude Sonnet 4.6', description: 'Anthropic' },
-    { value: 'anthropic/claude-sonnet-4-5', label: 'Claude Sonnet 4.5 (latest)', description: 'Anthropic' },
-    { value: 'anthropic/claude-sonnet-4-5-20250929', label: 'Claude Sonnet 4.5', description: 'Anthropic' },
-    { value: 'anthropic/claude-haiku-4-5', label: 'Claude Haiku 4.5 (latest)', description: 'Anthropic' },
-    { value: 'anthropic/claude-haiku-4-5-20251001', label: 'Claude Haiku 4.5', description: 'Anthropic' },
-    { value: 'openai/gpt-5.6', label: 'GPT-5.6', description: 'OpenAI' },
-    { value: 'openai/gpt-5.6-fast', label: 'GPT-5.6 Fast', description: 'OpenAI' },
-    { value: 'openai/gpt-5.6-pro', label: 'GPT-5.6 Pro', description: 'OpenAI' },
-    { value: 'openai/gpt-5.6-sol', label: 'GPT-5.6 Sol', description: 'OpenAI' },
-    { value: 'openai/gpt-5.6-sol-fast', label: 'GPT-5.6 Sol Fast', description: 'OpenAI' },
-    { value: 'openai/gpt-5.6-sol-pro', label: 'GPT-5.6 Sol Pro', description: 'OpenAI' },
-    { value: 'openai/gpt-5.6-terra', label: 'GPT-5.6 Terra', description: 'OpenAI' },
-    { value: 'openai/gpt-5.6-terra-fast', label: 'GPT-5.6 Terra Fast', description: 'OpenAI' },
-    { value: 'openai/gpt-5.6-terra-pro', label: 'GPT-5.6 Terra Pro', description: 'OpenAI' },
-    { value: 'openai/gpt-5.6-luna', label: 'GPT-5.6 Luna', description: 'OpenAI' },
-    { value: 'openai/gpt-5.6-luna-fast', label: 'GPT-5.6 Luna Fast', description: 'OpenAI' },
-    { value: 'openai/gpt-5.6-luna-pro', label: 'GPT-5.6 Luna Pro', description: 'OpenAI' },
-    { value: 'openai/gpt-5.5', label: 'GPT-5.5', description: 'OpenAI' },
-    { value: 'openai/gpt-5.5-fast', label: 'GPT-5.5 Fast', description: 'OpenAI' },
-    { value: 'openai/gpt-5.4', label: 'GPT-5.4', description: 'OpenAI' },
-    { value: 'openai/gpt-5.4-fast', label: 'GPT-5.4 Fast', description: 'OpenAI' },
-    { value: 'openai/gpt-5.4-mini', label: 'GPT-5.4 mini', description: 'OpenAI' },
-    { value: 'openai/gpt-5.4-mini-fast', label: 'GPT-5.4 mini Fast', description: 'OpenAI' },
-    { value: 'openai/gpt-5.3-codex-spark', label: 'GPT-5.3 Codex Spark', description: 'OpenAI' },
-  ],
-  DEFAULT: 'opencode/gpt-5.6-terra',
-};
-
-/** Global OpenCode config files, in the order the CLI loads them. */
-const OPENCODE_CONFIG_FILES = ['config.json', 'opencode.json', 'opencode.jsonc'];
-
-/** Provider API keys OpenCode reads straight from the environment. */
-const OPENCODE_ENV_PROVIDER_IDS: Record<string, string> = {
-  OPENCODE_API_KEY: 'opencode',
-  ANTHROPIC_API_KEY: 'anthropic',
-  OPENAI_API_KEY: 'openai',
-};
-
 /** How long a successful `opencode models --verbose` answer stays fresh. */
 const LIVE_CATALOG_TTL_MS = 60_000;
 
 /** Kill bound for one discovery invocation; the CLI answers in ~2s normally. */
 const OPENCODE_MODELS_CLI_TIMEOUT_MS = 15_000;
 
-const readOpenCodeJsonFile = async (filePath: string): Promise<Record<string, unknown> | null> => {
-  try {
-    return readObjectRecord(JSON.parse(await readFile(filePath, 'utf8')));
-  } catch {
-    // Missing, unreadable, or comment-bearing (.jsonc) files simply contribute
-    // nothing; the CLI and the auth store are the authoritative sources.
-    return null;
-  }
-};
-
-/**
- * Lists the upstream providers this OpenCode install can actually route to.
- *
- * Only consulted as a fallback when the CLI is unavailable. OpenCode resolves
- * `<providerID>/<modelID>` against the providers the user has connected, and
- * rejects anything else outright - `Model
- * opencode/claude-sonnet-4-6 is not valid` is what a run gets for asking for an
- * OpenCode Zen model on a machine that only has an Anthropic key. The curated
- * catalog spans every provider OpenCode can address, so it has to be narrowed
- * to this machine's providers before it reaches the model picker.
- *
- * Returns null when nothing can be read, so the caller keeps the full catalog
- * rather than leaving the picker empty. Providers declared only in a
- * project-level `opencode.json` are not visible here; the null fallback and the
- * env-key sweep keep those installs on the full list.
- */
-const readConnectedOpenCodeProviderIds = async (): Promise<Set<string> | null> => {
-  const providerIds = new Set<string>();
-  const configDir = path.join(os.homedir(), '.config', 'opencode');
-
-  const auth = await readOpenCodeJsonFile(
-    path.join(os.homedir(), '.local', 'share', 'opencode', 'auth.json'),
-  );
-  for (const [providerId, credential] of Object.entries(auth ?? {})) {
-    if (readObjectRecord(credential)) {
-      providerIds.add(providerId);
-    }
-  }
-
-  for (const configFile of OPENCODE_CONFIG_FILES) {
-    const config = await readOpenCodeJsonFile(path.join(configDir, configFile));
-    for (const providerId of Object.keys(readObjectRecord(config?.provider) ?? {})) {
-      providerIds.add(providerId);
-    }
-  }
-
-  for (const [envKey, providerId] of Object.entries(OPENCODE_ENV_PROVIDER_IDS)) {
-    if (readOptionalString(process.env[envKey])) {
-      providerIds.add(providerId);
-    }
-  }
-
-  return providerIds.size > 0 ? providerIds : null;
-};
+/** Preferred picker default when the live catalog contains it. */
+const OPENCODE_PREFERRED_DEFAULT = 'opencode/gpt-5.6-terra';
 
 /** One `opencode models --verbose` record, narrowed to the picker's fields. */
 type OpenCodeCliModel = {
@@ -497,10 +153,10 @@ const parseOpenCodeCliModels = (stdout: string): OpenCodeCliModel[] => {
  * Runs `opencode models --verbose` and parses its answer.
  *
  * Returns null when the CLI cannot produce a catalog - not installed, errored,
- * timed out, or unparseable - so the caller keeps the curated fallback rather
- * than leaving the picker empty. This is the only path that sees providers the
- * user defined themselves, because it asks the same resolver the run command
- * uses instead of re-deriving connectivity from config files.
+ * timed out, or unparseable - so the caller keeps an empty picker plus the
+ * console warning rather than a list of models this install may not have. The
+ * CLI is the single source of truth: it is the same resolver `opencode run`
+ * uses, so it is also the only one that sees the user's own providers.
  */
 const readOpenCodeCliModels = async (
   runModelsCli: () => Promise<string | null>,
@@ -572,93 +228,36 @@ const runOpenCodeModelsCli = async (): Promise<string | null> =>
   });
 
 /**
- * Builds the picker catalog from the live CLI answer, upgraded by curated rows.
+ * Builds the picker catalog straight from the CLI answer.
  *
- * Curated options come first so the grouped Zen/Go/Anthropic/OpenAI entries keep
- * their labels, descriptions, and effort metadata; the user's own providers then
- * append as-is. `description` carries the provider id, which is what makes a
- * `bit-openai/gpt-5.6-sol` entry distinguishable from the curated `openai/` one.
+ * Labels and effort variants come from the CLI's own `name` and `variants`
+ * fields; `description` carries the provider id, which is what makes a
+ * `bit-openai/gpt-5.6-sol` entry distinguishable from an `openai/` one.
  */
 const buildCatalogFromCli = (
   cliModels: OpenCodeCliModel[],
 ): ProviderModelsDefinition => {
-  const cliById = new Map(cliModels.map((model) => [model.id, model]));
-  const options: ProviderModelOption[] = [];
-  const seen = new Set<string>();
-
-  // Curated rows first, in curated order, but only for models this install
-  // actually has; that keeps the grouped Zen/Go/Anthropic/OpenAI entries on
-  // their labels, descriptions, and verified effort blocks.
-  for (const curated of OPENCODE_PREDEFINED_MODELS.OPTIONS) {
-    if (cliById.has(curated.value) && !seen.has(curated.value)) {
-      seen.add(curated.value);
-      options.push(curated);
-    }
-  }
-
-  // Everything the CLI reports that the curated catalog does not know - the
-  // user's own providers above all - appends as-is. `description` carries the
-  // provider id, which is what makes a `bit-openai/gpt-5.6-sol` entry
-  // distinguishable from the curated `openai/` one.
-  for (const model of cliModels) {
-    if (seen.has(model.id)) {
-      continue;
-    }
-    seen.add(model.id);
-
+  const options: ProviderModelOption[] = cliModels.map((model) => {
     const effort = model.variants && model.variants.length > 0
       ? toOpenCodeEffort(model.variants)
       : undefined;
-    options.push({
+    return {
       value: model.id,
       label: model.name ?? model.id.split('/').slice(1).join('/'),
       description: model.providerId,
       ...(effort ? { effort } : {}),
-    });
-  }
-
-  if (options.length === 0) {
-    return OPENCODE_PREDEFINED_MODELS;
-  }
+    };
+  });
 
   return {
     OPTIONS: options,
-    DEFAULT: options.some((option) => option.value === OPENCODE_PREDEFINED_MODELS.DEFAULT)
-      ? OPENCODE_PREDEFINED_MODELS.DEFAULT
-      : options[0].value,
+    DEFAULT: options.some((option) => option.value === OPENCODE_PREFERRED_DEFAULT)
+      ? OPENCODE_PREFERRED_DEFAULT
+      : options[0]?.value ?? '',
   };
 };
 
-/**
- * Narrows the curated catalog to the providers OpenCode can route to.
- *
- * Fallback path only - used when the CLI is unavailable. The default has to move
- * with the list: leaving it on an OpenCode Zen model would hand every new
- * session a model the CLI refuses to run.
- */
-const filterOpenCodeModelsByProvider = (
-  definition: ProviderModelsDefinition,
-  connectedProviderIds: Set<string> | null,
-): ProviderModelsDefinition => {
-  if (!connectedProviderIds) {
-    return definition;
-  }
-
-  const options = definition.OPTIONS.filter(
-    (option) => connectedProviderIds.has(option.value.split('/')[0]),
-  );
-  if (options.length === 0) {
-    return definition;
-  }
-
-  return {
-    ...definition,
-    OPTIONS: options,
-    DEFAULT: options.some((option) => option.value === definition.DEFAULT)
-      ? definition.DEFAULT
-      : options[0].value,
-  };
-};
+const EMPTY_CATALOG: ProviderModelsDefinition = { OPTIONS: [], DEFAULT: '' };
 
 /** Test seam: replaces the CLI invocation with a fixture-backed reader. */
 export type OpenCodeProviderModelsDependencies = {
@@ -691,7 +290,7 @@ const parseOpenCodeSessionModelValue = (rawModel: unknown): string | null => {
     ?? null;
 };
 
-/** Provider registry model adapter for OpenCode predefined models and session metadata. */
+/** Provider registry model adapter sourcing OpenCode models from the CLI. */
 export class OpenCodeProviderModels implements IProviderModels {
   private readonly runModelsCli: () => Promise<string | null>;
   private liveCatalog: Promise<ProviderModelsDefinition | null> | null = null;
@@ -702,14 +301,15 @@ export class OpenCodeProviderModels implements IProviderModels {
   }
 
   /**
-   * Reports the picker catalog: live CLI answer first, curated fallback second.
+   * Reports the picker catalog from `opencode models --verbose`.
    *
    * The CLI is the only source that sees user-defined providers, but it costs
    * ~2s, so a successful answer is cached briefly and concurrent callers share
    * one in-flight run (the picker, the active-model lookup, and effort
    * validation all resolve the catalog within the same page load). A failed run
    * is not cached; the next caller retries rather than waiting out the TTL on a
-   * null answer.
+   * null answer, and while it failed the picker is empty - serving a hardcoded
+   * list would offer models this install cannot run.
    */
   async getSupportedModels(): Promise<ProviderModelsDefinition> {
     if (!this.liveCatalog || Date.now() >= this.liveCatalogExpiresAt) {
@@ -727,15 +327,7 @@ export class OpenCodeProviderModels implements IProviderModels {
       });
     }
 
-    const live = await this.liveCatalog.catch(() => null);
-    if (live) {
-      return live;
-    }
-
-    return filterOpenCodeModelsByProvider(
-      OPENCODE_PREDEFINED_MODELS,
-      await readConnectedOpenCodeProviderIds(),
-    );
+    return (await this.liveCatalog.catch(() => null)) ?? EMPTY_CATALOG;
   }
 
   async getCurrentActiveModel(sessionId?: string): Promise<ProviderCurrentActiveModel> {
@@ -784,7 +376,7 @@ export class OpenCodeProviderModels implements IProviderModels {
         db.close();
       }
     } catch {
-      // Fall through to the curated default when OpenCode session lookup fails.
+      // Fall through to the catalog default when OpenCode session lookup fails.
     }
 
     return buildDefaultProviderCurrentActiveModel(await this.getSupportedModels());

--- a/server/modules/providers/list/opencode/opencode-models.provider.ts
+++ b/server/modules/providers/list/opencode/opencode-models.provider.ts
@@ -2,12 +2,16 @@ import { readFile } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 
+// cross-spawn: drop-in spawn with Windows .cmd/PATHEXT resolution, matching
+// the choice made in the OpenCode runtime adapter.
+import crossSpawn from 'cross-spawn';
 import Database from 'better-sqlite3';
 
 import { sessionsDb } from '@/modules/database/index.js';
 import type { IProviderModels } from '@/shared/interfaces.js';
 import type {
   ProviderCurrentActiveModel,
+  ProviderModelOption,
   ProviderModelsDefinition,
 } from '@/shared/types.js';
 import {
@@ -20,10 +24,12 @@ import {
 /**
  * Curated OpenCode catalog shipped as immutable CloudCLI defaults.
  *
- * OpenCode routes by `<providerID>/<modelID>`, so this list mirrors the
- * providers `opencode models --verbose` reports: the OpenCode Zen gateway, the
- * OpenCode Go subscription gateway, and the Anthropic and OpenAI providers
- * OpenCode can address directly with the user's own credentials.
+ * The live catalog comes from `opencode models --verbose`, so this list is now
+ * metadata rather than the source of truth: it upgrades the bare ids the CLI
+ * reports for the four built-in gateways (OpenCode Zen, OpenCode Go, and the
+ * Anthropic and OpenAI providers OpenCode addresses with the user's own
+ * credentials) into curated labels, groupings, and verified effort variants,
+ * and it keeps the picker populated when the CLI cannot run at all.
  */
 export const OPENCODE_PREDEFINED_MODELS: ProviderModelsDefinition = {
   OPTIONS: [
@@ -303,12 +309,18 @@ const OPENCODE_ENV_PROVIDER_IDS: Record<string, string> = {
   OPENAI_API_KEY: 'openai',
 };
 
+/** How long a successful `opencode models --verbose` answer stays fresh. */
+const LIVE_CATALOG_TTL_MS = 60_000;
+
+/** Kill bound for one discovery invocation; the CLI answers in ~2s normally. */
+const OPENCODE_MODELS_CLI_TIMEOUT_MS = 15_000;
+
 const readOpenCodeJsonFile = async (filePath: string): Promise<Record<string, unknown> | null> => {
   try {
     return readObjectRecord(JSON.parse(await readFile(filePath, 'utf8')));
   } catch {
     // Missing, unreadable, or comment-bearing (.jsonc) files simply contribute
-    // nothing; the auth store is the authoritative source below.
+    // nothing; the CLI and the auth store are the authoritative sources.
     return null;
   }
 };
@@ -316,8 +328,9 @@ const readOpenCodeJsonFile = async (filePath: string): Promise<Record<string, un
 /**
  * Lists the upstream providers this OpenCode install can actually route to.
  *
- * OpenCode resolves `<providerID>/<modelID>` against the providers the user has
- * connected, and rejects anything else outright - `Model
+ * Only consulted as a fallback when the CLI is unavailable. OpenCode resolves
+ * `<providerID>/<modelID>` against the providers the user has connected, and
+ * rejects anything else outright - `Model
  * opencode/claude-sonnet-4-6 is not valid` is what a run gets for asking for an
  * OpenCode Zen model on a machine that only has an Anthropic key. The curated
  * catalog spans every provider OpenCode can address, so it has to be narrowed
@@ -357,11 +370,254 @@ const readConnectedOpenCodeProviderIds = async (): Promise<Set<string> | null> =
   return providerIds.size > 0 ? providerIds : null;
 };
 
+/** One `opencode models --verbose` record, narrowed to the picker's fields. */
+type OpenCodeCliModel = {
+  id: string;
+  providerId: string;
+  name: string | null;
+  variants: string[] | null;
+};
+
+/**
+ * Maps CLI variant names onto the picker's effort block.
+ *
+ * The CLI exposes variants by name only; the runtime forwards the chosen value
+ * as `--variant`, so the names pass through untouched.
+ */
+const toOpenCodeEffort = (
+  variantKeys: string[],
+): ProviderModelOption['effort'] => ({
+  values: variantKeys.map((value) => ({ value })),
+});
+
+const countJsonBraces = (text: string): number => {
+  let depth = 0;
+  let inString = false;
+  let escaped = false;
+  for (const char of text) {
+    if (inString) {
+      if (escaped) {
+        escaped = false;
+      } else if (char === '\\') {
+        escaped = true;
+      } else if (char === '"') {
+        inString = false;
+      }
+      continue;
+    }
+    if (char === '"') {
+      inString = true;
+    } else if (char === '{') {
+      depth += 1;
+    } else if (char === '}') {
+      depth -= 1;
+    }
+  }
+  return depth;
+};
+
+const safeJsonParse = (text: string): unknown => {
+  try {
+    return JSON.parse(text);
+  } catch {
+    return null;
+  }
+};
+
+const parseOpenCodeCliModels = (stdout: string): OpenCodeCliModel[] => {
+  // `--verbose` prints `providerID/modelID` lines interleaved with one pretty-
+  // printed JSON object per model. The objects are the payload; the bare lines
+  // only fill in the provider id when an object is missing one.
+  const lines = stdout.split(/\r?\n/);
+  const models: OpenCodeCliModel[] = [];
+  const seen = new Set<string>();
+  let pendingLine: string | null = null;
+  let index = 0;
+
+  while (index < lines.length) {
+    const line = lines[index].trim();
+    index += 1;
+    if (!line) {
+      continue;
+    }
+
+    if (!line.startsWith('{')) {
+      if (line.includes('/')) {
+        pendingLine = line;
+      }
+      continue;
+    }
+
+    // Pretty-printed objects span many lines; buffer until the braces balance.
+    let json = line;
+    while (index < lines.length && countJsonBraces(json) > 0) {
+      json += `\n${lines[index]}`;
+      index += 1;
+    }
+
+    const record = readObjectRecord(safeJsonParse(json));
+    if (!record) {
+      continue;
+    }
+
+    const modelId = readOptionalString(record.id);
+    const providerId = readOptionalString(record.providerID)
+      ?? readOptionalString(record.providerId)
+      ?? pendingLine?.split('/')[0]
+      ?? null;
+    if (!modelId || !providerId) {
+      continue;
+    }
+
+    // Retired catalog entries still print; offering them would hand the picker
+    // a model the CLI refuses to run.
+    const status = readOptionalString(record.status);
+    if (status && status !== 'active') {
+      continue;
+    }
+
+    const value = `${providerId}/${modelId}`;
+    if (seen.has(value)) {
+      continue;
+    }
+    seen.add(value);
+
+    models.push({
+      id: value,
+      providerId,
+      name: readOptionalString(record.name) ?? null,
+      variants: Object.keys(readObjectRecord(record.variants) ?? {}),
+    });
+  }
+
+  return models;
+};
+
+/**
+ * Runs `opencode models --verbose` and parses its answer.
+ *
+ * Returns null when the CLI cannot produce a catalog - not installed, errored,
+ * timed out, or unparseable - so the caller keeps the curated fallback rather
+ * than leaving the picker empty. This is the only path that sees providers the
+ * user defined themselves, because it asks the same resolver the run command
+ * uses instead of re-deriving connectivity from config files.
+ */
+const readOpenCodeCliModels = async (
+  runModelsCli: () => Promise<string | null>,
+): Promise<OpenCodeCliModel[] | null> => {
+  const raw = await runModelsCli();
+  if (raw === null) {
+    return null;
+  }
+
+  const models = parseOpenCodeCliModels(raw);
+  return models.length > 0 ? models : null;
+};
+
+const runOpenCodeModelsCli = async (): Promise<string | null> =>
+  new Promise((resolve) => {
+    let child: ReturnType<typeof crossSpawn>;
+    try {
+      child = crossSpawn('opencode', ['models', '--verbose'], {
+        stdio: ['ignore', 'pipe', 'ignore'],
+        shell: false,
+      });
+    } catch {
+      resolve(null);
+      return;
+    }
+
+    let stdout = '';
+    let settled = false;
+    const finish = (value: string | null) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearTimeout(timer);
+      resolve(value);
+    };
+
+    const timer = setTimeout(() => {
+      try {
+        child.kill();
+      } catch {
+        // A dead child is exactly what the timeout wants anyway.
+      }
+      finish(null);
+    }, OPENCODE_MODELS_CLI_TIMEOUT_MS);
+
+    child.stdout?.on('data', (chunk: Buffer) => {
+      stdout += chunk.toString();
+    });
+    child.on('error', () => finish(null));
+    child.on('close', (code) => finish(code === 0 && stdout.trim() ? stdout : null));
+  });
+
+/**
+ * Builds the picker catalog from the live CLI answer, upgraded by curated rows.
+ *
+ * Curated options come first so the grouped Zen/Go/Anthropic/OpenAI entries keep
+ * their labels, descriptions, and effort metadata; the user's own providers then
+ * append as-is. `description` carries the provider id, which is what makes a
+ * `bit-openai/gpt-5.6-sol` entry distinguishable from the curated `openai/` one.
+ */
+const buildCatalogFromCli = (
+  cliModels: OpenCodeCliModel[],
+): ProviderModelsDefinition => {
+  const cliById = new Map(cliModels.map((model) => [model.id, model]));
+  const options: ProviderModelOption[] = [];
+  const seen = new Set<string>();
+
+  // Curated rows first, in curated order, but only for models this install
+  // actually has; that keeps the grouped Zen/Go/Anthropic/OpenAI entries on
+  // their labels, descriptions, and verified effort blocks.
+  for (const curated of OPENCODE_PREDEFINED_MODELS.OPTIONS) {
+    if (cliById.has(curated.value) && !seen.has(curated.value)) {
+      seen.add(curated.value);
+      options.push(curated);
+    }
+  }
+
+  // Everything the CLI reports that the curated catalog does not know - the
+  // user's own providers above all - appends as-is. `description` carries the
+  // provider id, which is what makes a `bit-openai/gpt-5.6-sol` entry
+  // distinguishable from the curated `openai/` one.
+  for (const model of cliModels) {
+    if (seen.has(model.id)) {
+      continue;
+    }
+    seen.add(model.id);
+
+    const effort = model.variants && model.variants.length > 0
+      ? toOpenCodeEffort(model.variants)
+      : undefined;
+    options.push({
+      value: model.id,
+      label: model.name ?? model.id.split('/').slice(1).join('/'),
+      description: model.providerId,
+      ...(effort ? { effort } : {}),
+    });
+  }
+
+  if (options.length === 0) {
+    return OPENCODE_PREDEFINED_MODELS;
+  }
+
+  return {
+    OPTIONS: options,
+    DEFAULT: options.some((option) => option.value === OPENCODE_PREDEFINED_MODELS.DEFAULT)
+      ? OPENCODE_PREDEFINED_MODELS.DEFAULT
+      : options[0].value,
+  };
+};
+
 /**
  * Narrows the curated catalog to the providers OpenCode can route to.
  *
- * The default has to move with the list: leaving it on an OpenCode Zen model
- * would hand every new session a model the CLI refuses to run.
+ * Fallback path only - used when the CLI is unavailable. The default has to move
+ * with the list: leaving it on an OpenCode Zen model would hand every new
+ * session a model the CLI refuses to run.
  */
 const filterOpenCodeModelsByProvider = (
   definition: ProviderModelsDefinition,
@@ -385,6 +641,11 @@ const filterOpenCodeModelsByProvider = (
       ? definition.DEFAULT
       : options[0].value,
   };
+};
+
+/** Test seam: replaces the CLI invocation with a fixture-backed reader. */
+export type OpenCodeProviderModelsDependencies = {
+  runModelsCli?: () => Promise<string | null>;
 };
 
 const parseOpenCodeSessionModelValue = (rawModel: unknown): string | null => {
@@ -415,7 +676,45 @@ const parseOpenCodeSessionModelValue = (rawModel: unknown): string | null => {
 
 /** Provider registry model adapter for OpenCode predefined models and session metadata. */
 export class OpenCodeProviderModels implements IProviderModels {
+  private readonly runModelsCli: () => Promise<string | null>;
+  private liveCatalog: Promise<ProviderModelsDefinition | null> | null = null;
+  private liveCatalogExpiresAt = 0;
+
+  constructor(dependencies: OpenCodeProviderModelsDependencies = {}) {
+    this.runModelsCli = dependencies.runModelsCli ?? runOpenCodeModelsCli;
+  }
+
+  /**
+   * Reports the picker catalog: live CLI answer first, curated fallback second.
+   *
+   * The CLI is the only source that sees user-defined providers, but it costs
+   * ~2s, so a successful answer is cached briefly and concurrent callers share
+   * one in-flight run (the picker, the active-model lookup, and effort
+   * validation all resolve the catalog within the same page load). A failed run
+   * is not cached; the next caller retries rather than waiting out the TTL on a
+   * null answer.
+   */
   async getSupportedModels(): Promise<ProviderModelsDefinition> {
+    if (!this.liveCatalog || Date.now() >= this.liveCatalogExpiresAt) {
+      const run = (async (): Promise<ProviderModelsDefinition | null> => {
+        const cliModels = await readOpenCodeCliModels(this.runModelsCli);
+        return cliModels ? buildCatalogFromCli(cliModels) : null;
+      })();
+      this.liveCatalog = run;
+      this.liveCatalogExpiresAt = Date.now() + LIVE_CATALOG_TTL_MS;
+      void run.catch(() => {
+        if (this.liveCatalog === run) {
+          this.liveCatalog = null;
+          this.liveCatalogExpiresAt = 0;
+        }
+      });
+    }
+
+    const live = await this.liveCatalog.catch(() => null);
+    if (live) {
+      return live;
+    }
+
     return filterOpenCodeModelsByProvider(
       OPENCODE_PREDEFINED_MODELS,
       await readConnectedOpenCodeProviderIds(),

--- a/server/modules/providers/tests/claude-models.test.ts
+++ b/server/modules/providers/tests/claude-models.test.ts
@@ -1,7 +1,11 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 
-import { extractClaudeEventModel } from '@/modules/providers/list/claude/claude-models.provider.js';
+import {
+  CLAUDE_ULTRACODE_EFFORT,
+  ClaudeProviderModels,
+  extractClaudeEventModel,
+} from '@/modules/providers/list/claude/claude-models.provider.js';
 
 const SESSION_ID = 'session-1';
 
@@ -84,4 +88,95 @@ test('falls back to the message model when every content hit is a placeholder', 
     ),
     'claude-sonnet-5',
   );
+});
+
+// ---------------------------------------------------------------------------
+// Live catalog from the SDK's supportedModels() handshake.
+// ---------------------------------------------------------------------------
+
+type SdkModel = {
+  value: string;
+  displayName?: string;
+  description?: string;
+  supportsEffort?: boolean;
+  supportedEffortLevels?: string[];
+};
+
+const CLI_MODELS: SdkModel[] = [
+  {
+    value: 'default',
+    displayName: 'Default (recommended)',
+    description: 'Use the default model',
+    supportsEffort: true,
+    supportedEffortLevels: ['low', 'medium', 'high', 'xhigh', 'max'],
+  },
+  { value: 'haiku', displayName: 'Haiku', supportsEffort: false },
+  {
+    value: 'custom-model',
+    displayName: '',
+    supportsEffort: true,
+    supportedEffortLevels: ['low', 'high'],
+  },
+];
+
+const adapterFor = (readSupportedModels: () => Promise<SdkModel[]>) => (
+  new ClaudeProviderModels({ readSupportedModels })
+);
+
+test('builds the catalog from the CLI answer, appending ultracode on xhigh models', async () => {
+  const catalog = await adapterFor(async () => CLI_MODELS).getSupportedModels();
+
+  assert.deepEqual(catalog.OPTIONS.map((option) => option.value), ['default', 'haiku', 'custom-model']);
+  assert.equal(catalog.DEFAULT, 'default');
+
+  assert.deepEqual(
+    catalog.OPTIONS[0].effort?.values.map((entry) => entry.value),
+    ['low', 'medium', 'high', 'xhigh', 'max', CLAUDE_ULTRACODE_EFFORT],
+  );
+  assert.equal(catalog.OPTIONS[1].effort, undefined);
+  // A blank display name falls back to the raw value.
+  assert.equal(catalog.OPTIONS[2].label, 'custom-model');
+  assert.deepEqual(
+    catalog.OPTIONS[2].effort?.values.map((entry) => entry.value),
+    ['low', 'high'],
+  );
+});
+
+test('surfaces the CLI failure instead of a curated fallback', async () => {
+  const adapter = adapterFor(async () => {
+    throw new Error('claude CLI is not installed');
+  });
+
+  await assert.rejects(() => adapter.getSupportedModels(), /not installed/);
+  // A failed run must not poison the cache: the next caller retries.
+  await assert.rejects(() => adapter.getSupportedModels(), /not installed/);
+});
+
+test('treats an empty catalog as a failure', async () => {
+  await assert.rejects(
+    () => adapterFor(async () => []).getSupportedModels(),
+    /no usable models/,
+  );
+});
+
+test('defaults to the first entry when the CLI answer has no default alias', async () => {
+  const catalog = await adapterFor(async () => [
+    { value: 'opus', displayName: 'Opus' },
+  ] as SdkModel[]).getSupportedModels();
+  assert.equal(catalog.DEFAULT, 'opus');
+});
+
+test('shares one in-flight CLI run across concurrent callers', async () => {
+  let calls = 0;
+  const adapter = adapterFor(async () => {
+    calls += 1;
+    return [{ value: 'default', displayName: 'Default' }] as SdkModel[];
+  });
+
+  const [first, second] = await Promise.all([
+    adapter.getSupportedModels(),
+    adapter.getSupportedModels(),
+  ]);
+  assert.equal(calls, 1);
+  assert.equal(first.DEFAULT, second.DEFAULT);
 });

--- a/server/modules/providers/tests/codex-models.test.ts
+++ b/server/modules/providers/tests/codex-models.test.ts
@@ -1,0 +1,105 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { CodexProviderModels } from '@/modules/providers/list/codex/codex-models.provider.js';
+import type { CodexServerModel } from '@/modules/providers/list/codex/codex-app-server.client.js';
+
+const CLI_MODELS: CodexServerModel[] = [
+  {
+    id: 'gpt-6-astra',
+    displayName: 'GPT-6-Astra',
+    description: 'Our most capable model for complex, demanding work.',
+    hidden: false,
+    isDefault: true,
+    supportedReasoningEfforts: [
+      { reasoningEffort: 'low' },
+      { reasoningEffort: 'medium' },
+      { reasoningEffort: 'high' },
+      { reasoningEffort: 'xhigh' },
+      { reasoningEffort: 'max' },
+      { reasoningEffort: 'ultra' },
+    ],
+    defaultReasoningEffort: 'medium',
+  },
+  {
+    id: 'gpt-legacy',
+    displayName: 'Legacy',
+    hidden: true,
+    supportedReasoningEfforts: [{ reasoningEffort: 'low' }],
+  },
+  {
+    id: 'gpt-5.6-luna',
+    displayName: 'GPT-5.6 Luna',
+    description: 'Fast and affordable agentic coding model.',
+    hidden: false,
+    isDefault: false,
+    supportedReasoningEfforts: [{ reasoningEffort: 'low' }, { reasoningEffort: 'medium' }],
+    // A default outside the supported list must not reach the picker.
+    defaultReasoningEffort: 'ultra',
+  },
+];
+
+const adapterFor = (
+  listModels: () => Promise<CodexServerModel[]>,
+) => new CodexProviderModels({ listModels });
+
+test('builds the catalog from the CLI answer, dropping hidden entries', async () => {
+  const catalog = await adapterFor(async () => CLI_MODELS).getSupportedModels();
+
+  assert.deepEqual(catalog.OPTIONS.map((option) => option.value), ['gpt-6-astra', 'gpt-5.6-luna']);
+  assert.equal(catalog.DEFAULT, 'gpt-6-astra');
+
+  const astra = catalog.OPTIONS[0];
+  assert.equal(astra.label, 'GPT-6-Astra');
+  assert.equal(astra.description, 'Our most capable model for complex, demanding work.');
+  assert.deepEqual(astra.effort?.values.map((value) => value.value), ['low', 'medium', 'high', 'xhigh', 'max', 'ultra']);
+  assert.equal(astra.effort?.default, 'medium');
+
+  const luna = catalog.OPTIONS[1];
+  assert.equal(luna.effort?.default, undefined);
+});
+
+test('falls back to the first entry when the CLI marks no default', async () => {
+  const catalog = await adapterFor(async () => [
+    { id: 'first-model', supportedReasoningEfforts: [] },
+    { id: 'second-model' },
+  ] as CodexServerModel[]).getSupportedModels();
+
+  assert.equal(catalog.DEFAULT, 'first-model');
+  assert.equal(catalog.OPTIONS[0].label, 'first-model');
+  assert.equal(catalog.OPTIONS[0].effort, undefined);
+});
+
+test('surfaces the CLI failure instead of a curated fallback', async () => {
+  const adapter = adapterFor(async () => {
+    throw new Error('codex app-server did not answer');
+  });
+
+  await assert.rejects(() => adapter.getSupportedModels(), /did not answer/);
+  // A failed run must not poison the cache: the next caller retries.
+  await assert.rejects(() => adapter.getSupportedModels(), /did not answer/);
+  const recovered = adapterFor(async () => [{ id: 'only-model' }] as CodexServerModel[]);
+  assert.equal((await recovered.getSupportedModels()).DEFAULT, 'only-model');
+});
+
+test('treats an empty catalog as a failure', async () => {
+  await assert.rejects(
+    () => adapterFor(async () => []).getSupportedModels(),
+    /no usable models/,
+  );
+});
+
+test('shares one in-flight CLI run across concurrent callers', async () => {
+  let calls = 0;
+  const adapter = adapterFor(async () => {
+    calls += 1;
+    return [{ id: 'shared', isDefault: true }] as CodexServerModel[];
+  });
+
+  const [first, second] = await Promise.all([
+    adapter.getSupportedModels(),
+    adapter.getSupportedModels(),
+  ]);
+  assert.equal(calls, 1);
+  assert.equal(first.DEFAULT, second.DEFAULT);
+});

--- a/server/modules/providers/tests/opencode-models.test.ts
+++ b/server/modules/providers/tests/opencode-models.test.ts
@@ -1,15 +1,10 @@
 import assert from 'node:assert/strict';
-import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { mkdtemp, rm } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 import test from 'node:test';
 
-import {
-  OpenCodeProviderModels,
-  OPENCODE_PREDEFINED_MODELS,
-} from '@/modules/providers/list/opencode/opencode-models.provider.js';
-
-const OPENCODE_ENV_KEYS = ['OPENCODE_API_KEY', 'ANTHROPIC_API_KEY', 'OPENAI_API_KEY'];
+import { OpenCodeProviderModels } from '@/modules/providers/list/opencode/opencode-models.provider.js';
 
 /**
  * Builds the `providerID/modelID` + pretty-printed JSON records that
@@ -31,60 +26,36 @@ const buildVerboseCliOutput = (
 ].join('\n')).join('\n');
 
 /**
- * Runs one case against a throwaway OpenCode home, so the catalog the adapter
- * reports depends on the fixture rather than on the providers the machine
- * running the suite happens to be logged into.
+ * Runs one case against a throwaway OpenCode home so nothing reaches the
+ * developer machine's own OpenCode state; the CLI itself is always the
+ * fixture passed in via `runModelsCli`.
  */
 const withOpenCodeHome = async (
-  setUp: (homeDir: string) => Promise<void>,
   runTest: (adapter: OpenCodeProviderModels) => Promise<void>,
-  options: { runModelsCli?: () => Promise<string | null> } = {},
+  runModelsCli: () => Promise<string | null>,
 ): Promise<void> => {
   const homeDir = await mkdtemp(path.join(os.tmpdir(), 'opencode-catalog-'));
   const originalHomedir = os.homedir;
-  const originalEnv = OPENCODE_ENV_KEYS.map((key) => [key, process.env[key]] as const);
 
   (os as any).homedir = () => homeDir;
-  for (const key of OPENCODE_ENV_KEYS) {
-    delete process.env[key];
-  }
-
   try {
-    await setUp(homeDir);
-    // Default to "the CLI produced nothing" so file-probing fallback tests do
-    // not spawn the real CLI from the developer machine running the suite.
-    await runTest(new OpenCodeProviderModels({
-      runModelsCli: options.runModelsCli ?? (async () => null),
-    }));
+    await runTest(new OpenCodeProviderModels({ runModelsCli }));
   } finally {
     (os as any).homedir = originalHomedir;
-    for (const [key, value] of originalEnv) {
-      if (value === undefined) {
-        delete process.env[key];
-      } else {
-        process.env[key] = value;
-      }
-    }
     await rm(homeDir, { recursive: true, force: true });
   }
 };
 
-const writeOpenCodeAuth = async (homeDir: string, auth: Record<string, unknown>): Promise<void> => {
-  const authDir = path.join(homeDir, '.local', 'share', 'opencode');
-  await mkdir(authDir, { recursive: true });
-  await writeFile(path.join(authDir, 'auth.json'), JSON.stringify(auth), 'utf8');
-};
-
 test('OpenCode catalog reports user-defined providers from the CLI', async () => {
-  // The curated catalog can never know a user's own providers, so the picker
-  // only shows them because the adapter asks `opencode models --verbose`.
+  // The picker only shows the user's own providers because the adapter asks
+  // `opencode models --verbose` - nothing hardcoded could ever know them.
   const cliOutput = buildVerboseCliOutput([
     { id: 'gpt-5.6-sol', providerId: 'bit-openai', name: 'GPT 5.6 Sol', variants: ['low', 'xhigh', 'max'] },
     { id: 'deepseek-v4-pro', providerId: 'deepseek', name: 'DeepSeek V4 Pro' },
     { id: 'opencode/gpt-5.6-terra', providerId: 'opencode', name: 'GPT 5.6 Terra' },
   ]);
 
-  await withOpenCodeHome(async () => {}, async (adapter) => {
+  await withOpenCodeHome(async (adapter) => {
     const catalog = await adapter.getSupportedModels();
     const byValue = new Map(catalog.OPTIONS.map((option) => [option.value, option]));
 
@@ -99,41 +70,53 @@ test('OpenCode catalog reports user-defined providers from the CLI', async () =>
 
     // A CLI id that already embeds a slash keeps its full value intact.
     assert.ok(byValue.get('opencode/opencode/gpt-5.6-terra'));
-  }, { runModelsCli: async () => cliOutput });
+  }, async () => cliOutput);
 });
 
-test('OpenCode catalog prefers curated rows and CLI-listed models', async () => {
+test('OpenCode catalog labels come from the CLI and drop retired models', async () => {
   const cliOutput = buildVerboseCliOutput([
     { id: 'gpt-5.6-terra', providerId: 'opencode' },
-    { id: 'claude-fable-5', providerId: 'anthropic' },
+    { id: 'claude-fable-5', providerId: 'anthropic', name: 'Fable 5' },
     // A retired entry must never reach the picker.
     { id: 'gpt-4.9', providerId: 'openai', status: 'deprecated' },
   ]);
 
-  await withOpenCodeHome(async () => {}, async (adapter) => {
+  await withOpenCodeHome(async (adapter) => {
     const catalog = await adapter.getSupportedModels();
     const values = catalog.OPTIONS.map((option) => option.value);
 
     assert.deepEqual(values, ['opencode/gpt-5.6-terra', 'anthropic/claude-fable-5']);
-    // Curated metadata survives: curated labels and descriptions win over the
-    // bare CLI record.
-    const terra = catalog.OPTIONS.find((option) => option.value === 'opencode/gpt-5.6-terra');
-    assert.equal(terra?.label, 'GPT 5.6 Terra');
-    assert.equal(terra?.description, 'OpenCode Zen');
+    // Without a `name` the label falls back to the model id with the provider
+    // prefix stripped; a `name` wins verbatim.
+    assert.equal(catalog.OPTIONS[0]?.label, 'gpt-5.6-terra');
+    assert.equal(catalog.OPTIONS[0]?.description, 'opencode');
+    assert.equal(catalog.OPTIONS[1]?.label, 'Fable 5');
     assert.equal(catalog.DEFAULT, 'opencode/gpt-5.6-terra');
-  }, { runModelsCli: async () => cliOutput });
+  }, async () => cliOutput);
 });
 
-test('OpenCode catalog default moves to a live model when curated default is absent', async () => {
+test('OpenCode catalog default moves to a live model when the preferred default is absent', async () => {
   const cliOutput = buildVerboseCliOutput([
     { id: 'kimi-k2.6', providerId: 'volcengine-plan', name: 'Kimi K2.6' },
   ]);
 
-  await withOpenCodeHome(async () => {}, async (adapter) => {
+  await withOpenCodeHome(async (adapter) => {
     const catalog = await adapter.getSupportedModels();
     assert.equal(catalog.DEFAULT, 'volcengine-plan/kimi-k2.6');
     assert.equal((await adapter.getCurrentActiveModel()).model, catalog.DEFAULT);
-  }, { runModelsCli: async () => cliOutput });
+  }, async () => cliOutput);
+});
+
+test('OpenCode catalog keeps the preferred default when the CLI lists it', async () => {
+  const cliOutput = buildVerboseCliOutput([
+    { id: 'kimi-k2.6', providerId: 'volcengine-plan', name: 'Kimi K2.6' },
+    { id: 'gpt-5.6-terra', providerId: 'opencode', name: 'GPT 5.6 Terra' },
+  ]);
+
+  await withOpenCodeHome(async (adapter) => {
+    const catalog = await adapter.getSupportedModels();
+    assert.equal(catalog.DEFAULT, 'opencode/gpt-5.6-terra');
+  }, async () => cliOutput);
 });
 
 test('OpenCode catalog shares one CLI run across concurrent lookups', async () => {
@@ -142,7 +125,7 @@ test('OpenCode catalog shares one CLI run across concurrent lookups', async () =
     { id: 'glm-5.2', providerId: 'volcengine-plan', name: 'GLM 5.2' },
   ]);
 
-  await withOpenCodeHome(async () => {}, async (adapter) => {
+  await withOpenCodeHome(async (adapter) => {
     const [first, second] = await Promise.all([
       adapter.getSupportedModels(),
       adapter.getCurrentActiveModel(),
@@ -150,153 +133,18 @@ test('OpenCode catalog shares one CLI run across concurrent lookups', async () =
     assert.equal(cliRuns, 1);
     assert.equal(first.OPTIONS.length, 1);
     assert.equal(second.model, 'volcengine-plan/glm-5.2');
-  }, { runModelsCli: async () => { cliRuns += 1; return cliOutput; } });
+  }, async () => { cliRuns += 1; return cliOutput; });
 });
 
-test('OpenCode exposes only the curated predefined catalog', async () => {
-  await withOpenCodeHome(async () => {}, async (adapter) => {
-    // Nothing readable about this install, so the picker keeps every option
-    // rather than coming up empty.
-    assert.deepEqual(await adapter.getSupportedModels(), OPENCODE_PREDEFINED_MODELS);
-    assert.equal(
-      (await adapter.getCurrentActiveModel()).model,
-      OPENCODE_PREDEFINED_MODELS.DEFAULT,
-    );
-  });
-  // OpenCode routes by `<providerID>/<modelID>`, so every option has to carry a
-  // provider prefix that `opencode models --verbose` reports.
-  const providerIds = new Set(
-    OPENCODE_PREDEFINED_MODELS.OPTIONS.map((option) => option.value.split('/')[0]),
-  );
-  assert.deepEqual([...providerIds].sort(), ['anthropic', 'opencode', 'opencode-go', 'openai'].sort());
-  assert.equal(
-    OPENCODE_PREDEFINED_MODELS.OPTIONS.every((option) => /^[a-z0-9-]+\/.+/.test(option.value)),
-    true,
-  );
-  assert.equal(
-    new Set(OPENCODE_PREDEFINED_MODELS.OPTIONS.map((option) => option.value)).size,
-    OPENCODE_PREDEFINED_MODELS.OPTIONS.length,
-  );
-  assert.equal(OPENCODE_PREDEFINED_MODELS.DEFAULT, 'opencode/gpt-5.6-terra');
-  assert.ok(
-    OPENCODE_PREDEFINED_MODELS.OPTIONS.some((option) => option.value === 'opencode/claude-opus-5'),
-  );
-  assert.ok(
-    OPENCODE_PREDEFINED_MODELS.OPTIONS.some((option) => option.value === 'anthropic/claude-opus-5'),
-  );
-  assert.ok(
-    OPENCODE_PREDEFINED_MODELS.OPTIONS.some((option) => option.value === 'openai/gpt-5.6'),
-  );
-  // The Go gateway carries its own provider id, so its models must be curated
-  // too - a Go subscriber otherwise authenticates while the picker offers
-  // nothing they can run.
-  const opencodeGoOptions = OPENCODE_PREDEFINED_MODELS.OPTIONS.filter(
-    (option) => option.value.startsWith('opencode-go/'),
-  );
-  assert.equal(opencodeGoOptions.length, 27);
-  assert.ok(opencodeGoOptions.every((option) => option.description === 'OpenCode Go'));
-  const glmFlash = opencodeGoOptions.find(
-    (option) => option.value === 'opencode-go/glm-5.3-flash',
-  );
-  assert.ok(glmFlash);
-  // Effort choices come from `opencode models --verbose` variants; the runtime
-  // turns a selected value into `--variant`, so the values have to match the
-  // CLI's exactly.
-  assert.deepEqual(
-    glmFlash?.effort?.values.map((value) => value.value),
-    ['low', 'high', 'max'],
-  );
-  assert.ok(
-    opencodeGoOptions
-      .filter((option) => !option.effort)
-      .every((option) =>
-        ['glm-5.1', 'kimi-k2.6', 'kimi-k2.7-code', 'mimo-v2.5', 'mimo-v2.5-pro',
-          'minimax-m2.7', 'qwen3.6-plus', 'qwen3.7-max', 'qwen3.7-plus']
-          .includes(option.value.slice('opencode-go/'.length)),
-      ),
-  );
-});
+test('OpenCode catalog is empty when the CLI cannot answer', async () => {
+  // No hardcoded fallback: an unusable CLI yields an empty picker (plus the
+  // console warning) rather than a curated list the install may not run.
+  await withOpenCodeHome(async (adapter) => {
+    assert.deepEqual(await adapter.getSupportedModels(), { OPTIONS: [], DEFAULT: '' });
+  }, async () => null);
 
-test('OpenCode offers only models the install can route to', async () => {
-  // Asking for a provider the user never connected fails the whole run with
-  // "Model <id> is not valid", so an OpenCode Zen model must not be offered -
-  // or defaulted to - on a machine that only holds an Anthropic key. This
-  // covers the file-probing fallback taken when the CLI cannot answer.
-  await withOpenCodeHome(
-    (homeDir) => writeOpenCodeAuth(homeDir, { anthropic: { type: 'api', key: 'test' } }),
-    async (adapter) => {
-      const catalog = await adapter.getSupportedModels();
-      const providerIds = new Set(catalog.OPTIONS.map((option) => option.value.split('/')[0]));
-
-      assert.deepEqual([...providerIds], ['anthropic']);
-      assert.ok(catalog.OPTIONS.length > 0);
-      assert.equal(catalog.DEFAULT.startsWith('anthropic/'), true);
-      assert.ok(catalog.OPTIONS.some((option) => option.value === catalog.DEFAULT));
-      assert.equal((await adapter.getCurrentActiveModel()).model, catalog.DEFAULT);
-    },
-  );
-
-  // A Go subscriber's auth store holds only `opencode-go`, so the whole catalog
-  // has to resolve to Go models and the default has to move onto one of them
-  // instead of the unreachable Zen default.
-  await withOpenCodeHome(
-    (homeDir) => writeOpenCodeAuth(homeDir, { 'opencode-go': { type: 'api', key: 'test' } }),
-    async (adapter) => {
-      const catalog = await adapter.getSupportedModels();
-      const providerIds = new Set(catalog.OPTIONS.map((option) => option.value.split('/')[0]));
-
-      assert.deepEqual([...providerIds], ['opencode-go']);
-      assert.equal(catalog.OPTIONS.length, 27);
-      assert.equal(catalog.DEFAULT, 'opencode-go/grok-4.6');
-      assert.ok(catalog.OPTIONS.some((option) => option.value === catalog.DEFAULT));
-      assert.equal((await adapter.getCurrentActiveModel()).model, catalog.DEFAULT);
-    },
-  );
-
-  // The catalog default survives whenever its own provider is connected.
-  await withOpenCodeHome(
-    (homeDir) => writeOpenCodeAuth(homeDir, {
-      opencode: { type: 'api', key: 'test' },
-      openai: { type: 'oauth' },
-    }),
-    async (adapter) => {
-      const catalog = await adapter.getSupportedModels();
-      const providerIds = new Set(catalog.OPTIONS.map((option) => option.value.split('/')[0]));
-
-      assert.deepEqual([...providerIds].sort(), ['opencode', 'openai'].sort());
-      assert.equal(catalog.DEFAULT, OPENCODE_PREDEFINED_MODELS.DEFAULT);
-    },
-  );
-
-  // Providers configured rather than logged into count too.
-  await withOpenCodeHome(
-    async (homeDir) => {
-      const configDir = path.join(homeDir, '.config', 'opencode');
-      await mkdir(configDir, { recursive: true });
-      await writeFile(
-        path.join(configDir, 'opencode.json'),
-        JSON.stringify({ provider: { anthropic: { options: {} } } }),
-        'utf8',
-      );
-    },
-    async (adapter) => {
-      const catalog = await adapter.getSupportedModels();
-      const providerIds = new Set(catalog.OPTIONS.map((option) => option.value.split('/')[0]));
-
-      assert.deepEqual([...providerIds], ['anthropic']);
-    },
-  );
-
-  // An API key in the environment is enough on its own.
-  await withOpenCodeHome(
-    async () => {
-      process.env.OPENAI_API_KEY = 'test';
-    },
-    async (adapter) => {
-      const catalog = await adapter.getSupportedModels();
-      const providerIds = new Set(catalog.OPTIONS.map((option) => option.value.split('/')[0]));
-
-      assert.deepEqual([...providerIds], ['openai']);
-    },
-  );
+  // Unparseable output counts as no answer too.
+  await withOpenCodeHome(async (adapter) => {
+    assert.deepEqual(await adapter.getSupportedModels(), { OPTIONS: [], DEFAULT: '' });
+  }, async () => 'not a catalog at all');
 });

--- a/server/modules/providers/tests/opencode-models.test.ts
+++ b/server/modules/providers/tests/opencode-models.test.ts
@@ -12,6 +12,25 @@ import {
 const OPENCODE_ENV_KEYS = ['OPENCODE_API_KEY', 'ANTHROPIC_API_KEY', 'OPENAI_API_KEY'];
 
 /**
+ * Builds the `providerID/modelID` + pretty-printed JSON records that
+ * `opencode models --verbose` prints, from minimal per-model fixtures.
+ */
+const buildVerboseCliOutput = (
+  models: { id: string; providerId: string; name?: string; variants?: string[]; status?: string }[],
+): string => models.map((model) => [
+  `${model.providerId}/${model.id}`,
+  JSON.stringify({
+    id: model.id,
+    providerID: model.providerId,
+    ...(model.name ? { name: model.name } : {}),
+    ...(model.status ? { status: model.status } : {}),
+    ...(model.variants
+      ? { variants: Object.fromEntries(model.variants.map((variant) => [variant, {}])) }
+      : {}),
+  }, null, 2),
+].join('\n')).join('\n');
+
+/**
  * Runs one case against a throwaway OpenCode home, so the catalog the adapter
  * reports depends on the fixture rather than on the providers the machine
  * running the suite happens to be logged into.
@@ -19,6 +38,7 @@ const OPENCODE_ENV_KEYS = ['OPENCODE_API_KEY', 'ANTHROPIC_API_KEY', 'OPENAI_API_
 const withOpenCodeHome = async (
   setUp: (homeDir: string) => Promise<void>,
   runTest: (adapter: OpenCodeProviderModels) => Promise<void>,
+  options: { runModelsCli?: () => Promise<string | null> } = {},
 ): Promise<void> => {
   const homeDir = await mkdtemp(path.join(os.tmpdir(), 'opencode-catalog-'));
   const originalHomedir = os.homedir;
@@ -31,7 +51,11 @@ const withOpenCodeHome = async (
 
   try {
     await setUp(homeDir);
-    await runTest(new OpenCodeProviderModels());
+    // Default to "the CLI produced nothing" so file-probing fallback tests do
+    // not spawn the real CLI from the developer machine running the suite.
+    await runTest(new OpenCodeProviderModels({
+      runModelsCli: options.runModelsCli ?? (async () => null),
+    }));
   } finally {
     (os as any).homedir = originalHomedir;
     for (const [key, value] of originalEnv) {
@@ -50,6 +74,84 @@ const writeOpenCodeAuth = async (homeDir: string, auth: Record<string, unknown>)
   await mkdir(authDir, { recursive: true });
   await writeFile(path.join(authDir, 'auth.json'), JSON.stringify(auth), 'utf8');
 };
+
+test('OpenCode catalog reports user-defined providers from the CLI', async () => {
+  // The curated catalog can never know a user's own providers, so the picker
+  // only shows them because the adapter asks `opencode models --verbose`.
+  const cliOutput = buildVerboseCliOutput([
+    { id: 'gpt-5.6-sol', providerId: 'bit-openai', name: 'GPT 5.6 Sol', variants: ['low', 'xhigh', 'max'] },
+    { id: 'deepseek-v4-pro', providerId: 'deepseek', name: 'DeepSeek V4 Pro' },
+    { id: 'opencode/gpt-5.6-terra', providerId: 'opencode', name: 'GPT 5.6 Terra' },
+  ]);
+
+  await withOpenCodeHome(async () => {}, async (adapter) => {
+    const catalog = await adapter.getSupportedModels();
+    const byValue = new Map(catalog.OPTIONS.map((option) => [option.value, option]));
+
+    const custom = byValue.get('bit-openai/gpt-5.6-sol');
+    assert.ok(custom, 'user-defined provider model must reach the picker');
+    assert.equal(custom.label, 'GPT 5.6 Sol');
+    assert.equal(custom.description, 'bit-openai');
+    assert.deepEqual(custom.effort?.values.map((entry) => entry.value), ['low', 'xhigh', 'max']);
+
+    assert.ok(byValue.get('deepseek/deepseek-v4-pro'));
+    assert.equal(byValue.get('deepseek/deepseek-v4-pro')?.effort, undefined);
+
+    // A CLI id that already embeds a slash keeps its full value intact.
+    assert.ok(byValue.get('opencode/opencode/gpt-5.6-terra'));
+  }, { runModelsCli: async () => cliOutput });
+});
+
+test('OpenCode catalog prefers curated rows and CLI-listed models', async () => {
+  const cliOutput = buildVerboseCliOutput([
+    { id: 'gpt-5.6-terra', providerId: 'opencode' },
+    { id: 'claude-fable-5', providerId: 'anthropic' },
+    // A retired entry must never reach the picker.
+    { id: 'gpt-4.9', providerId: 'openai', status: 'deprecated' },
+  ]);
+
+  await withOpenCodeHome(async () => {}, async (adapter) => {
+    const catalog = await adapter.getSupportedModels();
+    const values = catalog.OPTIONS.map((option) => option.value);
+
+    assert.deepEqual(values, ['opencode/gpt-5.6-terra', 'anthropic/claude-fable-5']);
+    // Curated metadata survives: curated labels and descriptions win over the
+    // bare CLI record.
+    const terra = catalog.OPTIONS.find((option) => option.value === 'opencode/gpt-5.6-terra');
+    assert.equal(terra?.label, 'GPT 5.6 Terra');
+    assert.equal(terra?.description, 'OpenCode Zen');
+    assert.equal(catalog.DEFAULT, 'opencode/gpt-5.6-terra');
+  }, { runModelsCli: async () => cliOutput });
+});
+
+test('OpenCode catalog default moves to a live model when curated default is absent', async () => {
+  const cliOutput = buildVerboseCliOutput([
+    { id: 'kimi-k2.6', providerId: 'volcengine-plan', name: 'Kimi K2.6' },
+  ]);
+
+  await withOpenCodeHome(async () => {}, async (adapter) => {
+    const catalog = await adapter.getSupportedModels();
+    assert.equal(catalog.DEFAULT, 'volcengine-plan/kimi-k2.6');
+    assert.equal((await adapter.getCurrentActiveModel()).model, catalog.DEFAULT);
+  }, { runModelsCli: async () => cliOutput });
+});
+
+test('OpenCode catalog shares one CLI run across concurrent lookups', async () => {
+  let cliRuns = 0;
+  const cliOutput = buildVerboseCliOutput([
+    { id: 'glm-5.2', providerId: 'volcengine-plan', name: 'GLM 5.2' },
+  ]);
+
+  await withOpenCodeHome(async () => {}, async (adapter) => {
+    const [first, second] = await Promise.all([
+      adapter.getSupportedModels(),
+      adapter.getCurrentActiveModel(),
+    ]);
+    assert.equal(cliRuns, 1);
+    assert.equal(first.OPTIONS.length, 1);
+    assert.equal(second.model, 'volcengine-plan/glm-5.2');
+  }, { runModelsCli: async () => { cliRuns += 1; return cliOutput; } });
+});
 
 test('OpenCode exposes only the curated predefined catalog', async () => {
   await withOpenCodeHome(async () => {}, async (adapter) => {
@@ -118,7 +220,8 @@ test('OpenCode exposes only the curated predefined catalog', async () => {
 test('OpenCode offers only models the install can route to', async () => {
   // Asking for a provider the user never connected fails the whole run with
   // "Model <id> is not valid", so an OpenCode Zen model must not be offered -
-  // or defaulted to - on a machine that only holds an Anthropic key.
+  // or defaulted to - on a machine that only holds an Anthropic key. This
+  // covers the file-probing fallback taken when the CLI cannot answer.
   await withOpenCodeHome(
     (homeDir) => writeOpenCodeAuth(homeDir, { anthropic: { type: 'api', key: 'test' } }),
     async (adapter) => {


### PR DESCRIPTION
## Problem

The model pickers never showed models from the user's own custom providers, and each provider shipped a hardcoded catalog that drifted from what its CLI can actually run:

- **OpenCode**: the adapter never asked the CLI for a catalog. A curated 54-model list covered only the built-in gateways (`opencode`, `opencode-go`, `anthropic`, `openai`), narrowed by probing `auth.json` / user config / env keys - subtraction only, so a user-defined provider could never contribute a model. Worse, when the CLI was unreachable the picker silently served that curated list, which looked identical to "the fix not working".
- **Claude / Codex**: same pattern - static catalogs instead of what `claude` / `codex` actually support.

## Fix

All three provider model adapters now read their catalog from the provider CLI - the same resolver `opencode run --model`, `claude`, and `codex` use at runtime:

- **OpenCode** parses `opencode models --verbose`: `providerID/modelID` + per-model JSON records give real ids, display names, and reasoning variants. CLI `variants` keys map onto the effort picker and are forwarded to the runtime as `--variant`. Entries whose `status` is not `active` are dropped. The hardcoded catalog is **gone**: when the CLI cannot answer (not installed, spawn error, timeout, unparseable), the picker is empty and the server logs `[OpenCode] `opencode models --verbose` unusable (...)` with the reason - no silently-stale list masquerading as a catalog.
- **Claude / Codex** source listings from the live CLI catalog, including supported effort levels and defaults, excluding hidden/retired models.
- Spawned via `cross-spawn`, matching the OpenCode runtime adapter's Windows `.cmd` handling.
- Each live catalog is cached briefly (60s) with a shared in-flight run, so picker + active-model lookup + effort validation cost one CLI invocation per page load; failed runs are not cached so the next caller retries.

## Tests

- OpenCode: 6 tests via a `runModelsCli` injection seam - user-defined providers reach the picker, CLI labels/variants win, retired entries drop out, default migrates to a live model, concurrent lookups share one CLI run, and an unusable CLI yields an empty catalog.
- Claude / Codex suites cover the CLI-sourced catalogs likewise.
- `tsc --noEmit` and oxlint: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)