### PR TITLE
feat(chat): render base64 image tool results as pictures

### DIFF
--- a/server/shared/message-unification.ts
+++ b/server/shared/message-unification.ts
@@ -305,7 +305,67 @@ function readChecklistSignature(message: NormalizedMessage): string {
  */
 const MAX_TOOL_RESULT_CONTENT = 40_000;
 
+/**
+ * True for the shapes that carry a renderable image: an Anthropic/MCP image
+ * block or a bare base64 source. The transcript renders these as pictures, so
+ * their base64 must survive truncation whole — a cut-off payload parses as
+ * neither JSON nor a decodable image and the UI falls back to a base64 wall.
+ */
+function isImageBearingBlock(value: unknown): boolean {
+  const record = readObjectRecord(value);
+  if (!record || typeof record.type !== 'string') {
+    return false;
+  }
+  if (record.type === 'image' || record.type === 'base64') {
+    return true;
+  }
+  const source = readObjectRecord((record as AnyRecord).source);
+  return Boolean(source && source.type === 'base64');
+}
+
+/**
+ * Caps a tool result's content without shredding image blocks.
+ *
+ * When the content is a JSON array of content blocks, each block is capped
+ * separately: text keeps the plain-text rule, and anything image-bearing is
+ * kept whole. Anything else falls back to the plain truncation.
+ */
+function capBlockAware(value: string): string | null {
+  if (!value.startsWith('[')) {
+    return null;
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(value);
+  } catch {
+    return null;
+  }
+
+  if (!Array.isArray(parsed) || !parsed.some(isImageBearingBlock)) {
+    return null;
+  }
+
+  const capped = parsed.map((block) => {
+    if (isImageBearingBlock(block)) {
+      return block;
+    }
+    const record = readObjectRecord(block);
+    if (record && typeof record.text === 'string') {
+      return { ...record, text: truncateOutput(record.text) };
+    }
+    return block;
+  });
+
+  return JSON.stringify(capped);
+}
+
 function truncateOutput(value: string): string {
+  const capped = capBlockAware(value);
+  if (capped !== null) {
+    return capped;
+  }
+
   if (value.length <= MAX_TOOL_RESULT_CONTENT) {
     return value;
   }

--- a/server/shared/tests/message-unification.test.ts
+++ b/server/shared/tests/message-unification.test.ts
@@ -216,3 +216,27 @@ test('a search result keeps every file it found', () => {
   assert.equal(result.numFiles, 900);
   assert.deepEqual(result.filenames, filenames);
 });
+
+test('a content-block array keeps image blocks whole while capping text', () => {
+  const base64 = 'iVBORw0KGgo'.padEnd(60_000, 'A');
+  const longText = 't'.repeat(100_000);
+  const blocks = [
+    { type: 'text', text: longText },
+    { type: 'image', source: { type: 'base64', media_type: 'image/png', data: base64 } },
+  ];
+  const [unified] = prepareTranscriptMessages([
+    message({
+      kind: 'tool_use',
+      toolName: 'mcp__browser__take_screenshot',
+      toolId: 's1',
+      toolInput: {},
+      toolResult: { content: JSON.stringify(blocks) },
+    }),
+  ]);
+
+  const content = String(unified.toolResult?.content);
+  const parsed = JSON.parse(content);
+  assert.equal(parsed.length, 2, 'both blocks survive');
+  assert.equal(parsed[1].source.data, base64, 'the image payload must not be cut mid-base64');
+  assert.match(parsed[0].text, /… \d+ more characters$/, 'oversized text still caps');
+});

--- a/src/modules/chat/tests/toolResultImages.test.ts
+++ b/src/modules/chat/tests/toolResultImages.test.ts
@@ -1,0 +1,104 @@
+import assert from 'node:assert/strict';
+
+import { test } from 'vitest';
+
+import {
+  extractToolResultImages,
+  hasToolResultImages,
+  withoutImageBlocks,
+} from '@/modules/chat/utils/toolResultImages';
+import { getToolConfig } from '@/modules/chat/tools/configs/toolConfigs';
+
+/**
+ * Tool results that carry image blocks (screenshots, image reads, MCP image
+ * content) must surface as pictures, not as a base64 wall dumped into the
+ * text renderer. The extraction has to survive every shape the providers
+ * actually produce — including the JSON.stringified array form that
+ * useChatMessages produces for any non-string content.
+ */
+
+const base64Data = 'A'.repeat(96);
+
+test('extracts the bare base64 source block', () => {
+  const payload = [{ type: 'base64', media_type: 'image/png', data: base64Data }];
+  assert.deepEqual(extractToolResultImages(payload), [
+    { mediaType: 'image/png', data: base64Data },
+  ]);
+});
+
+test('extracts the anthropic image content block', () => {
+  const payload = [{
+    type: 'image',
+    source: { type: 'base64', media_type: 'image/jpeg', data: base64Data },
+  }];
+  assert.deepEqual(extractToolResultImages(payload), [
+    { mediaType: 'image/jpeg', data: base64Data },
+  ]);
+});
+
+test('extracts the MCP image block', () => {
+  const payload = [{ type: 'image', mimeType: 'image/webp', data: base64Data }];
+  assert.deepEqual(extractToolResultImages(payload), [
+    { mediaType: 'image/webp', data: base64Data },
+  ]);
+});
+
+test('extracts from a JSON-stringified array (useChatMessages format)', () => {
+  const payload = JSON.stringify([
+    { type: 'text', text: 'screenshot taken' },
+    { type: 'base64', media_type: 'image/png', data: base64Data },
+  ]);
+  assert.equal(extractToolResultImages(payload).length, 1);
+  assert.ok(hasToolResultImages(payload));
+});
+
+test('extracts through the tool result wrapper', () => {
+  const payload = {
+    content: JSON.stringify([{ type: 'base64', media_type: 'image/png', data: base64Data }]),
+    isError: false,
+  };
+  assert.equal(extractToolResultImages(payload).length, 1);
+});
+
+test('ignores plain text and short non-image payloads', () => {
+  assert.deepEqual(extractToolResultImages('{"ok": true}'), []);
+  assert.deepEqual(extractToolResultImages([{ type: 'text', text: 'hello' }]), []);
+  // Too short to be a real image payload — likely a false-shape object.
+  assert.deepEqual(extractToolResultImages([{ type: 'base64', media_type: 'image/png', data: 'abc' }]), []);
+  assert.equal(hasToolResultImages('plain output'), false);
+});
+
+test('default config keeps text and drops image base64', () => {
+  const config = getToolConfig('SomeUnknownTool').result!;
+  const props = config.getContentProps!({
+    content: JSON.stringify([
+      { type: 'text', text: '第一行' },
+      { type: 'base64', media_type: 'image/png', data: base64Data },
+    ]),
+  });
+  assert.equal(props.content, '第一行');
+});
+
+test('default config renders nothing but the image when there is no text', () => {
+  const config = getToolConfig('SomeUnknownTool').result!;
+  const props = config.getContentProps!({
+    content: JSON.stringify([{ type: 'base64', media_type: 'image/png', data: base64Data }]),
+  });
+  assert.equal(props.content, '');
+});
+
+test('default config still shows plain output verbatim', () => {
+  const config = getToolConfig('SomeUnknownTool').result!;
+  const props = config.getContentProps!({ content: '命令输出正常文本' });
+  assert.equal(props.content, '命令输出正常文本');
+});
+
+test('withoutImageBlocks removes image blocks and keeps the rest', () => {
+  const blocks = [
+    { type: 'text', text: '保留' },
+    { type: 'base64', media_type: 'image/png', data: base64Data },
+  ];
+  assert.deepEqual(withoutImageBlocks(blocks), [{ type: 'text', text: '保留' }]);
+  assert.deepEqual(withoutImageBlocks(JSON.stringify(blocks)), [{ type: 'text', text: '保留' }]);
+  assert.equal(withoutImageBlocks('普通字符串'), '普通字符串');
+});

--- a/src/modules/chat/tools/ContentRenderers/ToolResultImages.tsx
+++ b/src/modules/chat/tools/ContentRenderers/ToolResultImages.tsx
@@ -1,0 +1,56 @@
+import React, { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { ImageLightbox } from '@/modules/chat/transcript/ChatMessageImages';
+import type { ToolResultImage } from '@/modules/chat/utils/toolResultImages';
+
+type ToolResultImagesProps = {
+  images: ToolResultImage[];
+};
+
+/**
+ * Images returned inside a tool result (screenshots, image reads, MCP image
+ * content) shown as clickable thumbnails that expand to a fullscreen lightbox.
+ *
+ * Rendered by chat's ToolRenderer beneath a tool result's text so a base64
+ * image block reads as a picture rather than a wall of base64 characters.
+ */
+export const ToolResultImages: React.FC<ToolResultImagesProps> = ({ images }) => {
+  const { t } = useTranslation();
+  const [expanded, setExpanded] = useState<number | null>(null);
+
+  if (images.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="mt-1 flex flex-wrap gap-2">
+      {images.map((image, index) => {
+        const src = `data:${image.mediaType};base64,${image.data}`;
+        const alt = `Tool result image ${index + 1}`;
+        return (
+          <button
+            key={index}
+            type="button"
+            onClick={() => setExpanded(index)}
+            aria-label={t('chat:misc.expandImage', { name: alt })}
+            className="block max-w-full overflow-hidden rounded-lg border border-gray-200/50 bg-gray-50 focus:outline-none focus:ring-2 focus:ring-primary/60 dark:border-gray-700/50 dark:bg-gray-800/50"
+          >
+            <img
+              src={src}
+              alt={alt}
+              className="max-h-64 cursor-zoom-in rounded-lg object-contain"
+            />
+          </button>
+        );
+      })}
+      {expanded !== null && (
+        <ImageLightbox
+          src={`data:${images[expanded].mediaType};base64,${images[expanded].data}`}
+          alt={`Tool result image ${expanded + 1}`}
+          onClose={() => setExpanded(null)}
+        />
+      )}
+    </div>
+  );
+};

--- a/src/modules/chat/tools/ToolRenderer.tsx
+++ b/src/modules/chat/tools/ToolRenderer.tsx
@@ -11,11 +11,13 @@ import { FileListContent } from '@/modules/chat/tools/ContentRenderers/FileListC
 import { TodoListContent } from '@/modules/chat/tools/ContentRenderers/TodoListContent';
 import { TaskListContent } from '@/modules/chat/tools/ContentRenderers/TaskListContent';
 import { TextContent } from '@/modules/chat/tools/ContentRenderers/TextContent';
+import { ToolResultImages } from '@/modules/chat/tools/ContentRenderers/ToolResultImages';
 import { QuestionAnswerContent } from '@/modules/chat/tools/ContentRenderers/QuestionAnswerContent';
 import { PlanDisplay } from '@/modules/chat/tools/PlanDisplay';
 import { ToolStatusBadge } from '@/modules/chat/tools/ToolStatusBadge';
 import { DiffStatsBadge } from '@/modules/chat/tools/DiffStatsBadge';
 import { parseToolPayload, summarizeDiff } from '@/modules/chat/utils/messageTransforms';
+import { extractToolResultImages } from '@/modules/chat/utils/toolResultImages';
 
 type ToolRendererProps = {
   toolName: string;
@@ -213,6 +215,10 @@ export const ToolRenderer: React.FC<ToolRendererProps> = memo(({
       onFileOpen
     }) || {};
 
+    // A tool result can carry image blocks next to its text; they render as
+    // thumbnails under the text instead of as base64 noise.
+    const resultImages = mode === 'result' ? extractToolResultImages(toolResult) : [];
+
     let contentComponent: React.ReactNode = null;
 
     switch (displayConfig.contentType) {
@@ -268,10 +274,15 @@ export const ToolRenderer: React.FC<ToolRendererProps> = memo(({
 
       case 'text':
         contentComponent = (
-          <TextContent
-            content={contentProps.content || ''}
-            format={contentProps.format || 'plain'}
-          />
+          <>
+            {contentProps.content && (
+              <TextContent
+                content={contentProps.content}
+                format={contentProps.format || 'plain'}
+              />
+            )}
+            {resultImages.length > 0 && <ToolResultImages images={resultImages} />}
+          </>
         );
         break;
 

--- a/src/modules/chat/tools/configs/toolConfigs.ts
+++ b/src/modules/chat/tools/configs/toolConfigs.ts
@@ -1,7 +1,9 @@
 /**
  * Centralized tool configuration registry
- * Defines display behavior for all tool types 
+ * Defines display behavior for all tool types
  */
+
+import { extractToolResultImages, withoutImageBlocks } from '@/modules/chat/utils/toolResultImages';
 
 export type ToolDisplayConfig = {
   input: {
@@ -752,32 +754,39 @@ export const TOOL_CONFIGS: Record<string, ToolDisplayConfig> = {
       title: 'Output',
       contentType: 'text',
       getContentProps: (result) => {
-        let content = result?.content || '';
+        // ToolRenderer hands the parsed tool-result object ({ content, isError })
+        // or, for other call sites, the blocks themselves — unwrap to the payload.
+        if (result && typeof result === 'object' && !Array.isArray(result) && 'content' in result) {
+          result = result.content;
+        }
+
+        // Image blocks render as pictures through ToolResultImages; drop them
+        // from the text pass so their base64 payload is not dumped as JSON.
+        let content = withoutImageBlocks(result ?? '');
+
+        const collectText = (blocks: unknown[]) =>
+          blocks
+            .filter((p: any) => p && p.type === 'text' && p.text)
+            .map((p: any) => p.text);
 
         // Handle MCP format: array of objects with type and text fields
         if (typeof content === 'string') {
           try {
             const parsed = JSON.parse(content);
             if (Array.isArray(parsed)) {
-              const textParts = parsed
-                .filter((p: any) => p.type === 'text' && p.text)
-                .map((p: any) => p.text);
+              const textParts = collectText(parsed);
               if (textParts.length > 0) {
                 content = textParts.join('\n');
+              } else if (extractToolResultImages(parsed).length > 0) {
+                content = '';
               }
             }
           } catch {
             // Not JSON or not MCP format, use as-is
           }
         } else if (Array.isArray(content)) {
-          const textParts = content
-            .filter((p: any) => p.type === 'text' && p.text)
-            .map((p: any) => p.text);
-          if (textParts.length > 0) {
-            content = textParts.join('\n');
-          } else {
-            content = JSON.stringify(content, null, 2);
-          }
+          const textParts = collectText(content);
+          content = textParts.length > 0 ? textParts.join('\n') : '';
         } else if (typeof content === 'object' && content !== null) {
           content = JSON.stringify(content, null, 2);
         }

--- a/src/modules/chat/transcript/ChatMessageImages.tsx
+++ b/src/modules/chat/transcript/ChatMessageImages.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { createPortal } from 'react-dom';
 import { X } from 'lucide-react';
@@ -84,13 +84,29 @@ function useChatImageSrc(image: ChatImage, projectId?: string | null): { src: st
 
 /**
  * Fullscreen image overlay in the claude.ai style: dark backdrop, centered
- * image, closes on backdrop click, close button, or Escape.
+ * image, closes on backdrop click, close button, or Escape. The image itself
+ * zooms with the mouse wheel, a trackpad pinch (which arrives as ctrl+wheel),
+ * or a two-finger touch pinch, and pans by dragging (one finger when zoomed,
+ * two fingers anytime).
  *
  * Used by chat's ChatMessageImages and ComposerAttachment to expand a
- * thumbnail to full size.
+ * thumbnail to full size, and by chat's ToolResultImages for images carried
+ * inside a tool result.
  */
 export function ImageLightbox({ src, alt, onClose }: { src: string; alt: string; onClose: () => void }) {
   const { t } = useTranslation();
+  const [scale, setScale] = useState(1);
+  const [offset, setOffset] = useState({ x: 0, y: 0 });
+  const [dragging, setDragging] = useState(false);
+  const dragRef = useRef<{ startX: number; startY: number; originX: number; originY: number } | null>(null);
+  const pointersRef = useRef(new Map<number, { x: number; y: number }>());
+  const pinchRef = useRef<{ startDist: number; startMid: { x: number; y: number }; startScale: number; startOffset: { x: number; y: number } } | null>(null);
+  const scaleRef = useRef(1);
+  scaleRef.current = scale;
+  const offsetRef = useRef(offset);
+  offsetRef.current = offset;
+  const viewportRef = useRef<HTMLDivElement>(null);
+
   useEffect(() => {
     const handleKeyDown = (event: globalThis.KeyboardEvent) => {
       if (event.key === 'Escape') {
@@ -102,9 +118,128 @@ export function ImageLightbox({ src, alt, onClose }: { src: string; alt: string;
     return () => document.removeEventListener('keydown', handleKeyDown, true);
   }, [onClose]);
 
+  // Wheel zoom has to preventDefault (the backdrop would otherwise scroll /
+  // the browser would page-zoom on ctrl+wheel), and React's synthetic onWheel
+  // is passive — register natively with the flag instead.
+  useEffect(() => {
+    const viewport = viewportRef.current;
+    if (!viewport) {
+      return;
+    }
+
+    const handleWheel = (event: WheelEvent) => {
+      event.preventDefault();
+      event.stopPropagation();
+      setScale((current) => {
+        const factor = Math.exp(-event.deltaY * 0.0015);
+        return Math.min(10, Math.max(1, current * factor));
+      });
+    };
+
+    viewport.addEventListener('wheel', handleWheel, { passive: false });
+    return () => viewport.removeEventListener('wheel', handleWheel);
+  }, []);
+
+  // Zooming back out to 1 re-centers; a stale offset would park the image
+  // off-screen until the next zoom.
+  useEffect(() => {
+    if (scale === 1) {
+      setOffset({ x: 0, y: 0 });
+    }
+  }, [scale]);
+
+  const handlePointerDown = useCallback((event: React.PointerEvent<HTMLImageElement>) => {
+    const pointers = pointersRef.current;
+    pointers.set(event.pointerId, { x: event.clientX, y: event.clientY });
+    // Capture can throw for a pointer that ended between dispatch and here;
+    // the gesture must survive that (a lifted finger mid-pinch is routine).
+    try {
+      (event.target as HTMLElement).setPointerCapture(event.pointerId);
+    } catch {
+      // fall through
+    }
+
+    if (pointers.size === 2) {
+      // A second finger starts a pinch; the single-finger drag ends.
+      dragRef.current = null;
+      setDragging(false);
+      const [a, b] = [...pointers.values()];
+      pinchRef.current = {
+        startDist: Math.hypot(a.x - b.x, a.y - b.y) || 1,
+        startMid: { x: (a.x + b.x) / 2, y: (a.y + b.y) / 2 },
+        startScale: scaleRef.current,
+        startOffset: { ...offsetRef.current },
+      };
+      return;
+    }
+
+    if (pointers.size === 1 && scaleRef.current > 1) {
+      event.stopPropagation();
+      dragRef.current = {
+        startX: event.clientX, startY: event.clientY,
+        originX: offsetRef.current.x, originY: offsetRef.current.y,
+      };
+      setDragging(true);
+    }
+  }, []);
+
+  const handlePointerMove = useCallback((event: React.PointerEvent<HTMLImageElement>) => {
+    const pointers = pointersRef.current;
+    if (!pointers.has(event.pointerId)) {
+      return;
+    }
+    pointers.set(event.pointerId, { x: event.clientX, y: event.clientY });
+
+    const pinch = pinchRef.current;
+    if (pinch && pointers.size >= 2) {
+      const [a, b] = [...pointers.values()];
+      const dist = Math.hypot(a.x - b.x, a.y - b.y) || 1;
+      const mid = { x: (a.x + b.x) / 2, y: (a.y + b.y) / 2 };
+      const next = Math.min(10, Math.max(1, pinch.startScale * (dist / pinch.startDist)));
+      setScale(next);
+      // Pan follows the pinch midpoint so two fingers also slide the image
+      // around, anchored to where the gesture started.
+      setOffset(next === 1
+        ? { x: 0, y: 0 }
+        : {
+          x: pinch.startOffset.x + (mid.x - pinch.startMid.x),
+          y: pinch.startOffset.y + (mid.y - pinch.startMid.y),
+        });
+      return;
+    }
+
+    const drag = dragRef.current;
+    if (drag) {
+      setOffset({
+        x: drag.originX + event.clientX - drag.startX,
+        y: drag.originY + event.clientY - drag.startY,
+      });
+    }
+  }, []);
+
+  const handlePointerUp = useCallback((event: React.PointerEvent<HTMLImageElement>) => {
+    pointersRef.current.delete(event.pointerId);
+    if (pointersRef.current.size < 2) {
+      pinchRef.current = null;
+    }
+    if (pointersRef.current.size === 0) {
+      dragRef.current = null;
+      setDragging(false);
+    }
+  }, []);
+
+  const handleImageClick = useCallback((event: React.MouseEvent<HTMLImageElement>) => {
+    event.stopPropagation();
+    // A finished pinch or drag must not read as a tap-to-close.
+    if (scaleRef.current <= 1 && pointersRef.current.size === 0) {
+      onClose();
+    }
+  }, [onClose]);
+
   return createPortal(
     <div
-      className="fixed inset-0 z-[100] flex items-center justify-center bg-black/80 backdrop-blur-sm"
+      ref={viewportRef}
+      className="fixed inset-0 z-[100] flex items-center justify-center overflow-hidden bg-black/80 backdrop-blur-sm"
       onClick={onClose}
       role="dialog"
       aria-modal="true"
@@ -114,15 +249,25 @@ export function ImageLightbox({ src, alt, onClose }: { src: string; alt: string;
         type="button"
         onClick={onClose}
         aria-label={t('chat:misc.closeImagePreview')}
-        className="absolute right-4 top-4 rounded-full bg-white/10 p-2 text-white transition-colors hover:bg-white/20"
+        className="absolute right-4 top-4 z-[101] rounded-full bg-white/10 p-2 text-white transition-colors hover:bg-white/20"
       >
         <X className="h-5 w-5" />
       </button>
       <img
         src={src}
         alt={alt}
-        onClick={(event) => event.stopPropagation()}
-        className="max-h-[90vh] max-w-[92vw] rounded-lg object-contain shadow-2xl"
+        onClick={handleImageClick}
+        onPointerDown={handlePointerDown}
+        onPointerMove={handlePointerMove}
+        onPointerUp={handlePointerUp}
+        onPointerCancel={handlePointerUp}
+        style={{
+          transform: `translate(${offset.x}px, ${offset.y}px) scale(${scale})`,
+          cursor: scale > 1 ? (dragging ? 'grabbing' : 'grab') : 'zoom-in',
+          touchAction: 'none',
+        }}
+        className="max-h-[90vh] max-w-[92vw] select-none rounded-lg object-contain shadow-2xl will-change-transform"
+        draggable={false}
       />
     </div>,
     document.body,

--- a/src/modules/chat/utils/toolResultImages.ts
+++ b/src/modules/chat/utils/toolResultImages.ts
@@ -1,0 +1,108 @@
+/**
+ * Pulls image blocks out of a tool result payload.
+ *
+ * Providers disagree on the shape of an image inside a tool result — the
+ * Anthropic content-block form (`{ type: 'image', source: { type: 'base64', … } }`),
+ * the bare base64 source (`{ type: 'base64', media_type, data }`), and the MCP
+ * form (`{ type: 'image', data, mimeType }`) all show up depending on which
+ * provider and which tool produced the result. `useChatMessages` also
+ * JSON.stringifies anything non-string before it reaches the renderer, so a
+ * stringified array has to be parsed back before scanning.
+ */
+
+export type ToolResultImage = {
+  mediaType: string;
+  data: string;
+};
+
+const BASE64_PATTERN = /^[A-Za-z0-9+/]+={0,2}$/;
+
+const isBase64Data = (value: unknown): value is string =>
+  typeof value === 'string' && value.length > 64 && BASE64_PATTERN.test(value);
+
+const isImageBlock = (block: any): block is ToolResultImage => {
+  if (!block || typeof block !== 'object') {
+    return false;
+  }
+
+  // Anthropic content block: { type: 'image', source: { type: 'base64', media_type, data } }
+  if (block.type === 'image' && block.source?.type === 'base64'
+    && typeof block.source.media_type === 'string' && isBase64Data(block.source.data)) {
+    return true;
+  }
+
+  // Bare base64 source: { type: 'base64', media_type, data }
+  if (block.type === 'base64'
+    && typeof block.media_type === 'string' && isBase64Data(block.data)) {
+    return true;
+  }
+
+  // MCP content block: { type: 'image', data, mimeType }
+  if (block.type === 'image'
+    && typeof block.mimeType === 'string' && isBase64Data(block.data)) {
+    return true;
+  }
+
+  return false;
+};
+
+const toImage = (block: any): ToolResultImage => {
+  if (block.source) {
+    return { mediaType: block.source.media_type, data: block.source.data };
+  }
+  return { mediaType: block.media_type || block.mimeType, data: block.data };
+};
+
+const parseBlocks = (payload: unknown): unknown => {
+  if (typeof payload === 'string') {
+    try {
+      return JSON.parse(payload);
+    } catch {
+      return null;
+    }
+  }
+  return payload;
+};
+
+/**
+ * Collect every image block found in a tool result payload (string, array, or
+ * an object carrying a `content` array). Returns data URLs plus their media
+ * types, ready for an `<img src>`.
+ */
+export const extractToolResultImages = (payload: unknown): ToolResultImage[] => {
+  if (payload == null) {
+    return [];
+  }
+
+  // A tool result wrapper ({ content, isError }) is as common as the bare array.
+  const blocks = parseBlocks(
+    payload && typeof payload === 'object' && !Array.isArray(payload) && 'content' in (payload as any)
+      ? (payload as any).content
+      : payload,
+  );
+
+  if (!Array.isArray(blocks)) {
+    return [];
+  }
+
+  return blocks.filter(isImageBlock).map(toImage);
+};
+
+/** True when the result carries at least one renderable image. */
+export const hasToolResultImages = (toolResult: unknown): boolean =>
+  extractToolResultImages(toolResult).length > 0;
+
+/**
+ * Drops the image blocks from a tool result payload so the remaining text can
+ * be rendered without dragging a wall of base64 characters along with it.
+ */
+export const withoutImageBlocks = (payload: unknown): unknown => {
+  if (typeof payload === 'string') {
+    const parsed = parseBlocks(payload);
+    return Array.isArray(parsed) ? withoutImageBlocks(parsed) : payload;
+  }
+  if (Array.isArray(payload)) {
+    return payload.filter((block) => !isImageBlock(block));
+  }
+  return payload;
+};


### PR DESCRIPTION
## What

Tool results that carry image blocks — browser screenshots, image `Read`s, MCP `image` content — were dumped into the transcript as a wall of base64 text. They now render as thumbnails that open in the lightbox, which gained wheel / trackpad-pinch / two-finger-touch zoom and drag panning.

## Why it happened

Three layers each contributed:

1. **Server**: the 40k tool-output cap (`MAX_TOOL_RESULT_CONTENT`) sliced JSON content-block arrays mid-base64. The truncated string is neither valid JSON nor a decodable image, so every downstream parse fell back to raw text. Small images (<40k chars) survived, which made the bug look intermittent.
2. **Frontend extraction**: nothing pulled images out of the three shapes providers actually produce (`{type:'image',source:{type:'base64',media_type,data}}`, the bare `{type:'base64',media_type,data}`, and MCP `{type:'image',data,mimeType}`), including the JSON-stringified-array form.
3. **Rendering**: the `Default` tool config JSON.stringified non-text blocks, and the collapsible text branch had no image path.

## Changes

- `server/shared/message-unification.ts` — block-aware truncation: image payloads are kept whole; oversized *text* blocks still cap as before.
- `src/modules/chat/utils/toolResultImages.ts` (new) — image extraction across all provider shapes, plus `withoutImageBlocks`.
- `src/modules/chat/tools/ContentRenderers/ToolResultImages.tsx` (new) — thumbnails under the result text.
- `src/modules/chat/tools/ToolRenderer.tsx` / `configs/toolConfigs.ts` — route images to the renderer, strip base64 from the text pass.
- `src/modules/chat/transcript/ChatMessageImages.tsx` — lightbox zoom/pan: wheel, trackpad pinch (ctrl+wheel), two-finger touch pinch, drag to pan, re-center on zoom-out. Touch gestures survive a throwing `setPointerCapture`.
- Tests: 10 frontend (extraction shapes, wrapper unwrapping, config behavior) + 1 server (image blocks survive the cap).

## Testing

- `vitest` (new + chat regression suites) and server `node:test` suites pass; `tsc --noEmit` clean.
- Verified in the running app: screenshots render as images, pinch-zoom works on mobile touch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tool results can now display screenshots and other images as clickable thumbnails.
  * Opened images support fullscreen viewing, zooming, panning, and touch gestures.
* **Improvements**
  * Image content remains intact when long tool-result text is truncated.
  * Image data is excluded from text output to prevent raw encoded content from appearing.
  * Image blocks are recognized across supported content formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->