### PR TITLE
fix(codex): stop spawning console windows for Codex child processes

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "start": "npm run build && npm run server",
     "release": "./release.sh",
     "prepublishOnly": "npm run build",
-    "postinstall": "node scripts/fix-node-pty.js",
+    "postinstall": "node scripts/fix-node-pty.js && node scripts/fix-codex-sdk-windows-hide.js",
     "prepare": "husky",
     "update:platform": "./update-platform.sh"
   },

--- a/scripts/fix-codex-sdk-windows-hide.js
+++ b/scripts/fix-codex-sdk-windows-hide.js
@@ -1,0 +1,78 @@
+#!/usr/bin/env node
+/**
+ * Hide the console window @openai/codex-sdk spawns codex.exe with
+ *
+ * The SDK runs one `codex exec` child process per turn through
+ * child_process.spawn without passing windowsHide: true. On Windows that
+ * makes the OS allocate a fresh console for the console-subsystem codex.exe,
+ * so every Codex turn flashes a cmd window when the server itself has no
+ * console (Electron, double-click launch). The SDK offers no option to pass
+ * spawn flags through, so the shipped bundle is patched in place.
+ *
+ * The patch is anchored on the spawn call inside the bundled executor and is
+ * skipped with a warning when the anchor is absent (new SDK layout, or the
+ * upstream already fixed it), so a silent divergence is impossible.
+ *
+ * @see https://github.com/openai/codex — sdk/typescript/src/exec.ts
+ * @module scripts/fix-codex-sdk-windows-hide
+ */
+
+import { promises as fs } from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+/** The spawn call the bundle uses to launch codex.exe, verbatim. */
+const SPAWN_ANCHOR = [
+  'spawn(this.executablePath, commandArgs, {',
+  '      env,',
+  '      signal: args.signal',
+  '    });',
+].join('\n');
+
+const SPAWN_PATCHED = SPAWN_ANCHOR.replace(
+  '{\n      env,',
+  '{\n      windowsHide: true,\n      env,',
+);
+
+async function patchExecutorBundle() {
+  if (process.platform !== 'win32') {
+    return;
+  }
+
+  const sdkIndex = path.join(
+    __dirname, '..', 'node_modules', '@openai', 'codex-sdk', 'dist', 'index.js',
+  );
+
+  let source;
+  try {
+    source = await fs.readFile(sdkIndex, 'utf8');
+  } catch (err) {
+    if (err.code !== 'ENOENT') {
+      console.warn(`[postinstall] Warning: could not read ${sdkIndex}: ${err.message}`);
+    }
+    return;
+  }
+
+  if (source.includes(SPAWN_PATCHED)) {
+    return;
+  }
+  if (!source.includes(SPAWN_ANCHOR)) {
+    console.warn(
+      '[postinstall] Warning: @openai/codex-sdk spawn call not found; skipped the ' +
+      'windowsHide patch. Codex turns may flash a console window. If the SDK updated, ' +
+      'check whether upstream now passes windowsHide and remove this script if so.',
+    );
+    return;
+  }
+
+  await fs.writeFile(sdkIndex, source.replace(SPAWN_ANCHOR, SPAWN_PATCHED), 'utf8');
+  console.log('[postinstall] Patched @openai/codex-sdk to spawn codex.exe with windowsHide');
+}
+
+patchExecutorBundle().catch((err) => {
+  // A failed patch costs a cosmetic window, not a conversation; never block install.
+  console.warn(`[postinstall] Warning: codex-sdk windowsHide patch failed: ${err.message}`);
+});

--- a/server/modules/providers/list/codex/codex-app-server.client.ts
+++ b/server/modules/providers/list/codex/codex-app-server.client.ts
@@ -74,9 +74,12 @@ async function withAppServer<T>(
   run: (call: (method: string, params: unknown) => Promise<unknown>) => Promise<T>,
 ): Promise<T> {
   const launcher = resolveCodexLauncher();
+  // windowsHide keeps Windows from allocating a console for the child; without
+  // it every fork flashes a cmd window when the server runs without one.
   const child = spawn(process.execPath, [launcher, 'app-server'], {
     env: process.env,
     stdio: ['pipe', 'pipe', 'pipe'],
+    windowsHide: true,
   });
 
   // The server logs sandbox and skill warnings to stderr on every start. They


### PR DESCRIPTION
## Problem

On Windows, Codex conversations flash a black console window on every turn (most visible when the server runs without a console, e.g. Electron or double-click launch; invisible when started from a terminal, which is why it reads as "random").

Node on Windows allocates a fresh console for spawned console-subsystem children unless `windowsHide: true` is passed. Two spawns were exposed:

1. **`codex app-server`** (`codex-app-server.client.ts`) — spawned by this app for `thread/fork` (editing/branching Codex conversations). Every fork flashed a cmd window.
2. **`codex.exe`** — `@openai/codex-sdk` spawns one `codex exec` per turn and passes no spawn flags through, so the SDK provides no way to set `windowsHide`. Verified upstream `@openai/codex-sdk@0.154.0` still omits it.

## Fix

1. Added `windowsHide: true` to the app-server spawn, matching what this repo already does for its other spawns (`claude-cli-path.ts`, `session-conversations-search.service.ts`).
2. Added `scripts/fix-codex-sdk-windows-hide.js`, chained into `postinstall` alongside the existing `fix-node-pty.js`, following the same in-place-patch pattern:
   - only runs on Windows;
   - anchors on the bundled spawn call in `@openai/codex-sdk/dist/index.js` and inserts `windowsHide: true`;
   - idempotent; skips with a console warning when the anchor disappears (SDK restructured, or upstream fixes it — the warning tells maintainers to remove the script);
   - failures warn but never break `npm install`.

## Verification

- Script patches the current install; second run is a no-op.
- After patching, `@openai/codex-sdk` spawns `codex.exe` with `windowsHide: true`; Codex turns no longer flash a console window.
- Codex provider tests: 36 tests, 35 pass / 1 pre-existing skip / 0 fail; `tsc --noEmit -p server/tsconfig.json` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented an unwanted console window from briefly appearing when launching Codex on Windows.
  - Applied the same Windows display improvement during installation setup to ensure consistent behavior across environments.

- **Chores**
  - Updated installation steps to automatically apply the Windows compatibility adjustment when needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->