### PR TITLE
feat(chat): stream provider thinking token-by-token across claude, codex, and opencode

### DIFF
--- a/server/modules/providers/list/claude/claude-runtime.provider.js
+++ b/server/modules/providers/list/claude/claude-runtime.provider.js
@@ -286,6 +286,13 @@ function mapCliOptionsToSDK(options = {}) {
 
   sdkOptions.settingSources = ['project', 'user', 'local'];
 
+  // Token-level streaming: without this the SDK only yields whole assistant
+  // messages, so reply text and thinking appear one lump per turn. The
+  // partial `stream_event` frames feed the client's accumulated stream_delta /
+  // thinking_delta rendering; the complete assistant messages still arrive
+  // alongside and remain the persisted record.
+  sdkOptions.includePartialMessages = true;
+
   // The SDK resumes with the provider-native session id, never the app id.
   // `resumeFromScratch` is set when the very first prompt of a conversation was
   // edited: there is nothing before it to resume through, so the turn has to

--- a/server/modules/providers/list/claude/claude-sessions.provider.ts
+++ b/server/modules/providers/list/claude/claude-sessions.provider.ts
@@ -680,11 +680,35 @@ export class ClaudeSessionsProvider implements IProviderSessions {
       return [];
     }
 
-    if (raw.type === 'content_block_delta' && raw.delta?.text) {
-      return [createNormalizedMessage({ kind: 'stream_delta', content: raw.delta.text, sessionId, provider: PROVIDER })];
+    // Partial-message frames from the SDK arrive as { type: 'stream_event',
+    // event: <raw anthropic stream frame> } (verified against the SDK types:
+    // SDKPartialAssistantMessage). The per-delta branches below answer both
+    // that envelope and the bare frame, since the client folds each kind into
+    // one accumulated row anyway. input_json_delta / signature_delta are
+    // deliberately ignored: tool input only renders from the complete
+    // assistant message that follows.
+    const streamEvent = raw.type === 'stream_event' ? readObjectRecord(raw.event) : null;
+    const deltaFrame = streamEvent?.type
+      ? streamEvent
+      : (raw.type === 'content_block_delta' || raw.type === 'content_block_stop' ? raw : null);
+
+    if (deltaFrame?.type === 'content_block_delta') {
+      const delta = readObjectRecord(deltaFrame.delta);
+      if (delta?.type === 'thinking_delta' && typeof delta.thinking === 'string' && delta.thinking) {
+        return [createNormalizedMessage({ kind: 'thinking_delta', content: delta.thinking, sessionId, provider: PROVIDER })];
+      }
+      if (delta?.type === 'text_delta' && typeof delta.text === 'string' && delta.text) {
+        return [createNormalizedMessage({ kind: 'stream_delta', content: delta.text, sessionId, provider: PROVIDER })];
+      }
+      return [];
     }
-    if (raw.type === 'content_block_stop') {
+    if (deltaFrame?.type === 'content_block_stop') {
       return [createNormalizedMessage({ kind: 'stream_end', sessionId, provider: PROVIDER })];
+    }
+    if (raw.type === 'stream_event') {
+      // message_start / message_delta / message_stop and the tool-input
+      // deltas: nothing to render until the complete message arrives.
+      return [];
     }
 
     const messages: NormalizedMessage[] = [];

--- a/server/modules/providers/list/codex/codex-runtime.provider.ts
+++ b/server/modules/providers/list/codex/codex-runtime.provider.ts
@@ -36,9 +36,11 @@ const activeCodexSessions = new Map<string, ActiveCodexSession>();
 
 /**
  * Item types whose in-flight updates are worth showing. These are the ones a
- * user waits on — a shell command's output, an MCP call, and the running plan.
+ * user waits on — a shell command's output, an MCP call, the running plan,
+ * and the growing reasoning summary (each `item.updated` carries the text
+ * snapshot so far, and the stable itemId makes it update one row).
  */
-const PROGRESSIVE_CODEX_ITEM_TYPES = new Set(['command_execution', 'mcp_tool_call', 'todo_list']);
+const PROGRESSIVE_CODEX_ITEM_TYPES = new Set(['command_execution', 'mcp_tool_call', 'todo_list', 'reasoning']);
 
 function readUsageNumber(value: unknown) {
   const parsed = Number(value);

--- a/server/modules/providers/list/codex/codex-sessions.provider.ts
+++ b/server/modules/providers/list/codex/codex-sessions.provider.ts
@@ -1894,13 +1894,20 @@ export class CodexSessionsProvider implements IProviderSessions {
       })];
     }
 
-    if (raw.type === 'thinking' || raw.isReasoning) {
+    // The live item transform marks reasoning on the message itself
+    // (message.isReasoning); history rows carry the flag at top level. Both
+    // mean the same row — missing the nested one rendered reasoning as an
+    // ordinary assistant bubble.
+    if (raw.type === 'thinking' || raw.isReasoning || readObjectRecord(raw.message)?.isReasoning) {
       const thinkingContent = typeof raw.message?.content === 'string' ? raw.message.content : '';
       if (!thinkingContent.trim()) {
         return [];
       }
       return [createNormalizedMessage({
-        id: baseId,
+        // Live SDK items carry their stable `itemId`, so an in-progress
+        // reasoning tick and its completion normalize onto one row; history
+        // entries have no itemId and keep their uuid.
+        id: (typeof raw.itemId === 'string' && raw.itemId) || baseId,
         sessionId,
         timestamp: ts,
         provider: PROVIDER,

--- a/server/modules/providers/list/opencode/opencode-runtime.provider.js
+++ b/server/modules/providers/list/opencode/opencode-runtime.provider.js
@@ -257,6 +257,10 @@ async function spawnOpenCode(command, options = {}, ws, context) {
 
       const resolvedEffort = resolveOpenCodeEffort(resolvedModel, effort, effortModels);
       const args = ['run', '--format', 'json'];
+      // Without --thinking the json stream silently omits every reasoning part
+      // even when the model produced one (verified against v1.18.30) — the
+      // thinking accordion would only ever fill from the reload path.
+      args.push('--thinking');
       // OpenCode's `run` command owns workspace selection through `--dir`.
       // Relying on the child-process cwd alone is not enough on Linux, where
       // the CLI can still resolve the session under the server install dir.

--- a/server/modules/providers/list/opencode/opencode-runtime.provider.test.js
+++ b/server/modules/providers/list/opencode/opencode-runtime.provider.test.js
@@ -105,8 +105,11 @@ test('spawnOpenCode emits session_created before normalized live messages for ne
     const capture = JSON.parse(await readFile(argsCapturePath, 'utf8'));
     const launchedArgs = capture.args;
     assert.ok(Array.isArray(launchedArgs));
-    assert.deepEqual(launchedArgs.slice(0, 4), ['run', '--format', 'json', '--dir']);
-    assert.equal(launchedArgs[4], tempRoot);
+    // --thinking must stay on: without it the json stream drops every
+    // reasoning part and the live thinking bubble never fills.
+    assert.deepEqual(launchedArgs.slice(0, 4), ['run', '--format', 'json', '--thinking']);
+    assert.equal(launchedArgs[4], '--dir');
+    assert.equal(launchedArgs[5], tempRoot);
     // No permission mode requested → no permission flags and no env override.
     assert.equal(launchedArgs.includes('--auto'), false);
     assert.equal(launchedArgs.includes('--agent'), false);

--- a/server/modules/providers/list/opencode/opencode-sessions.provider.ts
+++ b/server/modules/providers/list/opencode/opencode-sessions.provider.ts
@@ -201,6 +201,14 @@ const aggregateOpenCodeSessionTokenUsage = (
 export class OpenCodeSessionsProvider implements IProviderSessions {
   /**
    * Normalizes live `opencode run --format json` events into frontend messages.
+   *
+   * Verified against a live v1.18 CLI: every event carries the payload nested
+   * under `part` (top level is only `type` / `timestamp` / `sessionID`), each
+   * part is emitted as ONE whole event when it finishes (the CLI has no
+   * token-delta frames), and reasoning parts only appear at all when the run
+   * passes `--thinking` — which the runtime now always does. Ids are the
+   * provider's own (`part.id`, and `part.callID` for tools) so an in-flight
+   * row and its later update replace the same transcript entry.
    */
   normalizeMessage(rawMessage: unknown, sessionId: string | null): NormalizedMessage[] {
     const raw = readObjectRecord(rawMessage);
@@ -210,8 +218,12 @@ export class OpenCodeSessionsProvider implements IProviderSessions {
 
     const type = readOptionalString(raw.type) ?? readOptionalString(raw.event);
     const eventSessionId = readOptionalString(raw.sessionID) ?? readOptionalString(raw.sessionId) ?? sessionId;
-    const timestamp = normalizeProviderTimestamp(raw.time ?? raw.timestamp);
-    const baseId = readOptionalString(raw.id)
+    const part = readObjectRecord(raw.part);
+    const timestamp = normalizeProviderTimestamp(
+      readObjectRecord(part?.time)?.end ?? raw.time ?? raw.timestamp,
+    );
+    const baseId = readOptionalString(part?.id)
+      ?? readOptionalString(raw.id)
       ?? readOptionalString(raw.messageID)
       ?? generateMessageId('opencode');
 
@@ -222,7 +234,7 @@ export class OpenCodeSessionsProvider implements IProviderSessions {
         return [];
       }
 
-      const content = extractText(raw.text ?? raw.delta ?? raw.message);
+      const content = extractText(part?.text ?? raw.text ?? raw.delta ?? raw.message);
       if (!content.trim()) {
         return [];
       }
@@ -238,7 +250,7 @@ export class OpenCodeSessionsProvider implements IProviderSessions {
     }
 
     if (type === 'reasoning') {
-      const content = extractText(raw.text ?? raw.delta ?? raw.message);
+      const content = extractText(part?.text ?? raw.text ?? raw.delta ?? raw.message);
       if (!content.trim()) {
         return [];
       }
@@ -254,8 +266,19 @@ export class OpenCodeSessionsProvider implements IProviderSessions {
     }
 
     if (type === 'tool_use') {
-      const toolName = readOptionalString(raw.tool) ?? readOptionalString(raw.name) ?? 'Tool';
-      const toolId = readOptionalString(raw.callID) ?? readOptionalString(raw.toolCallId) ?? baseId;
+      // Live tool parts carry { tool, callID, state: { status, input, output,
+      // error } }; a running part arrives first and the completed one reuses
+      // the same callID, so the client updates the one row instead of stacking.
+      const toolName = readOptionalString(part?.tool)
+        ?? readOptionalString(raw.tool)
+        ?? readOptionalString(raw.name)
+        ?? 'Tool';
+      const toolId = readOptionalString(part?.callID)
+        ?? readOptionalString(raw.callID)
+        ?? readOptionalString(raw.toolCallId)
+        ?? baseId;
+      const state = readObjectRecord(part?.state);
+      const status = readOptionalString(state?.status);
       const toolMessage = createNormalizedMessage({
         id: baseId,
         sessionId: eventSessionId,
@@ -263,14 +286,15 @@ export class OpenCodeSessionsProvider implements IProviderSessions {
         provider: PROVIDER,
         kind: 'tool_use',
         toolName,
-        toolInput: raw.input ?? raw.arguments ?? {},
+        toolInput: state?.input ?? part?.input ?? raw.input ?? raw.arguments ?? {},
         toolId,
+        ...(status ? { status } : {}),
       });
 
-      if (raw.output !== undefined || raw.error !== undefined) {
+      if (status === 'completed' || status === 'error' || state?.output !== undefined || state?.error !== undefined) {
         toolMessage.toolResult = {
-          content: formatToolContent(raw.output ?? raw.error),
-          isError: raw.error !== undefined,
+          content: formatToolContent(state?.output ?? state?.error ?? raw.output ?? raw.error),
+          isError: status === 'error' || raw.error !== undefined,
         };
       }
 

--- a/server/modules/providers/tests/claude-sessions.test.ts
+++ b/server/modules/providers/tests/claude-sessions.test.ts
@@ -32,6 +32,49 @@ const SESSION_ID = 'claude-session-1';
 const AGENT_ID = 'a1b2c3d4e5f60718';
 const AGENT_TOOL_USE_ID = 'toolu_agent_1';
 
+test('Claude sessions provider normalizes SDK partial stream_event deltas', () => {
+  const provider = new ClaudeSessionsProvider();
+
+  // SDKPartialAssistantMessage shape: { type: 'stream_event', event: <raw frame> }
+  const thinking = provider.normalizeMessage({
+    type: 'stream_event',
+    session_id: SESSION_ID,
+    uuid: 'partial-1',
+    event: { type: 'content_block_delta', delta: { type: 'thinking_delta', thinking: '想一' } },
+  }, SESSION_ID);
+  assert.equal(thinking.length, 1);
+  assert.equal(thinking[0]?.kind, 'thinking_delta');
+  assert.equal(thinking[0]?.content, '想一');
+
+  const text = provider.normalizeMessage({
+    type: 'stream_event',
+    session_id: SESSION_ID,
+    uuid: 'partial-2',
+    event: { type: 'content_block_delta', delta: { type: 'text_delta', text: '你好' } },
+  }, SESSION_ID);
+  assert.equal(text.length, 1);
+  assert.equal(text[0]?.kind, 'stream_delta');
+  assert.equal(text[0]?.content, '你好');
+
+  // Tool-input and signature deltas carry nothing renderable — the complete
+  // assistant message that follows is what shows them.
+  const ignored = provider.normalizeMessage({
+    type: 'stream_event',
+    session_id: SESSION_ID,
+    uuid: 'partial-3',
+    event: { type: 'content_block_delta', delta: { type: 'input_json_delta', partial_json: '{"a"' } },
+  }, SESSION_ID);
+  assert.deepEqual(ignored, []);
+
+  const messageStart = provider.normalizeMessage({
+    type: 'stream_event',
+    session_id: SESSION_ID,
+    uuid: 'partial-4',
+    event: { type: 'message_start' },
+  }, SESSION_ID);
+  assert.deepEqual(messageStart, []);
+});
+
 /**
  * Writes the transcript pair current Claude versions produce for one async
  * subagent: the parent session, and the agent's own transcript plus sidecar

--- a/server/modules/providers/tests/codex-sessions.test.ts
+++ b/server/modules/providers/tests/codex-sessions.test.ts
@@ -64,6 +64,30 @@ const writeCodexTranscript = async (
   return filePath;
 };
 
+test('Codex live reasoning ticks normalize onto one row by itemId', () => {
+  const provider = new CodexSessionsProvider();
+
+  // Shape the runtime's transformCodexEvent produces for item.started/updated/
+  // completed reasoning items: a stable itemId, and isReasoning + assistant
+  // role so it routes through the history-entry branch.
+  const tick = (content: string) => ({
+    type: 'item',
+    itemType: 'reasoning',
+    itemId: 'item_reason_1',
+    message: { role: 'assistant', content, isReasoning: true },
+  });
+
+  const first = provider.normalizeMessage(tick('partial'), 'codex-live-1');
+  const second = provider.normalizeMessage(tick('partial plus more'), 'codex-live-1');
+
+  assert.equal(first.length, 1);
+  assert.equal(first[0]?.kind, 'thinking');
+  // Same itemId → same message id, so the client replaces the row in place
+  // rather than stacking one thinking bubble per SDK tick.
+  assert.equal(second[0]?.id, first[0]?.id);
+  assert.equal(second[0]?.content, 'partial plus more');
+});
+
 test('Codex synchronizer preserves the title assigned when CloudCLI creates a session', { concurrency: false }, async () => {
   const tempRoot = await mkdtemp(path.join(os.tmpdir(), 'codex-session-sync-app-'));
   const workspacePath = path.join(tempRoot, 'workspace');

--- a/server/modules/providers/tests/opencode-sessions.test.ts
+++ b/server/modules/providers/tests/opencode-sessions.test.ts
@@ -379,6 +379,105 @@ test('OpenCode sessions provider normalizes quoted live text and skips user echo
   assert.deepEqual(userEcho, []);
 });
 
+// Shapes below are verbatim captures from a live `opencode run --thinking
+// --format json` (v1.18.30): payload nested under `part`, one whole event per
+// finished part, and reasoning only present because of --thinking.
+test('OpenCode sessions provider normalizes real CLI reasoning events as thinking rows', () => {
+  const provider = new OpenCodeSessionsProvider();
+  const normalized = provider.normalizeMessage({
+    type: 'reasoning',
+    timestamp: 1789132139489,
+    sessionID: 'ses_probe',
+    part: {
+      id: 'prt_reasoning1',
+      messageID: 'msg_assistant1',
+      sessionID: 'ses_probe',
+      type: 'reasoning',
+      text: '用户要求执行 echo，直接执行即可。',
+      time: { start: 1789132139400, end: 1789132139473 },
+    },
+  }, null);
+
+  assert.equal(normalized.length, 1);
+  assert.equal(normalized[0]?.kind, 'thinking');
+  assert.equal(normalized[0]?.content, '用户要求执行 echo，直接执行即可。');
+  assert.equal(normalized[0]?.id, 'prt_reasoning1');
+  assert.equal(normalized[0]?.timestamp, new Date(1789132139473).toISOString());
+});
+
+test('OpenCode sessions provider normalizes real CLI text events nested under part', () => {
+  const provider = new OpenCodeSessionsProvider();
+  const normalized = provider.normalizeMessage({
+    type: 'text',
+    timestamp: 1789132140420,
+    sessionID: 'ses_probe',
+    part: {
+      id: 'prt_text1',
+      messageID: 'msg_assistant2',
+      sessionID: 'ses_probe',
+      type: 'text',
+      text: 'hello-tool-probe',
+      time: { start: 1789132140391, end: 1789132140403 },
+    },
+  }, null);
+
+  assert.equal(normalized.length, 1);
+  assert.equal(normalized[0]?.kind, 'stream_delta');
+  assert.equal(normalized[0]?.content, 'hello-tool-probe');
+});
+
+test('OpenCode sessions provider normalizes real CLI tool parts with stable call ids', () => {
+  const provider = new OpenCodeSessionsProvider();
+  const running = provider.normalizeMessage({
+    type: 'tool_use',
+    timestamp: 1789132139550,
+    sessionID: 'ses_probe',
+    part: {
+      type: 'tool',
+      tool: 'bash',
+      callID: 'call_probe1',
+      state: { status: 'running', input: { command: 'echo hi' } },
+      id: 'prt_tool1',
+      sessionID: 'ses_probe',
+      messageID: 'msg_assistant1',
+    },
+  }, null);
+
+  assert.equal(running.length, 1);
+  assert.equal(running[0]?.kind, 'tool_use');
+  assert.equal(running[0]?.toolName, 'bash');
+  assert.equal(running[0]?.toolId, 'call_probe1');
+  assert.deepEqual(running[0]?.toolInput, { command: 'echo hi' });
+  assert.equal(running[0]?.toolResult, undefined);
+
+  const completed = provider.normalizeMessage({
+    type: 'tool_use',
+    timestamp: 1789132139699,
+    sessionID: 'ses_probe',
+    part: {
+      type: 'tool',
+      tool: 'bash',
+      callID: 'call_probe1',
+      state: {
+        status: 'completed',
+        input: { command: 'echo hi' },
+        output: 'hi\n',
+        metadata: { output: 'hi\n', exit: 0, truncated: false },
+        title: 'echo hi',
+        time: { start: 1789132139501, end: 1789132139664 },
+      },
+      id: 'prt_tool1',
+      sessionID: 'ses_probe',
+      messageID: 'msg_assistant1',
+    },
+  }, null);
+
+  assert.equal(completed.length, 1);
+  // Same part id → the client replaces the in-flight row instead of stacking.
+  assert.equal(completed[0]?.id, running[0]?.id);
+  assert.deepEqual(completed[0]?.toolResult, { content: 'hi\n', isError: false });
+});
+
 test('OpenCode sessions provider reads sqlite history and token usage', { concurrency: false }, async () => {
   const tempRoot = await mkdtemp(path.join(os.tmpdir(), 'opencode-session-history-'));
   const workspacePath = path.join(tempRoot, 'workspace');

--- a/server/shared/types.ts
+++ b/server/shared/types.ts
@@ -180,6 +180,7 @@ export type MessageKind =
   | 'tool_use'
   | 'tool_result'
   | 'thinking'
+  | 'thinking_delta'
   | 'stream_delta'
   | 'stream_end'
   | 'error'

--- a/src/modules/chat/ChatInterface.tsx
+++ b/src/modules/chat/ChatInterface.tsx
@@ -80,6 +80,11 @@ function ChatInterface({
   const sessionStore = useSessionStore();
   const streamTimerRef = useRef<number | null>(null);
   const accumulatedStreamRef = useRef('');
+  // Thinking stream buffers parallel to the text ones: a turn streams
+  // reasoning first and answer second, and one shared buffer would clobber
+  // the other whenever the two overlapped.
+  const thinkingStreamTimerRef = useRef<number | null>(null);
+  const accumulatedThinkingStreamRef = useRef('');
   // When each session's `chat.subscribe` was last sent; idle acks older than
   // a later local request are discarded as stale.
   const statusCheckSentAtRef = useRef(new Map<string, number>());
@@ -94,6 +99,11 @@ function ChatInterface({
       streamTimerRef.current = null;
     }
     accumulatedStreamRef.current = '';
+    if (thinkingStreamTimerRef.current) {
+      clearTimeout(thinkingStreamTimerRef.current);
+      thinkingStreamTimerRef.current = null;
+    }
+    accumulatedThinkingStreamRef.current = '';
   }, []);
 
   const {
@@ -284,6 +294,8 @@ function ChatInterface({
     setPendingPermissionRequests,
     streamTimerRef,
     accumulatedStreamRef,
+    thinkingStreamTimerRef,
+    accumulatedThinkingStreamRef,
     lastSeqRef,
     statusCheckSentAtRef,
     onSessionProcessing,

--- a/src/modules/chat/hooks/useChatMessages.ts
+++ b/src/modules/chat/hooks/useChatMessages.ts
@@ -308,6 +308,22 @@ export function normalizedToChatMessages(messages: NormalizedMessage[]): ChatMes
         }
         break;
 
+      case 'thinking_delta':
+        // Accumulated reasoning row from the session store's thinking stream
+        // (updateStreamingThinking); renders as a live-open Reasoning bubble
+        // that the finished `thinking` row replaces.
+        if (msg.content?.trim()) {
+          converted.push({
+            type: 'assistant',
+            content: msg.content,
+            timestamp: msg.timestamp,
+            isThinking: true,
+            isStreaming: true,
+            ...sharedMetadata,
+          });
+        }
+        break;
+
       case 'error':
         converted.push({
           type: 'error',

--- a/src/modules/chat/hooks/useChatRealtimeHandlers.ts
+++ b/src/modules/chat/hooks/useChatRealtimeHandlers.ts
@@ -25,6 +25,8 @@ type UseChatRealtimeHandlersArgs = {
   setPendingPermissionRequests: Dispatch<SetStateAction<PendingPermissionRequest[]>>;
   streamTimerRef: MutableRefObject<number | null>;
   accumulatedStreamRef: MutableRefObject<string>;
+  thinkingStreamTimerRef: MutableRefObject<number | null>;
+  accumulatedThinkingStreamRef: MutableRefObject<string>;
   /**
    * Highest live `seq` observed per session. Essential for reconnect catch-up:
    * `chat.subscribe` sends this value as `lastSeq` so the server replays only
@@ -65,6 +67,8 @@ export function useChatRealtimeHandlers({
   setPendingPermissionRequests,
   streamTimerRef,
   accumulatedStreamRef,
+  thinkingStreamTimerRef,
+  accumulatedThinkingStreamRef,
   lastSeqRef,
   statusCheckSentAtRef,
   onSessionProcessing,
@@ -186,9 +190,43 @@ export function useChatRealtimeHandlers({
       /* -------------------------------------------------------------- */
 
       // --- Streaming: buffer for performance ---
+      if (msg.kind === 'thinking_delta') {
+        const text = (msg.content as string) || '';
+        if (!text) return;
+        accumulatedThinkingStreamRef.current += text;
+        if (!thinkingStreamTimerRef.current) {
+          thinkingStreamTimerRef.current = window.setTimeout(() => {
+            thinkingStreamTimerRef.current = null;
+            if (sid) {
+              sessionStore.updateStreamingThinking(sid, accumulatedThinkingStreamRef.current, provider);
+            }
+          }, 100);
+        }
+        // Also route to store for non-active sessions
+        if (sid && sid !== activeViewSessionId) {
+          sessionStore.appendRealtime(sid, msg as unknown as NormalizedMessage);
+        }
+        return;
+      }
+
       if (msg.kind === 'stream_delta') {
         const text = (msg.content as string) || '';
         if (!text) return;
+        // Reasoning precedes the answer, so the first answer delta means the
+        // thinking stream is over: freeze the accumulated bubble.
+        if (accumulatedThinkingStreamRef.current || thinkingStreamTimerRef.current) {
+          if (thinkingStreamTimerRef.current) {
+            clearTimeout(thinkingStreamTimerRef.current);
+            thinkingStreamTimerRef.current = null;
+          }
+          if (sid && accumulatedThinkingStreamRef.current) {
+            sessionStore.updateStreamingThinking(sid, accumulatedThinkingStreamRef.current, provider);
+          }
+          if (sid) {
+            sessionStore.finalizeStreamingThinking(sid);
+          }
+          accumulatedThinkingStreamRef.current = '';
+        }
         accumulatedStreamRef.current += text;
         if (!streamTimerRef.current) {
           streamTimerRef.current = window.setTimeout(() => {
@@ -210,11 +248,20 @@ export function useChatRealtimeHandlers({
           clearTimeout(streamTimerRef.current);
           streamTimerRef.current = null;
         }
+        if (thinkingStreamTimerRef.current) {
+          clearTimeout(thinkingStreamTimerRef.current);
+          thinkingStreamTimerRef.current = null;
+        }
         if (sid) {
           if (accumulatedStreamRef.current) {
             sessionStore.updateStreaming(sid, accumulatedStreamRef.current, provider);
           }
           sessionStore.finalizeStreaming(sid);
+          if (accumulatedThinkingStreamRef.current) {
+            sessionStore.updateStreamingThinking(sid, accumulatedThinkingStreamRef.current, provider);
+            sessionStore.finalizeStreamingThinking(sid);
+            accumulatedThinkingStreamRef.current = '';
+          }
         }
         accumulatedStreamRef.current = '';
         return;
@@ -245,6 +292,15 @@ export function useChatRealtimeHandlers({
             sessionStore.finalizeStreaming(sid);
           }
           accumulatedStreamRef.current = '';
+          if (thinkingStreamTimerRef.current) {
+            clearTimeout(thinkingStreamTimerRef.current);
+            thinkingStreamTimerRef.current = null;
+          }
+          if (sid && accumulatedThinkingStreamRef.current) {
+            sessionStore.updateStreamingThinking(sid, accumulatedThinkingStreamRef.current, provider);
+            sessionStore.finalizeStreamingThinking(sid);
+          }
+          accumulatedThinkingStreamRef.current = '';
 
           // `complete` is the unified terminal event — every provider run ends
           // with exactly one, regardless of success, failure, or abort. The
@@ -360,6 +416,8 @@ export function useChatRealtimeHandlers({
     setPendingPermissionRequests,
     streamTimerRef,
     accumulatedStreamRef,
+    thinkingStreamTimerRef,
+    accumulatedThinkingStreamRef,
     lastSeqRef,
     statusCheckSentAtRef,
     onSessionProcessing,

--- a/src/modules/chat/hooks/useSessionStore.ts
+++ b/src/modules/chat/hooks/useSessionStore.ts
@@ -281,10 +281,50 @@ function dedupeAdjacentAssistantEchoes(merged: NormalizedMessage[]): NormalizedM
           continue;
         }
       }
+      // Same story for reasoning: the streamed thinking row finalizes under a
+      // synthetic id, and the provider's complete message re-emits the same
+      // text as a fresh `thinking` row beside it. Collapse onto the latter.
+      if (prev.kind === 'thinking' && m.kind === 'thinking') {
+        const ms = (m.content || '').trim();
+        if (ms.length > 0 && ms === (prev.content || '').trim()) {
+          out[out.length - 1] = m;
+          continue;
+        }
+      }
     }
     out.push(m);
   }
   return out;
+}
+
+/**
+ * Thinking counterpart of the assistant-echo check: a live reasoning row (or
+ * its frozen finalization) is superseded once the persisted transcript carries
+ * the same reasoning inside the same user turn. Without this the streamed
+ * thinking bubble stacks on top of the reloaded one until realtime clears.
+ */
+function isThinkingEchoedInSameTurnOnServer(
+  message: NormalizedMessage,
+  serverMessages: NormalizedMessage[],
+  realtimeMessages: NormalizedMessage[],
+): boolean {
+  const thinkingText = (message.content || '').trim();
+  if (!thinkingText) {
+    return false;
+  }
+
+  const turnOrdinal = getUserTurnOrdinalBefore(message, serverMessages, realtimeMessages);
+  const turnRange = findServerTurnRangeByOrdinal(serverMessages, turnOrdinal);
+  if (!turnRange) {
+    return false;
+  }
+
+  return serverMessages
+    .slice(turnRange.start + 1, turnRange.end)
+    .some((serverMessage) =>
+      serverMessage.kind === 'thinking'
+      && (serverMessage.content || '').trim() === thinkingText,
+    );
 }
 
 /**
@@ -313,6 +353,21 @@ function pruneRealtimeSupersededByServer(
       if (isAssistantTextEchoedInSameTurnOnServer(message, serverMessages, realtimeMessages)) {
         return false;
       }
+      return true;
+    }
+
+    if (
+      message.kind === 'thinking'
+      || message.kind === 'thinking_delta'
+      || message.id === `__streaming_thinking_${message.sessionId}`
+    ) {
+      if (isThinkingEchoedInSameTurnOnServer(message, serverMessages, realtimeMessages)) {
+        return false;
+      }
+      // A thinking_delta that got no finalization tick (aborted run) must not
+      // linger as an orphan streaming row once the turn is on disk either —
+      // but while nothing is persisted it is the only view of the reasoning,
+      // so it survives exactly like the text stream row above.
       return true;
     }
 
@@ -754,7 +809,18 @@ export function useSessionStore() {
       msg.sessionId === sessionId
         ? msg
         : { ...msg, sessionId };
-    let updated = [...slot.realtimeMessages, normalizedMessage];
+    // A live provider event that repeats an id already in the transcript is
+    // an update to that row, not a new one — the Codex SDK pushes `item.updated`
+    // ticks for the same item, and appending them stacked one bubble per tick.
+    // Replace in place, keeping the row's position.
+    const existingIdx = slot.realtimeMessages.findIndex(m => m.id === normalizedMessage.id);
+    let updated: NormalizedMessage[];
+    if (existingIdx >= 0) {
+      updated = [...slot.realtimeMessages];
+      updated[existingIdx] = normalizedMessage;
+    } else {
+      updated = [...slot.realtimeMessages, normalizedMessage];
+    }
     if (updated.length > MAX_REALTIME_MESSAGES) {
       updated = updated.slice(-MAX_REALTIME_MESSAGES);
     }
@@ -853,6 +919,57 @@ export function useSessionStore() {
   }, [notify]);
 
   /**
+   * Thinking counterpart of `updateStreaming`: one well-known row carrying the
+   * accumulated reasoning text, replaced in place on every throttled tick.
+   * Separate from the text sentinel because a turn streams both at once
+   * (reasoning first, then the answer) and one buffer would clobber the other.
+   */
+  const updateStreamingThinking = useCallback((sessionId: string, accumulatedText: string, msgProvider: LLMProvider) => {
+    const slot = getSlot(sessionId);
+    const streamId = `__streaming_thinking_${sessionId}`;
+    const msg: NormalizedMessage = {
+      id: streamId,
+      sessionId,
+      timestamp: new Date().toISOString(),
+      provider: msgProvider,
+      kind: 'thinking_delta',
+      content: accumulatedText,
+    };
+    const idx = slot.realtimeMessages.findIndex(m => m.id === streamId);
+    if (idx >= 0) {
+      slot.realtimeMessages = [...slot.realtimeMessages];
+      slot.realtimeMessages[idx] = msg;
+    } else {
+      slot.realtimeMessages = [...slot.realtimeMessages, msg];
+    }
+    recomputeMergedIfNeeded(slot);
+    notify(sessionId);
+  }, [getSlot, notify]);
+
+  /**
+   * Finalize thinking streaming: freeze the accumulated row into a regular
+   * `thinking` message so it renders as the finished reasoning bubble and
+   * survives until the persisted-history refresh retires it.
+   */
+  const finalizeStreamingThinking = useCallback((sessionId: string) => {
+    const slot = storeRef.current.get(sessionId);
+    if (!slot) return;
+    const streamId = `__streaming_thinking_${sessionId}`;
+    const idx = slot.realtimeMessages.findIndex(m => m.id === streamId);
+    if (idx >= 0) {
+      const stream = slot.realtimeMessages[idx];
+      slot.realtimeMessages = [...slot.realtimeMessages];
+      slot.realtimeMessages[idx] = {
+        ...stream,
+        id: `thinking_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`,
+        kind: 'thinking',
+      };
+      recomputeMergedIfNeeded(slot);
+      notify(sessionId);
+    }
+  }, [notify]);
+
+  /**
    * Get merged messages for a session (for rendering).
    */
   const getMessages = useCallback((sessionId: string): NormalizedMessage[] => {
@@ -876,11 +993,14 @@ export function useSessionStore() {
     isStale,
     updateStreaming,
     finalizeStreaming,
+    updateStreamingThinking,
+    finalizeStreamingThinking,
     getMessages,
     getSessionSlot,
   }), [
     fetchFromServer, fetchMore, appendRealtime, truncateAt, refreshLatestFromServer,
     setActiveSession, isStale, updateStreaming, finalizeStreaming,
+    updateStreamingThinking, finalizeStreamingThinking,
     getMessages, getSessionSlot,
   ]);
 }

--- a/src/modules/chat/tests/permissionPromptReplay.test.tsx
+++ b/src/modules/chat/tests/permissionPromptReplay.test.tsx
@@ -35,6 +35,8 @@ const renderHandlers = () => {
     },
     streamTimerRef: { current: null },
     accumulatedStreamRef: { current: '' },
+    thinkingStreamTimerRef: { current: null },
+    accumulatedThinkingStreamRef: { current: '' },
     lastSeqRef: { current: new Map() },
     statusCheckSentAtRef: { current: new Map() },
     requestLatestMessages: async () => {},

--- a/src/modules/chat/tests/thinkingStreaming.test.tsx
+++ b/src/modules/chat/tests/thinkingStreaming.test.tsx
@@ -1,0 +1,161 @@
+import assert from 'node:assert/strict';
+
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, it, vi } from 'vitest';
+
+import type { NormalizedMessage } from '@/shared/types';
+
+/**
+ * Live reasoning has to appear token-by-token, so the store keeps a
+ * well-known thinking row that updateStreamingThinking replaces in place, and
+ * finalizeStreamingThinking freezes it into a regular `thinking` row — the
+ * same contract the text stream pair already honors.
+ */
+
+const sessionMessages = vi.fn();
+
+vi.mock('@/shared/api', () => ({
+  api: {
+    providers: {
+      sessionMessages: (...args: unknown[]) => sessionMessages(...args),
+    },
+  },
+}));
+
+const row = (id: string, content: string, kind: NormalizedMessage['kind'] = 'text'): NormalizedMessage => ({
+  id,
+  kind,
+  role: kind === 'text' ? (id.startsWith('u') ? 'user' : 'assistant') : undefined,
+  provider: 'claude',
+  sessionId: 'session-1',
+  content,
+  timestamp: '2026-01-01T00:00:00.000Z',
+} as NormalizedMessage);
+
+const HISTORY = [
+  row('u1', 'first prompt'),
+  row('a1', 'first answer'),
+];
+
+beforeEach(() => {
+  sessionMessages.mockReset();
+  sessionMessages.mockResolvedValue({
+    ok: true,
+    json: async () => ({ data: { messages: HISTORY, total: HISTORY.length, hasMore: false } }),
+  });
+});
+
+afterEach(() => {
+  vi.resetModules();
+});
+
+async function loadedStore() {
+  const { useSessionStore } = await import('@/modules/chat/hooks/useSessionStore');
+  const view = renderHook(() => useSessionStore());
+  await act(async () => {
+    await view.result.current.fetchFromServer('session-1', { limit: 20, offset: 0 });
+  });
+  return view;
+}
+
+describe('thinking streaming', () => {
+  it('replaces the same accumulated row instead of appending one per tick', async () => {
+    const { result } = await loadedStore();
+
+    act(() => {
+      result.current.updateStreamingThinking('session-1', '想', 'claude');
+    });
+    act(() => {
+      result.current.updateStreamingThinking('session-1', '想一想', 'claude');
+    });
+
+    const streamed = result.current.getMessages('session-1').filter(
+      (message) => message.kind === 'thinking_delta',
+    );
+    assert.equal(streamed.length, 1);
+    assert.equal(streamed[0]?.content, '想一想');
+  });
+
+  it('keeps thinking and text streams as separate rows', async () => {
+    const { result } = await loadedStore();
+
+    act(() => {
+      result.current.updateStreamingThinking('session-1', 'thinking text', 'claude');
+      result.current.updateStreaming('session-1', 'answer text', 'claude');
+    });
+
+    const messages = result.current.getMessages('session-1');
+    const thinkingRow = messages.find((message) => message.kind === 'thinking_delta');
+    const textRow = messages.find((message) => message.kind === 'stream_delta');
+    assert.equal(thinkingRow?.content, 'thinking text');
+    assert.equal(textRow?.content, 'answer text');
+  });
+
+  it('finalizes the thinking row into a regular thinking message', async () => {
+    const { result } = await loadedStore();
+
+    act(() => {
+      result.current.updateStreamingThinking('session-1', 'final thought', 'claude');
+      result.current.finalizeStreamingThinking('session-1');
+    });
+
+    const messages = result.current.getMessages('session-1');
+    assert.equal(messages.some((message) => message.kind === 'thinking_delta'), false);
+    const finished = messages.find((message) => message.kind === 'thinking');
+    assert.equal(finished?.content, 'final thought');
+  });
+
+  it('prunes the finalized thinking row once the server transcript carries it', async () => {
+    const { result } = await loadedStore();
+
+    act(() => {
+      result.current.updateStreamingThinking('session-1', 'final thought', 'claude');
+      result.current.finalizeStreamingThinking('session-1');
+    });
+    assert.equal(result.current.getMessages('session-1').some((m) => m.kind === 'thinking'), true);
+
+    // Simulate the complete-triggered refresh bringing the same reasoning back
+    // from the persisted transcript under fresh ids.
+    sessionMessages.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        data: {
+          messages: [
+            ...HISTORY,
+            row('srv_think', 'final thought', 'thinking'),
+          ],
+          total: HISTORY.length + 1,
+          hasMore: false,
+        },
+      }),
+    });
+    await act(async () => {
+      await result.current.refreshLatestFromServer('session-1', { limit: 20 });
+    });
+
+    const thinkingRows = result.current.getMessages('session-1').filter(
+      (message) => message.kind === 'thinking',
+    );
+    assert.equal(thinkingRows.length, 1);
+    assert.equal(thinkingRows[0]?.id, 'srv_think');
+  });
+});
+
+describe('appendRealtime same-id updates', () => {
+  it('replaces an existing row instead of stacking a duplicate', async () => {
+    const { result } = await loadedStore();
+
+    act(() => {
+      result.current.appendRealtime('session-1', row('item_1', 'partial reasoning', 'thinking'));
+    });
+    act(() => {
+      result.current.appendRealtime('session-1', row('item_1', 'fuller reasoning', 'thinking'));
+    });
+
+    const rows = result.current.getMessages('session-1').filter(
+      (message) => message.id === 'item_1',
+    );
+    assert.equal(rows.length, 1);
+    assert.equal(rows[0]?.content, 'fuller reasoning');
+  });
+});

--- a/src/modules/chat/tests/tokenBudgetSessionScope.test.tsx
+++ b/src/modules/chat/tests/tokenBudgetSessionScope.test.tsx
@@ -33,6 +33,8 @@ const renderHandlers = () => {
     setPendingPermissionRequests: () => {},
     streamTimerRef: { current: null },
     accumulatedStreamRef: { current: '' },
+    thinkingStreamTimerRef: { current: null },
+    accumulatedThinkingStreamRef: { current: '' },
     lastSeqRef: { current: new Map() },
     statusCheckSentAtRef: { current: new Map() },
     requestLatestMessages: async () => {},

--- a/src/modules/chat/transcript/MessageComponent.tsx
+++ b/src/modules/chat/transcript/MessageComponent.tsx
@@ -271,8 +271,13 @@ const MessageComponent = memo(({ message, prevMessage, createDiff, onFileOpen, s
                 )}
               </>
             ) : message.isThinking ? (
-              /* Thinking messages — Reasoning component (ai-elements pattern) */
-              <Reasoning defaultOpen={isExporting}>
+              /* Thinking messages — Reasoning component (ai-elements pattern).
+                 A streamed row (isStreaming) auto-opens and shimmers; the
+                 finalized row lands collapsed as before. */
+              <Reasoning
+                defaultOpen={isExporting || Boolean(message.isStreaming)}
+                isStreaming={Boolean(message.isStreaming)}
+              >
                 <ReasoningTrigger />
                 <ReasoningContent>
                   <Markdown className="prose prose-sm prose-gray max-w-none font-serif dark:prose-invert">

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -491,6 +491,7 @@ type MessageKind =
   | 'tool_use'
   | 'tool_result'
   | 'thinking'
+  | 'thinking_delta'
   | 'stream_delta'
   | 'stream_end'
   | 'error'


### PR DESCRIPTION
## What

Turn-by-turn "one lump" thinking/text output becomes true token-by-token streaming for all three providers.

### Root causes fixed

- **Claude**: the SDK was never asked for partial messages, so thinking and text each arrived as one lump per turn. Now `includePartialMessages` is enabled and `stream_event` frames are normalized (`text_delta` -> `stream_delta`, `thinking_delta` -> `thinking_delta`).
- **OpenCode**: the live normalizer read the wrong field shape (payloads live nested under `part`) and spawned the CLI without `--thinking`, so every reasoning/text/tool event was silently dropped until the end-of-run history reload. Fixed against a live v1.18.30 capture.
- **Codex**: live reasoning events lost their stable `itemId` in normalization and were mislabeled as ordinary text, stacking one row per SDK tick. Now `item.updated` ticks are forwarded with the `itemId` kept as the row id, and the nested `message.isReasoning` flag is honored so reasoning normalizes as thinking instead of prose.

### Client

- Accumulated thinking stream (`thinking_delta` + well-known row) alongside the existing text stream.
- Same-id in-place realtime updates; thinking dedupe against the persisted transcript.
- A streaming Reasoning bubble.

## Tests

- `thinkingStreaming.test.tsx` — 5 cases (accumulated thinking row, dedupe, bubble rendering).
- `claude-sessions.test.ts` / `codex-sessions.test.ts` / `opencode-sessions.test.ts` / `opencode-runtime.provider.test.js` — 36 cases covering the new normalization paths.
- All 41 green on this branch (rebased onto current `main`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Reasoning content now streams live while responses are generated.
  * The active Reasoning panel opens automatically during streaming and collapses after completion.
  * Live reasoning updates remain separate from answer text and avoid duplicate entries.
  * Claude, Codex, and OpenCode sessions now display streaming reasoning, text, and tool activity more reliably.

* **Bug Fixes**
  * Improved restoration and display of reasoning content from conversation history.
  * Prevented duplicate reasoning and tool entries during live updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->