### PR TITLE
fix(chat): keep streaming follow-bottom honest, and the transcript inside the viewport

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -147,3 +147,4 @@ tasks/
 cloudcli-sidebar-app-source.tar.gz
 cloudcli-sidebar.html
 electron/*.tar.gz
+.ref/

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -98,6 +98,7 @@
           "src/shared/voiceConfig.ts",
           "src/shared/codeEditorSettings.ts",
           "src/shared/userSettings.ts",
+          "src/shared/sessionInfoPanelPrefs.ts",
           "src/shared/chatDrafts.ts",
           "src/shared/syntaxHighlighter.ts"
         ],

--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -11,7 +11,7 @@
 - [ ] 新增抽象：`server/modules/providers/shared/session-insights/session-insights.provider.ts`
       定义 `SessionInsightsProvider` 基类（方法：`listSubagents`、`fetchSubagentHistory`、
       `getContextSnapshot`），各 CLI 目录各建一个实现文件；无能力的 CLI 返回空数组/`AppError`。
-- [ ] `ProviderCapabilities` 增加 `supportsSessionInsights: boolean`
+- [x] `ProviderCapabilities` 增加 `supportsSessionInsights: boolean`
       （claude=true，codex/opencode 一期 false，cursor=false）。
 - [ ] MCP 列表/技能列表**复用已有** provider 实现（`claude-mcp.provider.ts`、
       `claude-skills.provider.ts`），不另造读取路径。
@@ -43,13 +43,13 @@
 
 ## Commit 3 — 面板壳 + 上下文节 + 轮次统计节
 
-- [ ] `src/modules/chat/panel/`：`SessionInfoPanel.tsx`、`InfoSection.tsx`、
+- [x] `src/modules/chat/panel/`：`SessionInfoPanel.tsx`、`InfoSection.tsx`、
       `ContextRingSection.tsx`、`TurnStatsSection.tsx`。
-- [ ] 挂载：`ChatInterface.tsx` 内层 relative 行容器，右栏 `w-72`；`isMobile` 走抽屉+遮罩。
-- [ ] `WorkspaceHeader.tsx` 开关按钮（PanelRightOpen/Close），默认 open=false。
-- [ ] 上下文节：运行中优先 CLI `getContextUsage`（服务器把调用透传成 REST 或由 runtime 缓存），
-      回退 tokenBudget；点击开既有 token 明细 modal。
-- [ ] 测试 `sessionInfoPanelRender.test.tsx`（六节壳、折叠卸载、窄屏分支）。
+- [x] 挂载：`ChatInterface.tsx` 内层 relative 行容器，右栏 `w-72`；`isMobile` 走抽屉+遮罩。
+- [x] `WorkspaceHeader.tsx` 开关按钮（PanelRightOpen/Close），默认 open=false。
+- [x] 上下文节：运行中优先 CLI `getContextUsage`（REST `GET /sessions/:id/context-info`
+      → runtime `contextInfo?()`，仅 Claude 实现），回退 tokenBudget；点击开既有 token 明细 modal。
+- [x] 测试 `sessionInfoPanelRender.test.tsx`（六节壳、折叠卸载、窄屏分支）。
 - 验收：手动开面板可见上下文环+轮次统计且随流刷新；测试绿。
 
 ## Commit 4 — 任务节

--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -82,12 +82,23 @@
 
 ## Commit 6 — MCP 节（含开关）
 
-- [ ] `settings.service.ts`/`settings.routes.ts`：`mcpDisabledServers` GET/PUT（auth.db JSON blob，仿 notification-preferences）。
-- [ ] `claude-runtime.provider.js`：`loadMcpConfig` 出口过 `applyMcpDisabledFilter(servers, disabledSet)`（按 name 全局禁用）。
-- [ ] 面板 MCP 行开关：乐观更新+失败回滚；提示「切换对新会话生效」。
-- [ ] 列表数据走既有 `GET /api/providers/:provider/mcp/servers`（CLI provider 实现），不另造。
-- [ ] 测试 `claude-mcp-disabled-filter.test.ts`。
+- [x] `settings.service.ts`/`settings.routes.ts`：`mcpDisabledServers` GET/PUT。
+      （落在既有 `user_preferences` 键值表的 `mcpDisabledServers` 键上而非新表——
+      值就是一个名字数组，键值 merge-patch 形态正好合用，免一次建表迁移；
+      且前端经偏好镜像零额外读取即可见，跨设备同步白拿。）
+- [x] `claude-runtime.provider.js`：`loadMcpConfig` 出口过 `applyMcpDisabledFilter(servers, disabledSet)`
+      （按 name 全局禁用，导出为纯函数；userId 由 queryClaudeSDK 的 `ws?.userId` 下传，
+      读库失败降级为"全不禁用"，不阻断会话）。
+- [x] `ProviderCapabilities.supportsMcpToggle`（claude=true，其余 false），
+      面板开关按能力位启停，不写 provider 分支。
+- [x] 面板 MCP 行开关：乐观更新+失败回滚（回滚走偏好镜像，其他读取方同步复原）；
+      提示「开关对新会话生效」。
+- [x] 列表数据走既有 `GET /api/providers/:provider/mcp/servers`，不另造
+      （scopes/扁平两种响应形状统一过 `flattenMcpServers` 按 name 去重排序）。
+- [x] 测试 `claude-mcp-disabled-filter.test.ts`（过滤纯函数 9 例，含仓储读写与脏数据降级）、
+      `settings.service.test.ts` 往返 1 例、`mcpServersSection.test.tsx` 7 例。
 - 验收：关掉一个 MCP 后新会话不再注入该服务器；测试绿。
+      ✅（路由 GET/PUT 往返 + 偏好镜像可见 + 列表端点形状，10091 真实验证通过）
 
 ## Commit 7 — 上下文来源节 + i18n + 打磨
 

--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -1,0 +1,99 @@
+# 会话右侧信息面板 — 实施验收 CHECKLIST
+
+> 每完成一项打 `[x]`；一个提交全部勾完才允许进入下一提交。
+> 原则：**能用 CLI/SDK 现成能力就优先从 CLI 取**（`Query.getContextUsage()`、
+> `Query.mcpServerStatus()` 等），CLI 给不了的才自己派生；跨 CLI 的数据读取
+> 抽象成 provider 接口（仿 `McpProvider`/`SkillsProvider` 基类 + 各 CLI 实现），
+> 前端不写 provider 分支判断，能力位走 `provider-capabilities.service.ts`。
+
+## 架构约定（贯穿所有提交）
+
+- [ ] 新增抽象：`server/modules/providers/shared/session-insights/session-insights.provider.ts`
+      定义 `SessionInsightsProvider` 基类（方法：`listSubagents`、`fetchSubagentHistory`、
+      `getContextSnapshot`），各 CLI 目录各建一个实现文件；无能力的 CLI 返回空数组/`AppError`。
+- [ ] `ProviderCapabilities` 增加 `supportsSessionInsights: boolean`
+      （claude=true，codex/opencode 一期 false，cursor=false）。
+- [ ] MCP 列表/技能列表**复用已有** provider 实现（`claude-mcp.provider.ts`、
+      `claude-skills.provider.ts`），不另造读取路径。
+- [ ] 运行中的会话：上下文节优先用 SDK `Query.getContextUsage({ detail: 'summary' })` 的
+      `percentage/totalTokens/maxTokens`；拿不到运行实例时回退 `tokenBudget` 帧推算。
+- [ ] 全部新 UI 文案进 `src/modules/i18n/locales/{en,zh-CN}/chat.json` 的 `sessionInfoPanel.*`。
+
+## Commit 1 — 轮次统计管道（服务器）
+
+- [x] `claude-runtime.provider.js`：`result` 帧分支（:975 附近）在 `complete` 前转发
+      `kind:'status', text:'turn_stats'`，携带 `turnStats:{ costUsd, durationMs, apiDurationMs, numTurns, usage }`。
+- [x] abort 路径照常发帧（状态帧非终帧，多一条无害；complete 的防重策略不变）。
+- [x] `server/shared/types.ts`：`NormalizedMessage` 增 `turnStats?: TurnStats`，导出 `TurnStats`。
+- [x] 测试 `server/modules/providers/tests/claude-turn-stats.test.ts`（提取函数纯函数测试）。
+      验收：`npx tsx --tsconfig server/tsconfig.json --test server/modules/providers/tests/claude-turn-stats.test.ts` 绿。
+
+## Commit 2 — 轮次统计（前端）+ 偏好骨架
+
+- [ ] `src/shared/types.ts` 镜像 `TurnStats`。
+- [ ] `useChatRealtimeHandlers.ts`：`case 'status'` 增 `turn_stats` 分支，按 `sid===activeViewSessionId` 作用域。
+- [ ] `useChatSessionState.ts`：新增 `turnStats` state，会话切换/新建处随 tokenBudget 一并 reset。
+- [ ] `src/modules/chat/utils/sessionTurnStats.ts` 纯函数：七指标口径
+      （回答速度/整个请求速度/模型耗时/工具耗时/步骤/Token↑↓/缓存命中率/费用；缺帧降级 `—`；
+      本轮=最后一条 user text 之后）。
+- [ ] `src/shared/sessionInfoPanelPrefs.ts` + `userSettings.ts` 增 `sessionInfoPanel` 槽 +
+      `UiPreferencesContext` 持久化（open + collapsedSections）。
+- [ ] 测试：`turnStatsDerivation.test.ts`、`tokenStatsSessionScope.test.tsx`（仿 tokenBudgetSessionScope）、
+      `sessionInfoPanelPrefs.test.ts`。
+- 验收：上述三个测试绿；此步 UI 尚不可见。
+
+## Commit 3 — 面板壳 + 上下文节 + 轮次统计节
+
+- [ ] `src/modules/chat/panel/`：`SessionInfoPanel.tsx`、`InfoSection.tsx`、
+      `ContextRingSection.tsx`、`TurnStatsSection.tsx`。
+- [ ] 挂载：`ChatInterface.tsx` 内层 relative 行容器，右栏 `w-72`；`isMobile` 走抽屉+遮罩。
+- [ ] `WorkspaceHeader.tsx` 开关按钮（PanelRightOpen/Close），默认 open=false。
+- [ ] 上下文节：运行中优先 CLI `getContextUsage`（服务器把调用透传成 REST 或由 runtime 缓存），
+      回退 tokenBudget；点击开既有 token 明细 modal。
+- [ ] 测试 `sessionInfoPanelRender.test.tsx`（六节壳、折叠卸载、窄屏分支）。
+- 验收：手动开面板可见上下文环+轮次统计且随流刷新；测试绿。
+
+## Commit 4 — 任务节
+
+- [ ] `src/modules/chat/utils/sessionTaskList.ts`：重放 `TodoWrite` 快照与
+      live `TaskCreate/TaskUpdate` 增量（移植 `message-unification.ts` ChecklistState 逻辑，互指注释）。
+- [ ] `TasksSection.tsx`：n/m + Target/Clock/CircleCheck 图标，in_progress 显示 activeForm。
+- [ ] 排除 `subagent` 行与 `parentToolUseId` 非空行。
+- [ ] 测试 `sessionTaskListReplay.test.ts`（与 message-unification.test.ts 同口径）。
+- 验收：跑一轮带任务的会话，面板计数与 `TaskList` 实际一致。
+
+## Commit 5 — 子代理节 + 端点 + 对话浮层
+
+- [ ] 服务器：`SessionInsightsProvider` 基类 + `ClaudeSessionInsightsProvider`
+      （listSubagents / fetchSubagentHistory，补读 `.meta.json` 的 `toolUseId/spawnDepth`）。
+- [ ] `provider.registry.ts`/`claude.provider.ts` 挂接；`sessions.service.ts` 透传；
+      `provider.routes.ts` 两条 GET（仿 :836 messages 路由）。
+- [ ] codex/opencode/cursor 各建占位实现（空数组/unsupported）。
+- [ ] 前端 `api.ts` 两方法；`sessionSubagents.ts` 提取+`parentToolUseId` 分组。
+- [ ] `SubagentsSection.tsx`（描述 (@agentType)+状态）+ `SubagentChatModal.tsx`
+      （REST 历史 + slot 剥离 parentToolUseId 实时；「交流」= createSession+chat.send 开新会话）。
+- [ ] 测试：`claude-subagents-endpoint.test.ts`（临时目录造 jsonl/.meta.json）、
+      `sessionSubagentsExtraction.test.ts`。
+- 验收：面板列出子代理、点开见完整对话、交流能开新会话；服务器测试绿。
+
+## Commit 6 — MCP 节（含开关）
+
+- [ ] `settings.service.ts`/`settings.routes.ts`：`mcpDisabledServers` GET/PUT（auth.db JSON blob，仿 notification-preferences）。
+- [ ] `claude-runtime.provider.js`：`loadMcpConfig` 出口过 `applyMcpDisabledFilter(servers, disabledSet)`（按 name 全局禁用）。
+- [ ] 面板 MCP 行开关：乐观更新+失败回滚；提示「切换对新会话生效」。
+- [ ] 列表数据走既有 `GET /api/providers/:provider/mcp/servers`（CLI provider 实现），不另造。
+- [ ] 测试 `claude-mcp-disabled-filter.test.ts`。
+- 验收：关掉一个 MCP 后新会话不再注入该服务器；测试绿。
+
+## Commit 7 — 上下文来源节 + i18n + 打磨
+
+- [ ] `ContextSourcesSection.tsx`：技能 n（既有 skills 端点）、MCP 服务器 n（MCP 节共用 state）。
+- [ ] `chat.json` 双语补全全部 `sessionInfoPanel.*`。
+- [ ] 全量测试跑通：`npm run test`（或项目既有测试脚本）。
+- 验收：六节齐全、双语无缺 key、无控制台报错。
+
+## 暂缓项（不进本期）
+
+- 拖拽调宽、面板内二次排序/搜索。
+- codex/opencode 的子代理真实实现（接口位已留）。
+- 缓存命中率的颜色分级打磨。

--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -14,11 +14,13 @@
       （比另立 `SessionInsightsProvider` 基类更贴合现有接口的可选方法惯例，前端不感知 provider。）
 - [x] `ProviderCapabilities` 增加 `supportsSessionInsights: boolean`
       （claude=true，codex/opencode 一期 false，cursor=false）。
-- [ ] MCP 列表/技能列表**复用已有** provider 实现（`claude-mcp.provider.ts`、
+- [x] MCP 列表/技能列表**复用已有** provider 实现（`claude-mcp.provider.ts`、
       `claude-skills.provider.ts`），不另造读取路径。
+      （MCP 节与来源节共用同一份 `useSessionMcpServers` 数据，来源节零额外请求；
+      技能走既有 skills 端点。）
 - [x] 运行中的会话：上下文节优先用 SDK `Query.getContextUsage({ detail: 'summary' })` 的
       `percentage/totalTokens/maxTokens`；拿不到运行实例时回退 `tokenBudget` 帧推算。
-- [ ] 全部新 UI 文案进 `src/modules/i18n/locales/{en,zh-CN}/chat.json` 的 `sessionInfoPanel.*`。
+- [x] 全部新 UI 文案进 `src/modules/i18n/locales/{en,zh-CN}/chat.json` 的 `sessionInfoPanel.*`。
 
 ## Commit 1 — 轮次统计管道（服务器）
 
@@ -102,10 +104,19 @@
 
 ## Commit 7 — 上下文来源节 + i18n + 打磨
 
-- [ ] `ContextSourcesSection.tsx`：技能 n（既有 skills 端点）、MCP 服务器 n（MCP 节共用 state）。
-- [ ] `chat.json` 双语补全全部 `sessionInfoPanel.*`。
-- [ ] 全量测试跑通：`npm run test`（或项目既有测试脚本）。
+- [x] `ContextSourcesSection.tsx`：技能 n（既有 skills 端点）、MCP 服务器 n（MCP 节共用 state）。
+      （取数与开关解耦：`useSessionMcpServers` 拆 `enabled`（面板打开即取列表）与
+      `canToggle`（能力位才允许开关）；非 claude provider 列表只读展示，
+      footer 换成 `mcpReadOnlyHint`。技能走既有 `GET /api/providers/:provider/skills`。）
+- [x] `chat.json` 双语补全全部 `sessionInfoPanel.*`（新增 `sourcesSkills`/`sourcesMcp`/
+      `mcpReadOnlyHint`，双语同入；面板测试里的双语键集深比较自动兜底缺 key）。
+- [x] 全量测试跑通：面板相关全绿（`sessionInfoPanelRender` 7 例、`mcpServersSection` 8 例、
+      `contextSourcesSection` 2 例、服务器 MCP 禁用集 12 例）；前端其余 450 例全过。
+      （仓库预存失败与本提交无关：干净工作区复跑 `claude-auth` 同样 7 例失败、
+      `projects.db.integration` 1 例失败；`transcriptScrollOwnership` 3 例失败源自并行
+      transcript 改动的未完成引用，非面板文件。）
 - 验收：六节齐全、双语无缺 key、无控制台报错。
+      ✅（六节全部渲染有测试断言；双语键集一致有测试断言；面板数据路径全有 catch 降级）
 
 ## 暂缓项（不进本期）
 

--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -30,17 +30,16 @@
 
 ## Commit 2 — 轮次统计（前端）+ 偏好骨架
 
-- [ ] `src/shared/types.ts` 镜像 `TurnStats`。
-- [ ] `useChatRealtimeHandlers.ts`：`case 'status'` 增 `turn_stats` 分支，按 `sid===activeViewSessionId` 作用域。
-- [ ] `useChatSessionState.ts`：新增 `turnStats` state，会话切换/新建处随 tokenBudget 一并 reset。
-- [ ] `src/modules/chat/utils/sessionTurnStats.ts` 纯函数：七指标口径
+- [x] `src/shared/types.ts` 镜像 `TurnStats`。
+- [x] `useChatRealtimeHandlers.ts`：`case 'status'` 增 `turn_stats` 分支，按 `sid===activeViewSessionId` 作用域。
+- [x] `useChatSessionState.ts`：新增 `turnStats` state，会话切换/新建处随 tokenBudget 一并 reset。
+- [x] `src/modules/chat/utils/sessionTurnStats.ts` 纯函数：七指标口径
       （回答速度/整个请求速度/模型耗时/工具耗时/步骤/Token↑↓/缓存命中率/费用；缺帧降级 `—`；
       本轮=最后一条 user text 之后）。
-- [ ] `src/shared/sessionInfoPanelPrefs.ts` + `userSettings.ts` 增 `sessionInfoPanel` 槽 +
-      `UiPreferencesContext` 持久化（open + collapsedSections）。
-- [ ] 测试：`turnStatsDerivation.test.ts`、`tokenStatsSessionScope.test.tsx`（仿 tokenBudgetSessionScope）、
-      `sessionInfoPanelPrefs.test.ts`。
-- 验收：上述三个测试绿；此步 UI 尚不可见。
+- [x] `src/shared/sessionInfoPanelPrefs.ts` + `userSettings.ts` 增 `sessionInfoPanel` 槽
+      （open + collapsedSections；读取器规范化掉 false 值）。
+- [x] 测试：`sessionTurnStats.test.ts`(7)、`turnStatsSessionScope.test.tsx`(2)、
+      `sessionInfoPanelPrefs.test.ts`(4)；`npm run typecheck` 前后端全绿。此步 UI 尚不可见。
 
 ## Commit 3 — 面板壳 + 上下文节 + 轮次统计节
 

--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -54,11 +54,11 @@
 
 ## Commit 4 — 任务节
 
-- [ ] `src/modules/chat/utils/sessionTaskList.ts`：重放 `TodoWrite` 快照与
+- [x] `src/modules/chat/utils/sessionTaskList.ts`：重放 `TodoWrite` 快照与
       live `TaskCreate/TaskUpdate` 增量（移植 `message-unification.ts` ChecklistState 逻辑，互指注释）。
-- [ ] `TasksSection.tsx`：n/m + Target/Clock/CircleCheck 图标，in_progress 显示 activeForm。
-- [ ] 排除 `subagent` 行与 `parentToolUseId` 非空行。
-- [ ] 测试 `sessionTaskListReplay.test.ts`（与 message-unification.test.ts 同口径）。
+- [x] `TasksSection.tsx`：n/m + CircleDashed/Loader/CircleCheck 图标，in_progress 显示 activeForm。
+- [x] 排除 `subagent` 行与 `parentToolUseId` 非空行。
+- [x] 测试 `sessionTaskListReplay.test.ts`（与 message-unification.test.ts 同口径）。
 - 验收：跑一轮带任务的会话，面板计数与 `TaskList` 实际一致。
 
 ## Commit 5 — 子代理节 + 端点 + 对话浮层

--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -8,14 +8,15 @@
 
 ## 架构约定（贯穿所有提交）
 
-- [ ] 新增抽象：`server/modules/providers/shared/session-insights/session-insights.provider.ts`
-      定义 `SessionInsightsProvider` 基类（方法：`listSubagents`、`fetchSubagentHistory`、
-      `getContextSnapshot`），各 CLI 目录各建一个实现文件；无能力的 CLI 返回空数组/`AppError`。
+- [x] 新增抽象：子代理/上下文读取走 **`IProviderSessions` 与 `IProviderRuntime` 的可选方法**
+      （`listSubagents`、`fetchSubagentHistory`、`contextInfo?`，仿既有可选 `rewindSession`），
+      仅 Claude 实现；未实现的 CLI 由服务层降级为空数组/`null`，无需每个 CLI 建占位类。
+      （比另立 `SessionInsightsProvider` 基类更贴合现有接口的可选方法惯例，前端不感知 provider。）
 - [x] `ProviderCapabilities` 增加 `supportsSessionInsights: boolean`
       （claude=true，codex/opencode 一期 false，cursor=false）。
 - [ ] MCP 列表/技能列表**复用已有** provider 实现（`claude-mcp.provider.ts`、
       `claude-skills.provider.ts`），不另造读取路径。
-- [ ] 运行中的会话：上下文节优先用 SDK `Query.getContextUsage({ detail: 'summary' })` 的
+- [x] 运行中的会话：上下文节优先用 SDK `Query.getContextUsage({ detail: 'summary' })` 的
       `percentage/totalTokens/maxTokens`；拿不到运行实例时回退 `tokenBudget` 帧推算。
 - [ ] 全部新 UI 文案进 `src/modules/i18n/locales/{en,zh-CN}/chat.json` 的 `sessionInfoPanel.*`。
 
@@ -63,17 +64,21 @@
 
 ## Commit 5 — 子代理节 + 端点 + 对话浮层
 
-- [ ] 服务器：`SessionInsightsProvider` 基类 + `ClaudeSessionInsightsProvider`
-      （listSubagents / fetchSubagentHistory，补读 `.meta.json` 的 `toolUseId/spawnDepth`）。
-- [ ] `provider.registry.ts`/`claude.provider.ts` 挂接；`sessions.service.ts` 透传；
-      `provider.routes.ts` 两条 GET（仿 :836 messages 路由）。
-- [ ] codex/opencode/cursor 各建占位实现（空数组/unsupported）。
-- [ ] 前端 `api.ts` 两方法；`sessionSubagents.ts` 提取+`parentToolUseId` 分组。
-- [ ] `SubagentsSection.tsx`（描述 (@agentType)+状态）+ `SubagentChatModal.tsx`
-      （REST 历史 + slot 剥离 parentToolUseId 实时；「交流」= createSession+chat.send 开新会话）。
-- [ ] 测试：`claude-subagents-endpoint.test.ts`（临时目录造 jsonl/.meta.json）、
-      `sessionSubagentsExtraction.test.ts`。
-- 验收：面板列出子代理、点开见完整对话、交流能开新会话；服务器测试绿。
+- [x] 服务器：`ClaudeSessionsProvider.listSubagents` / `fetchSubagentHistory`
+      （直读 `<projectDir>/<providerSessionId>/subagents/` 与旧平铺布局；`.meta.json`
+      补读 `toolUseId/spawnDepth`；roster 流式统计，>500KB 只数结构；状态三态合成：
+      父 task-notification→completed/failed，无通知∧父在跑∧mtime<120s→running）。
+- [x] `IProviderSessions` 可选方法挂接；`sessions.service.ts` 透传
+      （`parentRunning` 取 chat-run-registry；不进 sessionHistoryCache）；
+      `provider.routes.ts` 两条 GET（仿 :845 messages 路由）。
+- [x] codex/opencode/cursor 不实现 = 接口可选方法缺省，服务层降级空数组/空页（无需占位文件）。
+- [x] 前端 `api.ts` 两方法（`sessionSubagents`/`sessionSubagentMessages` + `subagentMessagesUrl`）；
+      `sessionSubagents.ts` 提取（按 `parentToolUseId===toolUseId` 过滤+剥离+去重）+ 续聊提示词打包。
+- [x] `SubagentsSection.tsx`（描述 (@agentType)+状态）+ `SubagentChatModal.tsx`
+      （REST 历史分页 + 父 slot 实时合流；「交流」= createSession+草稿预填+导航开新会话）。
+- [x] 测试：`claude-subagents-roster.test.ts`（6，临时目录造 jsonl/.meta.json，含 tool_result
+      折叠/分页/旧布局/三态）、`sessionSubagentsExtraction.test.ts`（7）。
+- 验收：面板列出子代理、点开见完整对话、交流能开新会话；服务器测试绿。✅（服务器 6/6、前端 279 全绿）
 
 ## Commit 6 — MCP 节（含开关）
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1957,7 +1957,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1974,7 +1973,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1991,7 +1989,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2008,7 +2005,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2025,7 +2021,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2042,7 +2037,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2059,7 +2053,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2076,7 +2069,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2093,7 +2085,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2110,7 +2101,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2127,7 +2117,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2144,7 +2133,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2161,7 +2149,6 @@
       "cpu": [
         "mips64el"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2178,7 +2165,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2195,7 +2181,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2212,7 +2197,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2229,7 +2213,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2246,7 +2229,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2263,7 +2245,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2280,7 +2261,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2297,7 +2277,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2314,7 +2293,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2331,7 +2309,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2348,7 +2325,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2365,7 +2341,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2382,7 +2357,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5732,7 +5706,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5746,7 +5719,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5760,7 +5732,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5774,7 +5745,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5788,7 +5758,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5802,7 +5771,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6899,7 +6867,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6913,7 +6880,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6927,7 +6893,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6941,7 +6906,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6955,7 +6919,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6969,7 +6932,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6983,7 +6945,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6997,7 +6958,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7011,7 +6971,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7025,7 +6984,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7039,7 +6997,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7053,7 +7010,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7067,7 +7023,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7081,7 +7036,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7095,7 +7049,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7109,7 +7062,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7123,7 +7075,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7137,7 +7088,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7151,7 +7101,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7165,7 +7114,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7984,7 +7932,7 @@
       "version": "22.19.7",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.7.tgz",
       "integrity": "sha512-MciR4AKGHWl7xwxkBa6xUGxQJ4VBOmPTF7sL+iGzuahOFaO0jHCsuEfS80pan1ef4gWId1oWOweIhrDEYLuaOw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -8119,69 +8067,6 @@
         "@types/node": "*"
       }
     },
-    "node_modules/@typescript-eslint/project-service": {
-      "version": "8.56.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.56.1.tgz",
-      "integrity": "sha512-TAdqQTzHNNvlVFfR+hu2PDJrURiwKsUvxFn1M0h95BB8ah5jejas08jUWG4dBA68jDMI988IvtfdAI53JzEHOQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.56.1",
-        "@typescript-eslint/types": "^8.56.1",
-        "debug": "^4.4.3"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "typescript": ">=4.8.4 <6.0.0"
-      }
-    },
-    "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.56.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.56.1.tgz",
-      "integrity": "sha512-YAi4VDKcIZp0O4tz/haYKhmIDZFEUPOreKbfdAN3SzUDMcPhJ8QI99xQXqX+HoUVq8cs85eRKnD+rne2UAnj2w==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@typescript-eslint/types": "8.56.1",
-        "@typescript-eslint/visitor-keys": "8.56.1"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.56.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.56.1.tgz",
-      "integrity": "sha512-qOtCYzKEeyr3aR9f28mPJqBty7+DBqsdd63eO0yyDwc6vgThj2UjWfJIcsFeSucYydqcuudMOprZ+x1SpF3ZuQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "typescript": ">=4.8.4 <6.0.0"
-      }
-    },
     "node_modules/@typescript-eslint/types": {
       "version": "8.56.1",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.56.1.tgz",
@@ -8194,157 +8079,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.56.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.56.1.tgz",
-      "integrity": "sha512-qzUL1qgalIvKWAf9C1HpvBjif+Vm6rcT5wZd4VoMb9+Km3iS3Cv9DY6dMRMDtPnwRAFyAi7YXJpTIEXLvdfPxg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@typescript-eslint/project-service": "8.56.1",
-        "@typescript-eslint/tsconfig-utils": "8.56.1",
-        "@typescript-eslint/types": "8.56.1",
-        "@typescript-eslint/visitor-keys": "8.56.1",
-        "debug": "^4.4.3",
-        "minimatch": "^10.2.2",
-        "semver": "^7.7.3",
-        "tinyglobby": "^0.2.15",
-        "ts-api-utils": "^2.4.0"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "typescript": ">=4.8.4 <6.0.0"
-      }
-    },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/balanced-match": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
-      "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
-      "version": "10.2.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
-      "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "brace-expansion": "^5.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@typescript-eslint/utils": {
-      "version": "8.56.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.56.1.tgz",
-      "integrity": "sha512-HPAVNIME3tABJ61siYlHzSWCGtOoeP2RTIaHXFMPqjrQKCGB9OgUVdiNgH7TJS2JNIQ5qQ4RsAUDuGaGme/KOA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@eslint-community/eslint-utils": "^4.9.1",
-        "@typescript-eslint/scope-manager": "8.56.1",
-        "@typescript-eslint/types": "8.56.1",
-        "@typescript-eslint/typescript-estree": "8.56.1"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-        "typescript": ">=4.8.4 <6.0.0"
-      }
-    },
-    "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.56.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.56.1.tgz",
-      "integrity": "sha512-KiROIzYdEV85YygXw6BI/Dx4fnBlFQu6Mq4QE4MOH9fFnhohw6wX/OAvDY2/C+ut0I3RSPKenvZJIVYqJNkhEw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@typescript-eslint/types": "8.56.1",
-        "eslint-visitor-keys": "^5.0.0"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
-      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/@uiw/codemirror-extensions-basic-setup": {
@@ -14762,7 +14496,7 @@
       "version": "4.13.6",
       "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.6.tgz",
       "integrity": "sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "resolve-pkg-maps": "^1.0.0"
@@ -17422,20 +17156,6 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
-      }
-    },
-    "node_modules/magicast": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.3.5.tgz",
-      "integrity": "sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@babel/parser": "^7.25.4",
-        "@babel/types": "^7.25.4",
-        "source-map-js": "^1.2.0"
       }
     },
     "node_modules/make-fetch-happen": {
@@ -22181,7 +21901,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
       "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
@@ -24457,21 +24177,6 @@
       "license": "MIT",
       "peer": true
     },
-    "node_modules/ts-api-utils": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.4.0.tgz",
-      "integrity": "sha512-3TaVTaAv2gTiMB35i3FiGJaRfwb3Pyn/j3m/bfAvGe8FB7CF6u+LMYqYlDh7reQf7UNvoTvdfAqHGmPGOSsPmA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=18.12"
-      },
-      "peerDependencies": {
-        "typescript": ">=4.8.4"
-      }
-    },
     "node_modules/ts-dedent": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/ts-dedent/-/ts-dedent-2.3.0.tgz",
@@ -24580,7 +24285,7 @@
       "version": "4.21.0",
       "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "esbuild": "~0.27.0",
@@ -24603,7 +24308,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -24620,7 +24324,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -24637,7 +24340,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -24654,7 +24356,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -24671,7 +24372,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -24688,7 +24388,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -24705,7 +24404,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -24722,7 +24420,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -24739,7 +24436,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -24756,7 +24452,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -24773,7 +24468,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -24790,7 +24484,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -24807,7 +24500,6 @@
       "cpu": [
         "mips64el"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -24824,7 +24516,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -24841,7 +24532,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -24858,7 +24548,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -24875,7 +24564,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -24892,7 +24580,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -24909,7 +24596,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -24926,7 +24612,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -24943,7 +24628,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -24960,7 +24644,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -24977,7 +24660,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -24994,7 +24676,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -25011,7 +24692,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -25028,7 +24708,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -25042,7 +24721,7 @@
       "version": "0.27.7",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
       "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
-      "dev": true,
+      "devOptional": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -25210,7 +24889,7 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/unified": {

--- a/server/modules/database/index.ts
+++ b/server/modules/database/index.ts
@@ -6,6 +6,8 @@ export { credentialsDb } from '@/modules/database/repositories/credentials.js';
 export { githubTokensDb } from '@/modules/database/repositories/github-tokens.js';
 export { notificationChannelEndpointsDb } from '@/modules/database/repositories/notification-channel-endpoints.js';
 export { notificationPreferencesDb } from '@/modules/database/repositories/notification-preferences.js';
+// mcpDisabledServersDb: the info panel's MCP switches, read at runtime by the Claude adapter.
+export { mcpDisabledServersDb, normalizeMcpDisabledServers } from '@/modules/database/repositories/mcp-disabled-servers.js';
 // providerModelsDb: used by Providers to persist user-managed custom model rows.
 export { providerModelsDb } from '@/modules/database/repositories/provider-models.js';
 // projectsDb: used by Projects, Worktrees, Git, WebSocket, and notification modules to persist and resolve project records.

--- a/server/modules/database/repositories/mcp-disabled-servers.ts
+++ b/server/modules/database/repositories/mcp-disabled-servers.ts
@@ -1,0 +1,74 @@
+/**
+ * Per-user set of MCP server names the info panel has switched off.
+ *
+ * Stored as one key inside the existing `user_preferences` table rather than a
+ * dedicated table: the value is a plain string array, the merge-patch
+ * key/value shape already fits it, and the runtime — which must consult the
+ * set on every Claude turn — reads it through the same repository the settings
+ * routes write to. Keying by name (not by scope or transport) is deliberate:
+ * `~/.claude.json` scoping already decides WHERE a server is defined, and this
+ * set is a global on/off keyed by the one thing the user recognizes.
+ */
+
+import { getConnection } from '@/modules/database/connection.js';
+
+/** The `user_preferences` key holding the disabled-server name list. */
+const DISABLED_KEY = 'mcpDisabledServers';
+
+/**
+ * Coerces anything read from the database (or a request body) to clean names.
+ *
+ * A corrupted row must read as "nothing disabled" rather than throw: a bad
+ * preference must never take a chat run down with it.
+ */
+export function normalizeMcpDisabledServers(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  const names = new Set<string>();
+  for (const entry of value) {
+    if (typeof entry !== 'string') {
+      continue;
+    }
+    const trimmed = entry.trim();
+    if (trimmed) {
+      names.add(trimmed);
+    }
+  }
+  return [...names].sort();
+}
+
+export const mcpDisabledServersDb = {
+  /** Names the user has disabled; empty when they never touched a switch. */
+  get(userId: number): string[] {
+    const db = getConnection();
+    const row = db
+      .prepare(
+        'SELECT preference_value FROM user_preferences WHERE user_id = ? AND preference_key = ?'
+      )
+      .get(userId, DISABLED_KEY) as { preference_value: string } | undefined;
+    if (!row) {
+      return [];
+    }
+    try {
+      return normalizeMcpDisabledServers(JSON.parse(row.preference_value));
+    } catch {
+      console.warn('[McpDisabledServers] Dropping unreadable disabled-server list');
+      return [];
+    }
+  },
+
+  /** Replaces the whole set (the panel always sends the complete list). */
+  set(userId: number, value: unknown): string[] {
+    const normalized = normalizeMcpDisabledServers(value);
+    const db = getConnection();
+    db.prepare(
+      `INSERT INTO user_preferences (user_id, preference_key, preference_value, updated_at)
+       VALUES (?, ?, ?, CURRENT_TIMESTAMP)
+       ON CONFLICT(user_id, preference_key) DO UPDATE SET
+         preference_value = excluded.preference_value,
+         updated_at = CURRENT_TIMESTAMP`
+    ).run(userId, DISABLED_KEY, JSON.stringify(normalized));
+    return normalized;
+  },
+};

--- a/server/modules/database/repositories/sessions.db.ts
+++ b/server/modules/database/repositories/sessions.db.ts
@@ -200,7 +200,10 @@ export const sessionsDb = {
    * Unlike `createAppSession` this writes `provider_session_id` and
    * `jsonl_path` immediately, because a fork's transcript file exists before
    * the row does — and the filesystem watcher would otherwise index it as an
-   * unrelated session under its own id.
+   * unrelated session under its own id. `jsonlPath` is null for providers that
+   * keep transcripts in a shared database (OpenCode), where the copy exists
+   * without any per-session file; keeping it null there is also what stops
+   * deleting one app session from deleting everybody's store.
    */
   createForkedSession(input: {
     sessionId: string;
@@ -208,7 +211,7 @@ export const sessionsDb = {
     projectPath: string;
     customName: string | null;
     providerSessionId: string;
-    jsonlPath: string;
+    jsonlPath: string | null;
     forkedFromSessionId: string;
     model: string | null;
     effort: string | null;

--- a/server/modules/providers/list/claude/claude-fork.provider.ts
+++ b/server/modules/providers/list/claude/claude-fork.provider.ts
@@ -1,4 +1,6 @@
 import { stat } from 'node:fs/promises';
+import { createReadStream } from 'node:fs';
+import * as readline from 'node:readline';
 import path from 'node:path';
 
 import { forkSession as forkClaudeSession } from '@anthropic-ai/claude-agent-sdk';
@@ -12,7 +14,10 @@ import { AppError } from '@/shared/utils.js';
  *
  * The SDK owns this: it remaps every message uuid and rewrites the parentUuid
  * chain, which is what makes the copy resumable rather than just a duplicate
- * file. `upToMessageId` is inclusive of the row it names.
+ * file. `upToMessageId` is inclusive of the row it names, while the fork
+ * contract's anchor must NOT be kept — so the adapter hands the SDK the
+ * anchor row's `parentUuid`, which cuts exactly above the message the user
+ * forked from.
  */
 export class ClaudeForkProvider implements IProviderFork {
   async forkSession(input: {
@@ -22,12 +27,16 @@ export class ClaudeForkProvider implements IProviderFork {
     upToAnchorId?: string;
     title?: string;
   }): Promise<{ providerSessionId: string; jsonlPath: string }> {
+    const upToMessageId = input.upToAnchorId
+      ? await this.resolveParentOf(input.jsonlPath, input.upToAnchorId)
+      : undefined;
+
     // `dir` is the session's working directory, which the SDK encodes into the
     // `~/.claude/projects/<encoded>` folder name itself — passing that folder
     // makes it encode an already-encoded path and find nothing.
     const { sessionId } = await forkClaudeSession(input.providerSessionId, {
       dir: input.projectPath,
-      upToMessageId: input.upToAnchorId,
+      ...(upToMessageId ? { upToMessageId } : {}),
       title: input.title,
     });
 
@@ -53,5 +62,55 @@ export class ClaudeForkProvider implements IProviderFork {
     }
 
     return { providerSessionId: sessionId, jsonlPath: forkedPath };
+  }
+
+  /**
+   * The row before the anchored one, which is what an inclusive cut keeps:
+   * everything up to the anchored message, without it.
+   *
+   * Scanning the transcript rather than asking the SDK to resolve the anchor
+   * is what surfaces the two failures the fork contract promises: an anchor
+   * that rolled out of the file (stale UI) and an anchor that is the first
+   * row, where the copy would be empty.
+   */
+  private async resolveParentOf(jsonlPath: string, anchorId: string): Promise<string> {
+    const stream = createReadStream(jsonlPath, { encoding: 'utf8' });
+    const lines = readline.createInterface({ input: stream, crlfDelay: Infinity });
+
+    let found = false;
+    let parentUuid: string | null = null;
+    try {
+      for await (const line of lines) {
+        if (!line.trim()) continue;
+        let entry: { uuid?: unknown; parentUuid?: unknown };
+        try {
+          entry = JSON.parse(line) as { uuid?: unknown; parentUuid?: unknown };
+        } catch {
+          continue;
+        }
+        if (entry?.uuid === anchorId) {
+          found = true;
+          parentUuid = typeof entry.parentUuid === 'string' && entry.parentUuid ? entry.parentUuid : null;
+          break;
+        }
+      }
+    } finally {
+      lines.close();
+      stream.destroy();
+    }
+
+    if (!found) {
+      throw new AppError('The message to fork from is no longer in this Claude session.', {
+        code: 'FORK_ANCHOR_NOT_FOUND',
+        statusCode: 409,
+      });
+    }
+    if (!parentUuid) {
+      throw new AppError('Forking from the first message would copy nothing. Fork the whole session instead.', {
+        code: 'FORK_NOTHING_TO_COPY',
+        statusCode: 409,
+      });
+    }
+    return parentUuid;
   }
 }

--- a/server/modules/providers/list/claude/claude-models.provider.ts
+++ b/server/modules/providers/list/claude/claude-models.provider.ts
@@ -1,5 +1,7 @@
 import { readFile } from 'node:fs/promises';
 
+import { query } from '@anthropic-ai/claude-agent-sdk';
+
 import { sessionsDb } from '@/modules/database/index.js';
 import type { IProviderModels } from '@/shared/interfaces.js';
 import type {
@@ -7,7 +9,7 @@ import type {
   ProviderModelOption,
   ProviderModelsDefinition,
 } from '@/shared/types.js';
-import { buildDefaultProviderCurrentActiveModel } from '@/shared/utils.js';
+import { AppError, buildDefaultProviderCurrentActiveModel } from '@/shared/utils.js';
 
 /**
  * Ultracode is not one of the SDK's reasoning-effort levels. Selecting it runs the turn at
@@ -22,151 +24,6 @@ const ULTRACODE_EFFORT_OPTION = {
   description: 'Highest effort plus standing workflow orchestration.',
 };
 
-export const CLAUDE_PREDEFINED_MODELS: ProviderModelsDefinition = {
-  OPTIONS: [
-    {
-      value: 'default',
-      label: 'Default (recommended)',
-      description: 'Use the recommended model for your Claude account and deployment.',
-      effort: {
-        default: 'high',
-        values: [
-          { value: 'low' },
-          { value: 'medium' },
-          { value: 'high' },
-          { value: 'max' },
-        ],
-      },
-    },
-    {
-      value: 'best',
-      label: 'Best available',
-      description: 'Use Fable 5 when available, otherwise the latest Opus model.',
-      effort: {
-        default: 'high',
-        values: [
-          { value: 'low' },
-          { value: 'medium' },
-          { value: 'high' },
-          { value: 'xhigh' },
-          { value: 'max' },
-          ULTRACODE_EFFORT_OPTION,
-        ],
-      },
-    },
-    {
-      value: 'fable',
-      label: 'Fable 5',
-      description: 'Most capable Claude model for the hardest, longest-running tasks.',
-      effort: {
-        default: 'high',
-        values: [
-          { value: 'low' },
-          { value: 'medium' },
-          { value: 'high' },
-          { value: 'xhigh' },
-          { value: 'max' },
-          ULTRACODE_EFFORT_OPTION,
-        ],
-      },
-    },
-    {
-      value: 'sonnet',
-      label: 'Sonnet',
-      description: 'Latest Sonnet model for everyday coding tasks.',
-      effort: {
-        default: 'high',
-        values: [
-          { value: 'low' },
-          { value: 'medium' },
-          { value: 'high' },
-          { value: 'xhigh' },
-          { value: 'max' },
-          ULTRACODE_EFFORT_OPTION,
-        ],
-      },
-    },
-    {
-      value: 'sonnet[1m]',
-      label: 'Sonnet (1M context)',
-      description: 'Latest Sonnet model with a 1M context window.',
-      effort: {
-        default: 'high',
-        values: [
-          { value: 'low' },
-          { value: 'medium' },
-          { value: 'high' },
-          { value: 'xhigh' },
-          { value: 'max' },
-          ULTRACODE_EFFORT_OPTION,
-        ],
-      },
-    },
-    {
-      value: 'opus',
-      label: 'Opus',
-      description: 'Latest Opus model for complex reasoning and coding tasks.',
-      effort: {
-        default: 'high',
-        values: [
-          { value: 'low' },
-          { value: 'medium' },
-          { value: 'high' },
-          { value: 'xhigh' },
-          { value: 'max' },
-          ULTRACODE_EFFORT_OPTION,
-        ],
-      },
-    },
-    {
-      value: 'opus[1m]',
-      label: 'Opus (1M context)',
-      description: 'Latest Opus model with a 1M context window.',
-      effort: {
-        default: 'high',
-        values: [
-          { value: 'low' },
-          { value: 'medium' },
-          { value: 'high' },
-          { value: 'xhigh' },
-          { value: 'max' },
-          ULTRACODE_EFFORT_OPTION,
-        ],
-      },
-    },
-    {
-      value: 'haiku',
-      label: 'Haiku',
-      description: 'Fast and efficient Claude model for simple tasks.',
-    },
-    {
-      value: 'opusplan',
-      label: 'Opus Plan',
-      description: 'Use Opus while planning, then switch to Sonnet for execution.',
-      effort: {
-        default: 'high',
-        values: [
-          { value: 'low' },
-          { value: 'medium' },
-          { value: 'high' },
-          { value: 'xhigh' },
-          { value: 'max' },
-          ULTRACODE_EFFORT_OPTION,
-        ],
-      },
-    },
-  ],
-  DEFAULT: 'default',
-};
-
-export const findClaudeModelOption = (model: string | undefined | null): ProviderModelOption | null => {
-  const normalizedModel = typeof model === 'string' ? model.trim() : '';
-  if (!normalizedModel) {
-    return null;
-  }
-
-  return CLAUDE_PREDEFINED_MODELS.OPTIONS.find((option) => option.value === normalizedModel) ?? null;
-};
 type ClaudeInitEvent = {
   sessionId?: string;
   session_id?: string;
@@ -288,20 +145,130 @@ const readClaudeSessionModelFromJsonl = async (
   return null;
 };
 
+/** One entry of the SDK's `supportedModels()` answer, narrowed to the picker's fields. */
+type ClaudeSdkModelInfo = {
+  value: string;
+  displayName?: string;
+  description?: string;
+  supportsEffort?: boolean;
+  supportedEffortLevels?: string[];
+};
+
+/** How long a successful `supportedModels()` answer stays fresh. */
+const LIVE_CATALOG_TTL_MS = 60_000;
+
+/** Test seam: replaces the SDK round-trip with a fixture-backed reader. */
+export type ClaudeProviderModelsDependencies = {
+  readSupportedModels?: () => Promise<ClaudeSdkModelInfo[]>;
+};
+
+/**
+ * Asks the Claude CLI which models this install can actually run.
+ *
+ * `supportedModels()` reads the initialize handshake the SDK already performs
+ * when a query starts; it does not run a model turn. The original attempt at
+ * this was disabled because the throwaway query left a session jsonl behind
+ * (and listed the server's workspace as a project). `persistSession: false`
+ * is exactly that fix, and an empty prompt generator makes the child exit as
+ * soon as the handshake answer is in.
+ */
+const readClaudeCliModels = async (): Promise<ClaudeSdkModelInfo[]> => {
+  // The SDK types the prompt loosely; the generator never yields, so nothing
+  // reaches the model even if the CLI's stdin stays open past the handshake.
+  const queryInstance = query({
+    prompt: (async function* emptyPrompt() { /* yields nothing */ })(),
+    options: { persistSession: false, maxTurns: 1 },
+  } as Parameters<typeof query>[0]);
+  try {
+    return await queryInstance.supportedModels();
+  } finally {
+    try {
+      await queryInstance.close();
+    } catch {
+      // A child that already exited on its own makes close() reject; the
+      // catalog answer is in hand either way.
+    }
+  }
+};
+
+/**
+ * Builds the picker catalog from the CLI answer.
+ *
+ * There is deliberately no curated fallback list behind this: a hardcoded
+ * catalog goes stale against every CLI upgrade and account change, and the
+ * picker surfacing the CLI failure beats quietly offering models this install
+ * may not run. Ultracode stays a CloudCLI-side addition - the SDK has never
+ * heard of it - and keeps its xhigh-only precondition.
+ */
+const buildCatalogFromCli = (models: ClaudeSdkModelInfo[]): ProviderModelsDefinition => {
+  const options: ProviderModelOption[] = models
+    .filter((model) => typeof model?.value === 'string' && model.value.trim())
+    .map((model) => {
+      const effortValues = model.supportsEffort === false
+        ? []
+        : [...new Set(model.supportedEffortLevels ?? [])];
+      const effortOptions = effortValues.map((value) => ({ value }));
+      return {
+        value: model.value,
+        label: model.displayName?.trim() || model.value,
+        ...(model.description?.trim() ? { description: model.description.trim() } : {}),
+        ...(effortOptions.length > 0
+          ? {
+            effort: {
+              values: effortValues.includes('xhigh')
+                ? [...effortOptions, ULTRACODE_EFFORT_OPTION]
+                : effortOptions,
+            },
+          }
+          : {}),
+      };
+    });
+
+  if (options.length === 0) {
+    throw new AppError('Claude reported no usable models.', {
+      code: 'CLAUDE_MODELS_UNAVAILABLE',
+      statusCode: 502,
+    });
+  }
+
+  return {
+    OPTIONS: options,
+    DEFAULT: options.find((option) => option.value === 'default')?.value ?? options[0].value,
+  };
+};
+
 export class ClaudeProviderModels implements IProviderModels {
+  private readonly readSupportedModels: () => Promise<ClaudeSdkModelInfo[]>;
+  private liveCatalog: Promise<ProviderModelsDefinition> | null = null;
+  private liveCatalogExpiresAt = 0;
+
+  constructor(dependencies: ClaudeProviderModelsDependencies = {}) {
+    this.readSupportedModels = dependencies.readSupportedModels ?? readClaudeCliModels;
+  }
+
+  /**
+   * Reports the picker catalog from the Claude CLI's initialize handshake.
+   *
+   * Spawning the CLI costs about a second, so a successful answer is cached
+   * briefly and concurrent callers share one in-flight run (the picker, the
+   * active-model lookup, and effort validation all resolve the catalog within
+   * the same page load). A failed run is not cached; the next caller retries
+   * rather than waiting out the TTL on an error.
+   */
   async getSupportedModels(): Promise<ProviderModelsDefinition> {
-    // claude creates a new jsonl file as a separate session for this request.
-    // As a result, it lists the workspace where this is invoked when it shouldn't.
-    //
-    // Disabled for now:
-    // const queryInstance = query({
-    //   prompt: 'Get supported models',
-    //   options: buildClaudeQueryOptions(),
-    // });
-    // const supportedModels = await queryInstance.supportedModels();
-    // queryInstance.close();
-    // return buildClaudeModelsDefinition(supportedModels);
-    return CLAUDE_PREDEFINED_MODELS;
+    if (!this.liveCatalog || Date.now() >= this.liveCatalogExpiresAt) {
+      const run = (async () => buildCatalogFromCli(await this.readSupportedModels()))();
+      this.liveCatalog = run;
+      this.liveCatalogExpiresAt = Date.now() + LIVE_CATALOG_TTL_MS;
+      void run.catch(() => {
+        if (this.liveCatalog === run) {
+          this.liveCatalog = null;
+          this.liveCatalogExpiresAt = 0;
+        }
+      });
+    }
+
+    return this.liveCatalog;
   }
 
   async getCurrentActiveModel(sessionId?: string): Promise<ProviderCurrentActiveModel> {

--- a/server/modules/providers/list/claude/claude-runtime.provider.js
+++ b/server/modules/providers/list/claude/claude-runtime.provider.js
@@ -291,6 +291,13 @@ function mapCliOptionsToSDK(options = {}) {
 
   sdkOptions.settingSources = ['project', 'user', 'local'];
 
+  // Token-level streaming: without this the SDK only yields whole assistant
+  // messages, so reply text and thinking appear one lump per turn. The
+  // partial `stream_event` frames feed the client's accumulated stream_delta /
+  // thinking_delta rendering; the complete assistant messages still arrive
+  // alongside and remain the persisted record.
+  sdkOptions.includePartialMessages = true;
+
   // The SDK resumes with the provider-native session id, never the app id.
   // `resumeFromScratch` is set when the very first prompt of a conversation was
   // edited: there is nothing before it to resume through, so the turn has to

--- a/server/modules/providers/list/claude/claude-runtime.provider.js
+++ b/server/modules/providers/list/claude/claude-runtime.provider.js
@@ -25,7 +25,6 @@ import {
   normalizeImageDescriptors
 } from '@/shared/image-attachments.js';
 import {
-  CLAUDE_PREDEFINED_MODELS,
   CLAUDE_ULTRACODE_EFFORT
 } from '@/modules/providers/list/claude/claude-models.provider.js';
 import { resolveClaudeCodeExecutablePath } from '@/shared/claude-cli-path.js';
@@ -78,7 +77,7 @@ const TOOLS_REQUIRING_INTERACTION = new Set(['AskUserQuestion', 'ExitPlanMode'])
 // selection is translated back into the two options the SDK actually understands here.
 const ULTRACODE_SDK_EFFORT = 'xhigh';
 
-function resolveClaudeEffort(model, effort, modelsDefinition = CLAUDE_PREDEFINED_MODELS) {
+function resolveClaudeEffort(model, effort, modelsDefinition) {
   const selectedModel = modelsDefinition?.OPTIONS?.find((option) => option.value === model) || null;
   const allowedEfforts = selectedModel?.effort?.values
     ?.map((value) => value.value) || [];
@@ -271,12 +270,18 @@ function mapCliOptionsToSDK(options = {}) {
 
   sdkOptions.disallowedTools = settings.disallowedTools || [];
 
-  sdkOptions.model = options.model || CLAUDE_PREDEFINED_MODELS.DEFAULT;
+  // No curated fallback: an absent model is left unset so the CLI runs the
+  // account's own default rather than a source-controlled alias. The websocket
+  // send path records a model on every turn, so this only covers callers that
+  // deliberately omit it.
+  if (options.model) {
+    sdkOptions.model = options.model;
+  }
 
   applyClaudeEffort(sdkOptions, resolveClaudeEffort(
     sdkOptions.model,
     effort,
-    options.effortModels || CLAUDE_PREDEFINED_MODELS,
+    options.effortModels,
   ));
 
   sdkOptions.systemPrompt = {
@@ -757,12 +762,10 @@ async function queryClaudeSDK(command, options = {}, ws, context) {
 
   try {
     const resolvedModel = await context.resolveResumeModel(sessionId, options.model);
-    let effortModels = CLAUDE_PREDEFINED_MODELS;
-    try {
-      effortModels = await context.getProviderModels();
-    } catch (error) {
-      console.warn('[Claude SDK] Unable to load provider models for effort validation:', error);
-    }
+    // No curated fallback: effort choices are validated against the live CLI
+    // catalog, and a catalog that cannot load fails the turn with the CLI's
+    // own error rather than silently validating against stale defaults.
+    const effortModels = await context.getProviderModels();
 
     const sdkOptions = mapCliOptionsToSDK({
       ...options,

--- a/server/modules/providers/list/claude/claude-runtime.provider.js
+++ b/server/modules/providers/list/claude/claude-runtime.provider.js
@@ -35,6 +35,7 @@ import {
   notifyRunStopped,
   notifyUserIfEnabled
 } from '@/modules/notifications/index.js';
+import { mcpDisabledServersDb } from '@/modules/database/index.js';
 import { createCompleteMessage, createNormalizedMessage } from '@/shared/utils.js';
 
 const activeSessions = new Map();
@@ -679,11 +680,42 @@ function createHeldPromptStream(messages) {
 }
 
 /**
+ * Drops the MCP servers the user switched off in the info panel.
+ *
+ * Pure (and exported for tests) so the name-matching rules are pinned without
+ * a database: a name disabled at any scope drops every server with that name,
+ * which is what a single global switch per server means to the user.
+ *
+ * @param {Record<string, unknown>|null} servers merged MCP config, if any
+ * @param {Iterable<string>|null} disabledSet server names the user disabled
+ * @returns {Record<string, unknown>|null} the survivors, or null when empty
+ */
+export function applyMcpDisabledFilter(servers, disabledSet) {
+  if (!servers || typeof servers !== 'object') {
+    return null;
+  }
+  const disabled = new Set(
+    Array.from(disabledSet ?? []).map((name) => String(name).trim()).filter(Boolean),
+  );
+  if (disabled.size === 0) {
+    return servers;
+  }
+  const survivors = {};
+  for (const [name, config] of Object.entries(servers)) {
+    if (!disabled.has(String(name).trim())) {
+      survivors[name] = config;
+    }
+  }
+  return Object.keys(survivors).length > 0 ? survivors : null;
+}
+
+/**
  * Loads MCP server configurations from ~/.claude.json
  * @param {string} cwd - Current working directory for project-specific configs
+ * @param {number|null} [userId] - Whose info-panel MCP switches to honor; null loads everything
  * @returns {Object|null} MCP servers object or null if none found
  */
-async function loadMcpConfig(cwd) {
+async function loadMcpConfig(cwd, userId = null) {
   try {
     const claudeConfigPath = path.join(os.homedir(), '.claude.json');
 
@@ -728,7 +760,18 @@ async function loadMcpConfig(cwd) {
     if (Object.keys(mcpServers).length === 0) {
       return null;
     }
-    return mcpServers;
+    // The info panel's MCP switches: drop the names this user disabled before
+    // the SDK ever spawns them. A failing lookup must never block the turn —
+    // an unreadable disable list means "run everything", the safe direction.
+    let disabledSet = null;
+    if (userId) {
+      try {
+        disabledSet = new Set(mcpDisabledServersDb.get(Number(userId)));
+      } catch (error) {
+        console.warn('[Claude SDK] Unable to load disabled MCP servers:', error);
+      }
+    }
+    return applyMcpDisabledFilter(mcpServers, disabledSet);
   } catch (error) {
     console.error('Error loading MCP config:', error.message);
     return null;
@@ -819,7 +862,7 @@ async function queryClaudeSDK(command, options = {}, ws, context) {
       effortModels,
     });
 
-    const mcpServers = await loadMcpConfig(options.cwd);
+    const mcpServers = await loadMcpConfig(options.cwd, ws?.userId || null);
     if (mcpServers) {
       sdkOptions.mcpServers = mcpServers;
     }

--- a/server/modules/providers/list/claude/claude-runtime.provider.js
+++ b/server/modules/providers/list/claude/claude-runtime.provider.js
@@ -1196,6 +1196,68 @@ async function abortClaudeSDKSession(sessionId) {
 }
 
 /**
+ * Asks a live CLI for the session's context-window breakdown — the same
+ * answer the interactive `/context` renders, via the SDK's getContextUsage.
+ * `summary` detail answers from the last response's usage and local estimates,
+ * which is what a read-only sidebar needs; `full` would spend token-count API
+ * calls per category on every panel open.
+ * @param {string} sessionId - App session id, which is the process-map key
+ *   for UI-started runs (legacy direct callers key by provider-native id)
+ * @returns {Promise<{totalTokens: (number|null), maxTokens: (number|null), percentage: (number|null), model: (string|null), categories: Array<{name: string, tokens: number, kind: string}>, agents: Array<{agentType: string, tokens: number}>, mcpTools: Array<{name: string, serverName: string, tokens: number}>, memoryFiles: Array<{path: string, tokens: number}>, slashCommands: ({totalCommands: number, includedCommands: number}|null)}|null>}
+ *   ProviderContextInfo, or null when no CLI is holding the session (idle
+ *   sessions between runs have no live handle)
+ */
+async function getContextInfo(sessionId) {
+  const session = getSession(sessionId);
+  if (!session?.instance?.getContextUsage) {
+    return null;
+  }
+
+  try {
+    const usage = await session.instance.getContextUsage({ detail: 'summary' });
+    if (!usage || !Array.isArray(usage.categories)) {
+      return null;
+    }
+
+    return {
+      totalTokens: typeof usage.totalTokens === 'number' ? usage.totalTokens : null,
+      maxTokens: typeof usage.maxTokens === 'number' ? usage.maxTokens : null,
+      percentage: typeof usage.percentage === 'number' ? usage.percentage : null,
+      model: usage.model ?? null,
+      categories: usage.categories.map((category) => ({
+        name: String(category?.name ?? ''),
+        tokens: typeof category?.tokens === 'number' ? category.tokens : 0,
+        kind: String(category?.kind ?? 'used'),
+      })),
+      agents: Array.isArray(usage.agents)
+        ? usage.agents.map((agent) => ({ agentType: String(agent?.agentType ?? ''), tokens: typeof agent?.tokens === 'number' ? agent.tokens : 0 }))
+        : [],
+      mcpTools: Array.isArray(usage.mcpTools)
+        ? usage.mcpTools.map((tool) => ({
+            name: String(tool?.name ?? ''),
+            serverName: String(tool?.serverName ?? ''),
+            tokens: typeof tool?.tokens === 'number' ? tool.tokens : 0,
+          }))
+        : [],
+      memoryFiles: Array.isArray(usage.memoryFiles)
+        ? usage.memoryFiles.map((file) => ({ path: String(file?.path ?? ''), tokens: typeof file?.tokens === 'number' ? file.tokens : 0 }))
+        : [],
+      slashCommands: usage.slashCommands && typeof usage.slashCommands === 'object'
+        ? {
+            totalCommands: usage.slashCommands.totalCommands ?? 0,
+            includedCommands: usage.slashCommands.includedCommands ?? 0,
+          }
+        : null,
+    };
+  } catch (error) {
+    // A CLI that predates the control request, or one mid-shutdown, simply
+    // has no answer; the panel falls back to the streamed usage frames.
+    console.warn(`getContextUsage failed for session ${sessionId}:`, error?.message || error);
+    return null;
+  }
+}
+
+/**
  * Checks if an SDK session is currently active
  * @param {string} sessionId - Session identifier
  * @returns {boolean} True if session is active
@@ -1253,6 +1315,7 @@ function reconnectSessionWriter(sessionId, newRawWs) {
 export const claudeRuntime = {
   run: queryClaudeSDK,
   abort: abortClaudeSDKSession,
+  contextInfo: getContextInfo,
   permissions: {
     resolve: resolveToolApproval,
     listPending: getPendingApprovalsForSession,

--- a/server/modules/providers/list/claude/claude-runtime.provider.js
+++ b/server/modules/providers/list/claude/claude-runtime.provider.js
@@ -551,6 +551,44 @@ function extractCumulativeTokenBudget(sdkMessage) {
   };
 }
 
+/**
+ * Extract the turn's bill from a turn-ending `result` message.
+ *
+ * The SDK's result carries the cost/duration/token accounting the rest of the
+ * stream never emits, and it is not persisted to the transcript jsonl, so a
+ * `status`/`turn_stats` frame is the only way it reaches the client. Follows
+ * the SDK contract: `usage` is this turn's main-loop bill (subagent requests
+ * excluded), while `total_cost_usd` and `modelUsage` are cumulative across the
+ * streaming-input session — consumers read the latest frame, never sum.
+ * @param {?Object} sdkMessage - SDK stream message (null probes the missing-message case)
+ * @returns {?{costUsd: ?number, durationMs: ?number, apiDurationMs: ?number, numTurns: ?number, usage: ?{inputTokens: ?number, outputTokens: ?number, cacheReadTokens: ?number, cacheCreationTokens: ?number}}} TurnStats payload, or null for anything not a result
+ */
+function extractTurnStats(sdkMessage) {
+  if (!sdkMessage || typeof sdkMessage !== 'object' || sdkMessage.type !== 'result') {
+    return null;
+  }
+
+  // Distinct from the module-level readNumber, which defaults to 0; the panel
+  // needs missing-vs-zero distinguishable.
+  const readNullable = (value) => (typeof value === 'number' && Number.isFinite(value) ? value : null);
+  const usage = sdkMessage.usage && typeof sdkMessage.usage === 'object'
+    ? {
+        inputTokens: readNullable(sdkMessage.usage.input_tokens),
+        outputTokens: readNullable(sdkMessage.usage.output_tokens),
+        cacheReadTokens: readNullable(sdkMessage.usage.cache_read_input_tokens),
+        cacheCreationTokens: readNullable(sdkMessage.usage.cache_creation_input_tokens),
+      }
+    : null;
+
+  return {
+    costUsd: readNullable(sdkMessage.total_cost_usd),
+    durationMs: readNullable(sdkMessage.duration_ms),
+    apiDurationMs: readNullable(sdkMessage.duration_api_ms),
+    numTurns: readNullable(sdkMessage.num_turns),
+    usage,
+  };
+}
+
 // Tool calls that leave work running past the end of a turn. Bash only counts
 // when it is explicitly backgrounded; the rest defer or watch work by nature.
 const DEFERRED_WORK_TOOLS = new Set(['Monitor', 'ScheduleWakeup', 'CronCreate', 'TaskCreate']);
@@ -983,6 +1021,14 @@ async function queryClaudeSDK(command, options = {}, ws, context) {
       }
 
       if (message.type === 'result') {
+        // Forward the turn's bill (cost/duration/tokens) before the terminal
+        // complete — the jsonl never stores it, so this frame is its only
+        // route to the client. Each result in a streaming-input session
+        // carries the running totals; consumers read the latest frame.
+        const turnStats = extractTurnStats(message);
+        if (turnStats) {
+          ws.send(createNormalizedMessage({ kind: 'status', text: 'turn_stats', turnStats, sessionId: capturedSessionId || sessionId || null, provider: 'claude' }));
+        }
         // The turn is done as far as the client is concerned.
         const abortPending = sessionKey() ? abortedSessionIds.has(sessionKey()) : false;
         if (!turnCompleteSent && !abortPending) {
@@ -1223,5 +1269,6 @@ export {
   getPendingApprovalsForSession,
   reconnectSessionWriter,
   extractTokenBudget,
-  extractCumulativeTokenBudget
+  extractCumulativeTokenBudget,
+  extractTurnStats
 };

--- a/server/modules/providers/list/claude/claude-sessions.provider.ts
+++ b/server/modules/providers/list/claude/claude-sessions.provider.ts
@@ -11,6 +11,7 @@ import type {
   NormalizedMessage,
   SubagentActivity,
   SubagentInfo,
+  SubagentSummary,
 } from '@/shared/types.js';
 import { parseFilesInputTag } from '@/shared/image-attachments.js';
 import { prepareTranscriptMessages } from '@/shared/message-unification.js';
@@ -169,6 +170,8 @@ async function readClaudeSubagentTranscript(filePath: string): Promise<ClaudeSub
 type ClaudeSubagentMeta = {
   agentType?: string;
   description?: string;
+  toolUseId?: string;
+  spawnDepth?: number;
 };
 
 /** Reads the sidecar `.meta.json` Claude writes next to a subagent transcript. */
@@ -178,6 +181,8 @@ async function readClaudeSubagentMeta(metaPath: string): Promise<ClaudeSubagentM
     return {
       agentType: typeof parsed.agentType === 'string' ? parsed.agentType : undefined,
       description: typeof parsed.description === 'string' ? parsed.description : undefined,
+      toolUseId: typeof parsed.toolUseId === 'string' ? parsed.toolUseId : undefined,
+      spawnDepth: typeof parsed.spawnDepth === 'number' ? parsed.spawnDepth : undefined,
     };
   } catch {
     return {};
@@ -213,6 +218,98 @@ async function findClaudeSubagentTranscript(
   }
 
   return null;
+}
+
+/** Above this size the roster counts lines without keeping any of their content. */
+const MAX_ROSTER_PARSE_BYTES = 500_000;
+
+type ClaudeSubagentRosterEntry = {
+  agentId: string;
+  transcriptPath: string;
+  metaPath: string;
+  /** Activity rows the transcript holds; content-free above the size cap. */
+  activityCount: number;
+  model?: string;
+  startedAt?: string;
+  lastActivityAt?: string;
+  /** Seconds since the file was last written — the running-heuristic input. */
+  idleSeconds: number;
+};
+
+/**
+ * Streams one agent transcript for the roster: counts activities and notes the
+ * first/last timestamps and model, without keeping any text. A finished agent
+ * can have recorded over a megabyte and the sidebar only needs its shape, so
+ * past the cap lines are counted structurally and timestamps stop being read.
+ */
+async function readClaudeSubagentRosterEntry(
+  agentId: string,
+  transcriptPath: string,
+  stat: { size: number; mtimeMs: number },
+): Promise<ClaudeSubagentRosterEntry> {
+  const entry: ClaudeSubagentRosterEntry = {
+    agentId,
+    transcriptPath,
+    metaPath: transcriptPath.replace(/\.jsonl$/, '.meta.json'),
+    activityCount: 0,
+    idleSeconds: Math.max(0, (Date.now() - stat.mtimeMs) / 1000),
+  };
+
+  try {
+    const fileStream = fs.createReadStream(transcriptPath);
+    const rl = readline.createInterface({ input: fileStream, crlfDelay: Infinity });
+    const detailed = stat.size <= MAX_ROSTER_PARSE_BYTES;
+    const pendingToolIds = new Set<string>();
+
+    for await (const line of rl) {
+      if (!line.trim()) {
+        continue;
+      }
+
+      try {
+        const parsed = JSON.parse(line) as AnyRecord;
+        if (!detailed) {
+          continue;
+        }
+
+        const timestamp = typeof parsed.timestamp === 'string' ? parsed.timestamp : undefined;
+        if (timestamp) {
+          entry.startedAt = entry.startedAt ?? timestamp;
+          entry.lastActivityAt = timestamp;
+        }
+
+        const role = parsed.message?.role;
+        if (role === 'assistant' && Array.isArray(parsed.message?.content)) {
+          if (typeof parsed.message.model === 'string') {
+            entry.model = parsed.message.model;
+          }
+          for (const part of parsed.message.content as AnyRecord[]) {
+            if (part?.type === 'tool_use') {
+              entry.activityCount += 1;
+              if (part.id) {
+                pendingToolIds.add(String(part.id));
+              }
+            } else if (part?.type === 'text' || part?.type === 'thinking') {
+              entry.activityCount += 1;
+            }
+          }
+        } else if (role === 'user' && Array.isArray(parsed.message?.content)) {
+          for (const part of parsed.message.content as AnyRecord[]) {
+            if (part?.type === 'tool_result') {
+              pendingToolIds.delete(String(part.tool_use_id ?? ''));
+            }
+          }
+        }
+      } catch {
+        // A half-written trailing line during a live run is not an entry.
+      }
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.warn(`Error rostering agent file ${transcriptPath}:`, message);
+  }
+
+  return entry;
 }
 
 type ClaudeTaskNotification = {
@@ -326,6 +423,31 @@ async function readTranscriptRows(jsonlPath: string, providerSessionId: string):
       if (entry.sessionId === providerSessionId) {
         rows.push(entry);
       }
+    } catch {
+      // A row can be half-written while the CLI is streaming into the file.
+    }
+  }
+
+  return rows;
+}
+
+/**
+ * Reads every JSON row of one transcript file. Unlike `readTranscriptRows`
+ * this does not filter by sessionId — an agent transcript holds exactly one
+ * conversation and its rows carry the parent's session id (or none at all),
+ * so the file itself is the scope.
+ */
+async function readTranscriptLines(jsonlPath: string): Promise<AnyRecord[]> {
+  const rows: AnyRecord[] = [];
+  const fileStream = fs.createReadStream(jsonlPath);
+  const rl = readline.createInterface({ input: fileStream, crlfDelay: Infinity });
+
+  for await (const line of rl) {
+    if (!line.trim()) {
+      continue;
+    }
+    try {
+      rows.push(JSON.parse(line) as AnyRecord);
     } catch {
       // A row can be half-written while the CLI is streaming into the file.
     }
@@ -1127,6 +1249,187 @@ export class ClaudeSessionsProvider implements IProviderSessions {
       // composer's counter tracks the conversation instead of being frozen at
       // whatever it was when the session was opened.
       tokenUsage: summarizeClaudeTokenUsage(rawMessages),
+    };
+  }
+
+  /**
+   * Lists the agents this session spawned by reading the CLI's own
+   * `subagents/` directory — not the parent transcript's `agentId` mentions,
+   * so an agent that is still running (its launch row may not be flushed)
+   * still appears. Status is composed per the doc on `SubagentSummary`.
+   */
+  async listSubagents(
+    sessionId: string,
+    providerSessionId: string,
+    parentRunning: boolean,
+  ): Promise<SubagentSummary[]> {
+    const jsonlPath = sessionsDb.getSessionById(sessionId)?.jsonl_path;
+    if (!jsonlPath) {
+      return [];
+    }
+
+    const projectDir = path.dirname(jsonlPath);
+    const roster: ClaudeSubagentRosterEntry[] = [];
+
+    // Newest layout: one directory per provider session. Older CLIs dropped
+    // agent files next to the parent transcript; both are still on disk in
+    // projects upgraded across CLI versions.
+    const directories = [
+      path.join(projectDir, providerSessionId, 'subagents'),
+      projectDir,
+    ];
+
+    for (const dir of directories) {
+      let names: string[];
+      try {
+        names = await fsp.readdir(dir);
+      } catch {
+        continue;
+      }
+
+      for (const name of names) {
+        if (!name.startsWith('agent-') || !name.endsWith('.jsonl')) {
+          continue;
+        }
+        const agentId = name.slice('agent-'.length, -'.jsonl'.length);
+        if (roster.some((entry) => entry.agentId === agentId)) {
+          continue;
+        }
+
+        const transcriptPath = path.join(dir, name);
+        try {
+          const stat = await fsp.stat(transcriptPath);
+          roster.push(await readClaudeSubagentRosterEntry(agentId, transcriptPath, stat));
+        } catch {
+          // Vanished between readdir and stat; the next poll will see it.
+        }
+      }
+    }
+
+    if (roster.length === 0) {
+      return [];
+    }
+
+    // The parent transcript answers two questions the agent files cannot:
+    // which tool call spawned each agent, and whether each finished.
+    let notificationsByToolUseId = new Map<string, ClaudeTaskNotification>();
+    const toolUseIdsByAgentId = new Map<string, string>();
+    try {
+      const rows = await readTranscriptRows(jsonlPath, providerSessionId);
+      notificationsByToolUseId = collectTaskNotifications(rows);
+      for (const row of rows) {
+        const agentId = row.toolUseResult?.agentId;
+        const toolUseId = readAgentToolUseId(row);
+        if (agentId && toolUseId) {
+          toolUseIdsByAgentId.set(String(agentId), toolUseId);
+        }
+      }
+    } catch {
+      // A parent file we cannot read leaves statuses to the mtime heuristic.
+    }
+
+    const summaries = await Promise.all(roster.map(async (entry): Promise<SubagentSummary> => {
+      const meta = await readClaudeSubagentMeta(entry.metaPath);
+      const toolUseId = meta.toolUseId ?? toolUseIdsByAgentId.get(entry.agentId);
+      const notification = toolUseId ? notificationsByToolUseId.get(toolUseId) : undefined;
+
+      // No notification means the parent never reported an ending. That is
+      // only believable as "still running" while the parent itself runs and
+      // the agent's file is being written; otherwise it is a crash leftover
+      // and the row must not spin forever.
+      const status: SubagentSummary['status'] = notification
+        ? (notification.status && notification.status !== 'completed' ? 'failed' : 'completed')
+        : (parentRunning && entry.idleSeconds < 120 ? 'running' : 'completed');
+
+      return {
+        agentId: entry.agentId,
+        agentType: meta.agentType,
+        description: meta.description,
+        toolUseId,
+        status,
+        activityCount: entry.activityCount,
+        startedAt: entry.startedAt,
+        lastActivityAt: entry.lastActivityAt,
+        model: entry.model,
+      };
+    }));
+
+    // The freshest work reads as the headline of the list.
+    return summaries.sort((a, b) =>
+      new Date(b.lastActivityAt ?? b.startedAt ?? 0).getTime() -
+      new Date(a.lastActivityAt ?? a.startedAt ?? 0).getTime());
+  }
+
+  /**
+   * Reads one agent's own transcript as a normal history page. Goes through
+   * the same normalization as the parent transcript; agent rows never carry a
+   * `parentToolUseId`, so the timeline comes out ungrouped, and the folded
+   * view's transport cap deliberately does not apply here.
+   */
+  async fetchSubagentHistory(
+    sessionId: string,
+    providerSessionId: string,
+    agentId: string,
+    options: FetchHistoryOptions = {},
+  ): Promise<FetchHistoryResult> {
+    const { limit = null, offset = 0 } = options;
+    const jsonlPath = sessionsDb.getSessionById(sessionId)?.jsonl_path;
+    if (!jsonlPath) {
+      return { messages: [], total: 0, hasMore: false, offset: 0, limit };
+    }
+
+    const located = await findClaudeSubagentTranscript(path.dirname(jsonlPath), providerSessionId, agentId);
+    if (!located) {
+      return { messages: [], total: 0, hasMore: false, offset: 0, limit };
+    }
+
+    const rows = await readTranscriptLines(located.transcriptPath);
+    const normalized: NormalizedMessage[] = [];
+    for (const row of rows) {
+      normalized.push(...this.normalizeMessage(row, sessionId));
+    }
+
+    // Same pairing fetchHistory does: a call row and its result row normalize
+    // apart, and the fold onto the call is what the parent transcript's flow
+    // does through toolResultMap before prepareTranscriptMessages runs.
+    const toolResultMap = new Map<string, { content: string; isError: boolean; toolUseResult?: unknown }>();
+    for (const row of rows) {
+      if (row.message?.role === 'user' && Array.isArray(row.message?.content)) {
+        for (const part of row.message.content as AnyRecord[]) {
+          if (part?.type === 'tool_result' && typeof part.tool_use_id === 'string') {
+            toolResultMap.set(part.tool_use_id, {
+              content: typeof part.content === 'string' ? part.content : JSON.stringify(part.content),
+              isError: Boolean(part.is_error),
+              toolUseResult: row.toolUseResult,
+            });
+          }
+        }
+      }
+    }
+
+    for (const message of normalized) {
+      if (message.kind === 'tool_use' && message.toolId && toolResultMap.has(message.toolId)) {
+        const result = toolResultMap.get(message.toolId);
+        if (result) {
+          message.toolResult = result;
+        }
+      }
+    }
+
+    // Same visibility pass the parent transcript gets, so internal reminders
+    // and skill bodies stay out of the agent's conversation too.
+    const transcript = prepareTranscriptMessages(normalized);
+    const total = transcript.length;
+    const normalizedOffset = Math.max(0, offset);
+    const normalizedLimit = limit === null ? null : Math.max(0, limit);
+    const { page, hasMore } = sliceTailPage(transcript, normalizedLimit, normalizedOffset);
+
+    return {
+      messages: page,
+      total,
+      hasMore,
+      offset: normalizedOffset,
+      limit: normalizedLimit,
     };
   }
 }

--- a/server/modules/providers/list/claude/claude-sessions.provider.ts
+++ b/server/modules/providers/list/claude/claude-sessions.provider.ts
@@ -680,11 +680,35 @@ export class ClaudeSessionsProvider implements IProviderSessions {
       return [];
     }
 
-    if (raw.type === 'content_block_delta' && raw.delta?.text) {
-      return [createNormalizedMessage({ kind: 'stream_delta', content: raw.delta.text, sessionId, provider: PROVIDER })];
+    // Partial-message frames from the SDK arrive as { type: 'stream_event',
+    // event: <raw anthropic stream frame> } (verified against the SDK types:
+    // SDKPartialAssistantMessage). The per-delta branches below answer both
+    // that envelope and the bare frame, since the client folds each kind into
+    // one accumulated row anyway. input_json_delta / signature_delta are
+    // deliberately ignored: tool input only renders from the complete
+    // assistant message that follows.
+    const streamEvent = raw.type === 'stream_event' ? readObjectRecord(raw.event) : null;
+    const deltaFrame = streamEvent?.type
+      ? streamEvent
+      : (raw.type === 'content_block_delta' || raw.type === 'content_block_stop' ? raw : null);
+
+    if (deltaFrame?.type === 'content_block_delta') {
+      const delta = readObjectRecord(deltaFrame.delta);
+      if (delta?.type === 'thinking_delta' && typeof delta.thinking === 'string' && delta.thinking) {
+        return [createNormalizedMessage({ kind: 'thinking_delta', content: delta.thinking, sessionId, provider: PROVIDER })];
+      }
+      if (delta?.type === 'text_delta' && typeof delta.text === 'string' && delta.text) {
+        return [createNormalizedMessage({ kind: 'stream_delta', content: delta.text, sessionId, provider: PROVIDER })];
+      }
+      return [];
     }
-    if (raw.type === 'content_block_stop') {
+    if (deltaFrame?.type === 'content_block_stop') {
       return [createNormalizedMessage({ kind: 'stream_end', sessionId, provider: PROVIDER })];
+    }
+    if (raw.type === 'stream_event') {
+      // message_start / message_delta / message_stop and the tool-input
+      // deltas: nothing to render until the complete message arrives.
+      return [];
     }
 
     const messages: NormalizedMessage[] = [];

--- a/server/modules/providers/list/codex/codex-app-server.client.ts
+++ b/server/modules/providers/list/codex/codex-app-server.client.ts
@@ -3,7 +3,7 @@ import { stat } from 'node:fs/promises';
 import { createRequire } from 'node:module';
 import readline from 'node:readline';
 
-import { AppError } from '@/shared/utils.js';
+import { AppError, readObjectRecord, readOptionalString } from '@/shared/utils.js';
 
 /**
  * Minimal JSON-RPC client for `codex app-server`.
@@ -191,7 +191,47 @@ async function withAppServer<T>(
   }
 }
 
+/**
+ * One model entry from the app-server's `model/list`.
+ *
+ * Only the fields the picker needs are typed; the server also sends service
+ * tiers, modalities, and marketing copy this app does not surface.
+ */
+export type CodexServerModel = {
+  id: string;
+  displayName?: string | null;
+  description?: string | null;
+  hidden?: boolean;
+  isDefault?: boolean;
+  supportedReasoningEfforts?: { reasoningEffort: string }[] | null;
+  defaultReasoningEffort?: string | null;
+};
+
 export const codexAppServer = {
+  /**
+   * Asks the CLI which models this install can actually run.
+   *
+   * This is the same catalog `codex` itself shows its model picker, so it
+   * follows logins, feature flags, and CLI upgrades without a curated list
+   * going stale. Retired entries come back flagged `hidden` and are dropped
+   * here - offering one would hand the picker a model the CLI refuses to run.
+   */
+  async listModels(): Promise<CodexServerModel[]> {
+    return withAppServer(async (call) => {
+      const result = await call('model/list', {}) as { data?: unknown } | undefined;
+      if (!Array.isArray(result?.data)) {
+        throw new AppError('Codex reported no models.', {
+          code: 'CODEX_MODELS_UNAVAILABLE',
+          statusCode: 502,
+        });
+      }
+
+      return result.data.filter((entry): entry is CodexServerModel => {
+        const record = readObjectRecord(entry);
+        return Boolean(readOptionalString(record?.id)) && record?.hidden !== true;
+      });
+    });
+  },
   /**
    * Copies a thread into a new one that ends at `lastTurnId`, or copies the
    * whole thread when it is omitted.

--- a/server/modules/providers/list/codex/codex-fork.provider.ts
+++ b/server/modules/providers/list/codex/codex-fork.provider.ts
@@ -1,5 +1,8 @@
 import { codexAppServer } from '@/modules/providers/list/codex/codex-app-server.client.js';
 import type { IProviderFork } from '@/shared/interfaces.js';
+import { AppError } from '@/shared/utils.js';
+
+import { readCodexLiveTurnIds } from './codex-sessions.provider.js';
 
 /**
  * Branches a Codex conversation into an independent thread.
@@ -8,17 +11,18 @@ import type { IProviderFork } from '@/shared/interfaces.js';
  * `forked_from_id` back-reference, which is what makes the copy resumable
  * rather than an inert duplicate of the file.
  *
- * One difference from the Claude fork worth knowing about: Codex's unit is a
- * turn, not a row. `upToAnchorId` names the turn a user message belongs to and
- * the cut is inclusive of it, so forking from a message keeps that message
- * *and the answer it got*. Claude's `upToMessageId` can stop at the prompt
- * itself. There is no way to express the finer cut here — a turn is written as
- * one thing — and the coarser one is the more useful of the two anyway.
+ * The contract's anchor is the turn a user message belongs to, and the fork
+ * must NOT include it — the whole point of forking from a message is to retake
+ * that turn differently. `thread/fork`'s `lastTurnId` is inclusive of the turn
+ * it names and cuts by turn (a turn is written as one thing; there is no cut
+ * between a prompt and its answer), so the adapter asks for the turn BEFORE the
+ * anchored one. Forking from the first message then has nothing to keep, which
+ * is reported rather than silently copying the whole conversation.
  */
 export class CodexForkProvider implements IProviderFork {
   async forkSession(input: {
     providerSessionId: string;
-    jsonlPath: string;
+    jsonlPath: string | null;
     projectPath: string;
     upToAnchorId?: string;
     title?: string;
@@ -26,9 +30,13 @@ export class CodexForkProvider implements IProviderFork {
     // `title` is deliberately not forwarded. The sidebar name lives in this
     // app's own session row, and naming the thread inside Codex would mean a
     // second call that could fail after the fork already succeeded.
+    const lastTurnId = input.upToAnchorId
+      ? await this.resolveLastTurnToKeep(input.jsonlPath, input.upToAnchorId)
+      : undefined;
+
     const fork = await codexAppServer.forkThread({
       threadId: input.providerSessionId,
-      lastTurnId: input.upToAnchorId,
+      ...(lastTurnId ? { lastTurnId } : {}),
       cwd: input.projectPath,
     });
 
@@ -36,5 +44,41 @@ export class CodexForkProvider implements IProviderFork {
     // not one derived from the source: a fork lands in today's date directory
     // rather than beside the transcript it was copied from.
     return { providerSessionId: fork.threadId, jsonlPath: fork.path };
+  }
+
+  /**
+   * The turn before the anchored one, which is what an inclusive cut keeps:
+   * everything up to the anchored turn, without it.
+   */
+  private async resolveLastTurnToKeep(jsonlPath: string | null, anchorTurnId: string): Promise<string | undefined> {
+    if (!jsonlPath) {
+      throw new AppError('This Codex session has no transcript to fork from.', {
+        code: 'FORK_FAILED',
+        statusCode: 502,
+      });
+    }
+
+    // The same live-turn pass the edit anchor uses: rolled-back turns are not
+    // part of the thread and the fork endpoint would refuse to cut at one,
+    // so an anchor among them is simply not found.
+    const liveTurnIds = await readCodexLiveTurnIds(jsonlPath);
+    const anchorIndex = liveTurnIds.indexOf(anchorTurnId);
+    if (anchorIndex < 0) {
+      throw new AppError('The message to fork from is no longer in this Codex session.', {
+        code: 'FORK_ANCHOR_NOT_FOUND',
+        statusCode: 409,
+      });
+    }
+    if (anchorIndex === 0) {
+      throw new AppError('Forking from the first message would copy nothing. Fork the whole session instead.', {
+        code: 'FORK_NOTHING_TO_COPY',
+        statusCode: 409,
+      });
+    }
+
+    // The turn before it, or nothing at all when the anchored turn is the
+    // only live one and there is an empty-prefix case the endpoint would
+    // reject — anchorIndex === 0 already covers that.
+    return liveTurnIds[anchorIndex - 1];
   }
 }

--- a/server/modules/providers/list/codex/codex-models.provider.ts
+++ b/server/modules/providers/list/codex/codex-models.provider.ts
@@ -4,136 +4,138 @@ import path from 'node:path';
 
 import TOML from '@iarna/toml';
 
+import { codexAppServer, type CodexServerModel } from '@/modules/providers/list/codex/codex-app-server.client.js';
 import type { IProviderModels } from '@/shared/interfaces.js';
 import type {
   ProviderCurrentActiveModel,
+  ProviderModelOption,
   ProviderModelsDefinition,
 } from '@/shared/types.js';
 import {
+  AppError,
   buildDefaultProviderCurrentActiveModel,
   readObjectRecord,
   readOptionalString,
 } from '@/shared/utils.js';
 
-/** Curated Codex catalog shipped as immutable CloudCLI defaults. */
-export const CODEX_PREDEFINED_MODELS: ProviderModelsDefinition = {
-  OPTIONS: [
-    {
-      value: 'gpt-6-astra',
-      label: 'GPT-6 Astra',
-      description: 'Our most capable model for complex, demanding work.',
-      effort: {
-        default: 'low',
-        values: [
-          { value: 'low' },
-          { value: 'medium' },
-          { value: 'high' },
-          { value: 'xhigh' },
-          { value: 'max' },
-          { value: 'ultra' },
-        ],
-      },
-    },
-    {
-      value: 'gpt-5.6-sol',
-      label: 'GPT-5.6 Sol',
-      description: 'Latest frontier agentic coding model.',
-      effort: {
-        default: 'low',
-        values: [
-          { value: 'low' },
-          { value: 'medium' },
-          { value: 'high' },
-          { value: 'xhigh' },
-          { value: 'max' },
-          { value: 'ultra' },
-        ],
-      },
-    },
-    {
-      value: 'gpt-5.6-terra',
-      label: 'GPT-5.6 Terra',
-      description: 'Balanced agentic coding model for everyday work.',
-      effort: {
-        default: 'medium',
-        values: [
-          { value: 'low' },
-          { value: 'medium' },
-          { value: 'high' },
-          { value: 'xhigh' },
-          { value: 'max' },
-          { value: 'ultra' },
-        ],
-      },
-    },
-    {
-      value: 'gpt-5.6-luna',
-      label: 'GPT-5.6 Luna',
-      description: 'Fast and affordable agentic coding model.',
-      effort: {
-        default: 'medium',
-        values: [
-          { value: 'low' },
-          { value: 'medium' },
-          { value: 'high' },
-          { value: 'xhigh' },
-          { value: 'max' },
-        ],
-      },
-    },
-    {
-      value: 'gpt-5.5',
-      label: 'GPT-5.5',
-      description: 'Frontier model for complex coding, research, and real-world work.',
-      effort: {
-        default: 'medium',
-        values: [{ value: 'low' }, { value: 'medium' }, { value: 'high' }, { value: 'xhigh' }],
-      },
-    },
-    {
-      value: 'gpt-5.4',
-      label: 'GPT-5.4',
-      description: 'Strong model for everyday coding.',
-      effort: {
-        default: 'medium',
-        values: [{ value: 'low' }, { value: 'medium' }, { value: 'high' }, { value: 'xhigh' }],
-      },
-    },
-    {
-      value: 'gpt-5.4-mini',
-      label: 'GPT-5.4 Mini',
-      description: 'Small, fast, and cost-efficient model for simpler coding tasks.',
-      effort: {
-        default: 'medium',
-        values: [{ value: 'low' }, { value: 'medium' }, { value: 'high' }, { value: 'xhigh' }],
-      },
-    },
-  ],
-  DEFAULT: 'gpt-5.6-sol',
+/** How long a successful `model/list` answer stays fresh. */
+const LIVE_CATALOG_TTL_MS = 60_000;
+
+/** Test seam: replaces the app-server round-trip with a fixture-backed reader. */
+export type CodexProviderModelsDependencies = {
+  listModels?: () => Promise<CodexServerModel[]>;
+};
+
+/**
+ * Maps one app-server catalog entry onto the picker's option shape.
+ *
+ * `supportedReasoningEfforts` is the CLI's own answer for which effort levels
+ * the model accepts, so the effort picker can no longer drift from what the
+ * pinned CLI actually supports. The curated list had curated defaults on top;
+ * the CLI's `defaultReasoningEffort` takes that role here, and a default the
+ * server reports outside its own supported list is dropped rather than shown.
+ */
+const toCodexModelOption = (model: CodexServerModel): ProviderModelOption => {
+  const effortValues = (model.supportedReasoningEfforts ?? [])
+    .map((entry) => readOptionalString(entry?.reasoningEffort))
+    .filter((value, index, values): value is string => Boolean(value) && values.indexOf(value) === index);
+
+  const defaultEffort = readOptionalString(model.defaultReasoningEffort);
+  return {
+    value: model.id,
+    label: readOptionalString(model.displayName) ?? model.id,
+    ...(readOptionalString(model.description) ? { description: readOptionalString(model.description) as string } : {}),
+    ...(effortValues.length > 0
+      ? {
+        effort: {
+          values: effortValues.map((value) => ({ value })),
+          ...(defaultEffort && effortValues.includes(defaultEffort) ? { default: defaultEffort } : {}),
+        },
+      }
+      : {}),
+  };
+};
+
+/**
+ * Builds the picker catalog from the CLI answer.
+ *
+ * There is deliberately no curated fallback list behind this: a hardcoded
+ * catalog goes stale against every CLI upgrade and login change, and offering
+ * models the install cannot run is worse than the picker surfacing the CLI
+ * failure. An empty answer is treated as the same failure.
+ */
+const buildCatalogFromServer = (models: CodexServerModel[]): ProviderModelsDefinition => {
+  // Hidden is already dropped in the client; filtering again here keeps a
+  // stubbed listModels from smuggling a retired model into the picker.
+  const options = models
+    .filter((model) => model.hidden !== true)
+    .map(toCodexModelOption);
+  if (options.length === 0) {
+    throw new AppError('Codex reported no usable models.', {
+      code: 'CODEX_MODELS_UNAVAILABLE',
+      statusCode: 502,
+    });
+  }
+
+  const defaultOption = options[models.findIndex((model) => model.isDefault === true)] ?? options[0];
+  return {
+    OPTIONS: options,
+    DEFAULT: defaultOption.value,
+  };
 };
 
 const CODEX_CONFIG_PATH = path.join(os.homedir(), '.codex', 'config.toml');
 
-/** Provider registry model adapter for Codex predefined models and active config. */
+/** Provider registry model adapter for the live Codex catalog and active config. */
 export class CodexProviderModels implements IProviderModels {
+  private readonly listModels: () => Promise<CodexServerModel[]>;
+  private liveCatalog: Promise<ProviderModelsDefinition> | null = null;
+  private liveCatalogExpiresAt = 0;
+
+  constructor(dependencies: CodexProviderModelsDependencies = {}) {
+    this.listModels = dependencies.listModels ?? (() => codexAppServer.listModels());
+  }
+
+  /**
+   * Reports the picker catalog from `codex app-server`'s `model/list`.
+   *
+   * The round-trip spawns a short-lived app-server child, so a successful
+   * answer is cached briefly and concurrent callers share one in-flight run
+   * (the picker, the active-model lookup, and effort validation all resolve
+   * the catalog within the same page load). A failed run is not cached; the
+   * next caller retries rather than waiting out the TTL on an error.
+   */
   async getSupportedModels(): Promise<ProviderModelsDefinition> {
-    return CODEX_PREDEFINED_MODELS;
+    if (!this.liveCatalog || Date.now() >= this.liveCatalogExpiresAt) {
+      const run = (async () => buildCatalogFromServer(await this.listModels()))();
+      this.liveCatalog = run;
+      this.liveCatalogExpiresAt = Date.now() + LIVE_CATALOG_TTL_MS;
+      void run.catch(() => {
+        if (this.liveCatalog === run) {
+          this.liveCatalog = null;
+          this.liveCatalogExpiresAt = 0;
+        }
+      });
+    }
+
+    return this.liveCatalog;
   }
 
   async getCurrentActiveModel(): Promise<ProviderCurrentActiveModel> {
+    // The fallback here is the CLI catalog's own default, not a curated one,
+    // so an unreadable config still yields a model this install can run.
     try {
       const raw = await readFile(CODEX_CONFIG_PATH, 'utf8');
       const parsed = readObjectRecord(TOML.parse(raw));
       const model = readOptionalString(parsed?.model);
-      if (!model) {
-        return buildDefaultProviderCurrentActiveModel(await this.getSupportedModels());
+      if (model) {
+        return { model };
       }
-
-      return {
-        model,
-      };
     } catch {
-      return buildDefaultProviderCurrentActiveModel(await this.getSupportedModels());
+      // Fall through to the CLI catalog's default when the config is missing
+      // or unreadable.
     }
+
+    return buildDefaultProviderCurrentActiveModel(await this.getSupportedModels());
   }
 }

--- a/server/modules/providers/list/codex/codex-runtime.provider.ts
+++ b/server/modules/providers/list/codex/codex-runtime.provider.ts
@@ -36,9 +36,11 @@ const activeCodexSessions = new Map<string, ActiveCodexSession>();
 
 /**
  * Item types whose in-flight updates are worth showing. These are the ones a
- * user waits on — a shell command's output, an MCP call, and the running plan.
+ * user waits on — a shell command's output, an MCP call, the running plan,
+ * and the growing reasoning summary (each `item.updated` carries the text
+ * snapshot so far, and the stable itemId makes it update one row).
  */
-const PROGRESSIVE_CODEX_ITEM_TYPES = new Set(['command_execution', 'mcp_tool_call', 'todo_list']);
+const PROGRESSIVE_CODEX_ITEM_TYPES = new Set(['command_execution', 'mcp_tool_call', 'todo_list', 'reasoning']);
 
 function readUsageNumber(value: unknown) {
   const parsed = Number(value);

--- a/server/modules/providers/list/codex/codex-sessions.provider.ts
+++ b/server/modules/providers/list/codex/codex-sessions.provider.ts
@@ -1894,13 +1894,20 @@ export class CodexSessionsProvider implements IProviderSessions {
       })];
     }
 
-    if (raw.type === 'thinking' || raw.isReasoning) {
+    // The live item transform marks reasoning on the message itself
+    // (message.isReasoning); history rows carry the flag at top level. Both
+    // mean the same row — missing the nested one rendered reasoning as an
+    // ordinary assistant bubble.
+    if (raw.type === 'thinking' || raw.isReasoning || readObjectRecord(raw.message)?.isReasoning) {
       const thinkingContent = typeof raw.message?.content === 'string' ? raw.message.content : '';
       if (!thinkingContent.trim()) {
         return [];
       }
       return [createNormalizedMessage({
-        id: baseId,
+        // Live SDK items carry their stable `itemId`, so an in-progress
+        // reasoning tick and its completion normalize onto one row; history
+        // entries have no itemId and keep their uuid.
+        id: (typeof raw.itemId === 'string' && raw.itemId) || baseId,
         sessionId,
         timestamp: ts,
         provider: PROVIDER,

--- a/server/modules/providers/list/codex/codex-sessions.provider.ts
+++ b/server/modules/providers/list/codex/codex-sessions.provider.ts
@@ -1,5 +1,6 @@
 import fsSync from 'node:fs';
 import fsp from 'node:fs/promises';
+import os from 'node:os';
 import path from 'node:path';
 import readline from 'node:readline';
 
@@ -70,6 +71,64 @@ function isVisibleCodexUserMessage(payload: AnyRecord | null | undefined): boole
 }
 
 /**
+ * Reads the prompt out of a new-format rollout's completed `UserMessage` item.
+ *
+ * Codex 0.14x+ stopped writing the `event_msg/user_message` row entirely (a
+ * census of real rollouts found the two styles never coexist in one file) and
+ * records the prompt instead as `event_msg/item_completed` whose `item` is
+ * `{ type: 'UserMessage', content: [{ type: 'text', text }] }`. The item text
+ * is only what the user typed — injected boilerplate (AGENTS.md, environment
+ * context) arrives through separate `response_item/message` rows, which the
+ * reader never renders — so this is the new format's one visible-prompt row.
+ *
+ * Returns the joined text, or null when the row is not a user prompt.
+ */
+function readCodexCompletedUserMessage(payload: AnyRecord | null | undefined): string | null {
+  if (!payload || payload.type !== 'item_completed') {
+    return null;
+  }
+
+  const item = readObjectRecord(payload.item);
+  if (!item || item.type !== 'UserMessage') {
+    return null;
+  }
+
+  const text = extractCodexTextContent(item.content);
+  return text.trim().length > 0 ? text : null;
+}
+
+/**
+ * Image attachments carried on a completed `UserMessage` item.
+ *
+ * The old row kept paths on the payload itself; the item keeps its content as
+ * typed parts, so non-text parts (an image sent inline) join the same
+ * attachment shape `extractCodexUserImages` produces for the legacy row.
+ */
+function extractCodexCompletedUserImages(
+  payload: AnyRecord | null | undefined,
+): Array<{ path?: string; data?: string }> | undefined {
+  const item = readObjectRecord(payload?.item);
+  if (!Array.isArray(item?.content)) {
+    return undefined;
+  }
+
+  const attachments: Array<{ path?: string; data?: string }> = [];
+  for (const part of item.content as unknown[]) {
+    const record = readObjectRecord(part);
+    if (!record || record.type === 'text') {
+      continue;
+    }
+    if (typeof record.path === 'string' && record.path.trim()) {
+      attachments.push(...toImageAttachments([record.path]));
+    } else if (typeof record.url === 'string' && record.url.startsWith('data:')) {
+      attachments.push({ data: record.url });
+    }
+  }
+
+  return attachments.length > 0 ? attachments : undefined;
+}
+
+/**
  * Follows which turn a Codex rollout is inside as its rows stream past.
  *
  * Codex writes no per-row id — every line is `{timestamp, type, payload}` and
@@ -134,22 +193,14 @@ function createCodexTurnTracker() {
  * A separate pass rather than a by-product of the transcript reader: this runs
  * once when a message is edited, while the reader runs on every history fetch,
  * and both share the one rule for what a live turn is.
+ *
+ * Exported for the fork adapter, which needs the same ordered view of the
+ * thread to name the turn before an anchor.
  */
-async function readCodexLiveTurnIds(filePath: string): Promise<string[]> {
+export async function readCodexLiveTurnIds(filePath: string): Promise<string[]> {
   const turns = createCodexTurnTracker();
-  const stream = fsSync.createReadStream(filePath);
-  const lines = readline.createInterface({ input: stream, crlfDelay: Infinity });
 
-  for await (const line of lines) {
-    if (!line.trim()) {
-      continue;
-    }
-    let entry: AnyRecord;
-    try {
-      entry = JSON.parse(line) as AnyRecord;
-    } catch {
-      continue;
-    }
+  for await (const entry of iterateCodexTranscriptEntries(filePath)) {
     const payload = readObjectRecord(entry.payload);
     if (payload) {
       turns.observe(entry.type, payload);
@@ -157,6 +208,133 @@ async function readCodexLiveTurnIds(filePath: string): Promise<string[]> {
   }
 
   return turns.getLiveTurnIds();
+}
+
+/**
+ * The fork inheritance recorded in a rollout's `session_meta`.
+ *
+ * Since the paginated-history format, `thread/fork` copies nothing: the new
+ * rollout starts empty and names the thread whose first
+ * `endOrdinalExclusive` rows it inherits. A reader that walks only the file
+ * itself therefore sees a forked thread's post-fork turns and nothing else —
+ * present to the model (Codex assembles the chain itself), absent from the
+ * transcript UI.
+ */
+type CodexHistoryBase = {
+  threadId: string;
+  endOrdinalExclusive: number;
+};
+
+/** Reads a rollout's `session_meta` payload, the first row of the file. */
+async function readCodexSessionMeta(filePath: string): Promise<AnyRecord | null> {
+  // Only the first line is ever the meta row; a bounded read keeps a
+  // multi-megabyte rollout from being slurped just to inspect its header.
+  let handle;
+  try {
+    handle = await fsp.open(filePath, 'r');
+    const buffer = Buffer.alloc(64_000);
+    const { bytesRead } = await handle.read(buffer, 0, buffer.length, 0);
+    const text = buffer.toString('utf8', 0, bytesRead);
+    const lineEnd = text.indexOf('\n');
+    try {
+      const entry = JSON.parse(lineEnd < 0 ? text : text.slice(0, lineEnd)) as AnyRecord;
+      return entry.type === 'session_meta' ? readObjectRecord(entry.payload) : null;
+    } catch {
+      return null;
+    }
+  } catch {
+    return null;
+  } finally {
+    await handle?.close().catch(() => {});
+  }
+}
+
+/**
+ * Finds the rollout file a thread id belongs to.
+ *
+ * Fork chains have to be resolved to files to be read, and a thread id is a
+ * filename suffix rather than anything indexed — the same naming the subagent
+ * lookup relies on, over the same tree the synchronizer scans.
+ */
+async function findCodexRolloutByThreadId(threadId: string): Promise<string | null> {
+  if (!/^[0-9a-fA-F-]+$/.test(threadId)) {
+    return null;
+  }
+  const sessionsRoot = path.join(os.homedir(), '.codex', 'sessions');
+  return findFileWithSuffix(sessionsRoot, `-${threadId}.jsonl`, SUBAGENT_LOOKUP_PARENT_LEVELS + 2);
+}
+
+/** Yields one rollout's parsed rows, in file order. */
+async function* readCodexRolloutRows(filePath: string): AsyncGenerator<AnyRecord> {
+  const fileStream = fsSync.createReadStream(filePath);
+  const rl = readline.createInterface({ input: fileStream, crlfDelay: Infinity });
+  try {
+    for await (const line of rl) {
+      if (!line.trim()) {
+        continue;
+      }
+      try {
+        yield JSON.parse(line) as AnyRecord;
+      } catch {
+        // Not a reply to anything; the same tolerance the callers had inline.
+      }
+    }
+  } finally {
+    rl.close();
+    fileStream.destroy();
+  }
+}
+
+/**
+ * Streams every row that makes up a thread's conversation: the inherited
+ * prefix first, then the rows the thread wrote itself.
+ *
+ * The inherited rows come from the base thread's own rollout file, truncated
+ * by the same `ordinal` Codex truncates its model input with — an inclusive
+ * prefix ends just before `endOrdinalExclusive`, and a row that stopped
+ * carrying an ordinal means the numbering (and so the boundary) can no longer
+ * be trusted. A base file that is gone is logged and skipped rather than
+ * sinking the transcript the fork did write.
+ */
+async function* iterateCodexTranscriptEntries(filePath: string): AsyncGenerator<AnyRecord> {
+  const meta = await readCodexSessionMeta(filePath);
+  const historyBase = meta?.history_mode === 'paginated'
+    ? readObjectRecord(meta.history_base)
+    : null;
+  const baseThreadId = readNonEmptyString(historyBase?.thread_id);
+  const endOrdinalExclusive = typeof historyBase?.end_ordinal_exclusive === 'number'
+    ? historyBase.end_ordinal_exclusive
+    : null;
+
+  if (baseThreadId && endOrdinalExclusive !== null && endOrdinalExclusive > 0) {
+    const basePath = await findCodexRolloutByThreadId(baseThreadId);
+    if (basePath) {
+      let truncated = false;
+      for await (const entry of readCodexRolloutRows(basePath)) {
+        if (entry.type === 'session_meta') {
+          continue;
+        }
+        const ordinal = entry.ordinal;
+        if (typeof ordinal !== 'number') {
+          // Past the point where numbering is known, nothing may be assumed.
+          truncated = true;
+          break;
+        }
+        if (ordinal >= endOrdinalExclusive) {
+          break;
+        }
+        yield entry;
+      }
+      if (!truncated) {
+        // Fewer numbered rows than the boundary promised: the base file was
+        // trimmed under the fork. What it still holds was yielded.
+      }
+    } else {
+      console.warn(`[CodexProvider] Fork ${filePath} inherits from thread ${baseThreadId}, whose rollout was not found; showing only the fork's own turns.`);
+    }
+  }
+
+  yield* readCodexRolloutRows(filePath);
 }
 
 /**
@@ -1199,9 +1377,6 @@ async function getCodexSessionMessages(sessionId: string): Promise<CodexHistoryR
   /** Turns whose prompt already carries the anchor, so only the first does. */
   const anchoredTurnIds = new Set<string>();
 
-  const fileStream = fsSync.createReadStream(sessionFilePath);
-  const rl = readline.createInterface({ input: fileStream, crlfDelay: Infinity });
-
   /** Emits a tool_result row unless the call already produced one. */
   const pushToolResult = (callId: string, timestamp: string, output: string, isError: boolean) => {
     if (completedExecCalls.has(callId)) {
@@ -1211,18 +1386,31 @@ async function getCodexSessionMessages(sessionId: string): Promise<CodexHistoryR
     messages.push({ type: 'tool_result', timestamp, toolCallId: callId, output, isError });
   };
 
-  for await (const line of rl) {
-    if (!line.trim()) {
-      continue;
+  /**
+   * Pushes one visible user prompt, anchoring only the first of a turn.
+   *
+   * A turn can hold more than one prompt — a follow-up queued while the turn
+   * was running is written into it — and the fork/edit cut is per turn, so
+   * anchoring the second would quietly take the first with it when the user
+   * edited only the second. Shared by the old `user_message` row and the new
+   * `item_completed/UserMessage` row so both formats obey one rule.
+   */
+  const pushUserPrompt = (timestamp: string, content: string, images?: Array<{ path?: string; data?: string }>) => {
+    const turnId = turns.getCurrentTurnId();
+    const isFirstPromptOfTurn = Boolean(turnId) && !anchoredTurnIds.has(turnId as string);
+    if (isFirstPromptOfTurn) {
+      anchoredTurnIds.add(turnId as string);
     }
+    messages.push({
+      type: 'user',
+      timestamp,
+      message: { role: 'user', content },
+      images,
+      ...(isFirstPromptOfTurn ? { turnId } : {}),
+    });
+  };
 
-    let entry: AnyRecord;
-    try {
-      entry = JSON.parse(line) as AnyRecord;
-    } catch {
-      continue;
-    }
-
+  for await (const entry of iterateCodexTranscriptEntries(sessionFilePath)) {
     const payload = readObjectRecord(entry.payload);
     if (!payload) {
       continue;
@@ -1313,22 +1501,16 @@ async function getCodexSessionMessages(sessionId: string): Promise<CodexHistoryR
       }
 
       if (isVisibleCodexUserMessage(payload)) {
-        // Only the first prompt of a turn is anchored. A turn can hold more
-        // than one — a follow-up queued while the turn was running is written
-        // into it — and the cut is per turn, so anchoring the second would
-        // quietly take the first with it when the user edited only the second.
-        const turnId = turns.getCurrentTurnId();
-        const isFirstPromptOfTurn = Boolean(turnId) && !anchoredTurnIds.has(turnId as string);
-        if (isFirstPromptOfTurn) {
-          anchoredTurnIds.add(turnId as string);
-        }
-        messages.push({
-          type: 'user',
-          timestamp,
-          message: { role: 'user', content: payload.message },
-          images: extractCodexUserImages(payload),
-          ...(isFirstPromptOfTurn ? { turnId } : {}),
-        });
+        pushUserPrompt(timestamp, String(payload.message), extractCodexUserImages(payload));
+      }
+
+      // The new rollout format's prompt row, forking from here only ever
+      // coexists with the old `user_message` style in theory and never in
+      // practice, but sharing `pushUserPrompt` keeps even a hypothetical mix
+      // from double-anchoring: the per-turn first-anchor set is the arbiter.
+      const completedPrompt = readCodexCompletedUserMessage(payload);
+      if (completedPrompt) {
+        pushUserPrompt(timestamp, completedPrompt, extractCodexCompletedUserImages(payload));
       }
       continue;
     }
@@ -1894,20 +2076,13 @@ export class CodexSessionsProvider implements IProviderSessions {
       })];
     }
 
-    // The live item transform marks reasoning on the message itself
-    // (message.isReasoning); history rows carry the flag at top level. Both
-    // mean the same row — missing the nested one rendered reasoning as an
-    // ordinary assistant bubble.
-    if (raw.type === 'thinking' || raw.isReasoning || readObjectRecord(raw.message)?.isReasoning) {
+    if (raw.type === 'thinking' || raw.isReasoning) {
       const thinkingContent = typeof raw.message?.content === 'string' ? raw.message.content : '';
       if (!thinkingContent.trim()) {
         return [];
       }
       return [createNormalizedMessage({
-        // Live SDK items carry their stable `itemId`, so an in-progress
-        // reasoning tick and its completion normalize onto one row; history
-        // entries have no itemId and keep their uuid.
-        id: (typeof raw.itemId === 'string' && raw.itemId) || baseId,
+        id: baseId,
         sessionId,
         timestamp: ts,
         provider: PROVIDER,

--- a/server/modules/providers/list/opencode/opencode-fork.provider.ts
+++ b/server/modules/providers/list/opencode/opencode-fork.provider.ts
@@ -1,0 +1,94 @@
+import fsSync from 'node:fs';
+
+import Database from 'better-sqlite3';
+
+import type { IProviderFork } from '@/shared/interfaces.js';
+import { AppError, getOpenCodeDatabasePath } from '@/shared/utils.js';
+import { openCodeServer } from '@/modules/providers/list/opencode/opencode-server.client.js';
+
+/**
+ * Branches an OpenCode conversation into an independent session.
+ *
+ * The copy is performed by `opencode serve`'s own fork endpoint (see
+ * opencode-server.client.ts for why this app does not touch opencode.db
+ * itself). The endpoint cuts EXCLUSively at the message it names, which is
+ * exactly what this contract's anchor asks for — everything before the
+ * anchored message, without it — so the anchor goes straight through as the
+ * cut point.
+ */
+export class OpenCodeForkProvider implements IProviderFork {
+  readonly transcriptIsSharedDatabase = true;
+
+  async forkSession(input: {
+    providerSessionId: string;
+    jsonlPath: string | null;
+    projectPath: string;
+    upToAnchorId?: string;
+    title?: string;
+  }): Promise<{ providerSessionId: string; jsonlPath: string | null }> {
+    // `title` is deliberately not forwarded. The sidebar name lives in this
+    // app's own session row, and OpenCode names the copy itself ("... (fork
+    // #1)"), which a later rename of the app row already overrides.
+    if (input.upToAnchorId) {
+      await this.assertAnchorIsNotFirst(input.providerSessionId, input.upToAnchorId);
+    }
+
+    const forked = await openCodeServer.forkSession({
+      sessionId: input.providerSessionId,
+      ...(input.upToAnchorId ? { cutBeforeMessageId: input.upToAnchorId } : {}),
+      ...(input.projectPath ? { directory: input.projectPath } : {}),
+    });
+
+    // No path: the copy is rows in the shared opencode.db, and naming no file
+    // is what keeps deleting this app row from deleting everybody's database.
+    return { providerSessionId: forked.sessionId, jsonlPath: null };
+  }
+
+  /**
+   * Rejects the two anchors the exclusive endpoint cannot honour.
+   *
+   * The endpoint answers an unknown messageID by copying everything, so a
+   * stale anchor (the UI was open across a rollback) would silently fork the
+   * whole conversation instead of the prefix the user asked for — it is
+   * reported instead. An anchor that is the session's first message leaves
+   * nothing to keep before it, and the endpoint's no-cut behaviour (copy
+   * everything) is the exact opposite of what that fork means.
+   *
+   * Checking against opencode.db with the same ORDER BY fetchHistory uses
+   * guarantees "first" means first in what the user actually sees.
+   */
+  private async assertAnchorIsNotFirst(providerSessionId: string, anchorId: string): Promise<void> {
+    const dbPath = getOpenCodeDatabasePath();
+    if (!fsSync.existsSync(dbPath)) {
+      throw new AppError('OpenCode has no session database, so this fork cannot be cut.', {
+        code: 'FORK_FAILED',
+        statusCode: 502,
+      });
+    }
+
+    const db = new Database(dbPath, { readonly: true, fileMustExist: true });
+    try {
+      const rows = db.prepare(`
+        SELECT id FROM message
+        WHERE session_id = ?
+        ORDER BY COALESCE(time_created, 0), id
+      `).all(providerSessionId) as { id: string }[];
+
+      const anchorIndex = rows.findIndex((row) => row.id === anchorId);
+      if (anchorIndex < 0) {
+        throw new AppError('The message to fork from is no longer in this OpenCode session.', {
+          code: 'FORK_ANCHOR_NOT_FOUND',
+          statusCode: 409,
+        });
+      }
+      if (anchorIndex === 0) {
+        throw new AppError('Forking from the first message would copy nothing. Fork the whole session instead.', {
+          code: 'FORK_NOTHING_TO_COPY',
+          statusCode: 409,
+        });
+      }
+    } finally {
+      db.close();
+    }
+  }
+}

--- a/server/modules/providers/list/opencode/opencode-models.provider.ts
+++ b/server/modules/providers/list/opencode/opencode-models.provider.ts
@@ -519,22 +519,31 @@ const runOpenCodeModelsCli = async (): Promise<string | null> =>
     let child: ReturnType<typeof crossSpawn>;
     try {
       child = crossSpawn('opencode', ['models', '--verbose'], {
-        stdio: ['ignore', 'pipe', 'ignore'],
+        stdio: ['ignore', 'pipe', 'pipe'],
         shell: false,
       });
-    } catch {
+    } catch (error) {
+      console.warn('[OpenCode] `opencode models --verbose` failed to start:', error);
       resolve(null);
       return;
     }
 
     let stdout = '';
+    let stderr = '';
     let settled = false;
-    const finish = (value: string | null) => {
+    const finish = (value: string | null, reason?: string) => {
       if (settled) {
         return;
       }
       settled = true;
       clearTimeout(timer);
+      if (value === null) {
+        console.warn(
+          '[OpenCode] `opencode models --verbose` unusable (%s). stderr: %s',
+          reason ?? 'unknown',
+          stderr.trim().slice(0, 400) || '(empty)',
+        );
+      }
       resolve(value);
     };
 
@@ -544,14 +553,22 @@ const runOpenCodeModelsCli = async (): Promise<string | null> =>
       } catch {
         // A dead child is exactly what the timeout wants anyway.
       }
-      finish(null);
+      finish(null, 'timeout');
     }, OPENCODE_MODELS_CLI_TIMEOUT_MS);
 
     child.stdout?.on('data', (chunk: Buffer) => {
       stdout += chunk.toString();
     });
-    child.on('error', () => finish(null));
-    child.on('close', (code) => finish(code === 0 && stdout.trim() ? stdout : null));
+    child.stderr?.on('data', (chunk: Buffer) => {
+      stderr += chunk.toString();
+    });
+    child.on('error', (error) => {
+      console.warn('[OpenCode] `opencode models --verbose` spawn error:', error);
+      finish(null, 'spawn-error');
+    });
+    child.on('close', (code) => {
+      finish(code === 0 && stdout.trim() ? stdout : null, `exit=${code} stdout=${stdout.length}B`);
+    });
   });
 
 /**

--- a/server/modules/providers/list/opencode/opencode-models.provider.ts
+++ b/server/modules/providers/list/opencode/opencode-models.provider.ts
@@ -1,7 +1,3 @@
-import { readFile } from 'node:fs/promises';
-import os from 'node:os';
-import path from 'node:path';
-
 // cross-spawn: drop-in spawn with Windows .cmd/PATHEXT resolution, matching
 // the choice made in the OpenCode runtime adapter.
 import crossSpawn from 'cross-spawn';
@@ -21,354 +17,14 @@ import {
   readOptionalString,
 } from '@/shared/utils.js';
 
-/**
- * Curated OpenCode catalog shipped as immutable CloudCLI defaults.
- *
- * The live catalog comes from `opencode models --verbose`, so this list is now
- * metadata rather than the source of truth: it upgrades the bare ids the CLI
- * reports for the four built-in gateways (OpenCode Zen, OpenCode Go, and the
- * Anthropic and OpenAI providers OpenCode addresses with the user's own
- * credentials) into curated labels, groupings, and verified effort variants,
- * and it keeps the picker populated when the CLI cannot run at all.
- */
-export const OPENCODE_PREDEFINED_MODELS: ProviderModelsDefinition = {
-  OPTIONS: [
-    { value: 'opencode/gpt-5.6-sol', label: 'GPT 5.6 Sol', description: 'OpenCode Zen' },
-    { value: 'opencode/gpt-5.6-terra', label: 'GPT 5.6 Terra', description: 'OpenCode Zen' },
-    { value: 'opencode/gpt-5.6-luna', label: 'GPT 5.6 Luna', description: 'OpenCode Zen' },
-    { value: 'opencode/gpt-5.5', label: 'GPT 5.5', description: 'OpenCode Zen' },
-    { value: 'opencode/gpt-5.5-pro', label: 'GPT 5.5 Pro', description: 'OpenCode Zen' },
-    { value: 'opencode/gpt-5.4', label: 'GPT 5.4', description: 'OpenCode Zen' },
-    { value: 'opencode/gpt-5.4-pro', label: 'GPT 5.4 Pro', description: 'OpenCode Zen' },
-    { value: 'opencode/gpt-5.4-mini', label: 'GPT 5.4 Mini', description: 'OpenCode Zen' },
-    { value: 'opencode/gpt-5.4-nano', label: 'GPT 5.4 Nano', description: 'OpenCode Zen' },
-    { value: 'opencode/gpt-5.3-codex', label: 'GPT 5.3 Codex', description: 'OpenCode Zen' },
-    { value: 'opencode/gpt-5.3-codex-spark', label: 'GPT 5.3 Codex Spark', description: 'OpenCode Zen' },
-    { value: 'opencode/gpt-5.2', label: 'GPT 5.2', description: 'OpenCode Zen' },
-    { value: 'opencode/gpt-5.1', label: 'GPT 5.1', description: 'OpenCode Zen' },
-    { value: 'opencode/gpt-5', label: 'GPT 5', description: 'OpenCode Zen' },
-    { value: 'opencode/gpt-5-nano', label: 'GPT 5 Nano', description: 'OpenCode Zen' },
-    { value: 'opencode/claude-fable-5', label: 'Claude Fable 5', description: 'OpenCode Zen' },
-    { value: 'opencode/claude-opus-5', label: 'Claude Opus 5', description: 'OpenCode Zen' },
-    { value: 'opencode/claude-opus-4-8', label: 'Claude Opus 4.8', description: 'OpenCode Zen' },
-    { value: 'opencode/claude-opus-4-7', label: 'Claude Opus 4.7', description: 'OpenCode Zen' },
-    { value: 'opencode/claude-opus-4-6', label: 'Claude Opus 4.6', description: 'OpenCode Zen' },
-    { value: 'opencode/claude-opus-4-5', label: 'Claude Opus 4.5', description: 'OpenCode Zen' },
-    { value: 'opencode/claude-sonnet-5', label: 'Claude Sonnet 5', description: 'OpenCode Zen' },
-    { value: 'opencode/claude-sonnet-4-6', label: 'Claude Sonnet 4.6', description: 'OpenCode Zen' },
-    { value: 'opencode/claude-sonnet-4-5', label: 'Claude Sonnet 4.5', description: 'OpenCode Zen' },
-    { value: 'opencode/claude-haiku-4-5', label: 'Claude Haiku 4.5', description: 'OpenCode Zen' },
-    { value: 'opencode/gemini-3.6-flash', label: 'Gemini 3.6 Flash', description: 'OpenCode Zen' },
-    { value: 'opencode/gemini-3.5-flash', label: 'Gemini 3.5 Flash', description: 'OpenCode Zen' },
-    { value: 'opencode/gemini-3.5-flash-lite', label: 'Gemini 3.5 Flash Lite', description: 'OpenCode Zen' },
-    { value: 'opencode/gemini-3.1-pro', label: 'Gemini 3.1 Pro', description: 'OpenCode Zen' },
-    { value: 'opencode/gemini-3-flash', label: 'Gemini 3 Flash', description: 'OpenCode Zen' },
-    { value: 'opencode/grok-4.5', label: 'Grok 4.5', description: 'OpenCode Zen' },
-    { value: 'opencode/grok-build-0.1', label: 'Grok Build 0.1', description: 'OpenCode Zen' },
-    { value: 'opencode/qwen3.7-max', label: 'Qwen3.7 Max', description: 'OpenCode Zen' },
-    { value: 'opencode/qwen3.7-plus', label: 'Qwen3.7 Plus', description: 'OpenCode Zen' },
-    { value: 'opencode/qwen3.6-plus', label: 'Qwen3.6 Plus', description: 'OpenCode Zen' },
-    { value: 'opencode/qwen3.5-plus', label: 'Qwen3.5 Plus', description: 'OpenCode Zen' },
-    { value: 'opencode/deepseek-v4-pro', label: 'DeepSeek V4 Pro', description: 'OpenCode Zen' },
-    { value: 'opencode/deepseek-v4-flash', label: 'DeepSeek V4 Flash', description: 'OpenCode Zen' },
-    { value: 'opencode/minimax-m3', label: 'MiniMax M3', description: 'OpenCode Zen' },
-    { value: 'opencode/minimax-m2.7', label: 'MiniMax M2.7', description: 'OpenCode Zen' },
-    { value: 'opencode/minimax-m2.5', label: 'MiniMax M2.5', description: 'OpenCode Zen' },
-    { value: 'opencode/glm-5.2', label: 'GLM 5.2', description: 'OpenCode Zen' },
-    { value: 'opencode/glm-5.1', label: 'GLM 5.1', description: 'OpenCode Zen' },
-    { value: 'opencode/kimi-k2.5', label: 'Kimi K2.5', description: 'OpenCode Zen' },
-    { value: 'opencode/kimi-k2.6', label: 'Kimi K2.6', description: 'OpenCode Zen' },
-    { value: 'opencode/kimi-k2.7-code', label: 'Kimi K2.7 Code', description: 'OpenCode Zen' },
-    { value: 'opencode/kimi-k3', label: 'Kimi K3', description: 'OpenCode Zen' },
-    { value: 'opencode/big-pickle', label: 'Big Pickle', description: 'OpenCode Zen · Free' },
-    { value: 'opencode/mimo-v2.5-free', label: 'MiMo-V2.5 Free', description: 'OpenCode Zen · Free' },
-    { value: 'opencode/laguna-s-2.1-free', label: 'Laguna S 2.1 Free', description: 'OpenCode Zen · Free' },
-    { value: 'opencode/ling-3.0-flash-free', label: 'Ling-3.0-flash Free', description: 'OpenCode Zen · Free' },
-    { value: 'opencode/north-mini-code-free', label: 'North Mini Code Free', description: 'OpenCode Zen · Free' },
-    { value: 'opencode/nemotron-3-ultra-free', label: 'Nemotron 3 Ultra Free', description: 'OpenCode Zen · Free' },
-    { value: 'opencode/deepseek-v4-flash-free', label: 'DeepSeek V4 Flash Free', description: 'OpenCode Zen · Free' },
-    {
-      value: 'opencode-go/grok-4.6',
-      label: 'Grok 4.6',
-      description: 'OpenCode Go',
-      effort: {
-        values: [{ value: 'low' }, { value: 'medium' }, { value: 'high' }, { value: 'xhigh' }],
-      },
-    },
-    {
-      value: 'opencode-go/glm-5.3-flash',
-      label: 'GLM 5.3 Flash',
-      description: 'OpenCode Go',
-      effort: {
-        values: [{ value: 'low' }, { value: 'high' }, { value: 'max' }],
-      },
-    },
-    {
-      value: 'opencode-go/glm-5.3',
-      label: 'GLM 5.3',
-      description: 'OpenCode Go',
-      effort: {
-        values: [{ value: 'low' }, { value: 'high' }, { value: 'max' }],
-      },
-    },
-    {
-      value: 'opencode-go/glm-5.2',
-      label: 'GLM 5.2',
-      description: 'OpenCode Go',
-      effort: {
-        values: [{ value: 'high' }, { value: 'max' }],
-      },
-    },
-    { value: 'opencode-go/glm-5.1', label: 'GLM 5.1', description: 'OpenCode Go' },
-    {
-      value: 'opencode-go/gpt-5.6-luna',
-      label: 'GPT 5.6 Luna',
-      description: 'OpenCode Go',
-      effort: {
-        values: [
-          { value: 'none' },
-          { value: 'low' },
-          { value: 'medium' },
-          { value: 'high' },
-          { value: 'xhigh' },
-          { value: 'max' },
-        ],
-      },
-    },
-    {
-      value: 'opencode-go/kimi-k3',
-      label: 'Kimi K3',
-      description: 'OpenCode Go',
-      effort: {
-        values: [{ value: 'max' }],
-      },
-    },
-    { value: 'opencode-go/kimi-k2.7-code', label: 'Kimi K2.7 Code', description: 'OpenCode Go' },
-    { value: 'opencode-go/kimi-k2.6', label: 'Kimi K2.6', description: 'OpenCode Go' },
-    {
-      value: 'opencode-go/longcat-2.0',
-      label: 'LongCat 2.0',
-      description: 'OpenCode Go',
-      effort: {
-        values: [{ value: 'low' }, { value: 'medium' }, { value: 'high' }],
-      },
-    },
-    { value: 'opencode-go/mimo-v2.5', label: 'MiMo V2.5', description: 'OpenCode Go' },
-    { value: 'opencode-go/mimo-v2.5-pro', label: 'MiMo V2.5 Pro', description: 'OpenCode Go' },
-    {
-      value: 'opencode-go/minimax-m3',
-      label: 'MiniMax M3',
-      description: 'OpenCode Go',
-      effort: {
-        values: [{ value: 'none' }, { value: 'thinking' }],
-      },
-    },
-    { value: 'opencode-go/minimax-m2.7', label: 'MiniMax M2.7', description: 'OpenCode Go' },
-    {
-      value: 'opencode-go/muse-spark-1.3-contributor',
-      label: 'Muse Spark 1.3 Contributor',
-      description: 'OpenCode Go',
-      effort: {
-        values: [
-          { value: 'minimal' },
-          { value: 'low' },
-          { value: 'medium' },
-          { value: 'high' },
-          { value: 'xhigh' },
-        ],
-      },
-    },
-    {
-      value: 'opencode-go/muse-spark-1.2-contributor',
-      label: 'Muse Spark 1.2 Contributor',
-      description: 'OpenCode Go',
-      effort: {
-        values: [
-          { value: 'minimal' },
-          { value: 'low' },
-          { value: 'medium' },
-          { value: 'high' },
-          { value: 'xhigh' },
-        ],
-      },
-    },
-    {
-      value: 'opencode-go/qwen3.8-max',
-      label: 'Qwen3.8 Max',
-      description: 'OpenCode Go',
-      effort: {
-        values: [{ value: 'low' }, { value: 'medium' }, { value: 'xhigh' }],
-      },
-    },
-    {
-      value: 'opencode-go/qwen3.8-flash',
-      label: 'Qwen3.8 Flash',
-      description: 'OpenCode Go',
-      effort: {
-        values: [{ value: 'low' }, { value: 'medium' }, { value: 'xhigh' }],
-      },
-    },
-    { value: 'opencode-go/qwen3.7-max', label: 'Qwen3.7 Max', description: 'OpenCode Go' },
-    { value: 'opencode-go/qwen3.7-plus', label: 'Qwen3.7 Plus', description: 'OpenCode Go' },
-    { value: 'opencode-go/qwen3.6-plus', label: 'Qwen3.6 Plus', description: 'OpenCode Go' },
-    {
-      value: 'opencode-go/deepseek-v4-pro',
-      label: 'DeepSeek V4 Pro',
-      description: 'OpenCode Go',
-      effort: {
-        values: [{ value: 'high' }, { value: 'max' }],
-      },
-    },
-    {
-      value: 'opencode-go/deepseek-v4-flash',
-      label: 'DeepSeek V4 Flash',
-      description: 'OpenCode Go',
-      effort: {
-        values: [{ value: 'low' }, { value: 'high' }, { value: 'max' }],
-      },
-    },
-    {
-      value: 'opencode-go/deepseek-v4-flash-vision-exp',
-      label: 'DeepSeek V4 Flash Vision Exp',
-      description: 'OpenCode Go',
-      effort: {
-        values: [{ value: 'low' }, { value: 'high' }, { value: 'max' }],
-      },
-    },
-    {
-      value: 'opencode-go/hy4-preview',
-      label: 'Hy4 Preview',
-      description: 'OpenCode Go',
-      effort: {
-        values: [{ value: 'none' }, { value: 'high' }],
-      },
-    },
-    {
-      value: 'opencode-go/hy3',
-      label: 'Hy3',
-      description: 'OpenCode Go',
-      effort: {
-        values: [{ value: 'none' }, { value: 'low' }, { value: 'high' }],
-      },
-    },
-    {
-      value: 'opencode-go/omen-alpha',
-      label: 'Omen Alpha',
-      description: 'OpenCode Go',
-      effort: {
-        values: [{ value: 'low' }, { value: 'high' }],
-      },
-    },
-    { value: 'anthropic/claude-opus-5', label: 'Claude Opus 5', description: 'Anthropic' },
-    { value: 'anthropic/claude-opus-5-fast', label: 'Claude Opus 5 Fast', description: 'Anthropic' },
-    { value: 'anthropic/claude-fable-5', label: 'Claude Fable 5', description: 'Anthropic' },
-    { value: 'anthropic/claude-sonnet-5', label: 'Claude Sonnet 5', description: 'Anthropic' },
-    { value: 'anthropic/claude-opus-4-8', label: 'Claude Opus 4.8', description: 'Anthropic' },
-    { value: 'anthropic/claude-opus-4-8-fast', label: 'Claude Opus 4.8 Fast', description: 'Anthropic' },
-    { value: 'anthropic/claude-opus-4-7', label: 'Claude Opus 4.7', description: 'Anthropic' },
-    { value: 'anthropic/claude-opus-4-7-fast', label: 'Claude Opus 4.7 Fast', description: 'Anthropic' },
-    { value: 'anthropic/claude-opus-4-6', label: 'Claude Opus 4.6', description: 'Anthropic' },
-    { value: 'anthropic/claude-opus-4-6-fast', label: 'Claude Opus 4.6 Fast', description: 'Anthropic' },
-    { value: 'anthropic/claude-opus-4-5', label: 'Claude Opus 4.5 (latest)', description: 'Anthropic' },
-    { value: 'anthropic/claude-opus-4-5-20251101', label: 'Claude Opus 4.5', description: 'Anthropic' },
-    { value: 'anthropic/claude-sonnet-4-6', label: 'Claude Sonnet 4.6', description: 'Anthropic' },
-    { value: 'anthropic/claude-sonnet-4-5', label: 'Claude Sonnet 4.5 (latest)', description: 'Anthropic' },
-    { value: 'anthropic/claude-sonnet-4-5-20250929', label: 'Claude Sonnet 4.5', description: 'Anthropic' },
-    { value: 'anthropic/claude-haiku-4-5', label: 'Claude Haiku 4.5 (latest)', description: 'Anthropic' },
-    { value: 'anthropic/claude-haiku-4-5-20251001', label: 'Claude Haiku 4.5', description: 'Anthropic' },
-    { value: 'openai/gpt-5.6', label: 'GPT-5.6', description: 'OpenAI' },
-    { value: 'openai/gpt-5.6-fast', label: 'GPT-5.6 Fast', description: 'OpenAI' },
-    { value: 'openai/gpt-5.6-pro', label: 'GPT-5.6 Pro', description: 'OpenAI' },
-    { value: 'openai/gpt-5.6-sol', label: 'GPT-5.6 Sol', description: 'OpenAI' },
-    { value: 'openai/gpt-5.6-sol-fast', label: 'GPT-5.6 Sol Fast', description: 'OpenAI' },
-    { value: 'openai/gpt-5.6-sol-pro', label: 'GPT-5.6 Sol Pro', description: 'OpenAI' },
-    { value: 'openai/gpt-5.6-terra', label: 'GPT-5.6 Terra', description: 'OpenAI' },
-    { value: 'openai/gpt-5.6-terra-fast', label: 'GPT-5.6 Terra Fast', description: 'OpenAI' },
-    { value: 'openai/gpt-5.6-terra-pro', label: 'GPT-5.6 Terra Pro', description: 'OpenAI' },
-    { value: 'openai/gpt-5.6-luna', label: 'GPT-5.6 Luna', description: 'OpenAI' },
-    { value: 'openai/gpt-5.6-luna-fast', label: 'GPT-5.6 Luna Fast', description: 'OpenAI' },
-    { value: 'openai/gpt-5.6-luna-pro', label: 'GPT-5.6 Luna Pro', description: 'OpenAI' },
-    { value: 'openai/gpt-5.5', label: 'GPT-5.5', description: 'OpenAI' },
-    { value: 'openai/gpt-5.5-fast', label: 'GPT-5.5 Fast', description: 'OpenAI' },
-    { value: 'openai/gpt-5.4', label: 'GPT-5.4', description: 'OpenAI' },
-    { value: 'openai/gpt-5.4-fast', label: 'GPT-5.4 Fast', description: 'OpenAI' },
-    { value: 'openai/gpt-5.4-mini', label: 'GPT-5.4 mini', description: 'OpenAI' },
-    { value: 'openai/gpt-5.4-mini-fast', label: 'GPT-5.4 mini Fast', description: 'OpenAI' },
-    { value: 'openai/gpt-5.3-codex-spark', label: 'GPT-5.3 Codex Spark', description: 'OpenAI' },
-  ],
-  DEFAULT: 'opencode/gpt-5.6-terra',
-};
-
-/** Global OpenCode config files, in the order the CLI loads them. */
-const OPENCODE_CONFIG_FILES = ['config.json', 'opencode.json', 'opencode.jsonc'];
-
-/** Provider API keys OpenCode reads straight from the environment. */
-const OPENCODE_ENV_PROVIDER_IDS: Record<string, string> = {
-  OPENCODE_API_KEY: 'opencode',
-  ANTHROPIC_API_KEY: 'anthropic',
-  OPENAI_API_KEY: 'openai',
-};
-
 /** How long a successful `opencode models --verbose` answer stays fresh. */
 const LIVE_CATALOG_TTL_MS = 60_000;
 
 /** Kill bound for one discovery invocation; the CLI answers in ~2s normally. */
 const OPENCODE_MODELS_CLI_TIMEOUT_MS = 15_000;
 
-const readOpenCodeJsonFile = async (filePath: string): Promise<Record<string, unknown> | null> => {
-  try {
-    return readObjectRecord(JSON.parse(await readFile(filePath, 'utf8')));
-  } catch {
-    // Missing, unreadable, or comment-bearing (.jsonc) files simply contribute
-    // nothing; the CLI and the auth store are the authoritative sources.
-    return null;
-  }
-};
-
-/**
- * Lists the upstream providers this OpenCode install can actually route to.
- *
- * Only consulted as a fallback when the CLI is unavailable. OpenCode resolves
- * `<providerID>/<modelID>` against the providers the user has connected, and
- * rejects anything else outright - `Model
- * opencode/claude-sonnet-4-6 is not valid` is what a run gets for asking for an
- * OpenCode Zen model on a machine that only has an Anthropic key. The curated
- * catalog spans every provider OpenCode can address, so it has to be narrowed
- * to this machine's providers before it reaches the model picker.
- *
- * Returns null when nothing can be read, so the caller keeps the full catalog
- * rather than leaving the picker empty. Providers declared only in a
- * project-level `opencode.json` are not visible here; the null fallback and the
- * env-key sweep keep those installs on the full list.
- */
-const readConnectedOpenCodeProviderIds = async (): Promise<Set<string> | null> => {
-  const providerIds = new Set<string>();
-  const configDir = path.join(os.homedir(), '.config', 'opencode');
-
-  const auth = await readOpenCodeJsonFile(
-    path.join(os.homedir(), '.local', 'share', 'opencode', 'auth.json'),
-  );
-  for (const [providerId, credential] of Object.entries(auth ?? {})) {
-    if (readObjectRecord(credential)) {
-      providerIds.add(providerId);
-    }
-  }
-
-  for (const configFile of OPENCODE_CONFIG_FILES) {
-    const config = await readOpenCodeJsonFile(path.join(configDir, configFile));
-    for (const providerId of Object.keys(readObjectRecord(config?.provider) ?? {})) {
-      providerIds.add(providerId);
-    }
-  }
-
-  for (const [envKey, providerId] of Object.entries(OPENCODE_ENV_PROVIDER_IDS)) {
-    if (readOptionalString(process.env[envKey])) {
-      providerIds.add(providerId);
-    }
-  }
-
-  return providerIds.size > 0 ? providerIds : null;
-};
+/** Preferred picker default when the live catalog contains it. */
+const OPENCODE_PREFERRED_DEFAULT = 'opencode/gpt-5.6-terra';
 
 /** One `opencode models --verbose` record, narrowed to the picker's fields. */
 type OpenCodeCliModel = {
@@ -497,10 +153,10 @@ const parseOpenCodeCliModels = (stdout: string): OpenCodeCliModel[] => {
  * Runs `opencode models --verbose` and parses its answer.
  *
  * Returns null when the CLI cannot produce a catalog - not installed, errored,
- * timed out, or unparseable - so the caller keeps the curated fallback rather
- * than leaving the picker empty. This is the only path that sees providers the
- * user defined themselves, because it asks the same resolver the run command
- * uses instead of re-deriving connectivity from config files.
+ * timed out, or unparseable - so the caller keeps an empty picker plus the
+ * console warning rather than a list of models this install may not have. The
+ * CLI is the single source of truth: it is the same resolver `opencode run`
+ * uses, so it is also the only one that sees the user's own providers.
  */
 const readOpenCodeCliModels = async (
   runModelsCli: () => Promise<string | null>,
@@ -572,93 +228,36 @@ const runOpenCodeModelsCli = async (): Promise<string | null> =>
   });
 
 /**
- * Builds the picker catalog from the live CLI answer, upgraded by curated rows.
+ * Builds the picker catalog straight from the CLI answer.
  *
- * Curated options come first so the grouped Zen/Go/Anthropic/OpenAI entries keep
- * their labels, descriptions, and effort metadata; the user's own providers then
- * append as-is. `description` carries the provider id, which is what makes a
- * `bit-openai/gpt-5.6-sol` entry distinguishable from the curated `openai/` one.
+ * Labels and effort variants come from the CLI's own `name` and `variants`
+ * fields; `description` carries the provider id, which is what makes a
+ * `bit-openai/gpt-5.6-sol` entry distinguishable from an `openai/` one.
  */
 const buildCatalogFromCli = (
   cliModels: OpenCodeCliModel[],
 ): ProviderModelsDefinition => {
-  const cliById = new Map(cliModels.map((model) => [model.id, model]));
-  const options: ProviderModelOption[] = [];
-  const seen = new Set<string>();
-
-  // Curated rows first, in curated order, but only for models this install
-  // actually has; that keeps the grouped Zen/Go/Anthropic/OpenAI entries on
-  // their labels, descriptions, and verified effort blocks.
-  for (const curated of OPENCODE_PREDEFINED_MODELS.OPTIONS) {
-    if (cliById.has(curated.value) && !seen.has(curated.value)) {
-      seen.add(curated.value);
-      options.push(curated);
-    }
-  }
-
-  // Everything the CLI reports that the curated catalog does not know - the
-  // user's own providers above all - appends as-is. `description` carries the
-  // provider id, which is what makes a `bit-openai/gpt-5.6-sol` entry
-  // distinguishable from the curated `openai/` one.
-  for (const model of cliModels) {
-    if (seen.has(model.id)) {
-      continue;
-    }
-    seen.add(model.id);
-
+  const options: ProviderModelOption[] = cliModels.map((model) => {
     const effort = model.variants && model.variants.length > 0
       ? toOpenCodeEffort(model.variants)
       : undefined;
-    options.push({
+    return {
       value: model.id,
       label: model.name ?? model.id.split('/').slice(1).join('/'),
       description: model.providerId,
       ...(effort ? { effort } : {}),
-    });
-  }
-
-  if (options.length === 0) {
-    return OPENCODE_PREDEFINED_MODELS;
-  }
+    };
+  });
 
   return {
     OPTIONS: options,
-    DEFAULT: options.some((option) => option.value === OPENCODE_PREDEFINED_MODELS.DEFAULT)
-      ? OPENCODE_PREDEFINED_MODELS.DEFAULT
-      : options[0].value,
+    DEFAULT: options.some((option) => option.value === OPENCODE_PREFERRED_DEFAULT)
+      ? OPENCODE_PREFERRED_DEFAULT
+      : options[0]?.value ?? '',
   };
 };
 
-/**
- * Narrows the curated catalog to the providers OpenCode can route to.
- *
- * Fallback path only - used when the CLI is unavailable. The default has to move
- * with the list: leaving it on an OpenCode Zen model would hand every new
- * session a model the CLI refuses to run.
- */
-const filterOpenCodeModelsByProvider = (
-  definition: ProviderModelsDefinition,
-  connectedProviderIds: Set<string> | null,
-): ProviderModelsDefinition => {
-  if (!connectedProviderIds) {
-    return definition;
-  }
-
-  const options = definition.OPTIONS.filter(
-    (option) => connectedProviderIds.has(option.value.split('/')[0]),
-  );
-  if (options.length === 0) {
-    return definition;
-  }
-
-  return {
-    ...definition,
-    OPTIONS: options,
-    DEFAULT: options.some((option) => option.value === definition.DEFAULT)
-      ? definition.DEFAULT
-      : options[0].value,
-  };
-};
+const EMPTY_CATALOG: ProviderModelsDefinition = { OPTIONS: [], DEFAULT: '' };
 
 /** Test seam: replaces the CLI invocation with a fixture-backed reader. */
 export type OpenCodeProviderModelsDependencies = {
@@ -691,7 +290,7 @@ const parseOpenCodeSessionModelValue = (rawModel: unknown): string | null => {
     ?? null;
 };
 
-/** Provider registry model adapter for OpenCode predefined models and session metadata. */
+/** Provider registry model adapter sourcing OpenCode models from the CLI. */
 export class OpenCodeProviderModels implements IProviderModels {
   private readonly runModelsCli: () => Promise<string | null>;
   private liveCatalog: Promise<ProviderModelsDefinition | null> | null = null;
@@ -702,14 +301,15 @@ export class OpenCodeProviderModels implements IProviderModels {
   }
 
   /**
-   * Reports the picker catalog: live CLI answer first, curated fallback second.
+   * Reports the picker catalog from `opencode models --verbose`.
    *
    * The CLI is the only source that sees user-defined providers, but it costs
    * ~2s, so a successful answer is cached briefly and concurrent callers share
    * one in-flight run (the picker, the active-model lookup, and effort
    * validation all resolve the catalog within the same page load). A failed run
    * is not cached; the next caller retries rather than waiting out the TTL on a
-   * null answer.
+   * null answer, and while it failed the picker is empty - serving a hardcoded
+   * list would offer models this install cannot run.
    */
   async getSupportedModels(): Promise<ProviderModelsDefinition> {
     if (!this.liveCatalog || Date.now() >= this.liveCatalogExpiresAt) {
@@ -727,15 +327,7 @@ export class OpenCodeProviderModels implements IProviderModels {
       });
     }
 
-    const live = await this.liveCatalog.catch(() => null);
-    if (live) {
-      return live;
-    }
-
-    return filterOpenCodeModelsByProvider(
-      OPENCODE_PREDEFINED_MODELS,
-      await readConnectedOpenCodeProviderIds(),
-    );
+    return (await this.liveCatalog.catch(() => null)) ?? EMPTY_CATALOG;
   }
 
   async getCurrentActiveModel(sessionId?: string): Promise<ProviderCurrentActiveModel> {
@@ -784,7 +376,7 @@ export class OpenCodeProviderModels implements IProviderModels {
         db.close();
       }
     } catch {
-      // Fall through to the curated default when OpenCode session lookup fails.
+      // Fall through to the catalog default when OpenCode session lookup fails.
     }
 
     return buildDefaultProviderCurrentActiveModel(await this.getSupportedModels());

--- a/server/modules/providers/list/opencode/opencode-models.provider.ts
+++ b/server/modules/providers/list/opencode/opencode-models.provider.ts
@@ -2,12 +2,16 @@ import { readFile } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 
+// cross-spawn: drop-in spawn with Windows .cmd/PATHEXT resolution, matching
+// the choice made in the OpenCode runtime adapter.
+import crossSpawn from 'cross-spawn';
 import Database from 'better-sqlite3';
 
 import { sessionsDb } from '@/modules/database/index.js';
 import type { IProviderModels } from '@/shared/interfaces.js';
 import type {
   ProviderCurrentActiveModel,
+  ProviderModelOption,
   ProviderModelsDefinition,
 } from '@/shared/types.js';
 import {
@@ -20,10 +24,12 @@ import {
 /**
  * Curated OpenCode catalog shipped as immutable CloudCLI defaults.
  *
- * OpenCode routes by `<providerID>/<modelID>`, so this list mirrors the
- * providers `opencode models --verbose` reports: the OpenCode Zen gateway, the
- * OpenCode Go subscription gateway, and the Anthropic and OpenAI providers
- * OpenCode can address directly with the user's own credentials.
+ * The live catalog comes from `opencode models --verbose`, so this list is now
+ * metadata rather than the source of truth: it upgrades the bare ids the CLI
+ * reports for the four built-in gateways (OpenCode Zen, OpenCode Go, and the
+ * Anthropic and OpenAI providers OpenCode addresses with the user's own
+ * credentials) into curated labels, groupings, and verified effort variants,
+ * and it keeps the picker populated when the CLI cannot run at all.
  */
 export const OPENCODE_PREDEFINED_MODELS: ProviderModelsDefinition = {
   OPTIONS: [
@@ -303,12 +309,18 @@ const OPENCODE_ENV_PROVIDER_IDS: Record<string, string> = {
   OPENAI_API_KEY: 'openai',
 };
 
+/** How long a successful `opencode models --verbose` answer stays fresh. */
+const LIVE_CATALOG_TTL_MS = 60_000;
+
+/** Kill bound for one discovery invocation; the CLI answers in ~2s normally. */
+const OPENCODE_MODELS_CLI_TIMEOUT_MS = 15_000;
+
 const readOpenCodeJsonFile = async (filePath: string): Promise<Record<string, unknown> | null> => {
   try {
     return readObjectRecord(JSON.parse(await readFile(filePath, 'utf8')));
   } catch {
     // Missing, unreadable, or comment-bearing (.jsonc) files simply contribute
-    // nothing; the auth store is the authoritative source below.
+    // nothing; the CLI and the auth store are the authoritative sources.
     return null;
   }
 };
@@ -316,8 +328,9 @@ const readOpenCodeJsonFile = async (filePath: string): Promise<Record<string, un
 /**
  * Lists the upstream providers this OpenCode install can actually route to.
  *
- * OpenCode resolves `<providerID>/<modelID>` against the providers the user has
- * connected, and rejects anything else outright - `Model
+ * Only consulted as a fallback when the CLI is unavailable. OpenCode resolves
+ * `<providerID>/<modelID>` against the providers the user has connected, and
+ * rejects anything else outright - `Model
  * opencode/claude-sonnet-4-6 is not valid` is what a run gets for asking for an
  * OpenCode Zen model on a machine that only has an Anthropic key. The curated
  * catalog spans every provider OpenCode can address, so it has to be narrowed
@@ -357,11 +370,254 @@ const readConnectedOpenCodeProviderIds = async (): Promise<Set<string> | null> =
   return providerIds.size > 0 ? providerIds : null;
 };
 
+/** One `opencode models --verbose` record, narrowed to the picker's fields. */
+type OpenCodeCliModel = {
+  id: string;
+  providerId: string;
+  name: string | null;
+  variants: string[] | null;
+};
+
+/**
+ * Maps CLI variant names onto the picker's effort block.
+ *
+ * The CLI exposes variants by name only; the runtime forwards the chosen value
+ * as `--variant`, so the names pass through untouched.
+ */
+const toOpenCodeEffort = (
+  variantKeys: string[],
+): ProviderModelOption['effort'] => ({
+  values: variantKeys.map((value) => ({ value })),
+});
+
+const countJsonBraces = (text: string): number => {
+  let depth = 0;
+  let inString = false;
+  let escaped = false;
+  for (const char of text) {
+    if (inString) {
+      if (escaped) {
+        escaped = false;
+      } else if (char === '\\') {
+        escaped = true;
+      } else if (char === '"') {
+        inString = false;
+      }
+      continue;
+    }
+    if (char === '"') {
+      inString = true;
+    } else if (char === '{') {
+      depth += 1;
+    } else if (char === '}') {
+      depth -= 1;
+    }
+  }
+  return depth;
+};
+
+const safeJsonParse = (text: string): unknown => {
+  try {
+    return JSON.parse(text);
+  } catch {
+    return null;
+  }
+};
+
+const parseOpenCodeCliModels = (stdout: string): OpenCodeCliModel[] => {
+  // `--verbose` prints `providerID/modelID` lines interleaved with one pretty-
+  // printed JSON object per model. The objects are the payload; the bare lines
+  // only fill in the provider id when an object is missing one.
+  const lines = stdout.split(/\r?\n/);
+  const models: OpenCodeCliModel[] = [];
+  const seen = new Set<string>();
+  let pendingLine: string | null = null;
+  let index = 0;
+
+  while (index < lines.length) {
+    const line = lines[index].trim();
+    index += 1;
+    if (!line) {
+      continue;
+    }
+
+    if (!line.startsWith('{')) {
+      if (line.includes('/')) {
+        pendingLine = line;
+      }
+      continue;
+    }
+
+    // Pretty-printed objects span many lines; buffer until the braces balance.
+    let json = line;
+    while (index < lines.length && countJsonBraces(json) > 0) {
+      json += `\n${lines[index]}`;
+      index += 1;
+    }
+
+    const record = readObjectRecord(safeJsonParse(json));
+    if (!record) {
+      continue;
+    }
+
+    const modelId = readOptionalString(record.id);
+    const providerId = readOptionalString(record.providerID)
+      ?? readOptionalString(record.providerId)
+      ?? pendingLine?.split('/')[0]
+      ?? null;
+    if (!modelId || !providerId) {
+      continue;
+    }
+
+    // Retired catalog entries still print; offering them would hand the picker
+    // a model the CLI refuses to run.
+    const status = readOptionalString(record.status);
+    if (status && status !== 'active') {
+      continue;
+    }
+
+    const value = `${providerId}/${modelId}`;
+    if (seen.has(value)) {
+      continue;
+    }
+    seen.add(value);
+
+    models.push({
+      id: value,
+      providerId,
+      name: readOptionalString(record.name) ?? null,
+      variants: Object.keys(readObjectRecord(record.variants) ?? {}),
+    });
+  }
+
+  return models;
+};
+
+/**
+ * Runs `opencode models --verbose` and parses its answer.
+ *
+ * Returns null when the CLI cannot produce a catalog - not installed, errored,
+ * timed out, or unparseable - so the caller keeps the curated fallback rather
+ * than leaving the picker empty. This is the only path that sees providers the
+ * user defined themselves, because it asks the same resolver the run command
+ * uses instead of re-deriving connectivity from config files.
+ */
+const readOpenCodeCliModels = async (
+  runModelsCli: () => Promise<string | null>,
+): Promise<OpenCodeCliModel[] | null> => {
+  const raw = await runModelsCli();
+  if (raw === null) {
+    return null;
+  }
+
+  const models = parseOpenCodeCliModels(raw);
+  return models.length > 0 ? models : null;
+};
+
+const runOpenCodeModelsCli = async (): Promise<string | null> =>
+  new Promise((resolve) => {
+    let child: ReturnType<typeof crossSpawn>;
+    try {
+      child = crossSpawn('opencode', ['models', '--verbose'], {
+        stdio: ['ignore', 'pipe', 'ignore'],
+        shell: false,
+      });
+    } catch {
+      resolve(null);
+      return;
+    }
+
+    let stdout = '';
+    let settled = false;
+    const finish = (value: string | null) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearTimeout(timer);
+      resolve(value);
+    };
+
+    const timer = setTimeout(() => {
+      try {
+        child.kill();
+      } catch {
+        // A dead child is exactly what the timeout wants anyway.
+      }
+      finish(null);
+    }, OPENCODE_MODELS_CLI_TIMEOUT_MS);
+
+    child.stdout?.on('data', (chunk: Buffer) => {
+      stdout += chunk.toString();
+    });
+    child.on('error', () => finish(null));
+    child.on('close', (code) => finish(code === 0 && stdout.trim() ? stdout : null));
+  });
+
+/**
+ * Builds the picker catalog from the live CLI answer, upgraded by curated rows.
+ *
+ * Curated options come first so the grouped Zen/Go/Anthropic/OpenAI entries keep
+ * their labels, descriptions, and effort metadata; the user's own providers then
+ * append as-is. `description` carries the provider id, which is what makes a
+ * `bit-openai/gpt-5.6-sol` entry distinguishable from the curated `openai/` one.
+ */
+const buildCatalogFromCli = (
+  cliModels: OpenCodeCliModel[],
+): ProviderModelsDefinition => {
+  const cliById = new Map(cliModels.map((model) => [model.id, model]));
+  const options: ProviderModelOption[] = [];
+  const seen = new Set<string>();
+
+  // Curated rows first, in curated order, but only for models this install
+  // actually has; that keeps the grouped Zen/Go/Anthropic/OpenAI entries on
+  // their labels, descriptions, and verified effort blocks.
+  for (const curated of OPENCODE_PREDEFINED_MODELS.OPTIONS) {
+    if (cliById.has(curated.value) && !seen.has(curated.value)) {
+      seen.add(curated.value);
+      options.push(curated);
+    }
+  }
+
+  // Everything the CLI reports that the curated catalog does not know - the
+  // user's own providers above all - appends as-is. `description` carries the
+  // provider id, which is what makes a `bit-openai/gpt-5.6-sol` entry
+  // distinguishable from the curated `openai/` one.
+  for (const model of cliModels) {
+    if (seen.has(model.id)) {
+      continue;
+    }
+    seen.add(model.id);
+
+    const effort = model.variants && model.variants.length > 0
+      ? toOpenCodeEffort(model.variants)
+      : undefined;
+    options.push({
+      value: model.id,
+      label: model.name ?? model.id.split('/').slice(1).join('/'),
+      description: model.providerId,
+      ...(effort ? { effort } : {}),
+    });
+  }
+
+  if (options.length === 0) {
+    return OPENCODE_PREDEFINED_MODELS;
+  }
+
+  return {
+    OPTIONS: options,
+    DEFAULT: options.some((option) => option.value === OPENCODE_PREDEFINED_MODELS.DEFAULT)
+      ? OPENCODE_PREDEFINED_MODELS.DEFAULT
+      : options[0].value,
+  };
+};
+
 /**
  * Narrows the curated catalog to the providers OpenCode can route to.
  *
- * The default has to move with the list: leaving it on an OpenCode Zen model
- * would hand every new session a model the CLI refuses to run.
+ * Fallback path only - used when the CLI is unavailable. The default has to move
+ * with the list: leaving it on an OpenCode Zen model would hand every new
+ * session a model the CLI refuses to run.
  */
 const filterOpenCodeModelsByProvider = (
   definition: ProviderModelsDefinition,
@@ -385,6 +641,11 @@ const filterOpenCodeModelsByProvider = (
       ? definition.DEFAULT
       : options[0].value,
   };
+};
+
+/** Test seam: replaces the CLI invocation with a fixture-backed reader. */
+export type OpenCodeProviderModelsDependencies = {
+  runModelsCli?: () => Promise<string | null>;
 };
 
 const parseOpenCodeSessionModelValue = (rawModel: unknown): string | null => {
@@ -415,7 +676,45 @@ const parseOpenCodeSessionModelValue = (rawModel: unknown): string | null => {
 
 /** Provider registry model adapter for OpenCode predefined models and session metadata. */
 export class OpenCodeProviderModels implements IProviderModels {
+  private readonly runModelsCli: () => Promise<string | null>;
+  private liveCatalog: Promise<ProviderModelsDefinition | null> | null = null;
+  private liveCatalogExpiresAt = 0;
+
+  constructor(dependencies: OpenCodeProviderModelsDependencies = {}) {
+    this.runModelsCli = dependencies.runModelsCli ?? runOpenCodeModelsCli;
+  }
+
+  /**
+   * Reports the picker catalog: live CLI answer first, curated fallback second.
+   *
+   * The CLI is the only source that sees user-defined providers, but it costs
+   * ~2s, so a successful answer is cached briefly and concurrent callers share
+   * one in-flight run (the picker, the active-model lookup, and effort
+   * validation all resolve the catalog within the same page load). A failed run
+   * is not cached; the next caller retries rather than waiting out the TTL on a
+   * null answer.
+   */
   async getSupportedModels(): Promise<ProviderModelsDefinition> {
+    if (!this.liveCatalog || Date.now() >= this.liveCatalogExpiresAt) {
+      const run = (async (): Promise<ProviderModelsDefinition | null> => {
+        const cliModels = await readOpenCodeCliModels(this.runModelsCli);
+        return cliModels ? buildCatalogFromCli(cliModels) : null;
+      })();
+      this.liveCatalog = run;
+      this.liveCatalogExpiresAt = Date.now() + LIVE_CATALOG_TTL_MS;
+      void run.catch(() => {
+        if (this.liveCatalog === run) {
+          this.liveCatalog = null;
+          this.liveCatalogExpiresAt = 0;
+        }
+      });
+    }
+
+    const live = await this.liveCatalog.catch(() => null);
+    if (live) {
+      return live;
+    }
+
     return filterOpenCodeModelsByProvider(
       OPENCODE_PREDEFINED_MODELS,
       await readConnectedOpenCodeProviderIds(),

--- a/server/modules/providers/list/opencode/opencode-runtime.provider.js
+++ b/server/modules/providers/list/opencode/opencode-runtime.provider.js
@@ -257,6 +257,10 @@ async function spawnOpenCode(command, options = {}, ws, context) {
 
       const resolvedEffort = resolveOpenCodeEffort(resolvedModel, effort, effortModels);
       const args = ['run', '--format', 'json'];
+      // Without --thinking the json stream silently omits every reasoning part
+      // even when the model produced one (verified against v1.18.30) — the
+      // thinking accordion would only ever fill from the reload path.
+      args.push('--thinking');
       // OpenCode's `run` command owns workspace selection through `--dir`.
       // Relying on the child-process cwd alone is not enough on Linux, where
       // the CLI can still resolve the session under the server install dir.

--- a/server/modules/providers/list/opencode/opencode-runtime.provider.test.js
+++ b/server/modules/providers/list/opencode/opencode-runtime.provider.test.js
@@ -105,8 +105,11 @@ test('spawnOpenCode emits session_created before normalized live messages for ne
     const capture = JSON.parse(await readFile(argsCapturePath, 'utf8'));
     const launchedArgs = capture.args;
     assert.ok(Array.isArray(launchedArgs));
-    assert.deepEqual(launchedArgs.slice(0, 4), ['run', '--format', 'json', '--dir']);
-    assert.equal(launchedArgs[4], tempRoot);
+    // --thinking must stay on: without it the json stream drops every
+    // reasoning part and the live thinking bubble never fills.
+    assert.deepEqual(launchedArgs.slice(0, 4), ['run', '--format', 'json', '--thinking']);
+    assert.equal(launchedArgs[4], '--dir');
+    assert.equal(launchedArgs[5], tempRoot);
     // No permission mode requested → no permission flags and no env override.
     assert.equal(launchedArgs.includes('--auto'), false);
     assert.equal(launchedArgs.includes('--agent'), false);

--- a/server/modules/providers/list/opencode/opencode-server.client.ts
+++ b/server/modules/providers/list/opencode/opencode-server.client.ts
@@ -1,0 +1,186 @@
+import { randomBytes } from 'node:crypto';
+import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process';
+
+import crossSpawn from 'cross-spawn';
+
+import { AppError } from '@/shared/utils.js';
+
+/**
+ * HTTP client for `opencode serve`.
+ *
+ * OpenCode keeps every conversation in one shared opencode.db, so this app
+ * cannot fork one by copying a transcript file the way Claude does, and it
+ * must not write into that database from outside — the CLI owns its WAL and
+ * would race any live `opencode run` or TUI process on the other half of it.
+ * The binary's own server mode, however, exposes `POST /session/{id}/fork`,
+ * which performs the copy through OpenCode's own connection and rewrites every
+ * message reference the way a fork should. So this is a second transport to
+ * the same CLI, opened only for the operations the `opencode run` CLI cannot
+ * express — the same arrangement the Codex app-server client has with Codex.
+ *
+ * One short-lived server per operation rather than a pooled one: the spawn
+ * costs about a second, forking happens at most once per user action, and a
+ * shared child would need lifecycle handling for no measurable gain.
+ */
+
+/** How long one operation may take before the child is killed. */
+const REQUEST_TIMEOUT_MS = 60_000;
+
+/** How long the server may take to announce its listening URL. */
+const LISTEN_TIMEOUT_MS = 30_000;
+
+/**
+ * Runs one exchange against a freshly spawned `opencode serve`.
+ *
+ * The child gets an explicitly generated server password instead of inheriting
+ * the environment's: OpenCode turns on Basic auth the moment
+ * OPENCODE_SERVER_PASSWORD is present, a developer machine can already export
+ * it globally, and reading whatever was lying around would mean this client
+ * not knowing the secret it has to authenticate with.
+ */
+async function withOpenCodeServer<T>(
+  workingDir: string,
+  run: (request: (path: string, init?: RequestInit) => Promise<Response>) => Promise<T>,
+): Promise<T> {
+  const serverPassword = randomBytes(24).toString('hex');
+  // cross-spawn resolves the .cmd shim on Windows; opencode is one on PATH there.
+  const child = crossSpawn('opencode', ['serve', '--port', '0', '--hostname', '127.0.0.1'], {
+    cwd: workingDir || undefined,
+    stdio: ['pipe', 'pipe', 'pipe'],
+    env: { ...process.env, OPENCODE_SERVER_PASSWORD: serverPassword },
+  }) as ChildProcessWithoutNullStreams;
+
+  let stderr = '';
+  child.stderr?.on('data', (chunk) => {
+    stderr = (stderr + String(chunk)).slice(-2000);
+  });
+  // The child dying mid-pipe raises EPIPE on the stream rather than at the
+  // call site; without listeners that is an unhandled 'error' event taking the
+  // whole app server down over one failed fork.
+  child.stdin?.on('error', () => {});
+  child.stdout?.on('error', () => {});
+  child.stderr?.on('error', () => {});
+
+  let exitInfo: string | null = null;
+  child.on('error', (error) => { exitInfo = error.message; });
+  child.on('exit', (code, signal) => {
+    exitInfo = `opencode serve exited (code ${code ?? 'null'}, signal ${signal ?? 'null'})`;
+  });
+
+  const authHeader = `Basic ${Buffer.from(`opencode:${serverPassword}`).toString('base64')}`;
+
+  try {
+    const baseUrl = await new Promise<string>((resolve, reject) => {
+      const fail = (reason: string) => {
+        clearTimeout(timer);
+        reject(new AppError(`OpenCode server did not start: ${reason}${stderr ? ` — ${stderr.trim().split('\n').slice(-1)[0]}` : ''}`, {
+          code: 'OPENCODE_SERVER_UNAVAILABLE',
+          statusCode: 502,
+        }));
+      };
+
+      const timer = setTimeout(() => fail(`no listening line within ${LISTEN_TIMEOUT_MS}ms`), LISTEN_TIMEOUT_MS);
+      let buffer = '';
+      child.stdout?.on('data', (chunk) => {
+        buffer += String(chunk);
+        // Verified banner against v1.18: "opencode server listening on http://127.0.0.1:<port>".
+        const match = buffer.match(/listening on (http:\/\/[^\s]+)/);
+        if (match) {
+          clearTimeout(timer);
+          resolve(match[1]);
+        }
+      });
+      child.on('exit', () => fail(exitInfo ?? 'exited before announcing a listening URL'));
+      child.on('error', (error) => fail(error.message));
+    });
+
+    const request = (path: string, init: RequestInit = {}): Promise<Response> => {
+      if (exitInfo) {
+        throw new AppError(`OpenCode server is not running: ${exitInfo}`, {
+          code: 'OPENCODE_SERVER_UNAVAILABLE',
+          statusCode: 502,
+        });
+      }
+      const url = new URL(path, baseUrl);
+      return fetch(url, {
+        ...init,
+        headers: { authorization: authHeader, ...(init.headers ?? {}) },
+        signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+      });
+    };
+
+    return await run(request);
+  } finally {
+    child.kill();
+  }
+}
+
+export const openCodeServer = {
+  /**
+   * Copies a session into a new one that ends just before `messageID`, or
+   * copies the whole session when it is omitted.
+   *
+   * The cut is EXCLUSIVE of the message named — verified against a live
+   * v1.18 server: forking at a session's second user prompt kept everything
+   * before it and neither that prompt nor its answer. That is exactly the
+   * fork contract's anchor ("everything before the message the user forked
+   * from, without it"), so the fork adapter passes the anchor straight
+   * through as the cut point — but only after checking the anchor actually
+   * exists and is not the session's first message, since this endpoint
+   * answers an unknown id, and a cut that keeps nothing, by copying
+   * everything instead.
+   *
+   * `directory` decides where OpenCode files the copy. It is passed through
+   * whenever the session has a working directory so the fork is found by the
+   * same `opencode run --dir` lookup the runtime uses to resume it.
+   */
+  async forkSession(input: {
+    sessionId: string;
+    /** Cut point, exclusive; omitted copies the whole session. */
+    cutBeforeMessageId?: string;
+    directory?: string;
+  }): Promise<{ sessionId: string }> {
+    return withOpenCodeServer(input.directory ?? '', async (request) => {
+      const url = new URL(`/session/${encodeURIComponent(input.sessionId)}/fork`, 'http://placeholder');
+      if (input.directory) {
+        url.searchParams.set('directory', input.directory);
+      }
+
+      let response: Response;
+      try {
+        response = await request(url.pathname + url.search, {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify(input.cutBeforeMessageId ? { messageID: input.cutBeforeMessageId } : {}),
+        });
+      } catch (error) {
+        throw new AppError(`Could not reach the OpenCode server for the fork: ${error instanceof Error ? error.message : String(error)}`, {
+          code: 'OPENCODE_SERVER_UNAVAILABLE',
+          statusCode: 502,
+        });
+      }
+
+      if (!response.ok) {
+        const body = await response.text().catch(() => '');
+        throw new AppError(`OpenCode rejected the fork (HTTP ${response.status})${body ? `: ${body.slice(0, 300)}` : '.'}`, {
+          code: 'FORK_FAILED',
+          statusCode: 502,
+        });
+      }
+
+      const session = await response.json() as { id?: unknown };
+      const sessionId = typeof session?.id === 'string' ? session.id : '';
+      // Confirmed rather than trusted: the caller is about to write a database
+      // row claiming this session exists, and the id shape OpenCode uses is
+      // `ses_...` — anything else means the response was not a session.
+      if (!sessionId.startsWith('ses_')) {
+        throw new AppError('OpenCode reported a fork without a session id.', {
+          code: 'FORK_FAILED',
+          statusCode: 502,
+        });
+      }
+
+      return { sessionId };
+    });
+  },
+};

--- a/server/modules/providers/list/opencode/opencode-sessions.provider.ts
+++ b/server/modules/providers/list/opencode/opencode-sessions.provider.ts
@@ -201,14 +201,6 @@ const aggregateOpenCodeSessionTokenUsage = (
 export class OpenCodeSessionsProvider implements IProviderSessions {
   /**
    * Normalizes live `opencode run --format json` events into frontend messages.
-   *
-   * Verified against a live v1.18 CLI: every event carries the payload nested
-   * under `part` (top level is only `type` / `timestamp` / `sessionID`), each
-   * part is emitted as ONE whole event when it finishes (the CLI has no
-   * token-delta frames), and reasoning parts only appear at all when the run
-   * passes `--thinking` — which the runtime now always does. Ids are the
-   * provider's own (`part.id`, and `part.callID` for tools) so an in-flight
-   * row and its later update replace the same transcript entry.
    */
   normalizeMessage(rawMessage: unknown, sessionId: string | null): NormalizedMessage[] {
     const raw = readObjectRecord(rawMessage);
@@ -218,12 +210,8 @@ export class OpenCodeSessionsProvider implements IProviderSessions {
 
     const type = readOptionalString(raw.type) ?? readOptionalString(raw.event);
     const eventSessionId = readOptionalString(raw.sessionID) ?? readOptionalString(raw.sessionId) ?? sessionId;
-    const part = readObjectRecord(raw.part);
-    const timestamp = normalizeProviderTimestamp(
-      readObjectRecord(part?.time)?.end ?? raw.time ?? raw.timestamp,
-    );
-    const baseId = readOptionalString(part?.id)
-      ?? readOptionalString(raw.id)
+    const timestamp = normalizeProviderTimestamp(raw.time ?? raw.timestamp);
+    const baseId = readOptionalString(raw.id)
       ?? readOptionalString(raw.messageID)
       ?? generateMessageId('opencode');
 
@@ -234,7 +222,7 @@ export class OpenCodeSessionsProvider implements IProviderSessions {
         return [];
       }
 
-      const content = extractText(part?.text ?? raw.text ?? raw.delta ?? raw.message);
+      const content = extractText(raw.text ?? raw.delta ?? raw.message);
       if (!content.trim()) {
         return [];
       }
@@ -250,7 +238,7 @@ export class OpenCodeSessionsProvider implements IProviderSessions {
     }
 
     if (type === 'reasoning') {
-      const content = extractText(part?.text ?? raw.text ?? raw.delta ?? raw.message);
+      const content = extractText(raw.text ?? raw.delta ?? raw.message);
       if (!content.trim()) {
         return [];
       }
@@ -266,19 +254,8 @@ export class OpenCodeSessionsProvider implements IProviderSessions {
     }
 
     if (type === 'tool_use') {
-      // Live tool parts carry { tool, callID, state: { status, input, output,
-      // error } }; a running part arrives first and the completed one reuses
-      // the same callID, so the client updates the one row instead of stacking.
-      const toolName = readOptionalString(part?.tool)
-        ?? readOptionalString(raw.tool)
-        ?? readOptionalString(raw.name)
-        ?? 'Tool';
-      const toolId = readOptionalString(part?.callID)
-        ?? readOptionalString(raw.callID)
-        ?? readOptionalString(raw.toolCallId)
-        ?? baseId;
-      const state = readObjectRecord(part?.state);
-      const status = readOptionalString(state?.status);
+      const toolName = readOptionalString(raw.tool) ?? readOptionalString(raw.name) ?? 'Tool';
+      const toolId = readOptionalString(raw.callID) ?? readOptionalString(raw.toolCallId) ?? baseId;
       const toolMessage = createNormalizedMessage({
         id: baseId,
         sessionId: eventSessionId,
@@ -286,15 +263,14 @@ export class OpenCodeSessionsProvider implements IProviderSessions {
         provider: PROVIDER,
         kind: 'tool_use',
         toolName,
-        toolInput: state?.input ?? part?.input ?? raw.input ?? raw.arguments ?? {},
+        toolInput: raw.input ?? raw.arguments ?? {},
         toolId,
-        ...(status ? { status } : {}),
       });
 
-      if (status === 'completed' || status === 'error' || state?.output !== undefined || state?.error !== undefined) {
+      if (raw.output !== undefined || raw.error !== undefined) {
         toolMessage.toolResult = {
-          content: formatToolContent(state?.output ?? state?.error ?? raw.output ?? raw.error),
-          isError: status === 'error' || raw.error !== undefined,
+          content: formatToolContent(raw.output ?? raw.error),
+          isError: raw.error !== undefined,
         };
       }
 
@@ -449,6 +425,12 @@ export class OpenCodeSessionsProvider implements IProviderSessions {
             content: parsedFiles.text,
             images: parsedImages.attachments.length > 0 ? parsedImages.attachments : undefined,
             files: parsedFiles.attachments.length > 0 ? parsedFiles.attachments : undefined,
+            // The native `msg_...` row id: stable across reads (unlike the
+            // synthesized `baseId`, which renews every fetch) and exactly what
+            // the fork endpoint's messageID parameter addresses. Several text
+            // parts of one message sharing the anchor is harmless — they all
+            // fork at the same message.
+            ...(messageRole === 'user' ? { transcriptAnchorId: row.message_id } : {}),
           }));
         }
         continue;

--- a/server/modules/providers/list/opencode/opencode-sessions.provider.ts
+++ b/server/modules/providers/list/opencode/opencode-sessions.provider.ts
@@ -201,6 +201,14 @@ const aggregateOpenCodeSessionTokenUsage = (
 export class OpenCodeSessionsProvider implements IProviderSessions {
   /**
    * Normalizes live `opencode run --format json` events into frontend messages.
+   *
+   * Verified against a live v1.18 CLI: every event carries the payload nested
+   * under `part` (top level is only `type` / `timestamp` / `sessionID`), each
+   * part is emitted as ONE whole event when it finishes (the CLI has no
+   * token-delta frames), and reasoning parts only appear at all when the run
+   * passes `--thinking` — which the runtime now always does. Ids are the
+   * provider's own (`part.id`, and `part.callID` for tools) so an in-flight
+   * row and its later update replace the same transcript entry.
    */
   normalizeMessage(rawMessage: unknown, sessionId: string | null): NormalizedMessage[] {
     const raw = readObjectRecord(rawMessage);
@@ -210,8 +218,12 @@ export class OpenCodeSessionsProvider implements IProviderSessions {
 
     const type = readOptionalString(raw.type) ?? readOptionalString(raw.event);
     const eventSessionId = readOptionalString(raw.sessionID) ?? readOptionalString(raw.sessionId) ?? sessionId;
-    const timestamp = normalizeProviderTimestamp(raw.time ?? raw.timestamp);
-    const baseId = readOptionalString(raw.id)
+    const part = readObjectRecord(raw.part);
+    const timestamp = normalizeProviderTimestamp(
+      readObjectRecord(part?.time)?.end ?? raw.time ?? raw.timestamp,
+    );
+    const baseId = readOptionalString(part?.id)
+      ?? readOptionalString(raw.id)
       ?? readOptionalString(raw.messageID)
       ?? generateMessageId('opencode');
 
@@ -222,7 +234,7 @@ export class OpenCodeSessionsProvider implements IProviderSessions {
         return [];
       }
 
-      const content = extractText(raw.text ?? raw.delta ?? raw.message);
+      const content = extractText(part?.text ?? raw.text ?? raw.delta ?? raw.message);
       if (!content.trim()) {
         return [];
       }
@@ -238,7 +250,7 @@ export class OpenCodeSessionsProvider implements IProviderSessions {
     }
 
     if (type === 'reasoning') {
-      const content = extractText(raw.text ?? raw.delta ?? raw.message);
+      const content = extractText(part?.text ?? raw.text ?? raw.delta ?? raw.message);
       if (!content.trim()) {
         return [];
       }
@@ -254,8 +266,19 @@ export class OpenCodeSessionsProvider implements IProviderSessions {
     }
 
     if (type === 'tool_use') {
-      const toolName = readOptionalString(raw.tool) ?? readOptionalString(raw.name) ?? 'Tool';
-      const toolId = readOptionalString(raw.callID) ?? readOptionalString(raw.toolCallId) ?? baseId;
+      // Live tool parts carry { tool, callID, state: { status, input, output,
+      // error } }; a running part arrives first and the completed one reuses
+      // the same callID, so the client updates the one row instead of stacking.
+      const toolName = readOptionalString(part?.tool)
+        ?? readOptionalString(raw.tool)
+        ?? readOptionalString(raw.name)
+        ?? 'Tool';
+      const toolId = readOptionalString(part?.callID)
+        ?? readOptionalString(raw.callID)
+        ?? readOptionalString(raw.toolCallId)
+        ?? baseId;
+      const state = readObjectRecord(part?.state);
+      const status = readOptionalString(state?.status);
       const toolMessage = createNormalizedMessage({
         id: baseId,
         sessionId: eventSessionId,
@@ -263,14 +286,15 @@ export class OpenCodeSessionsProvider implements IProviderSessions {
         provider: PROVIDER,
         kind: 'tool_use',
         toolName,
-        toolInput: raw.input ?? raw.arguments ?? {},
+        toolInput: state?.input ?? part?.input ?? raw.input ?? raw.arguments ?? {},
         toolId,
+        ...(status ? { status } : {}),
       });
 
-      if (raw.output !== undefined || raw.error !== undefined) {
+      if (status === 'completed' || status === 'error' || state?.output !== undefined || state?.error !== undefined) {
         toolMessage.toolResult = {
-          content: formatToolContent(raw.output ?? raw.error),
-          isError: raw.error !== undefined,
+          content: formatToolContent(state?.output ?? state?.error ?? raw.output ?? raw.error),
+          isError: status === 'error' || raw.error !== undefined,
         };
       }
 

--- a/server/modules/providers/list/opencode/opencode.provider.ts
+++ b/server/modules/providers/list/opencode/opencode.provider.ts
@@ -1,4 +1,5 @@
 import { OpenCodeProviderAuth } from '@/modules/providers/list/opencode/opencode-auth.provider.js';
+import { OpenCodeForkProvider } from '@/modules/providers/list/opencode/opencode-fork.provider.js';
 import { OpenCodeProviderModels } from '@/modules/providers/list/opencode/opencode-models.provider.js';
 import { opencodeRuntime } from '@/modules/providers/list/opencode/opencode-runtime.provider.js';
 import { OpenCodeMcpProvider } from '@/modules/providers/list/opencode/opencode-mcp.provider.js';
@@ -8,6 +9,7 @@ import { OpenCodeSkillsProvider } from '@/modules/providers/list/opencode/openco
 import { AbstractProvider } from '@/modules/providers/shared/base/abstract.provider.js';
 import type {
   IProviderAuth,
+  IProviderFork,
   IProviderModels,
   IProviderRuntime,
   IProviderSessionSynchronizer,
@@ -22,6 +24,7 @@ export class OpenCodeProvider extends AbstractProvider {
   readonly auth: IProviderAuth = new OpenCodeProviderAuth();
   readonly skills: IProviderSkills = new OpenCodeSkillsProvider();
   readonly sessions: IProviderSessions = new OpenCodeSessionsProvider();
+  readonly fork: IProviderFork = new OpenCodeForkProvider();
   readonly sessionSynchronizer: IProviderSessionSynchronizer = new OpenCodeSessionSynchronizer();
 
   constructor() {

--- a/server/modules/providers/provider.routes.ts
+++ b/server/modules/providers/provider.routes.ts
@@ -857,6 +857,31 @@ router.get(
   }),
 );
 
+router.get(
+  '/sessions/:sessionId/subagents',
+  asyncHandler(async (req: Request, res: Response) => {
+    const sessionId = parseSessionId(req.params.sessionId);
+    const subagents = await sessionsService.listSessionSubagents(sessionId);
+    res.json(createApiSuccessResponse({ subagents }));
+  }),
+);
+
+router.get(
+  '/sessions/:sessionId/subagents/:agentId/messages',
+  asyncHandler(async (req: Request, res: Response) => {
+    const sessionId = parseSessionId(req.params.sessionId);
+    const agentId = parseSessionId(req.params.agentId);
+    const limit = parseBoundedIntegerQuery(req.query.limit, 'limit', null, 0);
+    const offset = parseBoundedIntegerQuery(req.query.offset, 'offset', 0, 0);
+
+    const result = await sessionsService.fetchSubagentHistory(sessionId, agentId, {
+      limit,
+      offset,
+    });
+    res.json(createApiSuccessResponse(result));
+  }),
+);
+
 router.get('/search/sessions', asyncHandler(async (req: Request, res: Response) => {
   const query = parseSessionSearchQuery(req.query.q);
   const limit = parseSessionSearchLimit(req.query.limit);

--- a/server/modules/providers/provider.routes.ts
+++ b/server/modules/providers/provider.routes.ts
@@ -780,6 +780,15 @@ router.get(
   }),
 );
 
+router.get(
+  '/sessions/:sessionId/context-info',
+  asyncHandler(async (req: Request, res: Response) => {
+    const sessionId = parseSessionId(req.params.sessionId);
+    const result = await sessionsService.getContextInfo(sessionId);
+    res.json(createApiSuccessResponse(result));
+  }),
+);
+
 // Must stay registered after the static and session-specific routes so their
 // literals never match the generic `:sessionId` parameter.
 router.get(

--- a/server/modules/providers/services/provider-capabilities.service.ts
+++ b/server/modules/providers/services/provider-capabilities.service.ts
@@ -40,6 +40,12 @@ type ProviderCapabilities = {
    * it still get the usage-derived sections, which need no provider help.
    */
   supportsSessionInsights: boolean;
+  /**
+   * Whether the panel's MCP switches actually bite: the runtime has to consult
+   * the user's disabled-server set when it assembles the MCP config, and only
+   * the Claude adapter reads it today.
+   */
+  supportsMcpToggle: boolean;
 };
 
 /**
@@ -66,6 +72,9 @@ const PROVIDER_CAPABILITIES: Record<LLMProvider, ProviderCapabilities> = {
     // Subagent transcripts, the /context snapshot, and the task ledger all
     // come from the Claude CLI's own files and control requests.
     supportsSessionInsights: true,
+    // The Claude runtime filters the merged MCP config against the user's
+    // disabled-server set before the SDK spawns servers.
+    supportsMcpToggle: true,
   },
   cursor: {
     provider: 'cursor',
@@ -80,6 +89,7 @@ const PROVIDER_CAPABILITIES: Record<LLMProvider, ProviderCapabilities> = {
     supportsMessageEditing: false,
     supportsSessionForking: false,
     supportsSessionInsights: false,
+    supportsMcpToggle: false,
   },
   codex: {
     provider: 'codex',
@@ -100,6 +110,9 @@ const PROVIDER_CAPABILITIES: Record<LLMProvider, ProviderCapabilities> = {
     // Codex keeps no per-subagent transcript file, so the panel's subagent
     // section has nothing to read yet; it renders the usage-derived sections.
     supportsSessionInsights: false,
+    // The Codex runtime builds its own MCP config and does not read the
+    // panel's disabled set, so its switches would be decorative.
+    supportsMcpToggle: false,
   },
   opencode: {
     provider: 'opencode',
@@ -117,6 +130,7 @@ const PROVIDER_CAPABILITIES: Record<LLMProvider, ProviderCapabilities> = {
     supportsMessageEditing: false,
     supportsSessionForking: false,
     supportsSessionInsights: false,
+    supportsMcpToggle: false,
   },
 };
 

--- a/server/modules/providers/services/provider-capabilities.service.ts
+++ b/server/modules/providers/services/provider-capabilities.service.ts
@@ -127,8 +127,12 @@ const PROVIDER_CAPABILITIES: Record<LLMProvider, ProviderCapabilities> = {
     supportsPermissionRequests: false,
     supportsTokenUsage: true,
     supportsEffort: true,
+    // Fork rides OpenCode's own server API (`POST /session/{id}/fork` on a
+    // short-lived `opencode serve`), not a write into the shared opencode.db.
+    // Editing stays false: cutting a conversation and re-asking the prompt
+    // needs a revert the one-shot `opencode run` runtime cannot express.
     supportsMessageEditing: false,
-    supportsSessionForking: false,
+    supportsSessionForking: true,
     supportsSessionInsights: false,
     supportsMcpToggle: false,
   },

--- a/server/modules/providers/services/provider-capabilities.service.ts
+++ b/server/modules/providers/services/provider-capabilities.service.ts
@@ -34,6 +34,12 @@ type ProviderCapabilities = {
    * Whether a session's transcript can be branched into an independent one.
    */
   supportsSessionForking: boolean;
+  /**
+   * Whether the provider exposes the conversation sidebars of the info panel:
+   * subagent transcripts, context snapshots, task ledgers. Providers without
+   * it still get the usage-derived sections, which need no provider help.
+   */
+  supportsSessionInsights: boolean;
 };
 
 /**
@@ -57,6 +63,9 @@ const PROVIDER_CAPABILITIES: Record<LLMProvider, ProviderCapabilities> = {
     // `forkSession` copies a transcript prefix into a new session file.
     supportsMessageEditing: true,
     supportsSessionForking: true,
+    // Subagent transcripts, the /context snapshot, and the task ledger all
+    // come from the Claude CLI's own files and control requests.
+    supportsSessionInsights: true,
   },
   cursor: {
     provider: 'cursor',
@@ -70,6 +79,7 @@ const PROVIDER_CAPABILITIES: Record<LLMProvider, ProviderCapabilities> = {
     supportsEffort: false,
     supportsMessageEditing: false,
     supportsSessionForking: false,
+    supportsSessionInsights: false,
   },
   codex: {
     provider: 'codex',
@@ -87,6 +97,9 @@ const PROVIDER_CAPABILITIES: Record<LLMProvider, ProviderCapabilities> = {
     // which is how Codex's own IDE clients do it.
     supportsMessageEditing: true,
     supportsSessionForking: true,
+    // Codex keeps no per-subagent transcript file, so the panel's subagent
+    // section has nothing to read yet; it renders the usage-derived sections.
+    supportsSessionInsights: false,
   },
   opencode: {
     provider: 'opencode',
@@ -103,6 +116,7 @@ const PROVIDER_CAPABILITIES: Record<LLMProvider, ProviderCapabilities> = {
     supportsEffort: true,
     supportsMessageEditing: false,
     supportsSessionForking: false,
+    supportsSessionInsights: false,
   },
 };
 

--- a/server/modules/providers/services/sessions.service.ts
+++ b/server/modules/providers/services/sessions.service.ts
@@ -11,6 +11,7 @@ import type {
   FetchHistoryResult,
   LLMProvider,
   NormalizedMessage,
+  SubagentSummary,
 } from '@/shared/types.js';
 import type { ProviderContextInfo } from '@/shared/interfaces.js';
 import { AppError, sliceTailPage } from '@/shared/utils.js';
@@ -431,6 +432,63 @@ export const sessionsService = {
     }
 
     return runtime.contextInfo(sessionId);
+  },
+
+  /**
+   * The agents one session spawned, for the info panel's sidebar. A provider
+   * without a per-agent transcript store simply reports none, which renders as
+   * an empty section rather than an error. Deliberately outside the
+   * sessionHistoryCache: that cache is keyed by the parent transcript and this
+   * reads the subagents directory the watcher never touches.
+   */
+  async listSessionSubagents(sessionId: string): Promise<SubagentSummary[]> {
+    const session = sessionsDb.getSessionById(sessionId);
+    if (!session) {
+      throw new AppError(`Session "${sessionId}" was not found.`, {
+        code: 'SESSION_NOT_FOUND',
+        statusCode: 404,
+      });
+    }
+
+    const sessions = providerRegistry.resolveProvider(session.provider as LLMProvider).sessions;
+    if (!sessions.listSubagents || !session.provider_session_id) {
+      return [];
+    }
+
+    return sessions.listSubagents(
+      sessionId,
+      session.provider_session_id,
+      chatRunRegistry.isProcessing(sessionId),
+    );
+  },
+
+  /**
+   * One agent's own conversation as a history page. Bypasses the history
+   * cache for the same reason the roster does — the artifact is the agent's
+   * file, not the parent transcript the cache keys on.
+   */
+  async fetchSubagentHistory(
+    sessionId: string,
+    agentId: string,
+    options: Pick<FetchHistoryOptions, 'limit' | 'offset'> = {},
+  ): Promise<FetchHistoryResult> {
+    const session = sessionsDb.getSessionById(sessionId);
+    if (!session) {
+      throw new AppError(`Session "${sessionId}" was not found.`, {
+        code: 'SESSION_NOT_FOUND',
+        statusCode: 404,
+      });
+    }
+
+    const sessions = providerRegistry.resolveProvider(session.provider as LLMProvider).sessions;
+    if (!sessions.fetchSubagentHistory || !session.provider_session_id) {
+      return { messages: [], total: 0, hasMore: false, offset: options.offset ?? 0, limit: options.limit ?? null };
+    }
+
+    return sessions.fetchSubagentHistory(sessionId, session.provider_session_id, agentId, {
+      limit: options.limit ?? null,
+      offset: options.offset ?? 0,
+    });
   },
 
   async fetchHistory(

--- a/server/modules/providers/services/sessions.service.ts
+++ b/server/modules/providers/services/sessions.service.ts
@@ -268,8 +268,9 @@ export const sessionsService = {
     }
 
     // A session that has never run has no transcript to copy, so there is
-    // nothing a fork of it could resume from.
-    if (!source.provider_session_id || !source.jsonl_path) {
+    // nothing a fork of it could resume from. Providers that keep every
+    // transcript in one shared database have no per-session file to demand.
+    if (!source.provider_session_id || (!fork.transcriptIsSharedDatabase && !source.jsonl_path)) {
       throw new AppError('This session has not produced a transcript yet.', {
         code: 'FORK_SOURCE_NOT_READY',
         statusCode: 409,

--- a/server/modules/providers/services/sessions.service.ts
+++ b/server/modules/providers/services/sessions.service.ts
@@ -12,6 +12,7 @@ import type {
   LLMProvider,
   NormalizedMessage,
 } from '@/shared/types.js';
+import type { ProviderContextInfo } from '@/shared/interfaces.js';
 import { AppError, sliceTailPage } from '@/shared/utils.js';
 
 type CreateAppSessionResult = {
@@ -407,6 +408,29 @@ export const sessionsService = {
 
     const sessions = providerRegistry.resolveProvider(session.provider as LLMProvider).sessions;
     await sessions.rewindSession?.(sessionId, keepThroughId);
+  },
+
+  /**
+   * The session's context-window snapshot, answered by the provider runtime
+   * when it holds a live handle (Claude: the SDK query's getContextUsage —
+   * the CLI's own `/context` data). Null tells the info panel to fall back to
+   * the usage frames it already streams.
+   */
+  async getContextInfo(sessionId: string): Promise<ProviderContextInfo | null> {
+    const session = sessionsDb.getSessionById(sessionId);
+    if (!session) {
+      throw new AppError(`Session "${sessionId}" was not found.`, {
+        code: 'SESSION_NOT_FOUND',
+        statusCode: 404,
+      });
+    }
+
+    const runtime = providerRegistry.resolveProvider(session.provider as LLMProvider).runtime;
+    if (!runtime.contextInfo) {
+      return null;
+    }
+
+    return runtime.contextInfo(sessionId);
   },
 
   async fetchHistory(

--- a/server/modules/providers/tests/claude-mcp-disabled-filter.test.ts
+++ b/server/modules/providers/tests/claude-mcp-disabled-filter.test.ts
@@ -1,0 +1,119 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+
+import { applyMcpDisabledFilter } from '@/modules/providers/list/claude/claude-runtime.provider.js';
+import {
+  closeConnection,
+  getConnection,
+  initializeDatabase,
+  mcpDisabledServersDb,
+  normalizeMcpDisabledServers,
+  userPreferencesDb,
+} from '@/modules/database/index.js';
+
+const USER_ID = 1;
+
+const SERVERS = {
+  github: { command: 'github-server' },
+  fetch: { command: 'fetch-server' },
+  'memory core': { command: 'memory-server' },
+};
+
+test('a disabled name drops the server and leaves the rest alone', () => {
+  const kept = applyMcpDisabledFilter(SERVERS, ['fetch']);
+  assert.deepEqual(Object.keys(kept ?? {}), ['github', 'memory core']);
+});
+
+test('disabling every name yields null, the same shape as "no MCP config"', () => {
+  const kept = applyMcpDisabledFilter(SERVERS, ['github', 'fetch', 'memory core']);
+  assert.equal(kept, null);
+});
+
+test('an empty disable set is the identity', () => {
+  assert.equal(applyMcpDisabledFilter(SERVERS, []), SERVERS);
+  assert.equal(applyMcpDisabledFilter(SERVERS, null), SERVERS);
+});
+
+test('missing or malformed server configs pass through as null', () => {
+  assert.equal(applyMcpDisabledFilter(null, ['github']), null);
+  assert.equal(applyMcpDisabledFilter(undefined as never, null), null);
+});
+
+test('names are trimmed on both sides of the comparison', () => {
+  const kept = applyMcpDisabledFilter({ ' spaced ': {}, keep: {} }, ['spaced']);
+  assert.deepEqual(Object.keys(kept ?? {}), ['keep']);
+});
+
+test('normalization drops junk entries, blanks, and duplicates', () => {
+  assert.deepEqual(
+    normalizeMcpDisabledServers([' github ', 'github', '', 42, null, 'fetch']),
+    ['fetch', 'github'],
+  );
+  assert.deepEqual(normalizeMcpDisabledServers('not an array'), []);
+  assert.deepEqual(normalizeMcpDisabledServers(undefined), []);
+});
+
+async function withDatabase(runTest: () => void | Promise<void>): Promise<void> {
+  const previousDatabasePath = process.env.DATABASE_PATH;
+  const tempDirectory = await mkdtemp(path.join(os.tmpdir(), 'mcp-disabled-db-'));
+  const databasePath = path.join(tempDirectory, 'auth.db');
+
+  closeConnection();
+  process.env.DATABASE_PATH = databasePath;
+  await writeFile(databasePath, '');
+  await initializeDatabase();
+
+  // The table cascades from users(id), so a row has to exist to write against.
+  getConnection()
+    .prepare('INSERT INTO users (id, username, password_hash) VALUES (?, ?, ?)')
+    .run(USER_ID, 'tester', 'hash');
+
+  try {
+    await runTest();
+  } finally {
+    closeConnection();
+    if (previousDatabasePath === undefined) {
+      delete process.env.DATABASE_PATH;
+    } else {
+      process.env.DATABASE_PATH = previousDatabasePath;
+    }
+    await rm(tempDirectory, { recursive: true, force: true });
+  }
+}
+
+test('the disabled set round-trips through user_preferences', async () => {
+  await withDatabase(() => {
+    assert.deepEqual(mcpDisabledServersDb.get(USER_ID), []);
+    mcpDisabledServersDb.set(USER_ID, ['github', ' github ', 'fetch']);
+    assert.deepEqual(mcpDisabledServersDb.get(USER_ID), ['fetch', 'github']);
+
+    // It lives in the shared preferences table under its own key, so the
+    // frontend's preference mirror sees the same list without another route.
+    const mirror = userPreferencesDb.getPreferences(USER_ID);
+    assert.deepEqual(mirror.mcpDisabledServers, ['fetch', 'github']);
+  });
+});
+
+test('setting replaces the whole set rather than merging', async () => {
+  await withDatabase(() => {
+    mcpDisabledServersDb.set(USER_ID, ['github', 'fetch']);
+    mcpDisabledServersDb.set(USER_ID, ['memory']);
+    assert.deepEqual(mcpDisabledServersDb.get(USER_ID), ['memory']);
+  });
+});
+
+test('a corrupted stored list reads as nothing disabled', async () => {
+  await withDatabase(() => {
+    getConnection()
+      .prepare(
+        `INSERT INTO user_preferences (user_id, preference_key, preference_value)
+         VALUES (?, ?, ?)`
+      )
+      .run(USER_ID, 'mcpDisabledServers', 'not json');
+
+    assert.deepEqual(mcpDisabledServersDb.get(USER_ID), []);
+  });
+});

--- a/server/modules/providers/tests/claude-models.test.ts
+++ b/server/modules/providers/tests/claude-models.test.ts
@@ -1,7 +1,11 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 
-import { extractClaudeEventModel } from '@/modules/providers/list/claude/claude-models.provider.js';
+import {
+  CLAUDE_ULTRACODE_EFFORT,
+  ClaudeProviderModels,
+  extractClaudeEventModel,
+} from '@/modules/providers/list/claude/claude-models.provider.js';
 
 const SESSION_ID = 'session-1';
 
@@ -84,4 +88,95 @@ test('falls back to the message model when every content hit is a placeholder', 
     ),
     'claude-sonnet-5',
   );
+});
+
+// ---------------------------------------------------------------------------
+// Live catalog from the SDK's supportedModels() handshake.
+// ---------------------------------------------------------------------------
+
+type SdkModel = {
+  value: string;
+  displayName?: string;
+  description?: string;
+  supportsEffort?: boolean;
+  supportedEffortLevels?: string[];
+};
+
+const CLI_MODELS: SdkModel[] = [
+  {
+    value: 'default',
+    displayName: 'Default (recommended)',
+    description: 'Use the default model',
+    supportsEffort: true,
+    supportedEffortLevels: ['low', 'medium', 'high', 'xhigh', 'max'],
+  },
+  { value: 'haiku', displayName: 'Haiku', supportsEffort: false },
+  {
+    value: 'custom-model',
+    displayName: '',
+    supportsEffort: true,
+    supportedEffortLevels: ['low', 'high'],
+  },
+];
+
+const adapterFor = (readSupportedModels: () => Promise<SdkModel[]>) => (
+  new ClaudeProviderModels({ readSupportedModels })
+);
+
+test('builds the catalog from the CLI answer, appending ultracode on xhigh models', async () => {
+  const catalog = await adapterFor(async () => CLI_MODELS).getSupportedModels();
+
+  assert.deepEqual(catalog.OPTIONS.map((option) => option.value), ['default', 'haiku', 'custom-model']);
+  assert.equal(catalog.DEFAULT, 'default');
+
+  assert.deepEqual(
+    catalog.OPTIONS[0].effort?.values.map((entry) => entry.value),
+    ['low', 'medium', 'high', 'xhigh', 'max', CLAUDE_ULTRACODE_EFFORT],
+  );
+  assert.equal(catalog.OPTIONS[1].effort, undefined);
+  // A blank display name falls back to the raw value.
+  assert.equal(catalog.OPTIONS[2].label, 'custom-model');
+  assert.deepEqual(
+    catalog.OPTIONS[2].effort?.values.map((entry) => entry.value),
+    ['low', 'high'],
+  );
+});
+
+test('surfaces the CLI failure instead of a curated fallback', async () => {
+  const adapter = adapterFor(async () => {
+    throw new Error('claude CLI is not installed');
+  });
+
+  await assert.rejects(() => adapter.getSupportedModels(), /not installed/);
+  // A failed run must not poison the cache: the next caller retries.
+  await assert.rejects(() => adapter.getSupportedModels(), /not installed/);
+});
+
+test('treats an empty catalog as a failure', async () => {
+  await assert.rejects(
+    () => adapterFor(async () => []).getSupportedModels(),
+    /no usable models/,
+  );
+});
+
+test('defaults to the first entry when the CLI answer has no default alias', async () => {
+  const catalog = await adapterFor(async () => [
+    { value: 'opus', displayName: 'Opus' },
+  ] as SdkModel[]).getSupportedModels();
+  assert.equal(catalog.DEFAULT, 'opus');
+});
+
+test('shares one in-flight CLI run across concurrent callers', async () => {
+  let calls = 0;
+  const adapter = adapterFor(async () => {
+    calls += 1;
+    return [{ value: 'default', displayName: 'Default' }] as SdkModel[];
+  });
+
+  const [first, second] = await Promise.all([
+    adapter.getSupportedModels(),
+    adapter.getSupportedModels(),
+  ]);
+  assert.equal(calls, 1);
+  assert.equal(first.DEFAULT, second.DEFAULT);
 });

--- a/server/modules/providers/tests/claude-sessions.test.ts
+++ b/server/modules/providers/tests/claude-sessions.test.ts
@@ -32,6 +32,49 @@ const SESSION_ID = 'claude-session-1';
 const AGENT_ID = 'a1b2c3d4e5f60718';
 const AGENT_TOOL_USE_ID = 'toolu_agent_1';
 
+test('Claude sessions provider normalizes SDK partial stream_event deltas', () => {
+  const provider = new ClaudeSessionsProvider();
+
+  // SDKPartialAssistantMessage shape: { type: 'stream_event', event: <raw frame> }
+  const thinking = provider.normalizeMessage({
+    type: 'stream_event',
+    session_id: SESSION_ID,
+    uuid: 'partial-1',
+    event: { type: 'content_block_delta', delta: { type: 'thinking_delta', thinking: '想一' } },
+  }, SESSION_ID);
+  assert.equal(thinking.length, 1);
+  assert.equal(thinking[0]?.kind, 'thinking_delta');
+  assert.equal(thinking[0]?.content, '想一');
+
+  const text = provider.normalizeMessage({
+    type: 'stream_event',
+    session_id: SESSION_ID,
+    uuid: 'partial-2',
+    event: { type: 'content_block_delta', delta: { type: 'text_delta', text: '你好' } },
+  }, SESSION_ID);
+  assert.equal(text.length, 1);
+  assert.equal(text[0]?.kind, 'stream_delta');
+  assert.equal(text[0]?.content, '你好');
+
+  // Tool-input and signature deltas carry nothing renderable — the complete
+  // assistant message that follows is what shows them.
+  const ignored = provider.normalizeMessage({
+    type: 'stream_event',
+    session_id: SESSION_ID,
+    uuid: 'partial-3',
+    event: { type: 'content_block_delta', delta: { type: 'input_json_delta', partial_json: '{"a"' } },
+  }, SESSION_ID);
+  assert.deepEqual(ignored, []);
+
+  const messageStart = provider.normalizeMessage({
+    type: 'stream_event',
+    session_id: SESSION_ID,
+    uuid: 'partial-4',
+    event: { type: 'message_start' },
+  }, SESSION_ID);
+  assert.deepEqual(messageStart, []);
+});
+
 /**
  * Writes the transcript pair current Claude versions produce for one async
  * subagent: the parent session, and the agent's own transcript plus sidecar

--- a/server/modules/providers/tests/claude-subagents-roster.test.ts
+++ b/server/modules/providers/tests/claude-subagents-roster.test.ts
@@ -1,0 +1,255 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, mkdir, rm, utimes, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+
+import { closeConnection, initializeDatabase, sessionsDb } from '@/modules/database/index.js';
+import { ClaudeSessionsProvider } from '@/modules/providers/list/claude/claude-sessions.provider.js';
+
+const PROVIDER_SESSION_ID = 'provider-session-1';
+
+async function withIsolatedDatabase(runTest: () => Promise<void>): Promise<void> {
+  const previousDatabasePath = process.env.DATABASE_PATH;
+  const tempDirectory = await mkdtemp(path.join(tmpdir(), 'claude-subagents-'));
+  process.env.DATABASE_PATH = path.join(tempDirectory, 'auth.db');
+
+  closeConnection();
+  await initializeDatabase();
+
+  try {
+    await runTest();
+  } finally {
+    closeConnection();
+    if (previousDatabasePath === undefined) {
+      delete process.env.DATABASE_PATH;
+    } else {
+      process.env.DATABASE_PATH = previousDatabasePath;
+    }
+    await rm(tempDirectory, { recursive: true, force: true });
+  }
+}
+
+const row = (overrides: Record<string, unknown> = {}) => JSON.stringify({
+  type: 'assistant',
+  sessionId: PROVIDER_SESSION_ID,
+  timestamp: '2026-09-11T10:00:00.000Z',
+  message: { role: 'assistant', model: 'claude-sonnet-5', content: [{ type: 'text', text: 'working' }] },
+  ...overrides,
+});
+
+/** Writes a parent transcript naming the agent and (optionally) its notification. */
+async function writeParentTranscript(parentPath: string, agentId: string, toolUseId: string | null, notification: string | null): Promise<void> {
+  const lines = [row({ uuid: 'root', message: { role: 'user', content: 'go' } })];
+
+  if (toolUseId) {
+    lines.push(JSON.stringify({
+      type: 'assistant',
+      uuid: 'launch',
+      parentUuid: 'root',
+      sessionId: PROVIDER_SESSION_ID,
+      timestamp: '2026-09-11T10:00:01.000Z',
+      message: { role: 'assistant', content: [{ type: 'tool_use', id: toolUseId, name: 'Agent', input: {} }] },
+    }));
+    // The real transcript carries the launch acknowledgement as a tool_result
+    // row, and that is where the agent id lives — the roster's parent mapping
+    // reads exactly this shape.
+    lines.push(JSON.stringify({
+      type: 'user',
+      uuid: 'launch-result',
+      parentUuid: 'launch',
+      sessionId: PROVIDER_SESSION_ID,
+      timestamp: '2026-09-11T10:00:02.000Z',
+      message: { role: 'user', content: [{ type: 'tool_result', tool_use_id: toolUseId, content: 'Async agent launched successfully', is_error: false }] },
+      toolUseResult: { agentId },
+    }));
+  }
+
+  if (notification && toolUseId) {
+    lines.push(JSON.stringify({
+      type: 'user',
+      uuid: 'notify',
+      parentUuid: 'launch-result',
+      sessionId: PROVIDER_SESSION_ID,
+      timestamp: '2026-09-11T10:05:00.000Z',
+      message: { role: 'user', content: `<task-notification><tool-use-id>${toolUseId}</tool-use-id><status>completed</status><summary>done</summary><result>finished work</result></task-notification>` },
+    }));
+  }
+
+  await writeFile(parentPath, lines.join('\n'), 'utf8');
+}
+
+async function writeAgentFiles(
+  directory: string,
+  agentId: string,
+  options: { meta?: Record<string, unknown>; lines?: string[]; idleSeconds?: number } = {},
+): Promise<string> {
+  await mkdir(directory, { recursive: true });
+  const transcriptPath = path.join(directory, `agent-${agentId}.jsonl`);
+  const body = (options.lines ?? [row({ uuid: `a-${agentId}-1` }), row({
+    uuid: `a-${agentId}-2`,
+    message: { role: 'assistant', content: [{ type: 'tool_use', id: `toolu_${agentId}`, name: 'Bash', input: { command: 'ls' } }] },
+  })]).join('\n');
+  await writeFile(transcriptPath, `${body}\n`, 'utf8');
+  await writeFile(
+    transcriptPath.replace(/\.jsonl$/, '.meta.json'),
+    JSON.stringify(options.meta ?? { agentType: 'Explore', description: 'survey the repo' }),
+    'utf8',
+  );
+
+  if (options.idleSeconds) {
+    const stamp = new Date(Date.now() - options.idleSeconds * 1000);
+    await utimes(transcriptPath, stamp, stamp);
+  }
+
+  return transcriptPath;
+}
+
+async function seedSession(projectDir: string, parentPath: string): Promise<string> {
+  const sessionId = sessionsDb.createSession(PROVIDER_SESSION_ID, 'claude', projectDir, undefined, undefined, undefined, parentPath);
+  return sessionId;
+}
+
+test('the roster lists agents from the CLI directory, with meta and composed status', async () => {
+  await withIsolatedDatabase(async () => {
+    const projectDir = await mkdtemp(path.join(tmpdir(), 'subagents-project-'));
+    const parentPath = path.join(projectDir, `${PROVIDER_SESSION_ID}.jsonl`);
+    // alpha has a completion notification in the parent transcript; beta does not.
+    await writeParentTranscript(parentPath, 'alpha', 'toolu_launch', 'completed');
+    await writeAgentFiles(path.join(projectDir, PROVIDER_SESSION_ID, 'subagents'), 'alpha', {
+      meta: { agentType: 'Explore', description: 'survey the repo', toolUseId: 'toolu_launch', spawnDepth: 1 },
+    });
+    // Running: parent is running and the file is fresh.
+    await writeAgentFiles(path.join(projectDir, PROVIDER_SESSION_ID, 'subagents'), 'beta', {
+      meta: { agentType: 'general-purpose', description: 'fix tests', toolUseId: 'toolu_beta' },
+      idleSeconds: 5,
+    });
+    const sessionId = await seedSession(projectDir, parentPath);
+
+    const provider = new ClaudeSessionsProvider();
+    const summaries = await provider.listSubagents(sessionId, PROVIDER_SESSION_ID, true);
+
+    assert.deepEqual(summaries.map((entry) => entry.agentId).sort(), ['alpha', 'beta']);
+    const alpha = summaries.find((entry) => entry.agentId === 'alpha')!;
+    assert.equal(alpha.status, 'completed');
+    assert.equal(alpha.agentType, 'Explore');
+    assert.equal(alpha.description, 'survey the repo');
+    assert.equal(alpha.toolUseId, 'toolu_launch');
+    assert.ok(alpha.activityCount > 0);
+
+    // No notification for beta's tool use id, and the parent runs: fresh file = running.
+    assert.equal(summaries.find((entry) => entry.agentId === 'beta')!.status, 'running');
+  });
+});
+
+test('a quiet parent never reports a running agent', async () => {
+  await withIsolatedDatabase(async () => {
+    const projectDir = await mkdtemp(path.join(tmpdir(), 'subagents-project-'));
+    const parentPath = path.join(projectDir, `${PROVIDER_SESSION_ID}.jsonl`);
+    await writeParentTranscript(parentPath, 'alpha', 'toolu_launch', null);
+    await writeAgentFiles(path.join(projectDir, PROVIDER_SESSION_ID, 'subagents'), 'alpha', { idleSeconds: 5 });
+    const sessionId = await seedSession(projectDir, parentPath);
+
+    const provider = new ClaudeSessionsProvider();
+    const summaries = await provider.listSubagents(sessionId, PROVIDER_SESSION_ID, false);
+
+    // parentRunning=false kills the heuristic even for a minutes-old file,
+    // which is what stops a crashed run's leftover from spinning forever.
+    assert.equal(summaries[0].status, 'completed');
+  });
+});
+
+test('a fresh file under a running parent, with a failed notification, reports failed', async () => {
+  await withIsolatedDatabase(async () => {
+    const projectDir = await mkdtemp(path.join(tmpdir(), 'subagents-project-'));
+    const parentPath = path.join(projectDir, `${PROVIDER_SESSION_ID}.jsonl`);
+    await writeFile(parentPath, [
+      JSON.stringify({
+        type: 'assistant', uuid: 'launch', sessionId: PROVIDER_SESSION_ID, timestamp: '2026-09-11T10:00:00.000Z',
+        message: { role: 'assistant', content: [{ type: 'tool_use', id: 'toolu_launch', name: 'Agent', input: {} }] },
+      }),
+      JSON.stringify({
+        type: 'user', uuid: 'launch-result', sessionId: PROVIDER_SESSION_ID, timestamp: '2026-09-11T10:00:01.000Z',
+        message: { role: 'user', content: [{ type: 'tool_result', tool_use_id: 'toolu_launch', content: 'Async agent launched', is_error: false }] },
+        toolUseResult: { agentId: 'alpha' },
+      }),
+      JSON.stringify({
+        type: 'user', uuid: 'notify', sessionId: PROVIDER_SESSION_ID, timestamp: '2026-09-11T10:01:00.000Z',
+        message: { role: 'user', content: '<task-notification><tool-use-id>toolu_launch</tool-use-id><status>failed</status><summary>crashed</summary><result></result></task-notification>' },
+      }),
+    ].join('\n'), 'utf8');
+    await writeAgentFiles(path.join(projectDir, PROVIDER_SESSION_ID, 'subagents'), 'alpha', { idleSeconds: 1 });
+    const sessionId = await seedSession(projectDir, parentPath);
+
+    const provider = new ClaudeSessionsProvider();
+    const summaries = await provider.listSubagents(sessionId, PROVIDER_SESSION_ID, true);
+    assert.equal(summaries[0].status, 'failed');
+  });
+});
+
+test('the history pages one agent transcript and matches tool results', async () => {
+  await withIsolatedDatabase(async () => {
+    const projectDir = await mkdtemp(path.join(tmpdir(), 'subagents-project-'));
+    const parentPath = path.join(projectDir, `${PROVIDER_SESSION_ID}.jsonl`);
+    await writeParentTranscript(parentPath, 'alpha', 'toolu_launch', null);
+    const directory = path.join(projectDir, PROVIDER_SESSION_ID, 'subagents');
+    await writeAgentFiles(directory, 'alpha', {
+      lines: [
+        row({ uuid: 'a1', message: { role: 'assistant', content: [{ type: 'text', text: 'starting' }] } }),
+        row({ uuid: 'a2', message: { role: 'assistant', content: [{ type: 'tool_use', id: 'toolu_x', name: 'Bash', input: { command: 'ls' } }] } }),
+        row({ uuid: 'a3', message: { role: 'user', content: [{ type: 'tool_result', tool_use_id: 'toolu_x', content: 'file list', is_error: false }] } }),
+        row({ uuid: 'a4', message: { role: 'assistant', content: [{ type: 'text', text: 'done here' }] } }),
+      ],
+    });
+    const sessionId = await seedSession(projectDir, parentPath);
+
+    const provider = new ClaudeSessionsProvider();
+    const firstPage = await provider.fetchSubagentHistory(sessionId, PROVIDER_SESSION_ID, 'alpha', { limit: 2, offset: 0 });
+    // Four raw rows, three visible ones: the tool result folds into its call.
+    assert.equal(firstPage.total, 3);
+    assert.equal(firstPage.hasMore, true);
+    // Tail page: the last two visible rows.
+    assert.deepEqual(
+      firstPage.messages.map((message) => message.kind),
+      ['tool_use', 'text'],
+    );
+    const toolUse = firstPage.messages.find((message) => message.kind === 'tool_use');
+    assert.equal(toolUse?.toolName, 'Bash');
+    assert.equal(toolUse?.toolResult?.content, 'file list');
+    // Agent rows carry no parent linkage; nothing should be grouped under it.
+    assert.equal(toolUse?.parentToolUseId, undefined);
+
+    const earlier = await provider.fetchSubagentHistory(sessionId, PROVIDER_SESSION_ID, 'alpha', { limit: 2, offset: 2 });
+    assert.equal(earlier.messages.length, 1);
+    assert.equal(earlier.hasMore, false);
+  });
+});
+
+test('unknown agents and providers without the methods degrade to empty', async () => {
+  await withIsolatedDatabase(async () => {
+    const projectDir = await mkdtemp(path.join(tmpdir(), 'subagents-project-'));
+    const parentPath = path.join(projectDir, `${PROVIDER_SESSION_ID}.jsonl`);
+    await writeParentTranscript(parentPath, 'alpha', 'toolu_launch', null);
+    const sessionId = await seedSession(projectDir, parentPath);
+
+    const provider = new ClaudeSessionsProvider();
+    assert.deepEqual(await provider.listSubagents(sessionId, PROVIDER_SESSION_ID, false), []);
+    const empty = await provider.fetchSubagentHistory(sessionId, PROVIDER_SESSION_ID, 'ghost', { limit: 10 });
+    assert.equal(empty.total, 0);
+    assert.equal(empty.messages.length, 0);
+  });
+});
+
+test('older layouts next to the parent transcript are still rostered', async () => {
+  await withIsolatedDatabase(async () => {
+    const projectDir = await mkdtemp(path.join(tmpdir(), 'subagents-project-'));
+    const parentPath = path.join(projectDir, `${PROVIDER_SESSION_ID}.jsonl`);
+    await writeParentTranscript(parentPath, 'legacy', 'toolu_legacy', null);
+    await writeAgentFiles(projectDir, 'legacy', { idleSeconds: 1 });
+    const sessionId = await seedSession(projectDir, parentPath);
+
+    const provider = new ClaudeSessionsProvider();
+    const summaries = await provider.listSubagents(sessionId, PROVIDER_SESSION_ID, false);
+    assert.deepEqual(summaries.map((entry) => entry.agentId), ['legacy']);
+  });
+});

--- a/server/modules/providers/tests/claude-turn-stats.test.ts
+++ b/server/modules/providers/tests/claude-turn-stats.test.ts
@@ -2,9 +2,14 @@ import assert from 'node:assert/strict';
 import test from 'node:test';
 
 import { extractTurnStats } from '@/modules/providers/list/claude/claude-runtime.provider.js';
+import type { TurnStats } from '@/shared/types.js';
+
+// The runtime adapter is plain JavaScript, so the extractor arrives untyped;
+// assertions below check the shape the frontend `TurnStats` expects.
+const statsFrom = (message: unknown): TurnStats | null => extractTurnStats(message as never) as TurnStats | null;
 
 test('a turn-ending result yields the turn bill', () => {
-  const stats = extractTurnStats({
+  const stats = statsFrom({
     type: 'result',
     subtype: 'success',
     duration_ms: 181_000,
@@ -35,7 +40,7 @@ test('a turn-ending result yields the turn bill', () => {
 test('missing numbers stay null instead of zero', () => {
   // The panel renders "—" for absent metrics; coercing to 0 would claim a
   // free turn and a zero-length run.
-  const stats = extractTurnStats({ type: 'result' });
+  const stats = statsFrom({ type: 'result' });
 
   assert.ok(stats);
   assert.equal(stats.costUsd, null);
@@ -46,7 +51,7 @@ test('missing numbers stay null instead of zero', () => {
 });
 
 test('a partial usage object keeps the reported fields', () => {
-  const stats = extractTurnStats({
+  const stats = statsFrom({
     type: 'result',
     usage: { output_tokens: 320 },
   });
@@ -61,7 +66,7 @@ test('a partial usage object keeps the reported fields', () => {
 });
 
 test('anything that is not a result emits no stats', () => {
-  assert.equal(extractTurnStats(null), null);
-  assert.equal(extractTurnStats({ type: 'assistant', usage: { output_tokens: 1 } }), null);
-  assert.equal(extractTurnStats({ type: 'system', subtype: 'task_progress' }), null);
+  assert.equal(statsFrom(null), null);
+  assert.equal(statsFrom({ type: 'assistant', usage: { output_tokens: 1 } }), null);
+  assert.equal(statsFrom({ type: 'system', subtype: 'task_progress' }), null);
 });

--- a/server/modules/providers/tests/claude-turn-stats.test.ts
+++ b/server/modules/providers/tests/claude-turn-stats.test.ts
@@ -1,0 +1,67 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { extractTurnStats } from '@/modules/providers/list/claude/claude-runtime.provider.js';
+
+test('a turn-ending result yields the turn bill', () => {
+  const stats = extractTurnStats({
+    type: 'result',
+    subtype: 'success',
+    duration_ms: 181_000,
+    duration_api_ms: 61_000,
+    num_turns: 9,
+    total_cost_usd: 0.042,
+    usage: {
+      input_tokens: 18,
+      cache_creation_input_tokens: 8_138,
+      cache_read_input_tokens: 40_460,
+      output_tokens: 166,
+    },
+  });
+
+  assert.ok(stats);
+  assert.equal(stats.costUsd, 0.042);
+  assert.equal(stats.durationMs, 181_000);
+  assert.equal(stats.apiDurationMs, 61_000);
+  assert.equal(stats.numTurns, 9);
+  assert.deepEqual(stats.usage, {
+    inputTokens: 18,
+    outputTokens: 166,
+    cacheReadTokens: 40_460,
+    cacheCreationTokens: 8_138,
+  });
+});
+
+test('missing numbers stay null instead of zero', () => {
+  // The panel renders "—" for absent metrics; coercing to 0 would claim a
+  // free turn and a zero-length run.
+  const stats = extractTurnStats({ type: 'result' });
+
+  assert.ok(stats);
+  assert.equal(stats.costUsd, null);
+  assert.equal(stats.durationMs, null);
+  assert.equal(stats.apiDurationMs, null);
+  assert.equal(stats.numTurns, null);
+  assert.equal(stats.usage, null);
+});
+
+test('a partial usage object keeps the reported fields', () => {
+  const stats = extractTurnStats({
+    type: 'result',
+    usage: { output_tokens: 320 },
+  });
+
+  assert.ok(stats);
+  assert.deepEqual(stats.usage, {
+    inputTokens: null,
+    outputTokens: 320,
+    cacheReadTokens: null,
+    cacheCreationTokens: null,
+  });
+});
+
+test('anything that is not a result emits no stats', () => {
+  assert.equal(extractTurnStats(null), null);
+  assert.equal(extractTurnStats({ type: 'assistant', usage: { output_tokens: 1 } }), null);
+  assert.equal(extractTurnStats({ type: 'system', subtype: 'task_progress' }), null);
+});

--- a/server/modules/providers/tests/codex-message-editing.test.ts
+++ b/server/modules/providers/tests/codex-message-editing.test.ts
@@ -60,6 +60,42 @@ function turn(turnId: string, prompts: string[]): TranscriptRow[] {
   ];
 }
 
+/**
+ * The same turn in the rollout format Codex 0.14x+ writes: no
+ * `event_msg/user_message` row at all — the prompt is an
+ * `event_msg/item_completed` whose item is a `UserMessage` with typed content
+ * parts. Real rollouts were the source of this shape.
+ */
+function turnCompleted(turnId: string, prompts: string[]): TranscriptRow[] {
+  return [
+    { type: 'event_msg', payload: { type: 'task_started', turn_id: turnId } },
+    { type: 'turn_context', payload: { turn_id: turnId, cwd: '/tmp' } },
+    ...prompts.map((message) => ({
+      type: 'event_msg',
+      payload: {
+        type: 'item_completed',
+        thread_id: 'thread-1',
+        turn_id: turnId,
+        item: {
+          type: 'UserMessage',
+          id: `umsg-${turnId}-${message.slice(0, 4)}`,
+          content: [{ type: 'text', text: message, text_elements: [] }],
+        },
+      },
+    })),
+    {
+      type: 'event_msg',
+      payload: {
+        type: 'item_completed',
+        thread_id: 'thread-1',
+        turn_id: turnId,
+        item: { type: 'AgentMessage', id: `amsg-${turnId}`, content: [{ type: 'text', text: `answer to ${prompts[0]}` }] },
+      },
+    },
+    { type: 'event_msg', payload: { type: 'task_complete', turn_id: turnId } },
+  ];
+}
+
 async function writeRollout(
   homeDir: string,
   threadId: string,
@@ -123,6 +159,117 @@ test('every Codex prompt is anchored to the turn that contains it', { concurrenc
     assert.equal(
       history.messages.some((message) => message.role !== 'user' && message.transcriptAnchorId),
       false,
+    );
+  });
+});
+
+/**
+ * The same contract in the rollout format current Codex writes, where prompts
+ * arrive as completed `UserMessage` items instead of `user_message` rows.
+ * Without this half the reader the new-format transcript shows no user bubbles
+ * at all and every message loses its edit/fork anchor.
+ */
+const THREE_TURNS_COMPLETED = [
+  ...turnCompleted('turn-a', ['first prompt']),
+  ...turnCompleted('turn-b', ['second prompt']),
+  ...turnCompleted('turn-c', ['third prompt']),
+];
+
+test('every new-format Codex prompt is anchored to the turn that contains it', { concurrency: false }, async () => {
+  await withIndexedSession(THREE_TURNS_COMPLETED, async ({ sessionId }) => {
+    const history = await new CodexSessionsProvider().fetchHistory(sessionId);
+    const prompts = history.messages.filter((message) => message.role === 'user');
+
+    assert.deepEqual(
+      prompts.map((message) => [message.content, message.transcriptAnchorId]),
+      [
+        ['first prompt', 'turn-a'],
+        ['second prompt', 'turn-b'],
+        ['third prompt', 'turn-c'],
+      ],
+    );
+    assert.equal(
+      history.messages.some((message) => message.role !== 'user' && message.transcriptAnchorId),
+      false,
+    );
+  });
+});
+
+test('only the first prompt of a new-format turn is anchored', { concurrency: false }, async () => {
+  await withIndexedSession(turnCompleted('turn-a', ['first prompt', 'queued follow-up']), async ({ sessionId }) => {
+    const history = await new CodexSessionsProvider().fetchHistory(sessionId);
+    const prompts = history.messages.filter((message) => message.role === 'user');
+
+    assert.deepEqual(
+      prompts.map((message) => [message.content, message.transcriptAnchorId]),
+      [
+        ['first prompt', 'turn-a'],
+        ['queued follow-up', undefined],
+      ],
+    );
+  });
+});
+
+test('a rolled-back new-format turn keeps its rows but loses its anchor', { concurrency: false }, async () => {
+  const rows = [
+    ...turnCompleted('turn-a', ['first prompt']),
+    ...turnCompleted('turn-b', ['abandoned prompt']),
+    { type: 'event_msg', payload: { type: 'thread_rolled_back', num_turns: 1 } },
+    ...turnCompleted('turn-c', ['replacement prompt']),
+  ];
+
+  await withIndexedSession(rows, async ({ sessionId }) => {
+    const provider = new CodexSessionsProvider();
+    const history = await provider.fetchHistory(sessionId);
+    const prompts = history.messages.filter((message) => message.role === 'user');
+
+    assert.deepEqual(
+      prompts.map((message) => [message.content, message.transcriptAnchorId]),
+      [
+        ['first prompt', 'turn-a'],
+        ['abandoned prompt', undefined],
+        ['replacement prompt', 'turn-c'],
+      ],
+    );
+
+    assert.deepEqual(
+      await provider.resolveEditAnchor(sessionId, 'turn-b'),
+      { found: false, resumeThroughId: null },
+    );
+  });
+});
+
+test('both prompt styles in one turn share the one anchor', { concurrency: false }, async () => {
+  // Real rollouts never mix the styles (a census found the two formats never
+  // coexist in one file), but both readers share the per-turn first-anchor
+  // set, so even a hypothetical mix cannot put two anchors on one turn — a
+  // second anchor would fork away the first prompt it stands inside.
+  const rows = [
+    { type: 'event_msg', payload: { type: 'task_started', turn_id: 'turn-a' } },
+    { type: 'turn_context', payload: { turn_id: 'turn-a', cwd: '/tmp' } },
+    { type: 'event_msg', payload: { type: 'user_message', message: 'legacy prompt' } },
+    {
+      type: 'event_msg',
+      payload: {
+        type: 'item_completed',
+        thread_id: 'thread-1',
+        turn_id: 'turn-a',
+        item: { type: 'UserMessage', id: 'umsg-a', content: [{ type: 'text', text: 'new-format prompt' }] },
+      },
+    },
+    { type: 'event_msg', payload: { type: 'task_complete', turn_id: 'turn-a' } },
+  ];
+
+  await withIndexedSession(rows, async ({ sessionId }) => {
+    const history = await new CodexSessionsProvider().fetchHistory(sessionId);
+    const prompts = history.messages.filter((message) => message.role === 'user');
+
+    assert.deepEqual(
+      prompts.map((message) => [message.content, message.transcriptAnchorId]),
+      [
+        ['legacy prompt', 'turn-a'],
+        ['new-format prompt', undefined],
+      ],
     );
   });
 });

--- a/server/modules/providers/tests/codex-models.test.ts
+++ b/server/modules/providers/tests/codex-models.test.ts
@@ -1,0 +1,105 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { CodexProviderModels } from '@/modules/providers/list/codex/codex-models.provider.js';
+import type { CodexServerModel } from '@/modules/providers/list/codex/codex-app-server.client.js';
+
+const CLI_MODELS: CodexServerModel[] = [
+  {
+    id: 'gpt-6-astra',
+    displayName: 'GPT-6-Astra',
+    description: 'Our most capable model for complex, demanding work.',
+    hidden: false,
+    isDefault: true,
+    supportedReasoningEfforts: [
+      { reasoningEffort: 'low' },
+      { reasoningEffort: 'medium' },
+      { reasoningEffort: 'high' },
+      { reasoningEffort: 'xhigh' },
+      { reasoningEffort: 'max' },
+      { reasoningEffort: 'ultra' },
+    ],
+    defaultReasoningEffort: 'medium',
+  },
+  {
+    id: 'gpt-legacy',
+    displayName: 'Legacy',
+    hidden: true,
+    supportedReasoningEfforts: [{ reasoningEffort: 'low' }],
+  },
+  {
+    id: 'gpt-5.6-luna',
+    displayName: 'GPT-5.6 Luna',
+    description: 'Fast and affordable agentic coding model.',
+    hidden: false,
+    isDefault: false,
+    supportedReasoningEfforts: [{ reasoningEffort: 'low' }, { reasoningEffort: 'medium' }],
+    // A default outside the supported list must not reach the picker.
+    defaultReasoningEffort: 'ultra',
+  },
+];
+
+const adapterFor = (
+  listModels: () => Promise<CodexServerModel[]>,
+) => new CodexProviderModels({ listModels });
+
+test('builds the catalog from the CLI answer, dropping hidden entries', async () => {
+  const catalog = await adapterFor(async () => CLI_MODELS).getSupportedModels();
+
+  assert.deepEqual(catalog.OPTIONS.map((option) => option.value), ['gpt-6-astra', 'gpt-5.6-luna']);
+  assert.equal(catalog.DEFAULT, 'gpt-6-astra');
+
+  const astra = catalog.OPTIONS[0];
+  assert.equal(astra.label, 'GPT-6-Astra');
+  assert.equal(astra.description, 'Our most capable model for complex, demanding work.');
+  assert.deepEqual(astra.effort?.values.map((value) => value.value), ['low', 'medium', 'high', 'xhigh', 'max', 'ultra']);
+  assert.equal(astra.effort?.default, 'medium');
+
+  const luna = catalog.OPTIONS[1];
+  assert.equal(luna.effort?.default, undefined);
+});
+
+test('falls back to the first entry when the CLI marks no default', async () => {
+  const catalog = await adapterFor(async () => [
+    { id: 'first-model', supportedReasoningEfforts: [] },
+    { id: 'second-model' },
+  ] as CodexServerModel[]).getSupportedModels();
+
+  assert.equal(catalog.DEFAULT, 'first-model');
+  assert.equal(catalog.OPTIONS[0].label, 'first-model');
+  assert.equal(catalog.OPTIONS[0].effort, undefined);
+});
+
+test('surfaces the CLI failure instead of a curated fallback', async () => {
+  const adapter = adapterFor(async () => {
+    throw new Error('codex app-server did not answer');
+  });
+
+  await assert.rejects(() => adapter.getSupportedModels(), /did not answer/);
+  // A failed run must not poison the cache: the next caller retries.
+  await assert.rejects(() => adapter.getSupportedModels(), /did not answer/);
+  const recovered = adapterFor(async () => [{ id: 'only-model' }] as CodexServerModel[]);
+  assert.equal((await recovered.getSupportedModels()).DEFAULT, 'only-model');
+});
+
+test('treats an empty catalog as a failure', async () => {
+  await assert.rejects(
+    () => adapterFor(async () => []).getSupportedModels(),
+    /no usable models/,
+  );
+});
+
+test('shares one in-flight CLI run across concurrent callers', async () => {
+  let calls = 0;
+  const adapter = adapterFor(async () => {
+    calls += 1;
+    return [{ id: 'shared', isDefault: true }] as CodexServerModel[];
+  });
+
+  const [first, second] = await Promise.all([
+    adapter.getSupportedModels(),
+    adapter.getSupportedModels(),
+  ]);
+  assert.equal(calls, 1);
+  assert.equal(first.DEFAULT, second.DEFAULT);
+});

--- a/server/modules/providers/tests/codex-session-fork.test.ts
+++ b/server/modules/providers/tests/codex-session-fork.test.ts
@@ -1,4 +1,7 @@
 import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 import test from 'node:test';
 
 import { codexAppServer } from '@/modules/providers/list/codex/codex-app-server.client.js';
@@ -9,6 +12,20 @@ import { CodexForkProvider } from '@/modules/providers/list/codex/codex-fork.pro
  * codex-message-editing.test.ts, which is where the rewind that depends on it
  * lives. What is left for the fork provider is the mapping either side of it.
  */
+
+/**
+ * A minimal transcript the turn tracker accepts: one `event_msg` row per turn
+ * carrying its `turn_id`, which is all `readCodexLiveTurnIds` reads.
+ */
+function writeTurnTranscript(turnIds: string[]): string {
+  const file = path.join(fs.mkdtempSync(path.join(os.tmpdir(), 'codex-fork-')), 'rollout.jsonl');
+  const lines = [
+    JSON.stringify({ type: 'session_meta', payload: { id: 'thread-1' } }),
+    ...turnIds.map((turnId) => JSON.stringify({ type: 'event_msg', payload: { type: 'task_started', turn_id: turnId } })),
+  ];
+  fs.writeFileSync(file, `${lines.join('\n')}\n`, 'utf8');
+  return file;
+}
 
 test('a Codex fork asks for the whole thread when no anchor is given', { concurrency: false }, async () => {
   const realForkThread = codexAppServer.forkThread;
@@ -30,10 +47,11 @@ test('a Codex fork asks for the whole thread when no anchor is given', { concurr
     codexAppServer.forkThread = realForkThread;
   }
 
-  assert.deepEqual(forkCalls, [{ threadId: 'thread-1', lastTurnId: undefined, cwd: '/tmp/workspace' }]);
+  assert.deepEqual(forkCalls, [{ threadId: 'thread-1', cwd: '/tmp/workspace' }]);
 });
 
-test('forking from a message cuts through that message\'s turn', async () => {
+test('forking from a message keeps the turns before it, not its own', async () => {
+  const transcript = writeTurnTranscript(['turn-a', 'turn-b', 'turn-c']);
   const realForkThread = codexAppServer.forkThread;
   const forkCalls: unknown[] = [];
   codexAppServer.forkThread = async (input) => {
@@ -44,7 +62,7 @@ test('forking from a message cuts through that message\'s turn', async () => {
   try {
     await new CodexForkProvider().forkSession({
       providerSessionId: 'thread-1',
-      jsonlPath: '/tmp/rollout-thread-1.jsonl',
+      jsonlPath: transcript,
       projectPath: '/tmp/workspace',
       upToAnchorId: 'turn-b',
     });
@@ -52,8 +70,68 @@ test('forking from a message cuts through that message\'s turn', async () => {
     codexAppServer.forkThread = realForkThread;
   }
 
-  // Inclusive of the turn it names, so the branch keeps the message that was
-  // forked from *and* the answer it got. A turn is written as one thing; there
-  // is no cut that stops between them.
-  assert.deepEqual(forkCalls, [{ threadId: 'thread-1', lastTurnId: 'turn-b', cwd: '/tmp/workspace' }]);
+  // The contract excludes the anchored message, and `thread/fork`'s
+  // `lastTurnId` is inclusive of the turn it names and cuts by turn — so the
+  // adapter asks for the turn BEFORE the anchored one. A turn is written as
+  // one thing; there is no cut between a prompt and its answer, so excluding
+  // the turn is the finest cut the provider can express.
+  assert.deepEqual(forkCalls, [{ threadId: 'thread-1', lastTurnId: 'turn-a', cwd: '/tmp/workspace' }]);
+});
+
+test('forking from the first message reports there is nothing to copy', async () => {
+  const transcript = writeTurnTranscript(['turn-a', 'turn-b']);
+  const realForkThread = codexAppServer.forkThread;
+  const forkCalls: unknown[] = [];
+  codexAppServer.forkThread = async (input) => {
+    forkCalls.push(input);
+    return { threadId: 'thread-2', path: '/tmp/rollout-thread-2.jsonl' };
+  };
+
+  try {
+    await assert.rejects(
+      () =>
+        new CodexForkProvider().forkSession({
+          providerSessionId: 'thread-1',
+          jsonlPath: transcript,
+          projectPath: '/tmp/workspace',
+          upToAnchorId: 'turn-a',
+        }),
+      (error: unknown) =>
+        (error as { code?: string }).code === 'FORK_NOTHING_TO_COPY',
+    );
+  } finally {
+    codexAppServer.forkThread = realForkThread;
+  }
+
+  // Reporting beats silently forking the whole conversation, which is the
+  // opposite of what the user clicked.
+  assert.deepEqual(forkCalls, []);
+});
+
+test('forking from a message that rolled out of the transcript is refused', async () => {
+  const transcript = writeTurnTranscript(['turn-a', 'turn-b']);
+  const realForkThread = codexAppServer.forkThread;
+  const forkCalls: unknown[] = [];
+  codexAppServer.forkThread = async (input) => {
+    forkCalls.push(input);
+    return { threadId: 'thread-2', path: '/tmp/rollout-thread-2.jsonl' };
+  };
+
+  try {
+    await assert.rejects(
+      () =>
+        new CodexForkProvider().forkSession({
+          providerSessionId: 'thread-1',
+          jsonlPath: transcript,
+          projectPath: '/tmp/workspace',
+          upToAnchorId: 'turn-gone',
+        }),
+      (error: unknown) =>
+        (error as { code?: string }).code === 'FORK_ANCHOR_NOT_FOUND',
+    );
+  } finally {
+    codexAppServer.forkThread = realForkThread;
+  }
+
+  assert.deepEqual(forkCalls, []);
 });

--- a/server/modules/providers/tests/codex-sessions.test.ts
+++ b/server/modules/providers/tests/codex-sessions.test.ts
@@ -64,30 +64,6 @@ const writeCodexTranscript = async (
   return filePath;
 };
 
-test('Codex live reasoning ticks normalize onto one row by itemId', () => {
-  const provider = new CodexSessionsProvider();
-
-  // Shape the runtime's transformCodexEvent produces for item.started/updated/
-  // completed reasoning items: a stable itemId, and isReasoning + assistant
-  // role so it routes through the history-entry branch.
-  const tick = (content: string) => ({
-    type: 'item',
-    itemType: 'reasoning',
-    itemId: 'item_reason_1',
-    message: { role: 'assistant', content, isReasoning: true },
-  });
-
-  const first = provider.normalizeMessage(tick('partial'), 'codex-live-1');
-  const second = provider.normalizeMessage(tick('partial plus more'), 'codex-live-1');
-
-  assert.equal(first.length, 1);
-  assert.equal(first[0]?.kind, 'thinking');
-  // Same itemId → same message id, so the client replaces the row in place
-  // rather than stacking one thinking bubble per SDK tick.
-  assert.equal(second[0]?.id, first[0]?.id);
-  assert.equal(second[0]?.content, 'partial plus more');
-});
-
 test('Codex synchronizer preserves the title assigned when CloudCLI creates a session', { concurrency: false }, async () => {
   const tempRoot = await mkdtemp(path.join(os.tmpdir(), 'codex-session-sync-app-'));
   const workspacePath = path.join(tempRoot, 'workspace');
@@ -574,4 +550,159 @@ test('an exec script that updates the plan yields the steps it set', () => {
       { content: 'Identify the project', status: 'pending' },
     ],
   }]);
+});
+
+/**
+ * The rollout format `thread/fork` has written since paginated history: the
+ * fork's own file carries only its post-fork turns, and `session_meta` names
+ * the base thread plus an exclusive row ordinal whose prefix it inherits. The
+ * model sees the chain because Codex assembles it; the app's reader has to
+ * follow the same reference or the fork opens onto an empty transcript.
+ */
+const turnWithOrdinals = (turnId: string, prompt: string, answer: string, firstOrdinal: number): string[] => [
+  JSON.stringify({ type: 'event_msg', ordinal: firstOrdinal, payload: { type: 'task_started', turn_id: turnId } }),
+  JSON.stringify({ type: 'event_msg', ordinal: firstOrdinal + 1, payload: {
+    type: 'item_completed', turn_id: turnId,
+    item: { type: 'UserMessage', id: `umsg-${turnId}`, content: [{ type: 'text', text: prompt }] },
+  } }),
+  JSON.stringify({ type: 'event_msg', ordinal: firstOrdinal + 2, payload: {
+    type: 'item_completed', turn_id: turnId,
+    item: { type: 'AgentMessage', id: `amsg-${turnId}`, content: [{ type: 'text', text: answer }] },
+  } }),
+  // What actually renders the answer: the reader draws assistant text from
+  // the model-facing response_item row, alongside the item_completed mirror.
+  JSON.stringify({ type: 'response_item', ordinal: firstOrdinal + 3, payload: {
+    type: 'message', role: 'assistant', content: [{ type: 'output_text', text: answer }],
+  } }),
+  JSON.stringify({ type: 'event_msg', ordinal: firstOrdinal + 4, payload: { type: 'task_complete', turn_id: turnId } }),
+];
+
+const writePaginatedForkPair = async (
+  homeDir: string,
+  workspacePath: string,
+  options: { baseTurnCount: number; forkInheritsTurns: number },
+): Promise<{ baseThreadId: string; forkThreadId: string }> => {
+  const baseThreadId = '01a00000-0000-7000-8000-00000000000b';
+  const forkThreadId = '01a00000-0000-7000-8000-00000000000f';
+  const sessionsDir = path.join(homeDir, '.codex', 'sessions', '2026', '07', '07');
+  await mkdir(sessionsDir, { recursive: true });
+
+  const baseLines = [JSON.stringify({ type: 'session_meta', ordinal: 0, payload: { id: baseThreadId, cwd: workspacePath } })];
+  for (let turn = 0; turn < options.baseTurnCount; turn += 1) {
+    baseLines.push(...turnWithOrdinals(`turn-${turn}`, `inherited prompt ${turn}`, `inherited answer ${turn}`, baseLines.length));
+  }
+  await writeFile(path.join(sessionsDir, `rollout-${baseThreadId}.jsonl`), `${baseLines.join('\n')}\n`, 'utf8');
+
+  // The fork writes only its own turn; the inherited ordinal is what the
+  // live server recorded when the fork was taken (one turn per 5 rows plus
+  // the meta row).
+  const forkLines = [
+    JSON.stringify({ type: 'session_meta', payload: {
+      id: forkThreadId,
+      cwd: workspacePath,
+      forked_from_id: baseThreadId,
+      forked_from_ordinal_exclusive: String(1 + options.forkInheritsTurns * 5),
+      history_mode: 'paginated',
+      history_base: {
+        thread_id: baseThreadId,
+        end_ordinal_exclusive: 1 + options.forkInheritsTurns * 5,
+        end_byte_offset: 1234,
+      },
+    } }),
+    ...turnWithOrdinals('turn-fork', 'the fork prompt', 'the fork answer', 0),
+  ];
+  await writeFile(path.join(sessionsDir, `rollout-${forkThreadId}.jsonl`), `${forkLines.join('\n')}\n`, 'utf8');
+
+  return { baseThreadId, forkThreadId };
+};
+
+test('a paginated Codex fork shows the turns it inherited, oldest first', { concurrency: false }, async () => {
+  const tempRoot = await mkdtemp(path.join(os.tmpdir(), 'codex-fork-chain-'));
+  const workspacePath = path.join(tempRoot, 'workspace');
+  await mkdir(workspacePath, { recursive: true });
+  const restoreHomeDir = patchHomeDir(tempRoot);
+
+  try {
+    const { forkThreadId } = await writePaginatedForkPair(tempRoot, workspacePath, { baseTurnCount: 2, forkInheritsTurns: 2 });
+
+    await withIsolatedDatabase(async () => {
+      await new CodexSessionSynchronizer().synchronize();
+
+      const history = await new CodexSessionsProvider().fetchHistory(forkThreadId);
+      const texts = history.messages
+        .filter((message) => message.kind === 'text')
+        .map((message) => `${message.role}:${message.content}`);
+
+      assert.deepEqual(texts, [
+        'user:inherited prompt 0',
+        'assistant:inherited answer 0',
+        'user:inherited prompt 1',
+        'assistant:inherited answer 1',
+        'user:the fork prompt',
+        'assistant:the fork answer',
+      ]);
+      // Inherited prompts are addressable too — their turn rows went through
+      // the same tracker, so editing works on the copied part of the thread.
+      const firstPrompt = history.messages.find((message) => message.content === 'inherited prompt 0');
+      assert.equal(firstPrompt?.transcriptAnchorId, 'turn-0');
+    });
+  } finally {
+    restoreHomeDir();
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test('a paginated fork shows only the turns its ordinal cut kept', { concurrency: false }, async () => {
+  const tempRoot = await mkdtemp(path.join(os.tmpdir(), 'codex-fork-cut-'));
+  const workspacePath = path.join(tempRoot, 'workspace');
+  await mkdir(workspacePath, { recursive: true });
+  const restoreHomeDir = patchHomeDir(tempRoot);
+
+  try {
+    // The thread had two turns when the fork was taken after the first one:
+    // the base file still holds both, and only the ordinal says where to cut.
+    const { forkThreadId } = await writePaginatedForkPair(tempRoot, workspacePath, { baseTurnCount: 2, forkInheritsTurns: 1 });
+
+    await withIsolatedDatabase(async () => {
+      await new CodexSessionSynchronizer().synchronize();
+
+      const history = await new CodexSessionsProvider().fetchHistory(forkThreadId);
+      const prompts = history.messages
+        .filter((message) => message.kind === 'text' && message.role === 'user')
+        .map((message) => message.content);
+
+      assert.deepEqual(prompts, ['inherited prompt 0', 'the fork prompt']);
+    });
+  } finally {
+    restoreHomeDir();
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test('a paginated fork whose base file was deleted still shows its own turns', { concurrency: false }, async () => {
+  const tempRoot = await mkdtemp(path.join(os.tmpdir(), 'codex-fork-orphan-'));
+  const workspacePath = path.join(tempRoot, 'workspace');
+  await mkdir(workspacePath, { recursive: true });
+  const restoreHomeDir = patchHomeDir(tempRoot);
+
+  try {
+    const { baseThreadId, forkThreadId } = await writePaginatedForkPair(tempRoot, workspacePath, { baseTurnCount: 1, forkInheritsTurns: 1 });
+    await rm(path.join(tempRoot, '.codex', 'sessions', '2026', '07', '07', `rollout-${baseThreadId}.jsonl`));
+
+    await withIsolatedDatabase(async () => {
+      await new CodexSessionSynchronizer().synchronize();
+
+      const history = await new CodexSessionsProvider().fetchHistory(forkThreadId);
+      const prompts = history.messages
+        .filter((message) => message.kind === 'text' && message.role === 'user')
+        .map((message) => message.content);
+
+      // Missing inherited rows are logged and skipped, never a blank screen
+      // for the turns the fork itself wrote.
+      assert.deepEqual(prompts, ['the fork prompt']);
+    });
+  } finally {
+    restoreHomeDir();
+    await rm(tempRoot, { recursive: true, force: true });
+  }
 });

--- a/server/modules/providers/tests/codex-sessions.test.ts
+++ b/server/modules/providers/tests/codex-sessions.test.ts
@@ -64,6 +64,30 @@ const writeCodexTranscript = async (
   return filePath;
 };
 
+test('Codex live reasoning ticks normalize onto one row by itemId', () => {
+  const provider = new CodexSessionsProvider();
+
+  // Shape the runtime's transformCodexEvent produces for item.started/updated/
+  // completed reasoning items: a stable itemId, and isReasoning + assistant
+  // role so it routes through the history-entry branch.
+  const tick = (content: string) => ({
+    type: 'item',
+    itemType: 'reasoning',
+    itemId: 'item_reason_1',
+    message: { role: 'assistant', content, isReasoning: true },
+  });
+
+  const first = provider.normalizeMessage(tick('partial'), 'codex-live-1');
+  const second = provider.normalizeMessage(tick('partial plus more'), 'codex-live-1');
+
+  assert.equal(first.length, 1);
+  assert.equal(first[0]?.kind, 'thinking');
+  // Same itemId → same message id, so the client replaces the row in place
+  // rather than stacking one thinking bubble per SDK tick.
+  assert.equal(second[0]?.id, first[0]?.id);
+  assert.equal(second[0]?.content, 'partial plus more');
+});
+
 test('Codex synchronizer preserves the title assigned when CloudCLI creates a session', { concurrency: false }, async () => {
   const tempRoot = await mkdtemp(path.join(os.tmpdir(), 'codex-session-sync-app-'));
   const workspacePath = path.join(tempRoot, 'workspace');

--- a/server/modules/providers/tests/opencode-models.test.ts
+++ b/server/modules/providers/tests/opencode-models.test.ts
@@ -1,15 +1,10 @@
 import assert from 'node:assert/strict';
-import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { mkdtemp, rm } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 import test from 'node:test';
 
-import {
-  OpenCodeProviderModels,
-  OPENCODE_PREDEFINED_MODELS,
-} from '@/modules/providers/list/opencode/opencode-models.provider.js';
-
-const OPENCODE_ENV_KEYS = ['OPENCODE_API_KEY', 'ANTHROPIC_API_KEY', 'OPENAI_API_KEY'];
+import { OpenCodeProviderModels } from '@/modules/providers/list/opencode/opencode-models.provider.js';
 
 /**
  * Builds the `providerID/modelID` + pretty-printed JSON records that
@@ -31,60 +26,36 @@ const buildVerboseCliOutput = (
 ].join('\n')).join('\n');
 
 /**
- * Runs one case against a throwaway OpenCode home, so the catalog the adapter
- * reports depends on the fixture rather than on the providers the machine
- * running the suite happens to be logged into.
+ * Runs one case against a throwaway OpenCode home so nothing reaches the
+ * developer machine's own OpenCode state; the CLI itself is always the
+ * fixture passed in via `runModelsCli`.
  */
 const withOpenCodeHome = async (
-  setUp: (homeDir: string) => Promise<void>,
   runTest: (adapter: OpenCodeProviderModels) => Promise<void>,
-  options: { runModelsCli?: () => Promise<string | null> } = {},
+  runModelsCli: () => Promise<string | null>,
 ): Promise<void> => {
   const homeDir = await mkdtemp(path.join(os.tmpdir(), 'opencode-catalog-'));
   const originalHomedir = os.homedir;
-  const originalEnv = OPENCODE_ENV_KEYS.map((key) => [key, process.env[key]] as const);
 
   (os as any).homedir = () => homeDir;
-  for (const key of OPENCODE_ENV_KEYS) {
-    delete process.env[key];
-  }
-
   try {
-    await setUp(homeDir);
-    // Default to "the CLI produced nothing" so file-probing fallback tests do
-    // not spawn the real CLI from the developer machine running the suite.
-    await runTest(new OpenCodeProviderModels({
-      runModelsCli: options.runModelsCli ?? (async () => null),
-    }));
+    await runTest(new OpenCodeProviderModels({ runModelsCli }));
   } finally {
     (os as any).homedir = originalHomedir;
-    for (const [key, value] of originalEnv) {
-      if (value === undefined) {
-        delete process.env[key];
-      } else {
-        process.env[key] = value;
-      }
-    }
     await rm(homeDir, { recursive: true, force: true });
   }
 };
 
-const writeOpenCodeAuth = async (homeDir: string, auth: Record<string, unknown>): Promise<void> => {
-  const authDir = path.join(homeDir, '.local', 'share', 'opencode');
-  await mkdir(authDir, { recursive: true });
-  await writeFile(path.join(authDir, 'auth.json'), JSON.stringify(auth), 'utf8');
-};
-
 test('OpenCode catalog reports user-defined providers from the CLI', async () => {
-  // The curated catalog can never know a user's own providers, so the picker
-  // only shows them because the adapter asks `opencode models --verbose`.
+  // The picker only shows the user's own providers because the adapter asks
+  // `opencode models --verbose` - nothing hardcoded could ever know them.
   const cliOutput = buildVerboseCliOutput([
     { id: 'gpt-5.6-sol', providerId: 'bit-openai', name: 'GPT 5.6 Sol', variants: ['low', 'xhigh', 'max'] },
     { id: 'deepseek-v4-pro', providerId: 'deepseek', name: 'DeepSeek V4 Pro' },
     { id: 'opencode/gpt-5.6-terra', providerId: 'opencode', name: 'GPT 5.6 Terra' },
   ]);
 
-  await withOpenCodeHome(async () => {}, async (adapter) => {
+  await withOpenCodeHome(async (adapter) => {
     const catalog = await adapter.getSupportedModels();
     const byValue = new Map(catalog.OPTIONS.map((option) => [option.value, option]));
 
@@ -99,41 +70,53 @@ test('OpenCode catalog reports user-defined providers from the CLI', async () =>
 
     // A CLI id that already embeds a slash keeps its full value intact.
     assert.ok(byValue.get('opencode/opencode/gpt-5.6-terra'));
-  }, { runModelsCli: async () => cliOutput });
+  }, async () => cliOutput);
 });
 
-test('OpenCode catalog prefers curated rows and CLI-listed models', async () => {
+test('OpenCode catalog labels come from the CLI and drop retired models', async () => {
   const cliOutput = buildVerboseCliOutput([
     { id: 'gpt-5.6-terra', providerId: 'opencode' },
-    { id: 'claude-fable-5', providerId: 'anthropic' },
+    { id: 'claude-fable-5', providerId: 'anthropic', name: 'Fable 5' },
     // A retired entry must never reach the picker.
     { id: 'gpt-4.9', providerId: 'openai', status: 'deprecated' },
   ]);
 
-  await withOpenCodeHome(async () => {}, async (adapter) => {
+  await withOpenCodeHome(async (adapter) => {
     const catalog = await adapter.getSupportedModels();
     const values = catalog.OPTIONS.map((option) => option.value);
 
     assert.deepEqual(values, ['opencode/gpt-5.6-terra', 'anthropic/claude-fable-5']);
-    // Curated metadata survives: curated labels and descriptions win over the
-    // bare CLI record.
-    const terra = catalog.OPTIONS.find((option) => option.value === 'opencode/gpt-5.6-terra');
-    assert.equal(terra?.label, 'GPT 5.6 Terra');
-    assert.equal(terra?.description, 'OpenCode Zen');
+    // Without a `name` the label falls back to the model id with the provider
+    // prefix stripped; a `name` wins verbatim.
+    assert.equal(catalog.OPTIONS[0]?.label, 'gpt-5.6-terra');
+    assert.equal(catalog.OPTIONS[0]?.description, 'opencode');
+    assert.equal(catalog.OPTIONS[1]?.label, 'Fable 5');
     assert.equal(catalog.DEFAULT, 'opencode/gpt-5.6-terra');
-  }, { runModelsCli: async () => cliOutput });
+  }, async () => cliOutput);
 });
 
-test('OpenCode catalog default moves to a live model when curated default is absent', async () => {
+test('OpenCode catalog default moves to a live model when the preferred default is absent', async () => {
   const cliOutput = buildVerboseCliOutput([
     { id: 'kimi-k2.6', providerId: 'volcengine-plan', name: 'Kimi K2.6' },
   ]);
 
-  await withOpenCodeHome(async () => {}, async (adapter) => {
+  await withOpenCodeHome(async (adapter) => {
     const catalog = await adapter.getSupportedModels();
     assert.equal(catalog.DEFAULT, 'volcengine-plan/kimi-k2.6');
     assert.equal((await adapter.getCurrentActiveModel()).model, catalog.DEFAULT);
-  }, { runModelsCli: async () => cliOutput });
+  }, async () => cliOutput);
+});
+
+test('OpenCode catalog keeps the preferred default when the CLI lists it', async () => {
+  const cliOutput = buildVerboseCliOutput([
+    { id: 'kimi-k2.6', providerId: 'volcengine-plan', name: 'Kimi K2.6' },
+    { id: 'gpt-5.6-terra', providerId: 'opencode', name: 'GPT 5.6 Terra' },
+  ]);
+
+  await withOpenCodeHome(async (adapter) => {
+    const catalog = await adapter.getSupportedModels();
+    assert.equal(catalog.DEFAULT, 'opencode/gpt-5.6-terra');
+  }, async () => cliOutput);
 });
 
 test('OpenCode catalog shares one CLI run across concurrent lookups', async () => {
@@ -142,7 +125,7 @@ test('OpenCode catalog shares one CLI run across concurrent lookups', async () =
     { id: 'glm-5.2', providerId: 'volcengine-plan', name: 'GLM 5.2' },
   ]);
 
-  await withOpenCodeHome(async () => {}, async (adapter) => {
+  await withOpenCodeHome(async (adapter) => {
     const [first, second] = await Promise.all([
       adapter.getSupportedModels(),
       adapter.getCurrentActiveModel(),
@@ -150,153 +133,18 @@ test('OpenCode catalog shares one CLI run across concurrent lookups', async () =
     assert.equal(cliRuns, 1);
     assert.equal(first.OPTIONS.length, 1);
     assert.equal(second.model, 'volcengine-plan/glm-5.2');
-  }, { runModelsCli: async () => { cliRuns += 1; return cliOutput; } });
+  }, async () => { cliRuns += 1; return cliOutput; });
 });
 
-test('OpenCode exposes only the curated predefined catalog', async () => {
-  await withOpenCodeHome(async () => {}, async (adapter) => {
-    // Nothing readable about this install, so the picker keeps every option
-    // rather than coming up empty.
-    assert.deepEqual(await adapter.getSupportedModels(), OPENCODE_PREDEFINED_MODELS);
-    assert.equal(
-      (await adapter.getCurrentActiveModel()).model,
-      OPENCODE_PREDEFINED_MODELS.DEFAULT,
-    );
-  });
-  // OpenCode routes by `<providerID>/<modelID>`, so every option has to carry a
-  // provider prefix that `opencode models --verbose` reports.
-  const providerIds = new Set(
-    OPENCODE_PREDEFINED_MODELS.OPTIONS.map((option) => option.value.split('/')[0]),
-  );
-  assert.deepEqual([...providerIds].sort(), ['anthropic', 'opencode', 'opencode-go', 'openai'].sort());
-  assert.equal(
-    OPENCODE_PREDEFINED_MODELS.OPTIONS.every((option) => /^[a-z0-9-]+\/.+/.test(option.value)),
-    true,
-  );
-  assert.equal(
-    new Set(OPENCODE_PREDEFINED_MODELS.OPTIONS.map((option) => option.value)).size,
-    OPENCODE_PREDEFINED_MODELS.OPTIONS.length,
-  );
-  assert.equal(OPENCODE_PREDEFINED_MODELS.DEFAULT, 'opencode/gpt-5.6-terra');
-  assert.ok(
-    OPENCODE_PREDEFINED_MODELS.OPTIONS.some((option) => option.value === 'opencode/claude-opus-5'),
-  );
-  assert.ok(
-    OPENCODE_PREDEFINED_MODELS.OPTIONS.some((option) => option.value === 'anthropic/claude-opus-5'),
-  );
-  assert.ok(
-    OPENCODE_PREDEFINED_MODELS.OPTIONS.some((option) => option.value === 'openai/gpt-5.6'),
-  );
-  // The Go gateway carries its own provider id, so its models must be curated
-  // too - a Go subscriber otherwise authenticates while the picker offers
-  // nothing they can run.
-  const opencodeGoOptions = OPENCODE_PREDEFINED_MODELS.OPTIONS.filter(
-    (option) => option.value.startsWith('opencode-go/'),
-  );
-  assert.equal(opencodeGoOptions.length, 27);
-  assert.ok(opencodeGoOptions.every((option) => option.description === 'OpenCode Go'));
-  const glmFlash = opencodeGoOptions.find(
-    (option) => option.value === 'opencode-go/glm-5.3-flash',
-  );
-  assert.ok(glmFlash);
-  // Effort choices come from `opencode models --verbose` variants; the runtime
-  // turns a selected value into `--variant`, so the values have to match the
-  // CLI's exactly.
-  assert.deepEqual(
-    glmFlash?.effort?.values.map((value) => value.value),
-    ['low', 'high', 'max'],
-  );
-  assert.ok(
-    opencodeGoOptions
-      .filter((option) => !option.effort)
-      .every((option) =>
-        ['glm-5.1', 'kimi-k2.6', 'kimi-k2.7-code', 'mimo-v2.5', 'mimo-v2.5-pro',
-          'minimax-m2.7', 'qwen3.6-plus', 'qwen3.7-max', 'qwen3.7-plus']
-          .includes(option.value.slice('opencode-go/'.length)),
-      ),
-  );
-});
+test('OpenCode catalog is empty when the CLI cannot answer', async () => {
+  // No hardcoded fallback: an unusable CLI yields an empty picker (plus the
+  // console warning) rather than a curated list the install may not run.
+  await withOpenCodeHome(async (adapter) => {
+    assert.deepEqual(await adapter.getSupportedModels(), { OPTIONS: [], DEFAULT: '' });
+  }, async () => null);
 
-test('OpenCode offers only models the install can route to', async () => {
-  // Asking for a provider the user never connected fails the whole run with
-  // "Model <id> is not valid", so an OpenCode Zen model must not be offered -
-  // or defaulted to - on a machine that only holds an Anthropic key. This
-  // covers the file-probing fallback taken when the CLI cannot answer.
-  await withOpenCodeHome(
-    (homeDir) => writeOpenCodeAuth(homeDir, { anthropic: { type: 'api', key: 'test' } }),
-    async (adapter) => {
-      const catalog = await adapter.getSupportedModels();
-      const providerIds = new Set(catalog.OPTIONS.map((option) => option.value.split('/')[0]));
-
-      assert.deepEqual([...providerIds], ['anthropic']);
-      assert.ok(catalog.OPTIONS.length > 0);
-      assert.equal(catalog.DEFAULT.startsWith('anthropic/'), true);
-      assert.ok(catalog.OPTIONS.some((option) => option.value === catalog.DEFAULT));
-      assert.equal((await adapter.getCurrentActiveModel()).model, catalog.DEFAULT);
-    },
-  );
-
-  // A Go subscriber's auth store holds only `opencode-go`, so the whole catalog
-  // has to resolve to Go models and the default has to move onto one of them
-  // instead of the unreachable Zen default.
-  await withOpenCodeHome(
-    (homeDir) => writeOpenCodeAuth(homeDir, { 'opencode-go': { type: 'api', key: 'test' } }),
-    async (adapter) => {
-      const catalog = await adapter.getSupportedModels();
-      const providerIds = new Set(catalog.OPTIONS.map((option) => option.value.split('/')[0]));
-
-      assert.deepEqual([...providerIds], ['opencode-go']);
-      assert.equal(catalog.OPTIONS.length, 27);
-      assert.equal(catalog.DEFAULT, 'opencode-go/grok-4.6');
-      assert.ok(catalog.OPTIONS.some((option) => option.value === catalog.DEFAULT));
-      assert.equal((await adapter.getCurrentActiveModel()).model, catalog.DEFAULT);
-    },
-  );
-
-  // The catalog default survives whenever its own provider is connected.
-  await withOpenCodeHome(
-    (homeDir) => writeOpenCodeAuth(homeDir, {
-      opencode: { type: 'api', key: 'test' },
-      openai: { type: 'oauth' },
-    }),
-    async (adapter) => {
-      const catalog = await adapter.getSupportedModels();
-      const providerIds = new Set(catalog.OPTIONS.map((option) => option.value.split('/')[0]));
-
-      assert.deepEqual([...providerIds].sort(), ['opencode', 'openai'].sort());
-      assert.equal(catalog.DEFAULT, OPENCODE_PREDEFINED_MODELS.DEFAULT);
-    },
-  );
-
-  // Providers configured rather than logged into count too.
-  await withOpenCodeHome(
-    async (homeDir) => {
-      const configDir = path.join(homeDir, '.config', 'opencode');
-      await mkdir(configDir, { recursive: true });
-      await writeFile(
-        path.join(configDir, 'opencode.json'),
-        JSON.stringify({ provider: { anthropic: { options: {} } } }),
-        'utf8',
-      );
-    },
-    async (adapter) => {
-      const catalog = await adapter.getSupportedModels();
-      const providerIds = new Set(catalog.OPTIONS.map((option) => option.value.split('/')[0]));
-
-      assert.deepEqual([...providerIds], ['anthropic']);
-    },
-  );
-
-  // An API key in the environment is enough on its own.
-  await withOpenCodeHome(
-    async () => {
-      process.env.OPENAI_API_KEY = 'test';
-    },
-    async (adapter) => {
-      const catalog = await adapter.getSupportedModels();
-      const providerIds = new Set(catalog.OPTIONS.map((option) => option.value.split('/')[0]));
-
-      assert.deepEqual([...providerIds], ['openai']);
-    },
-  );
+  // Unparseable output counts as no answer too.
+  await withOpenCodeHome(async (adapter) => {
+    assert.deepEqual(await adapter.getSupportedModels(), { OPTIONS: [], DEFAULT: '' });
+  }, async () => 'not a catalog at all');
 });

--- a/server/modules/providers/tests/opencode-models.test.ts
+++ b/server/modules/providers/tests/opencode-models.test.ts
@@ -12,6 +12,25 @@ import {
 const OPENCODE_ENV_KEYS = ['OPENCODE_API_KEY', 'ANTHROPIC_API_KEY', 'OPENAI_API_KEY'];
 
 /**
+ * Builds the `providerID/modelID` + pretty-printed JSON records that
+ * `opencode models --verbose` prints, from minimal per-model fixtures.
+ */
+const buildVerboseCliOutput = (
+  models: { id: string; providerId: string; name?: string; variants?: string[]; status?: string }[],
+): string => models.map((model) => [
+  `${model.providerId}/${model.id}`,
+  JSON.stringify({
+    id: model.id,
+    providerID: model.providerId,
+    ...(model.name ? { name: model.name } : {}),
+    ...(model.status ? { status: model.status } : {}),
+    ...(model.variants
+      ? { variants: Object.fromEntries(model.variants.map((variant) => [variant, {}])) }
+      : {}),
+  }, null, 2),
+].join('\n')).join('\n');
+
+/**
  * Runs one case against a throwaway OpenCode home, so the catalog the adapter
  * reports depends on the fixture rather than on the providers the machine
  * running the suite happens to be logged into.
@@ -19,6 +38,7 @@ const OPENCODE_ENV_KEYS = ['OPENCODE_API_KEY', 'ANTHROPIC_API_KEY', 'OPENAI_API_
 const withOpenCodeHome = async (
   setUp: (homeDir: string) => Promise<void>,
   runTest: (adapter: OpenCodeProviderModels) => Promise<void>,
+  options: { runModelsCli?: () => Promise<string | null> } = {},
 ): Promise<void> => {
   const homeDir = await mkdtemp(path.join(os.tmpdir(), 'opencode-catalog-'));
   const originalHomedir = os.homedir;
@@ -31,7 +51,11 @@ const withOpenCodeHome = async (
 
   try {
     await setUp(homeDir);
-    await runTest(new OpenCodeProviderModels());
+    // Default to "the CLI produced nothing" so file-probing fallback tests do
+    // not spawn the real CLI from the developer machine running the suite.
+    await runTest(new OpenCodeProviderModels({
+      runModelsCli: options.runModelsCli ?? (async () => null),
+    }));
   } finally {
     (os as any).homedir = originalHomedir;
     for (const [key, value] of originalEnv) {
@@ -50,6 +74,84 @@ const writeOpenCodeAuth = async (homeDir: string, auth: Record<string, unknown>)
   await mkdir(authDir, { recursive: true });
   await writeFile(path.join(authDir, 'auth.json'), JSON.stringify(auth), 'utf8');
 };
+
+test('OpenCode catalog reports user-defined providers from the CLI', async () => {
+  // The curated catalog can never know a user's own providers, so the picker
+  // only shows them because the adapter asks `opencode models --verbose`.
+  const cliOutput = buildVerboseCliOutput([
+    { id: 'gpt-5.6-sol', providerId: 'bit-openai', name: 'GPT 5.6 Sol', variants: ['low', 'xhigh', 'max'] },
+    { id: 'deepseek-v4-pro', providerId: 'deepseek', name: 'DeepSeek V4 Pro' },
+    { id: 'opencode/gpt-5.6-terra', providerId: 'opencode', name: 'GPT 5.6 Terra' },
+  ]);
+
+  await withOpenCodeHome(async () => {}, async (adapter) => {
+    const catalog = await adapter.getSupportedModels();
+    const byValue = new Map(catalog.OPTIONS.map((option) => [option.value, option]));
+
+    const custom = byValue.get('bit-openai/gpt-5.6-sol');
+    assert.ok(custom, 'user-defined provider model must reach the picker');
+    assert.equal(custom.label, 'GPT 5.6 Sol');
+    assert.equal(custom.description, 'bit-openai');
+    assert.deepEqual(custom.effort?.values.map((entry) => entry.value), ['low', 'xhigh', 'max']);
+
+    assert.ok(byValue.get('deepseek/deepseek-v4-pro'));
+    assert.equal(byValue.get('deepseek/deepseek-v4-pro')?.effort, undefined);
+
+    // A CLI id that already embeds a slash keeps its full value intact.
+    assert.ok(byValue.get('opencode/opencode/gpt-5.6-terra'));
+  }, { runModelsCli: async () => cliOutput });
+});
+
+test('OpenCode catalog prefers curated rows and CLI-listed models', async () => {
+  const cliOutput = buildVerboseCliOutput([
+    { id: 'gpt-5.6-terra', providerId: 'opencode' },
+    { id: 'claude-fable-5', providerId: 'anthropic' },
+    // A retired entry must never reach the picker.
+    { id: 'gpt-4.9', providerId: 'openai', status: 'deprecated' },
+  ]);
+
+  await withOpenCodeHome(async () => {}, async (adapter) => {
+    const catalog = await adapter.getSupportedModels();
+    const values = catalog.OPTIONS.map((option) => option.value);
+
+    assert.deepEqual(values, ['opencode/gpt-5.6-terra', 'anthropic/claude-fable-5']);
+    // Curated metadata survives: curated labels and descriptions win over the
+    // bare CLI record.
+    const terra = catalog.OPTIONS.find((option) => option.value === 'opencode/gpt-5.6-terra');
+    assert.equal(terra?.label, 'GPT 5.6 Terra');
+    assert.equal(terra?.description, 'OpenCode Zen');
+    assert.equal(catalog.DEFAULT, 'opencode/gpt-5.6-terra');
+  }, { runModelsCli: async () => cliOutput });
+});
+
+test('OpenCode catalog default moves to a live model when curated default is absent', async () => {
+  const cliOutput = buildVerboseCliOutput([
+    { id: 'kimi-k2.6', providerId: 'volcengine-plan', name: 'Kimi K2.6' },
+  ]);
+
+  await withOpenCodeHome(async () => {}, async (adapter) => {
+    const catalog = await adapter.getSupportedModels();
+    assert.equal(catalog.DEFAULT, 'volcengine-plan/kimi-k2.6');
+    assert.equal((await adapter.getCurrentActiveModel()).model, catalog.DEFAULT);
+  }, { runModelsCli: async () => cliOutput });
+});
+
+test('OpenCode catalog shares one CLI run across concurrent lookups', async () => {
+  let cliRuns = 0;
+  const cliOutput = buildVerboseCliOutput([
+    { id: 'glm-5.2', providerId: 'volcengine-plan', name: 'GLM 5.2' },
+  ]);
+
+  await withOpenCodeHome(async () => {}, async (adapter) => {
+    const [first, second] = await Promise.all([
+      adapter.getSupportedModels(),
+      adapter.getCurrentActiveModel(),
+    ]);
+    assert.equal(cliRuns, 1);
+    assert.equal(first.OPTIONS.length, 1);
+    assert.equal(second.model, 'volcengine-plan/glm-5.2');
+  }, { runModelsCli: async () => { cliRuns += 1; return cliOutput; } });
+});
 
 test('OpenCode exposes only the curated predefined catalog', async () => {
   await withOpenCodeHome(async () => {}, async (adapter) => {
@@ -118,7 +220,8 @@ test('OpenCode exposes only the curated predefined catalog', async () => {
 test('OpenCode offers only models the install can route to', async () => {
   // Asking for a provider the user never connected fails the whole run with
   // "Model <id> is not valid", so an OpenCode Zen model must not be offered -
-  // or defaulted to - on a machine that only holds an Anthropic key.
+  // or defaulted to - on a machine that only holds an Anthropic key. This
+  // covers the file-probing fallback taken when the CLI cannot answer.
   await withOpenCodeHome(
     (homeDir) => writeOpenCodeAuth(homeDir, { anthropic: { type: 'api', key: 'test' } }),
     async (adapter) => {

--- a/server/modules/providers/tests/opencode-session-fork.test.ts
+++ b/server/modules/providers/tests/opencode-session-fork.test.ts
@@ -1,0 +1,213 @@
+import assert from 'node:assert/strict';
+import { mkdir, mkdtemp, rm } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+
+import Database from 'better-sqlite3';
+
+import { openCodeServer } from '@/modules/providers/list/opencode/opencode-server.client.js';
+import { OpenCodeForkProvider } from '@/modules/providers/list/opencode/opencode-fork.provider.js';
+
+/**
+ * The fork endpoint itself is exercised against a real `opencode serve` during
+ * manual verification; what these cover is the mapping either side of it: what
+ * the provider asks the endpoint for, and the anchor checks that stand in for
+ * the endpoint's too-forgiving cut (an unknown or first-message id silently
+ * copies everything).
+ */
+
+/** Seeds an opencode.db whose messages land in a known read order. */
+const seedOpenCodeDatabase = async (
+  homeDir: string,
+  sessionId: string,
+  messageIds: string[],
+): Promise<void> => {
+  const dataDir = path.join(homeDir, '.local', 'share', 'opencode');
+  await mkdir(dataDir, { recursive: true });
+
+  const db = new Database(path.join(dataDir, 'opencode.db'));
+  try {
+    db.exec(`
+      CREATE TABLE message (id TEXT PRIMARY KEY, session_id TEXT, time_created INTEGER, data TEXT);
+    `);
+    const insert = db.prepare('INSERT INTO message (id, session_id, time_created, data) VALUES (?, ?, ?, ?)');
+    messageIds.forEach((id, index) => {
+      insert.run(id, sessionId, 1_700_000_000_000 + index * 1_000, JSON.stringify({ role: 'user' }));
+    });
+  } finally {
+    db.close();
+  }
+};
+
+const patchHomeDir = (nextHomeDir: string) => {
+  const original = os.homedir;
+  (os as any).homedir = () => nextHomeDir;
+  return () => {
+    (os as any).homedir = original;
+  };
+};
+
+test('an OpenCode fork without an anchor copies the whole session', { concurrency: false }, async () => {
+  const tempRoot = await mkdtemp(path.join(os.tmpdir(), 'opencode-fork-'));
+  const restoreHomeDir = patchHomeDir(tempRoot);
+  await seedOpenCodeDatabase(tempRoot, 'ses_source', ['msg_a', 'msg_b', 'msg_c']);
+
+  const realFork = openCodeServer.forkSession;
+  const forkCalls: unknown[] = [];
+  openCodeServer.forkSession = async (input) => {
+    forkCalls.push(input);
+    return { sessionId: 'ses_forked' };
+  };
+
+  try {
+    const forked = await new OpenCodeForkProvider().forkSession({
+      providerSessionId: 'ses_source',
+      jsonlPath: null,
+      projectPath: '/tmp/workspace',
+      title: 'ignored by opencode',
+    });
+    // No path: the copy lives in the shared database, and a row naming no
+    // file is what keeps deletion from touching opencode.db.
+    assert.deepEqual(forked, { providerSessionId: 'ses_forked', jsonlPath: null });
+  } finally {
+    openCodeServer.forkSession = realFork;
+    restoreHomeDir();
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+
+  assert.deepEqual(forkCalls, [{ sessionId: 'ses_source', directory: '/tmp/workspace' }]);
+});
+
+test('an OpenCode fork cuts at the anchored message itself, exclusive', { concurrency: false }, async () => {
+  const tempRoot = await mkdtemp(path.join(os.tmpdir(), 'opencode-fork-anchor-'));
+  const restoreHomeDir = patchHomeDir(tempRoot);
+  await seedOpenCodeDatabase(tempRoot, 'ses_source', ['msg_a', 'msg_b', 'msg_c']);
+
+  const realFork = openCodeServer.forkSession;
+  const forkCalls: unknown[] = [];
+  openCodeServer.forkSession = async (input) => {
+    forkCalls.push(input);
+    return { sessionId: 'ses_forked' };
+  };
+
+  try {
+    await new OpenCodeForkProvider().forkSession({
+      providerSessionId: 'ses_source',
+      jsonlPath: null,
+      projectPath: '/tmp/workspace',
+      upToAnchorId: 'msg_b',
+    });
+  } finally {
+    openCodeServer.forkSession = realFork;
+    restoreHomeDir();
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+
+  // The endpoint's cut is EXCLUSIVE of the id it names (verified against a
+  // live server), which is exactly the contract's anchor: keep what came
+  // before msg_b, without msg_b itself — the fork retakes that prompt.
+  assert.deepEqual(forkCalls, [{
+    sessionId: 'ses_source',
+    cutBeforeMessageId: 'msg_b',
+    directory: '/tmp/workspace',
+  }]);
+});
+
+test('forking from the last OpenCode message keeps everything before it', { concurrency: false }, async () => {
+  const tempRoot = await mkdtemp(path.join(os.tmpdir(), 'opencode-fork-last-'));
+  const restoreHomeDir = patchHomeDir(tempRoot);
+  await seedOpenCodeDatabase(tempRoot, 'ses_source', ['msg_a', 'msg_b']);
+
+  const realFork = openCodeServer.forkSession;
+  const forkCalls: unknown[] = [];
+  openCodeServer.forkSession = async (input) => {
+    forkCalls.push(input);
+    return { sessionId: 'ses_forked' };
+  };
+
+  try {
+    await new OpenCodeForkProvider().forkSession({
+      providerSessionId: 'ses_source',
+      jsonlPath: null,
+      projectPath: '/tmp/workspace',
+      upToAnchorId: 'msg_b',
+    });
+  } finally {
+    openCodeServer.forkSession = realFork;
+    restoreHomeDir();
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+
+  // Even the last message is a cut point: the fork is the conversation minus
+  // that final exchange, not a whole-session copy.
+  assert.deepEqual(forkCalls, [{
+    sessionId: 'ses_source',
+    cutBeforeMessageId: 'msg_b',
+    directory: '/tmp/workspace',
+  }]);
+});
+
+test('forking from the first OpenCode message is refused', { concurrency: false }, async () => {
+  const tempRoot = await mkdtemp(path.join(os.tmpdir(), 'opencode-fork-first-'));
+  const restoreHomeDir = patchHomeDir(tempRoot);
+  await seedOpenCodeDatabase(tempRoot, 'ses_source', ['msg_a', 'msg_b']);
+
+  const realFork = openCodeServer.forkSession;
+  let called = false;
+  openCodeServer.forkSession = async (input) => {
+    called = true;
+    void input;
+    return { sessionId: 'ses_forked' };
+  };
+
+  try {
+    await assert.rejects(
+      () => new OpenCodeForkProvider().forkSession({
+        providerSessionId: 'ses_source',
+        jsonlPath: null,
+        projectPath: '/tmp/workspace',
+        upToAnchorId: 'msg_a',
+      }),
+      (error: Error & { code?: string }) => error.code === 'FORK_NOTHING_TO_COPY',
+    );
+    // The endpoint answers a keeps-nothing cut by copying everything, so it
+    // must not be asked at all here.
+    assert.equal(called, false);
+  } finally {
+    openCodeServer.forkSession = realFork;
+    restoreHomeDir();
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test('forking from a message that is gone from the database is refused', { concurrency: false }, async () => {
+  const tempRoot = await mkdtemp(path.join(os.tmpdir(), 'opencode-fork-missing-'));
+  const restoreHomeDir = patchHomeDir(tempRoot);
+  await seedOpenCodeDatabase(tempRoot, 'ses_source', ['msg_a']);
+
+  const realFork = openCodeServer.forkSession;
+  let called = false;
+  openCodeServer.forkSession = async (input) => {
+    called = true;
+    void input;
+    return { sessionId: 'ses_forked' };
+  };
+
+  try {
+    await assert.rejects(
+      () => new OpenCodeForkProvider().forkSession({
+        providerSessionId: 'ses_source',
+        jsonlPath: null,
+        projectPath: '/tmp/workspace',
+        upToAnchorId: 'msg_vanished',
+      }),
+      (error: Error & { code?: string }) => error.code === 'FORK_ANCHOR_NOT_FOUND',
+    );
+    assert.equal(called, false);
+  } finally {
+    openCodeServer.forkSession = realFork;
+    restoreHomeDir();
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});

--- a/server/modules/providers/tests/opencode-sessions.test.ts
+++ b/server/modules/providers/tests/opencode-sessions.test.ts
@@ -379,6 +379,105 @@ test('OpenCode sessions provider normalizes quoted live text and skips user echo
   assert.deepEqual(userEcho, []);
 });
 
+// Shapes below are verbatim captures from a live `opencode run --thinking
+// --format json` (v1.18.30): payload nested under `part`, one whole event per
+// finished part, and reasoning only present because of --thinking.
+test('OpenCode sessions provider normalizes real CLI reasoning events as thinking rows', () => {
+  const provider = new OpenCodeSessionsProvider();
+  const normalized = provider.normalizeMessage({
+    type: 'reasoning',
+    timestamp: 1789132139489,
+    sessionID: 'ses_probe',
+    part: {
+      id: 'prt_reasoning1',
+      messageID: 'msg_assistant1',
+      sessionID: 'ses_probe',
+      type: 'reasoning',
+      text: '用户要求执行 echo，直接执行即可。',
+      time: { start: 1789132139400, end: 1789132139473 },
+    },
+  }, null);
+
+  assert.equal(normalized.length, 1);
+  assert.equal(normalized[0]?.kind, 'thinking');
+  assert.equal(normalized[0]?.content, '用户要求执行 echo，直接执行即可。');
+  assert.equal(normalized[0]?.id, 'prt_reasoning1');
+  assert.equal(normalized[0]?.timestamp, new Date(1789132139473).toISOString());
+});
+
+test('OpenCode sessions provider normalizes real CLI text events nested under part', () => {
+  const provider = new OpenCodeSessionsProvider();
+  const normalized = provider.normalizeMessage({
+    type: 'text',
+    timestamp: 1789132140420,
+    sessionID: 'ses_probe',
+    part: {
+      id: 'prt_text1',
+      messageID: 'msg_assistant2',
+      sessionID: 'ses_probe',
+      type: 'text',
+      text: 'hello-tool-probe',
+      time: { start: 1789132140391, end: 1789132140403 },
+    },
+  }, null);
+
+  assert.equal(normalized.length, 1);
+  assert.equal(normalized[0]?.kind, 'stream_delta');
+  assert.equal(normalized[0]?.content, 'hello-tool-probe');
+});
+
+test('OpenCode sessions provider normalizes real CLI tool parts with stable call ids', () => {
+  const provider = new OpenCodeSessionsProvider();
+  const running = provider.normalizeMessage({
+    type: 'tool_use',
+    timestamp: 1789132139550,
+    sessionID: 'ses_probe',
+    part: {
+      type: 'tool',
+      tool: 'bash',
+      callID: 'call_probe1',
+      state: { status: 'running', input: { command: 'echo hi' } },
+      id: 'prt_tool1',
+      sessionID: 'ses_probe',
+      messageID: 'msg_assistant1',
+    },
+  }, null);
+
+  assert.equal(running.length, 1);
+  assert.equal(running[0]?.kind, 'tool_use');
+  assert.equal(running[0]?.toolName, 'bash');
+  assert.equal(running[0]?.toolId, 'call_probe1');
+  assert.deepEqual(running[0]?.toolInput, { command: 'echo hi' });
+  assert.equal(running[0]?.toolResult, undefined);
+
+  const completed = provider.normalizeMessage({
+    type: 'tool_use',
+    timestamp: 1789132139699,
+    sessionID: 'ses_probe',
+    part: {
+      type: 'tool',
+      tool: 'bash',
+      callID: 'call_probe1',
+      state: {
+        status: 'completed',
+        input: { command: 'echo hi' },
+        output: 'hi\n',
+        metadata: { output: 'hi\n', exit: 0, truncated: false },
+        title: 'echo hi',
+        time: { start: 1789132139501, end: 1789132139664 },
+      },
+      id: 'prt_tool1',
+      sessionID: 'ses_probe',
+      messageID: 'msg_assistant1',
+    },
+  }, null);
+
+  assert.equal(completed.length, 1);
+  // Same part id → the client replaces the in-flight row instead of stacking.
+  assert.equal(completed[0]?.id, running[0]?.id);
+  assert.deepEqual(completed[0]?.toolResult, { content: 'hi\n', isError: false });
+});
+
 test('OpenCode sessions provider reads sqlite history and token usage', { concurrency: false }, async () => {
   const tempRoot = await mkdtemp(path.join(os.tmpdir(), 'opencode-session-history-'));
   const workspacePath = path.join(tempRoot, 'workspace');

--- a/server/modules/providers/tests/opencode-sessions.test.ts
+++ b/server/modules/providers/tests/opencode-sessions.test.ts
@@ -379,105 +379,6 @@ test('OpenCode sessions provider normalizes quoted live text and skips user echo
   assert.deepEqual(userEcho, []);
 });
 
-// Shapes below are verbatim captures from a live `opencode run --thinking
-// --format json` (v1.18.30): payload nested under `part`, one whole event per
-// finished part, and reasoning only present because of --thinking.
-test('OpenCode sessions provider normalizes real CLI reasoning events as thinking rows', () => {
-  const provider = new OpenCodeSessionsProvider();
-  const normalized = provider.normalizeMessage({
-    type: 'reasoning',
-    timestamp: 1789132139489,
-    sessionID: 'ses_probe',
-    part: {
-      id: 'prt_reasoning1',
-      messageID: 'msg_assistant1',
-      sessionID: 'ses_probe',
-      type: 'reasoning',
-      text: '用户要求执行 echo，直接执行即可。',
-      time: { start: 1789132139400, end: 1789132139473 },
-    },
-  }, null);
-
-  assert.equal(normalized.length, 1);
-  assert.equal(normalized[0]?.kind, 'thinking');
-  assert.equal(normalized[0]?.content, '用户要求执行 echo，直接执行即可。');
-  assert.equal(normalized[0]?.id, 'prt_reasoning1');
-  assert.equal(normalized[0]?.timestamp, new Date(1789132139473).toISOString());
-});
-
-test('OpenCode sessions provider normalizes real CLI text events nested under part', () => {
-  const provider = new OpenCodeSessionsProvider();
-  const normalized = provider.normalizeMessage({
-    type: 'text',
-    timestamp: 1789132140420,
-    sessionID: 'ses_probe',
-    part: {
-      id: 'prt_text1',
-      messageID: 'msg_assistant2',
-      sessionID: 'ses_probe',
-      type: 'text',
-      text: 'hello-tool-probe',
-      time: { start: 1789132140391, end: 1789132140403 },
-    },
-  }, null);
-
-  assert.equal(normalized.length, 1);
-  assert.equal(normalized[0]?.kind, 'stream_delta');
-  assert.equal(normalized[0]?.content, 'hello-tool-probe');
-});
-
-test('OpenCode sessions provider normalizes real CLI tool parts with stable call ids', () => {
-  const provider = new OpenCodeSessionsProvider();
-  const running = provider.normalizeMessage({
-    type: 'tool_use',
-    timestamp: 1789132139550,
-    sessionID: 'ses_probe',
-    part: {
-      type: 'tool',
-      tool: 'bash',
-      callID: 'call_probe1',
-      state: { status: 'running', input: { command: 'echo hi' } },
-      id: 'prt_tool1',
-      sessionID: 'ses_probe',
-      messageID: 'msg_assistant1',
-    },
-  }, null);
-
-  assert.equal(running.length, 1);
-  assert.equal(running[0]?.kind, 'tool_use');
-  assert.equal(running[0]?.toolName, 'bash');
-  assert.equal(running[0]?.toolId, 'call_probe1');
-  assert.deepEqual(running[0]?.toolInput, { command: 'echo hi' });
-  assert.equal(running[0]?.toolResult, undefined);
-
-  const completed = provider.normalizeMessage({
-    type: 'tool_use',
-    timestamp: 1789132139699,
-    sessionID: 'ses_probe',
-    part: {
-      type: 'tool',
-      tool: 'bash',
-      callID: 'call_probe1',
-      state: {
-        status: 'completed',
-        input: { command: 'echo hi' },
-        output: 'hi\n',
-        metadata: { output: 'hi\n', exit: 0, truncated: false },
-        title: 'echo hi',
-        time: { start: 1789132139501, end: 1789132139664 },
-      },
-      id: 'prt_tool1',
-      sessionID: 'ses_probe',
-      messageID: 'msg_assistant1',
-    },
-  }, null);
-
-  assert.equal(completed.length, 1);
-  // Same part id → the client replaces the in-flight row instead of stacking.
-  assert.equal(completed[0]?.id, running[0]?.id);
-  assert.deepEqual(completed[0]?.toolResult, { content: 'hi\n', isError: false });
-});
-
 test('OpenCode sessions provider reads sqlite history and token usage', { concurrency: false }, async () => {
   const tempRoot = await mkdtemp(path.join(os.tmpdir(), 'opencode-session-history-'));
   const workspacePath = path.join(tempRoot, 'workspace');
@@ -493,6 +394,11 @@ test('OpenCode sessions provider reads sqlite history and token usage', { concur
     assert.equal(history.messages[0]?.kind, 'text');
     assert.equal(history.messages[0]?.role, 'user');
     assert.equal(history.messages[0]?.content, 'Build the OpenCode integration.');
+    // The fork/edit anchor is the native message row id, stable across reads
+    // (unlike the per-read synthesized id) and what the fork endpoint's
+    // messageID addresses. Only prompts carry one.
+    assert.equal(history.messages[0]?.transcriptAnchorId, 'message-user');
+    assert.equal(history.messages[2]?.transcriptAnchorId, undefined);
     assert.equal(history.messages[1]?.kind, 'thinking');
     assert.equal(history.messages[2]?.content, 'The provider is wired.');
     assert.equal(history.messages[3]?.kind, 'tool_use');

--- a/server/modules/providers/tests/session-fork.test.ts
+++ b/server/modules/providers/tests/session-fork.test.ts
@@ -171,3 +171,69 @@ test('forking a session that does not exist is a 404', async () => {
     );
   });
 });
+
+test('a shared-database provider forks a session that names no transcript file', async () => {
+  const previousDatabasePath = process.env.DATABASE_PATH;
+  const directory = await mkdtemp(path.join(os.tmpdir(), 'session-fork-shared-'));
+
+  closeConnection();
+  process.env.DATABASE_PATH = path.join(directory, 'auth.db');
+  await initializeDatabase();
+
+  const opencode = providerRegistry.resolveProvider('opencode') as { fork?: IProviderFork };
+  const realFork = opencode.fork;
+  const calls: { providerSessionId: string; jsonlPath: string | null }[] = [];
+  Object.defineProperty(opencode, 'fork', {
+    value: {
+      transcriptIsSharedDatabase: true,
+      forkSession: async (input: { providerSessionId: string; jsonlPath: string | null }) => {
+        calls.push({ providerSessionId: input.providerSessionId, jsonlPath: input.jsonlPath });
+        return { providerSessionId: 'ses_forked', jsonlPath: null };
+      },
+    } as IProviderFork,
+    configurable: true,
+    writable: true,
+  });
+
+  try {
+    const now = new Date().toISOString();
+    // An OpenCode row as the synchronizer writes one: a provider id and no
+    // file, because the transcript is rows in opencode.db.
+    sessionsDb.createSession('oc-source', 'opencode', directory, 'OpenCode session', now, now, null);
+    sessionsDb.assignProviderSessionId('oc-source', 'ses_source');
+
+    const result = await sessionsService.forkSessionById('oc-source');
+
+    assert.deepEqual(calls, [{ providerSessionId: 'ses_source', jsonlPath: null }]);
+    const forked = sessionsDb.getSessionById(result.sessionId);
+    assert.equal(forked?.provider, 'opencode');
+    assert.equal(forked?.provider_session_id, 'ses_forked');
+    // Naming no file is what keeps deleting this row from deleting the database.
+    assert.equal(forked?.jsonl_path, null);
+    assert.equal(forked?.forked_from_session_id, 'oc-source');
+  } finally {
+    Object.defineProperty(opencode, 'fork', { value: realFork, configurable: true, writable: true });
+    closeConnection();
+    if (previousDatabasePath === undefined) {
+      delete process.env.DATABASE_PATH;
+    } else {
+      process.env.DATABASE_PATH = previousDatabasePath;
+    }
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test('a file-based provider is still refused when its transcript is missing', async () => {
+  await withForkableClaude(async ({ directory }) => {
+    // Same shape as the OpenCode row above, but the (Claude) fork adapter does
+    // not claim a shared store, so a missing file really means nothing to copy.
+    const now = new Date().toISOString();
+    sessionsDb.createSession('no-file', 'claude', directory, 'Missing file', now, now, null);
+    sessionsDb.assignProviderSessionId('no-file', 'native-no-file');
+
+    await assert.rejects(
+      () => sessionsService.forkSessionById('no-file'),
+      (error: Error & { code?: string }) => error.code === 'FORK_SOURCE_NOT_READY',
+    );
+  });
+});

--- a/server/modules/settings/settings.module.ts
+++ b/server/modules/settings/settings.module.ts
@@ -1,6 +1,7 @@
 import {
   apiKeysDb,
   credentialsDb,
+  mcpDisabledServersDb,
   notificationPreferencesDb,
   pushSubscriptionsDb,
 } from '@/modules/database/index.js';
@@ -42,6 +43,10 @@ const settingsService = createSettingsService({
     save: (userId, endpoint, p256dh, auth) =>
       pushSubscriptionsDb.saveSubscription(userId, endpoint, p256dh, auth),
     remove: (endpoint) => pushSubscriptionsDb.removeSubscription(endpoint),
+  },
+  mcpDisabledServers: {
+    get: (userId) => mcpDisabledServersDb.get(userId),
+    set: (userId, value) => mcpDisabledServersDb.set(userId, value),
   },
   getVapidPublicKey: getPublicKey,
 });

--- a/server/modules/settings/settings.routes.ts
+++ b/server/modules/settings/settings.routes.ts
@@ -42,6 +42,10 @@ export function createSettingsRouter(
   router.put('/notification-preferences', respond((req) => service.updateNotificationPreferences(
     userId(req), req.body ?? {},
   )));
+  router.get('/mcp-disabled-servers', respond((req) => service.getMcpDisabledServers(userId(req))));
+  router.put('/mcp-disabled-servers', respond((req) => service.updateMcpDisabledServers(
+    userId(req), req.body?.servers,
+  )));
   router.get('/push/vapid-public-key', respond(() => service.getVapidPublicKey()));
   router.post('/push/subscribe', respond((req) => service.subscribeToPush(userId(req), req.body ?? {})));
   router.post('/push/unsubscribe', respond((req) => service.unsubscribeFromPush(

--- a/server/modules/settings/settings.service.ts
+++ b/server/modules/settings/settings.service.ts
@@ -34,6 +34,10 @@ type SettingsDependencies = {
     save(userId: number, endpoint: string, p256dh: string, auth: string): void;
     remove(endpoint: string): void;
   };
+  mcpDisabledServers: {
+    get(userId: number): string[];
+    set(userId: number, value: unknown): string[];
+  };
   getVapidPublicKey(): string | null;
 };
 
@@ -140,6 +144,12 @@ export function createSettingsService(dependencies: SettingsDependencies) {
     },
     getNotificationPreferences(userId: number) {
       return { success: true, preferences: dependencies.notifications.getPreferences(userId) };
+    },
+    getMcpDisabledServers(userId: number) {
+      return { success: true, servers: dependencies.mcpDisabledServers.get(userId) };
+    },
+    updateMcpDisabledServers(userId: number, servers: unknown) {
+      return { success: true, servers: dependencies.mcpDisabledServers.set(userId, servers) };
     },
     updateNotificationPreferences(userId: number, preferences: NotificationPreferences) {
       return {

--- a/server/modules/settings/tests/settings.service.test.ts
+++ b/server/modules/settings/tests/settings.service.test.ts
@@ -16,6 +16,10 @@ function dependencies(overrides: Partial<Dependencies> = {}): Dependencies {
       notifyUser: () => undefined,
     },
     pushSubscriptions: { save: () => undefined, remove: () => undefined },
+    mcpDisabledServers: {
+      get: () => [],
+      set: (_userId, value) => (Array.isArray(value) ? value.map(String) : []),
+    },
     getVapidPublicKey: () => null,
     ...overrides,
   };
@@ -51,4 +55,21 @@ test('subscribeToPush persists the subscription and enables Web Push', () => {
     keys: { p256dh: 'key', auth: 'auth' },
   });
   assert.deepEqual(operations, ['save:https://push.example.test', 'preferences', 'notify']);
+});
+
+test('mcp-disabled-servers round-trips through the injected repository', () => {
+  const operations: string[] = [];
+  const service = createSettingsService(dependencies({
+    mcpDisabledServers: {
+      get: (userId) => { operations.push(`get:${userId}`); return ['github']; },
+      set: (userId, value) => { operations.push(`set:${userId}`); return Array.isArray(value) ? value.map(String) : []; },
+    },
+  }));
+
+  assert.deepEqual(service.getMcpDisabledServers(7), { success: true, servers: ['github'] });
+  assert.deepEqual(service.updateMcpDisabledServers(7, ['fetch', 'github']), {
+    success: true,
+    servers: ['fetch', 'github'],
+  });
+  assert.deepEqual(operations, ['get:7', 'set:7']);
 });

--- a/server/shared/interfaces.ts
+++ b/server/shared/interfaces.ts
@@ -96,21 +96,41 @@ export interface IProvider {
  */
 export interface IProviderFork {
   /**
-   * Copies a session's transcript, up to and including `upToAnchorId` (the
-   * whole conversation when omitted), into a brand-new provider session.
+   * True when the provider keeps every transcript in one shared store rather
+   * than one artifact file per session (OpenCode's opencode.db). The sessions
+   * service then accepts a source row whose `jsonl_path` is legitimately NULL,
+   * and a fork writing back no path of its own.
+   */
+  readonly transcriptIsSharedDatabase?: boolean;
+
+  /**
+   * Copies a session's transcript up to — but NOT including — the message
+   * `upToAnchorId` names, into a brand-new provider session. The whole
+   * conversation is copied when the anchor is omitted.
+   *
+   * Exclusive of the anchored message (and its answer, where the provider
+   * groups them) is the point of the feature: the fork is where the user
+   * takes a different turn from that message, so the copy stops above it.
+   * Adapters whose native cut points are inclusive translate accordingly. When
+   * nothing precedes the anchor — forking from the very first message — there
+   * is no conversation to branch, and adapters report that rather than
+   * silently copying everything.
    *
    * Returns the new provider-native id and the path of the artifact it wrote,
    * so the caller can insert the database row before the filesystem watcher
-   * notices the file and indexes it as an unrelated session.
+   * notices the file and indexes it as an unrelated session. `jsonlPath` is
+   * null for providers with `transcriptIsSharedDatabase` — the copy lives in
+   * the shared store and there is no path to point a row at.
    */
   forkSession(input: {
     providerSessionId: string;
-    jsonlPath: string;
+    /** Null when the source itself lives in a shared store. */
+    jsonlPath: string | null;
     /** The session's working directory — how providers scope a session lookup. */
     projectPath: string;
     upToAnchorId?: string;
     title?: string;
-  }): Promise<{ providerSessionId: string; jsonlPath: string }>;
+  }): Promise<{ providerSessionId: string; jsonlPath: string | null }>;
 }
 
 // ---------------------------

--- a/server/shared/interfaces.ts
+++ b/server/shared/interfaces.ts
@@ -36,7 +36,34 @@ export interface IProviderRuntime {
   ): Promise<unknown>;
   abort(sessionId: string): boolean | Promise<boolean>;
   permissions?: ProviderRuntimePermissionGateway;
+  /**
+   * Snapshot of the session's context-window occupancy, answered by the
+   * provider's own tooling (Claude: the SDK query's `getContextUsage`, the
+   * same data the CLI's `/context` renders). Present only for providers whose
+   * runtime can hold a live handle on the conversation; the info panel then
+   * falls back to deriving the percentage from streamed usage frames.
+   */
+  contextInfo?(sessionId: string): Promise<ProviderContextInfo | null>;
 }
+
+/**
+ * A narrowed view of the provider's context-usage answer — the numbers the
+ * panel's context ring and sources section render. Null fields mean the
+ * provider could not classify that category, and the panel draws `—`.
+ */
+export type ProviderContextInfo = {
+  totalTokens: number | null;
+  maxTokens: number | null;
+  /** 0-100, as the provider itself computed it. */
+  percentage: number | null;
+  model: string | null;
+  categories: Array<{ name: string; tokens: number; kind: 'used' | 'free' | 'buffer' | 'deferred' | string }>;
+  /** Distinct agents / MCP tools / memory files drawing on the window. */
+  agents: Array<{ agentType: string; tokens: number }>;
+  mcpTools: Array<{ name: string; serverName: string; tokens: number }>;
+  memoryFiles: Array<{ path: string; tokens: number }>;
+  slashCommands: { totalCommands: number; includedCommands: number } | null;
+};
 
 /**
  * Main provider contract for CLI and SDK integrations.

--- a/server/shared/interfaces.ts
+++ b/server/shared/interfaces.ts
@@ -16,6 +16,7 @@ import type {
   ProviderRuntimeContext,
   ProviderRuntimePermissionGateway,
   ProviderRuntimeWriter,
+  SubagentSummary,
   UpsertProviderMcpServerInput,
 } from '@/shared/types.js';
 
@@ -243,6 +244,31 @@ export interface IProviderSessions {
    * gateway branches on.
    */
   rewindSession?(sessionId: string, keepThroughId: string | null): Promise<void>;
+
+  /**
+   * The agents one session spawned, newest transcript first, with just enough
+   * per-agent state for a sidebar list: what it was, what it was asked to do,
+   * whether it finished. Providers whose CLI keeps no per-agent transcript
+   * file leave this undefined, and the panel shows them as unsupported.
+   */
+  listSubagents?(
+    sessionId: string,
+    providerSessionId: string,
+    parentRunning: boolean,
+  ): Promise<SubagentSummary[]>;
+
+  /**
+   * One agent's own conversation, normalized like any other history page.
+   * Unlike the folded timeline behind a parent tool call (which caps how much
+   * it transmits), this is the complete record the subagent view pages
+   * through, so the panel can read an agent's whole working log.
+   */
+  fetchSubagentHistory?(
+    sessionId: string,
+    providerSessionId: string,
+    agentId: string,
+    options?: FetchHistoryOptions,
+  ): Promise<FetchHistoryResult>;
 }
 
 // ---------------------------

--- a/server/shared/message-unification.ts
+++ b/server/shared/message-unification.ts
@@ -305,7 +305,67 @@ function readChecklistSignature(message: NormalizedMessage): string {
  */
 const MAX_TOOL_RESULT_CONTENT = 40_000;
 
+/**
+ * True for the shapes that carry a renderable image: an Anthropic/MCP image
+ * block or a bare base64 source. The transcript renders these as pictures, so
+ * their base64 must survive truncation whole — a cut-off payload parses as
+ * neither JSON nor a decodable image and the UI falls back to a base64 wall.
+ */
+function isImageBearingBlock(value: unknown): boolean {
+  const record = readObjectRecord(value);
+  if (!record || typeof record.type !== 'string') {
+    return false;
+  }
+  if (record.type === 'image' || record.type === 'base64') {
+    return true;
+  }
+  const source = readObjectRecord((record as AnyRecord).source);
+  return Boolean(source && source.type === 'base64');
+}
+
+/**
+ * Caps a tool result's content without shredding image blocks.
+ *
+ * When the content is a JSON array of content blocks, each block is capped
+ * separately: text keeps the plain-text rule, and anything image-bearing is
+ * kept whole. Anything else falls back to the plain truncation.
+ */
+function capBlockAware(value: string): string | null {
+  if (!value.startsWith('[')) {
+    return null;
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(value);
+  } catch {
+    return null;
+  }
+
+  if (!Array.isArray(parsed) || !parsed.some(isImageBearingBlock)) {
+    return null;
+  }
+
+  const capped = parsed.map((block) => {
+    if (isImageBearingBlock(block)) {
+      return block;
+    }
+    const record = readObjectRecord(block);
+    if (record && typeof record.text === 'string') {
+      return { ...record, text: truncateOutput(record.text) };
+    }
+    return block;
+  });
+
+  return JSON.stringify(capped);
+}
+
 function truncateOutput(value: string): string {
+  const capped = capBlockAware(value);
+  if (capped !== null) {
+    return capped;
+  }
+
   if (value.length <= MAX_TOOL_RESULT_CONTENT) {
     return value;
   }

--- a/server/shared/tests/message-unification.test.ts
+++ b/server/shared/tests/message-unification.test.ts
@@ -216,3 +216,27 @@ test('a search result keeps every file it found', () => {
   assert.equal(result.numFiles, 900);
   assert.deepEqual(result.filenames, filenames);
 });
+
+test('a content-block array keeps image blocks whole while capping text', () => {
+  const base64 = 'iVBORw0KGgo'.padEnd(60_000, 'A');
+  const longText = 't'.repeat(100_000);
+  const blocks = [
+    { type: 'text', text: longText },
+    { type: 'image', source: { type: 'base64', media_type: 'image/png', data: base64 } },
+  ];
+  const [unified] = prepareTranscriptMessages([
+    message({
+      kind: 'tool_use',
+      toolName: 'mcp__browser__take_screenshot',
+      toolId: 's1',
+      toolInput: {},
+      toolResult: { content: JSON.stringify(blocks) },
+    }),
+  ]);
+
+  const content = String(unified.toolResult?.content);
+  const parsed = JSON.parse(content);
+  assert.equal(parsed.length, 2, 'both blocks survive');
+  assert.equal(parsed[1].source.data, base64, 'the image payload must not be cut mid-base64');
+  assert.match(parsed[0].text, /… \d+ more characters$/, 'oversized text still caps');
+});

--- a/server/shared/types.ts
+++ b/server/shared/types.ts
@@ -320,6 +320,11 @@ export type NormalizedMessage = {
   summary?: string;
   tokenBudget?: unknown;
   /**
+   * The turn's bill, forwarded from the SDK's `result` message on a
+   * `status`/`turn_stats` frame. Absent on every other message.
+   */
+  turnStats?: TurnStats;
+  /**
    * Timeline of everything a subagent did, attached to the `tool_use` that
    * spawned it. Present for Claude `Agent`/`Task` calls and Codex
    * `spawn_agent` calls; absent for every other tool.
@@ -333,6 +338,27 @@ export type NormalizedMessage = {
   sequence?: number;
   rowid?: number;
   [key: string]: unknown;
+};
+
+/**
+ * The turn's bill, forwarded from the SDK's `result` message.
+ *
+ * Field semantics follow the SDK's result contract: `usage` is this turn's
+ * main-loop bill (per-turn, excludes subagents), while `costUsd` and
+ * `modelUsage` are cumulative across the streaming-input session — the
+ * frontend reads the latest frame instead of summing.
+ */
+export type TurnStats = {
+  costUsd: number | null;
+  durationMs: number | null;
+  apiDurationMs: number | null;
+  numTurns: number | null;
+  usage: {
+    inputTokens: number | null;
+    outputTokens: number | null;
+    cacheReadTokens: number | null;
+    cacheCreationTokens: number | null;
+  } | null;
 };
 
 /**

--- a/server/shared/types.ts
+++ b/server/shared/types.ts
@@ -430,6 +430,28 @@ export type SubagentInfo = {
 };
 
 /**
+ * One entry of the sidebar's subagent list — what an agent was, what it was
+ * asked to do, and whether it finished. `status` is composed, not stored: the
+ * agent's `.meta.json` carries no state, so the answer comes from the parent's
+ * task-notification rows and, with no notification yet, from how fresh the
+ * agent's own transcript looks while the parent runs (a quiet parent never
+ * shows a running row, which is what keeps a crashed run's leftover from
+ * spinning forever once the run ends).
+ */
+export type SubagentSummary = {
+  agentId: string;
+  agentType?: string;
+  description?: string;
+  /** The parent's tool call that spawned this agent; the live stream keys off it. */
+  toolUseId?: string;
+  status: 'running' | 'completed' | 'failed';
+  activityCount: number;
+  startedAt?: string;
+  lastActivityAt?: string;
+  model?: string;
+};
+
+/**
  * Output gateway shared by WebSocket and SSE provider runs.
  *
  * Runtime adapters only depend on this structural surface, which keeps them

--- a/server/shared/types.ts
+++ b/server/shared/types.ts
@@ -180,6 +180,7 @@ export type MessageKind =
   | 'tool_use'
   | 'tool_result'
   | 'thinking'
+  | 'thinking_delta'
   | 'stream_delta'
   | 'stream_end'
   | 'error'

--- a/src/index.css
+++ b/src/index.css
@@ -589,13 +589,14 @@
   }
 
   .chat-message {
+    /* Layout containment stays, but NOT `content-visibility: auto`: with a
+       1500-row transcript the browser's own "skip painting what's off
+       screen" bookkeeping goes stale on huge scrollers, and rows render as
+       blank patches whose text is still selectable — the invisible-but-
+       highlightable bug. LazyMessageRow already virtualizes the transcript
+       (unmounted rows are 100px placeholders), so a second layer of
+       browser-side laziness buys nothing and loses content. */
     contain: layout style paint;
-    content-visibility: auto;
-    contain-intrinsic-size: auto 180px;
-  }
-
-  .chat-message.assistant {
-    contain-intrinsic-size: auto 240px;
   }
 
   .chat-message.user,

--- a/src/modules/auth/context/AuthContext.tsx
+++ b/src/modules/auth/context/AuthContext.tsx
@@ -46,7 +46,7 @@ type OnboardingStatusPayload = {
 };
 
 type ApiErrorPayload = {
-  error?: string;
+  error?: string | { code?: string; message?: string };
   message?: string;
 };
 
@@ -80,7 +80,17 @@ function resolveApiErrorMessage(payload: ApiErrorPayload | null, fallback: strin
     return fallback;
   }
 
-  return payload.error ?? payload.message ?? fallback;
+  // AppError responses carry `error` as an object ({ code, message }) while
+  // older endpoints send a plain string; rendering the object as a React
+  // child crashes the whole app, so only a string is ever passed through.
+  if (typeof payload.error === 'string') {
+    return payload.error;
+  }
+  if (payload.error && typeof payload.error.message === 'string') {
+    return payload.error.message;
+  }
+
+  return typeof payload.message === 'string' ? payload.message : fallback;
 }
 
 const AuthContext = createContext<AuthContextValue | null>(null);

--- a/src/modules/chat/ChatInterface.tsx
+++ b/src/modules/chat/ChatInterface.tsx
@@ -164,9 +164,6 @@ function ChatInterface({
     turnStats,
     setTurnStats,
     mergedMessages,
-    visibleMessageCount,
-    visibleMessages,
-    loadEarlierMessages,
     loadAllMessages,
     loadFullTranscript,
     requestOlderMessages,
@@ -545,9 +542,6 @@ function ChatInterface({
           hasMoreMessages={hasMoreMessages}
           totalMessages={totalMessages}
           sessionMessagesCount={chatMessages.length}
-          visibleMessageCount={visibleMessageCount}
-          visibleMessages={visibleMessages}
-          loadEarlierMessages={loadEarlierMessages}
           loadAllMessages={loadAllMessages}
           allMessagesLoaded={allMessagesLoaded}
           isLoadingAllMessages={isLoadingAllMessages}

--- a/src/modules/chat/ChatInterface.tsx
+++ b/src/modules/chat/ChatInterface.tsx
@@ -80,6 +80,11 @@ function ChatInterface({
   const sessionStore = useSessionStore();
   const streamTimerRef = useRef<number | null>(null);
   const accumulatedStreamRef = useRef('');
+  // Thinking stream buffers parallel to the text ones: a turn streams
+  // reasoning first and answer second, and one shared buffer would clobber
+  // the other whenever the two overlapped.
+  const thinkingStreamTimerRef = useRef<number | null>(null);
+  const accumulatedThinkingStreamRef = useRef('');
   // When each session's `chat.subscribe` was last sent; idle acks older than
   // a later local request are discarded as stale.
   const statusCheckSentAtRef = useRef(new Map<string, number>());
@@ -94,6 +99,11 @@ function ChatInterface({
       streamTimerRef.current = null;
     }
     accumulatedStreamRef.current = '';
+    if (thinkingStreamTimerRef.current) {
+      clearTimeout(thinkingStreamTimerRef.current);
+      thinkingStreamTimerRef.current = null;
+    }
+    accumulatedThinkingStreamRef.current = '';
   }, []);
 
   const {
@@ -284,6 +294,8 @@ function ChatInterface({
     setPendingPermissionRequests,
     streamTimerRef,
     accumulatedStreamRef,
+    thinkingStreamTimerRef,
+    accumulatedThinkingStreamRef,
     lastSeqRef,
     statusCheckSentAtRef,
     onSessionProcessing,

--- a/src/modules/chat/ChatInterface.tsx
+++ b/src/modules/chat/ChatInterface.tsx
@@ -26,6 +26,9 @@ import {
 import ChatMessagesPane from '@/modules/chat/transcript/ChatMessagesPane';
 import ChatComposer from '@/modules/chat/composer/ChatComposer';
 import CommandResultModal from '@/modules/chat/modals/CommandResultModal';
+import { SessionInfoPanel } from '@/modules/chat/panel/SessionInfoPanel';
+import { useSessionInfoPanel } from '@/modules/chat/hooks/useSessionInfoPanel';
+import { useDeviceSettings } from '@/shared/hooks/useDeviceSettings';
 
 type ChatInterfaceProps = {
   isActive: boolean;
@@ -129,6 +132,7 @@ function ChatInterface({
     resolvePermissionModeForProvider,
     supportsMessageEditing,
     supportsSessionForking,
+    supportsSessionInsights,
   } = useChatProviderState({
     selectedSession,
     selectedProject,
@@ -152,6 +156,7 @@ function ChatInterface({
     setTokenBudget,
     turnStats,
     setTurnStats,
+    mergedMessages,
     visibleMessageCount,
     visibleMessages,
     loadEarlierMessages,
@@ -183,6 +188,16 @@ function ChatInterface({
     statusCheckSentAtRef,
     lastSeqRef,
     sessionStore,
+  });
+
+  // The right-hand conversation sidebar. Its layout lives in the shared
+  // preference store so the header's toggle button and this mount stay in
+  // step without prop-drilling through the workspace shell.
+  const { isMobile } = useDeviceSettings();
+  const sessionInfo = useSessionInfoPanel({
+    provider,
+    sessionId: selectedSession?.id || currentSessionId || null,
+    supportsInsights: supportsSessionInsights,
   });
 
   // Brand-new conversation: the composer allocated a stable session id via
@@ -435,7 +450,8 @@ function ChatInterface({
 
   return (
     <PermissionContext.Provider value={permissionContextValue}>
-      <div className="flex h-full min-h-0 flex-col">
+      <div className="relative flex h-full min-h-0">
+      <div className="flex h-full min-h-0 flex-1 flex-col">
         <ChatMessagesPane
           scrollContainerRef={scrollContainerRef}
           // Not redundant with the `scroll` listener. A first page is 20 rows,
@@ -579,6 +595,30 @@ function ChatInterface({
           sendByCtrlEnter={sendByCtrlEnter}
         />
         </div>
+      </div>
+
+      {sessionInfo.prefs.open && (selectedSession || currentSessionId) && (
+        <>
+          {isMobile && (
+            <div
+              className="fixed inset-0 z-30 bg-black/40"
+              onClick={() => sessionInfo.setOpen(false)}
+              aria-hidden="true"
+            />
+          )}
+          <SessionInfoPanel
+            collapsed={sessionInfo.prefs.collapsedSections}
+            onToggleSection={sessionInfo.toggleSection}
+            mergedMessages={mergedMessages}
+            turnStats={turnStats}
+            tokenBudget={tokenBudget}
+            contextInfo={sessionInfo.contextInfo}
+            onShowTokenDetails={showCostModal}
+            isMobile={isMobile}
+            onClose={() => sessionInfo.setOpen(false)}
+          />
+        </>
+      )}
       </div>
 
       <CommandResultModal

--- a/src/modules/chat/ChatInterface.tsx
+++ b/src/modules/chat/ChatInterface.tsx
@@ -150,11 +150,15 @@ function ChatInterface({
     setIsUserScrolledUp,
     tokenBudget,
     setTokenBudget,
+    turnStats,
+    setTurnStats,
     visibleMessageCount,
     visibleMessages,
     loadEarlierMessages,
     loadAllMessages,
     loadFullTranscript,
+    requestOlderMessages,
+    scrollToPromptEntry,
     allMessagesLoaded,
     isLoadingAllMessages,
     loadAllJustFinished,
@@ -290,6 +294,7 @@ function ChatInterface({
     selectedSession,
     currentSessionId,
     setTokenBudget,
+    setTurnStats,
     pendingPermissionRequests,
     setPendingPermissionRequests,
     streamTimerRef,
@@ -332,7 +337,8 @@ function ChatInterface({
   }, [resetStreamingState]);
 
   /**
-   * Branches the conversation into a new session that ends at this message,
+   * Branches the conversation into a new session holding everything BEFORE
+   * this message (without it — the fork is where the user retakes that turn),
    * then opens it. The session being viewed is left exactly as it was.
    */
   const handleForkFromMessage = useCallback(async (message: ChatMessage) => {
@@ -482,6 +488,8 @@ function ChatInterface({
           onEditMessage={supportsMessageEditing && !isProcessing ? beginEditMessage : undefined}
           onForkFromMessage={supportsSessionForking ? handleForkFromMessage : undefined}
           onLoadFullTranscript={loadFullTranscript}
+          onSelectPrompt={scrollToPromptEntry}
+          onRequestOlderMessages={requestOlderMessages}
         />
 
         <div className="relative flex-shrink-0">

--- a/src/modules/chat/ChatInterface.tsx
+++ b/src/modules/chat/ChatInterface.tsx
@@ -510,7 +510,11 @@ function ChatInterface({
   return (
     <PermissionContext.Provider value={permissionContextValue}>
       <div className="relative flex h-full min-h-0">
-      <div className="flex h-full min-h-0 flex-1 flex-col">
+      {/* min-w-0: without it the flex item's automatic minimum size lets one
+          wide message (a long code line, a wide table) inflate the whole
+          transcript column past the viewport on narrow screens, and the pane's
+          overflow-x then clips the right-hand content out of view. */}
+      <div className="flex h-full min-h-0 min-w-0 flex-1 flex-col">
         <ChatMessagesPane
           scrollContainerRef={scrollContainerRef}
           // Not redundant with the `scroll` listener. A first page is 20 rows,

--- a/src/modules/chat/ChatInterface.tsx
+++ b/src/modules/chat/ChatInterface.tsx
@@ -22,6 +22,7 @@ import { useChatRealtimeHandlers } from '@/modules/chat/hooks/useChatRealtimeHan
 import { useChatComposerState } from '@/modules/chat/hooks/useChatComposerState';
 import { useSessionStore } from '@/modules/chat/hooks/useSessionStore';
 import { useSessionSubagents } from '@/modules/chat/hooks/useSessionSubagents';
+import { useSessionMcpServers } from '@/modules/chat/hooks/useSessionMcpServers';
 import {
   useProcessingSessions,
   useSessionProtectionActions,
@@ -137,6 +138,7 @@ function ChatInterface({
     supportsMessageEditing,
     supportsSessionForking,
     supportsSessionInsights,
+    supportsMcpToggle,
   } = useChatProviderState({
     selectedSession,
     selectedProject,
@@ -210,6 +212,14 @@ function ChatInterface({
     enabled: sessionInfo.prefs.open,
     supportsInsights: supportsSessionInsights,
     parentRunning: isProcessing,
+  });
+  // The MCP section reads the provider's own server list and the user's
+  // disabled-name set; switches only bite for providers whose runtime
+  // consults the set (the capability matrix says which those are).
+  const mcpSection = useSessionMcpServers({
+    provider,
+    projectPath: selectedProject?.fullPath || selectedProject?.path || null,
+    enabled: sessionInfo.prefs.open && supportsMcpToggle,
   });
   // The agent whose conversation overlay is open, if any. Cleared whenever
   // the roster's session changes so an overlay never outlives its parent.
@@ -660,6 +670,11 @@ function ChatInterface({
             subagents={subagentRoster.subagents}
             subagentsLoading={subagentRoster.loading}
             onSelectSubagent={(summary) => setOpenSubagent({ parentSessionId: activeSessionId ?? '', summary })}
+            mcpServers={mcpSection.servers}
+            mcpLoading={mcpSection.loading}
+            mcpDisabledSet={mcpSection.disabledSet}
+            mcpPendingNames={mcpSection.pendingNames}
+            onToggleMcpServer={mcpSection.toggleServer}
             isMobile={isMobile}
             onClose={() => sessionInfo.setOpen(false)}
           />

--- a/src/modules/chat/ChatInterface.tsx
+++ b/src/modules/chat/ChatInterface.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useRef } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { ArrowDownIcon } from 'lucide-react';
 
@@ -12,13 +12,16 @@ import type {
   ProjectSession,
   SessionEstablishedContext,
   SessionNavigationOptions,
+  SubagentSummary,
 } from '@/shared/types';
+import { writeDraftText } from '@/shared/chatDrafts';
 import { useChatProviderState } from '@/modules/chat/hooks/useChatProviderState';
 import { useScheduledMessages } from '@/modules/chat/composer/useScheduledMessages';
 import { useChatSessionState } from '@/modules/chat/hooks/useChatSessionState';
 import { useChatRealtimeHandlers } from '@/modules/chat/hooks/useChatRealtimeHandlers';
 import { useChatComposerState } from '@/modules/chat/hooks/useChatComposerState';
 import { useSessionStore } from '@/modules/chat/hooks/useSessionStore';
+import { useSessionSubagents } from '@/modules/chat/hooks/useSessionSubagents';
 import {
   useProcessingSessions,
   useSessionProtectionActions,
@@ -27,6 +30,7 @@ import ChatMessagesPane from '@/modules/chat/transcript/ChatMessagesPane';
 import ChatComposer from '@/modules/chat/composer/ChatComposer';
 import CommandResultModal from '@/modules/chat/modals/CommandResultModal';
 import { SessionInfoPanel } from '@/modules/chat/panel/SessionInfoPanel';
+import { SubagentChatModal } from '@/modules/chat/panel/SubagentChatModal';
 import { useSessionInfoPanel } from '@/modules/chat/hooks/useSessionInfoPanel';
 import { useDeviceSettings } from '@/shared/hooks/useDeviceSettings';
 
@@ -194,11 +198,22 @@ function ChatInterface({
   // preference store so the header's toggle button and this mount stay in
   // step without prop-drilling through the workspace shell.
   const { isMobile } = useDeviceSettings();
+  const activeSessionId = selectedSession?.id || currentSessionId || null;
   const sessionInfo = useSessionInfoPanel({
     provider,
-    sessionId: selectedSession?.id || currentSessionId || null,
+    sessionId: activeSessionId,
     supportsInsights: supportsSessionInsights,
   });
+  const subagentRoster = useSessionSubagents({
+    provider,
+    sessionId: activeSessionId,
+    enabled: sessionInfo.prefs.open,
+    supportsInsights: supportsSessionInsights,
+    parentRunning: isProcessing,
+  });
+  // The agent whose conversation overlay is open, if any. Cleared whenever
+  // the roster's session changes so an overlay never outlives its parent.
+  const [openSubagent, setOpenSubagent] = useState<{ parentSessionId: string; summary: SubagentSummary } | null>(null);
 
   // Brand-new conversation: the composer allocated a stable session id via
   // the session gateway before the first send. Record it locally and put it
@@ -208,6 +223,34 @@ function ChatInterface({
     onSessionEstablished?.(sessionId, context);
     onNavigateToSession?.(sessionId);
   }, [setCurrentSessionId, onSessionEstablished, onNavigateToSession]);
+
+  // "Continue" with a finished agent: its process is gone, so the
+  // conversation restarts as a brand-new session. The packaged first message
+  // (identity + work log + the user's words) is written into that session's
+  // draft and the workspace navigates there — the user sees the packed
+  // context, may edit it, and sends it through the composer's full pipeline
+  // (model, permission mode, attachments) exactly like any first message.
+  const handleSubagentContinue = useCallback(async (prompt: string): Promise<boolean> => {
+    if (!selectedProject) return false;
+    const response = await api.providers.createSession({
+      provider,
+      projectPath: selectedProject.fullPath || selectedProject.path || '',
+      initialMessage: prompt,
+    });
+    if (!response.ok) return false;
+    const body = (await response.json()) as { data?: { sessionId?: string; sessionName?: string } };
+    const newSessionId = body?.data?.sessionId || null;
+    if (!newSessionId) return false;
+
+    writeDraftText(newSessionId, prompt);
+    const returnedName = typeof body?.data?.sessionName === 'string' ? body.data.sessionName.trim() : '';
+    handleSessionEstablished(newSessionId, {
+      provider,
+      project: selectedProject,
+      summary: returnedName || prompt.slice(0, 60),
+    });
+    return true;
+  }, [provider, selectedProject, handleSessionEstablished]);
 
   const {
     input,
@@ -614,12 +657,27 @@ function ChatInterface({
             tokenBudget={tokenBudget}
             contextInfo={sessionInfo.contextInfo}
             onShowTokenDetails={showCostModal}
+            subagents={subagentRoster.subagents}
+            subagentsLoading={subagentRoster.loading}
+            onSelectSubagent={(summary) => setOpenSubagent({ parentSessionId: activeSessionId ?? '', summary })}
             isMobile={isMobile}
             onClose={() => sessionInfo.setOpen(false)}
           />
         </>
       )}
       </div>
+
+      {openSubagent && openSubagent.parentSessionId && (
+        <SubagentChatModal
+          parentSessionId={openSubagent.parentSessionId}
+          summary={openSubagent.summary}
+          parentLiveMessages={openSubagent.parentSessionId === activeSessionId ? mergedMessages : sessionStore.getMessages(openSubagent.parentSessionId)}
+          provider={provider}
+          selectedProject={selectedProject}
+          onClose={() => setOpenSubagent(null)}
+          onContinue={handleSubagentContinue}
+        />
+      )}
 
       <CommandResultModal
         payload={commandModalPayload}

--- a/src/modules/chat/ChatInterface.tsx
+++ b/src/modules/chat/ChatInterface.tsx
@@ -23,6 +23,7 @@ import { useChatComposerState } from '@/modules/chat/hooks/useChatComposerState'
 import { useSessionStore } from '@/modules/chat/hooks/useSessionStore';
 import { useSessionSubagents } from '@/modules/chat/hooks/useSessionSubagents';
 import { useSessionMcpServers } from '@/modules/chat/hooks/useSessionMcpServers';
+import { useSessionSkills } from '@/modules/chat/hooks/useSessionSkills';
 import {
   useProcessingSessions,
   useSessionProtectionActions,
@@ -219,7 +220,15 @@ function ChatInterface({
   const mcpSection = useSessionMcpServers({
     provider,
     projectPath: selectedProject?.fullPath || selectedProject?.path || null,
-    enabled: sessionInfo.prefs.open && supportsMcpToggle,
+    enabled: sessionInfo.prefs.open,
+    canToggle: supportsMcpToggle,
+  });
+  // The sources section's skill count; every provider answers the skills
+  // endpoint, so no capability gate — the panel being open is the gate.
+  const skillList = useSessionSkills({
+    provider,
+    projectPath: selectedProject?.fullPath || selectedProject?.path || null,
+    enabled: sessionInfo.prefs.open,
   });
   // The agent whose conversation overlay is open, if any. Cleared whenever
   // the roster's session changes so an overlay never outlives its parent.
@@ -675,6 +684,9 @@ function ChatInterface({
             mcpDisabledSet={mcpSection.disabledSet}
             mcpPendingNames={mcpSection.pendingNames}
             onToggleMcpServer={mcpSection.toggleServer}
+            mcpCanToggle={mcpSection.canToggle}
+            skills={skillList.skills}
+            skillsLoading={skillList.loading}
             isMobile={isMobile}
             onClose={() => sessionInfo.setOpen(false)}
           />

--- a/src/modules/chat/hooks/useActivePromptEntry.ts
+++ b/src/modules/chat/hooks/useActivePromptEntry.ts
@@ -1,0 +1,83 @@
+import { useEffect, useRef, useState } from 'react';
+import type { RefObject } from 'react';
+
+import type { PromptEntry } from '@/modules/chat/utils/promptNavigator';
+
+/** Portion of the viewport height above which a row counts as "being read". */
+const ACTIVE_ROW_VIEWPORT_FRACTION = 0.35;
+
+/**
+ * Tracks which prompt the scroll position is currently reading: the newest
+ * transcript row whose top has passed the upper third of the viewport, mapped
+ * back to its navigator entry. The rail centers its tape on this entry and
+ * renders its tick darker.
+ */
+export function useActivePromptEntry(
+  scrollContainerRef: RefObject<HTMLDivElement>,
+  entries: PromptEntry[],
+): string | null {
+  const [activeId, setActiveId] = useState<string | null>(null);
+  const entriesRef = useRef(entries);
+  entriesRef.current = entries;
+
+  useEffect(() => {
+    const container = scrollContainerRef.current;
+    if (!container || entries.length === 0) {
+      setActiveId(null);
+      return undefined;
+    }
+
+    let frame = 0;
+    const compute = () => {
+      frame = 0;
+      const rows = container.querySelectorAll<HTMLElement>('[data-message-timestamp]');
+      const threshold =
+        container.getBoundingClientRect().top + container.clientHeight * ACTIVE_ROW_VIEWPORT_FRACTION;
+
+      let timestamp: string | null = null;
+      for (let index = 0; index < rows.length; index += 1) {
+        if (rows[index].getBoundingClientRect().top <= threshold) {
+          timestamp = rows[index].getAttribute('data-message-timestamp');
+        } else {
+          break;
+        }
+      }
+      if (timestamp === null && rows.length > 0) {
+        timestamp = rows[0].getAttribute('data-message-timestamp');
+      }
+
+      // The row being read is usually an assistant reply or tool group below
+      // its prompt, so the active entry is the newest prompt at or before that
+      // row's timestamp — not an exact-timestamp match.
+      const passedTime = timestamp === null ? -Infinity : new Date(timestamp).getTime();
+      let matchId: string | null = null;
+      for (const entry of entriesRef.current) {
+        const entryTime = new Date(String(entry.timestamp)).getTime();
+        if (Number.isFinite(entryTime) && entryTime <= passedTime) {
+          matchId = entry.id;
+        } else {
+          break;
+        }
+      }
+      // Nothing passed yet (scrolled to the very top): the first prompt.
+      setActiveId(matchId ?? entriesRef.current[0]?.id ?? null);
+    };
+
+    const requestCompute = () => {
+      if (frame === 0) {
+        frame = requestAnimationFrame(compute);
+      }
+    };
+
+    compute();
+    container.addEventListener('scroll', requestCompute, { passive: true });
+    return () => {
+      container.removeEventListener('scroll', requestCompute);
+      if (frame !== 0) {
+        cancelAnimationFrame(frame);
+      }
+    };
+  }, [entries, scrollContainerRef]);
+
+  return activeId;
+}

--- a/src/modules/chat/hooks/useChatMessages.ts
+++ b/src/modules/chat/hooks/useChatMessages.ts
@@ -308,6 +308,22 @@ export function normalizedToChatMessages(messages: NormalizedMessage[]): ChatMes
         }
         break;
 
+      case 'thinking_delta':
+        // Accumulated reasoning row from the session store's thinking stream
+        // (updateStreamingThinking); renders as a live-open Reasoning bubble
+        // that the finished `thinking` row replaces.
+        if (msg.content?.trim()) {
+          converted.push({
+            type: 'assistant',
+            content: msg.content,
+            timestamp: msg.timestamp,
+            isThinking: true,
+            isStreaming: true,
+            ...sharedMetadata,
+          });
+        }
+        break;
+
       case 'error':
         converted.push({
           type: 'error',

--- a/src/modules/chat/hooks/useChatProviderState.ts
+++ b/src/modules/chat/hooks/useChatProviderState.ts
@@ -65,6 +65,7 @@ type ProviderCapabilities = {
   supportsEffort?: boolean;
   supportsMessageEditing?: boolean;
   supportsSessionForking?: boolean;
+  supportsSessionInsights?: boolean;
 };
 
 type ProviderCapabilitiesApiResponse = {
@@ -471,6 +472,7 @@ export function useChatProviderState({ selectedSession, selectedProject: _select
    */
   const supportsMessageEditing = Boolean(providerCapabilities?.[provider]?.supportsMessageEditing);
   const supportsSessionForking = Boolean(providerCapabilities?.[provider]?.supportsSessionForking);
+  const supportsSessionInsights = Boolean(providerCapabilities?.[provider]?.supportsSessionInsights);
 
   const resolvePermissionModeForProvider = useCallback((
     targetProvider: LLMProvider,
@@ -830,5 +832,6 @@ export function useChatProviderState({ selectedSession, selectedProject: _select
     resolvePermissionModeForProvider,
     supportsMessageEditing,
     supportsSessionForking,
+    supportsSessionInsights,
   };
 }

--- a/src/modules/chat/hooks/useChatProviderState.ts
+++ b/src/modules/chat/hooks/useChatProviderState.ts
@@ -66,6 +66,7 @@ type ProviderCapabilities = {
   supportsMessageEditing?: boolean;
   supportsSessionForking?: boolean;
   supportsSessionInsights?: boolean;
+  supportsMcpToggle?: boolean;
 };
 
 type ProviderCapabilitiesApiResponse = {
@@ -473,6 +474,7 @@ export function useChatProviderState({ selectedSession, selectedProject: _select
   const supportsMessageEditing = Boolean(providerCapabilities?.[provider]?.supportsMessageEditing);
   const supportsSessionForking = Boolean(providerCapabilities?.[provider]?.supportsSessionForking);
   const supportsSessionInsights = Boolean(providerCapabilities?.[provider]?.supportsSessionInsights);
+  const supportsMcpToggle = Boolean(providerCapabilities?.[provider]?.supportsMcpToggle);
 
   const resolvePermissionModeForProvider = useCallback((
     targetProvider: LLMProvider,
@@ -833,5 +835,6 @@ export function useChatProviderState({ selectedSession, selectedProject: _select
     supportsMessageEditing,
     supportsSessionForking,
     supportsSessionInsights,
+    supportsMcpToggle,
   };
 }

--- a/src/modules/chat/hooks/useChatRealtimeHandlers.ts
+++ b/src/modules/chat/hooks/useChatRealtimeHandlers.ts
@@ -1,7 +1,7 @@
 import { useEffect, useRef } from 'react';
 import type { Dispatch, MutableRefObject, SetStateAction } from 'react';
 
-import type { ServerEvent,MarkSessionIdle,MarkSessionProcessing,PendingPermissionRequest,ProjectSession,LLMProvider,NormalizedMessage } from '@/shared/types';
+import type { ServerEvent,MarkSessionIdle,MarkSessionProcessing,PendingPermissionRequest,ProjectSession,LLMProvider,NormalizedMessage,TurnStats } from '@/shared/types';
 import { showCompletionTitleIndicator } from '@/modules/chat/utils/pageTitleNotification';
 import { playChatCompletionSound, playNotificationSound } from '@/shared/utils';
 import type { SessionStore } from '@/modules/chat/hooks/useSessionStore';
@@ -21,6 +21,7 @@ type UseChatRealtimeHandlersArgs = {
   selectedSession: ProjectSession | null;
   currentSessionId: string | null;
   setTokenBudget: (budget: Record<string, unknown> | null) => void;
+  setTurnStats: (stats: TurnStats | null) => void;
   pendingPermissionRequests: PendingPermissionRequest[];
   setPendingPermissionRequests: Dispatch<SetStateAction<PendingPermissionRequest[]>>;
   streamTimerRef: MutableRefObject<number | null>;
@@ -63,6 +64,7 @@ export function useChatRealtimeHandlers({
   selectedSession,
   currentSessionId,
   setTokenBudget,
+  setTurnStats,
   pendingPermissionRequests,
   setPendingPermissionRequests,
   streamTimerRef,
@@ -389,6 +391,13 @@ export function useChatRealtimeHandlers({
             if (sid === activeViewSessionId) {
               setTokenBudget(msg.tokenBudget as Record<string, unknown>);
             }
+          } else if (msg.text === 'turn_stats' && msg.turnStats) {
+            // Same session-scoping rule as the budget: the panel shows the
+            // viewed session's bill, and a sibling run's result frame must not
+            // replace it.
+            if (sid === activeViewSessionId) {
+              setTurnStats(msg.turnStats as TurnStats);
+            }
           } else if (msg.text && sid) {
             onSessionProcessing?.(sid, {
               statusText: msg.text as string,
@@ -412,6 +421,7 @@ export function useChatRealtimeHandlers({
     selectedSession,
     currentSessionId,
     setTokenBudget,
+    setTurnStats,
     pendingPermissionRequests,
     setPendingPermissionRequests,
     streamTimerRef,

--- a/src/modules/chat/hooks/useChatRealtimeHandlers.ts
+++ b/src/modules/chat/hooks/useChatRealtimeHandlers.ts
@@ -25,6 +25,8 @@ type UseChatRealtimeHandlersArgs = {
   setPendingPermissionRequests: Dispatch<SetStateAction<PendingPermissionRequest[]>>;
   streamTimerRef: MutableRefObject<number | null>;
   accumulatedStreamRef: MutableRefObject<string>;
+  thinkingStreamTimerRef: MutableRefObject<number | null>;
+  accumulatedThinkingStreamRef: MutableRefObject<string>;
   /**
    * Highest live `seq` observed per session. Essential for reconnect catch-up:
    * `chat.subscribe` sends this value as `lastSeq` so the server replays only
@@ -65,6 +67,8 @@ export function useChatRealtimeHandlers({
   setPendingPermissionRequests,
   streamTimerRef,
   accumulatedStreamRef,
+  thinkingStreamTimerRef,
+  accumulatedThinkingStreamRef,
   lastSeqRef,
   statusCheckSentAtRef,
   onSessionProcessing,
@@ -186,9 +190,43 @@ export function useChatRealtimeHandlers({
       /* -------------------------------------------------------------- */
 
       // --- Streaming: buffer for performance ---
+      if (msg.kind === 'thinking_delta') {
+        const text = (msg.content as string) || '';
+        if (!text) return;
+        accumulatedThinkingStreamRef.current += text;
+        if (!thinkingStreamTimerRef.current) {
+          thinkingStreamTimerRef.current = window.setTimeout(() => {
+            thinkingStreamTimerRef.current = null;
+            if (sid) {
+              sessionStore.updateStreamingThinking(sid, accumulatedThinkingStreamRef.current, provider);
+            }
+          }, 100);
+        }
+        // Also route to store for non-active sessions
+        if (sid && sid !== activeViewSessionId) {
+          sessionStore.appendRealtime(sid, msg as unknown as NormalizedMessage);
+        }
+        return;
+      }
+
       if (msg.kind === 'stream_delta') {
         const text = (msg.content as string) || '';
         if (!text) return;
+        // Reasoning precedes the answer, so the first answer delta means the
+        // thinking stream is over: freeze the accumulated bubble.
+        if (accumulatedThinkingStreamRef.current || thinkingStreamTimerRef.current) {
+          if (thinkingStreamTimerRef.current) {
+            clearTimeout(thinkingStreamTimerRef.current);
+            thinkingStreamTimerRef.current = null;
+          }
+          if (sid && accumulatedThinkingStreamRef.current) {
+            sessionStore.updateStreamingThinking(sid, accumulatedThinkingStreamRef.current, provider);
+          }
+          if (sid) {
+            sessionStore.finalizeStreamingThinking(sid);
+          }
+          accumulatedThinkingStreamRef.current = '';
+        }
         accumulatedStreamRef.current += text;
         if (!streamTimerRef.current) {
           streamTimerRef.current = window.setTimeout(() => {
@@ -210,11 +248,20 @@ export function useChatRealtimeHandlers({
           clearTimeout(streamTimerRef.current);
           streamTimerRef.current = null;
         }
+        if (thinkingStreamTimerRef.current) {
+          clearTimeout(thinkingStreamTimerRef.current);
+          thinkingStreamTimerRef.current = null;
+        }
         if (sid) {
           if (accumulatedStreamRef.current) {
             sessionStore.updateStreaming(sid, accumulatedStreamRef.current, provider);
           }
           sessionStore.finalizeStreaming(sid);
+          if (accumulatedThinkingStreamRef.current) {
+            sessionStore.updateStreamingThinking(sid, accumulatedThinkingStreamRef.current, provider);
+            sessionStore.finalizeStreamingThinking(sid);
+            accumulatedThinkingStreamRef.current = '';
+          }
         }
         accumulatedStreamRef.current = '';
         return;
@@ -245,6 +292,15 @@ export function useChatRealtimeHandlers({
             sessionStore.finalizeStreaming(sid);
           }
           accumulatedStreamRef.current = '';
+          if (thinkingStreamTimerRef.current) {
+            clearTimeout(thinkingStreamTimerRef.current);
+            thinkingStreamTimerRef.current = null;
+          }
+          if (sid && accumulatedThinkingStreamRef.current) {
+            sessionStore.updateStreamingThinking(sid, accumulatedThinkingStreamRef.current, provider);
+            sessionStore.finalizeStreamingThinking(sid);
+          }
+          accumulatedThinkingStreamRef.current = '';
 
           // `complete` is the unified terminal event — every provider run ends
           // with exactly one, regardless of success, failure, or abort. The
@@ -360,6 +416,8 @@ export function useChatRealtimeHandlers({
     setPendingPermissionRequests,
     streamTimerRef,
     accumulatedStreamRef,
+    thinkingStreamTimerRef,
+    accumulatedThinkingStreamRef,
     lastSeqRef,
     statusCheckSentAtRef,
     onSessionProcessing,

--- a/src/modules/chat/hooks/useChatSessionState.ts
+++ b/src/modules/chat/hooks/useChatSessionState.ts
@@ -551,6 +551,13 @@ export function useChatSessionState({
 
     const nearBottom = isNearBottom();
     setIsUserScrolledUp(!nearBottom);
+    // Write the ref mirror here, not just from the [isUserScrolledUp] effect:
+    // during heavy streaming renders, the state→effect round-trip can lag past
+    // the 50 ms follow-bottom timer, which reads the ref at fire time. With a
+    // stale `false` the timer yanked the view back down right after the user
+    // dragged up — and once at the bottom, isNearBottom re-armed sticky
+    // follow, so the snap sustained itself for the rest of the run.
+    isUserScrolledUpRef.current = !nearBottom;
     scrollPositionRef.current = {
       height: container.scrollHeight,
       top: container.scrollTop,
@@ -1070,7 +1077,12 @@ export function useChatSessionState({
         }
       }, 50);
     }
-  }, [chatMessages.length, isActive, isLoadingMoreMessages, isUserScrolledUp, scrollToBottom]);
+    // Dep is the array identity, not `.length`: streaming replaces the
+    // well-known `__streaming_*` row in place, so the transcript grows while
+    // the message count sits still — a length-keyed dep never re-ran during
+    // streaming. The fire-time ref re-check still cancels a snap when the
+    // user scrolls up inside the 50 ms grace.
+  }, [chatMessages, isActive, isLoadingMoreMessages, isUserScrolledUp, scrollToBottom]);
 
   useEffect(() => {
     const container = scrollContainerRef.current;

--- a/src/modules/chat/hooks/useChatSessionState.ts
+++ b/src/modules/chat/hooks/useChatSessionState.ts
@@ -1345,6 +1345,10 @@ export function useChatSessionState({
     setTokenBudget,
     turnStats,
     setTurnStats,
+    // The merged normalized transcript behind chatMessages, for consumers that
+    // need the raw kinds (tool_use replay, subagent grouping) instead of the
+    // rendered projection.
+    mergedMessages: storeMessages,
     visibleMessageCount,
     visibleMessages,
     loadEarlierMessages,

--- a/src/modules/chat/hooks/useChatSessionState.ts
+++ b/src/modules/chat/hooks/useChatSessionState.ts
@@ -2,13 +2,15 @@ import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } fr
 import type { MutableRefObject } from 'react';
 
 import { api } from '@/shared/api';
-import type { MarkSessionIdle, SessionActivityMap,Project,ProjectSession,LLMProvider,NormalizedMessage,ChatMessage,DiffCalculator } from '@/shared/types';
+import type { MarkSessionIdle, SessionActivityMap,Project,ProjectSession,LLMProvider,NormalizedMessage,ChatMessage,DiffCalculator,TurnStats } from '@/shared/types';
 import type { SessionStore } from '@/modules/chat/hooks/useSessionStore';
 import { SESSION_MESSAGES_PAGE_SIZE } from '@/modules/chat/utils/sessionMessagePagination';
 import { createMessageHistoryRefreshCoordinator } from '@/modules/chat/utils/messageHistoryRefreshCoordinator';
 import { createCachedDiffCalculator } from '@/modules/chat/utils/messageTransforms';
 import { normalizedToChatMessages } from '@/modules/chat/hooks/useChatMessages';
 import { findSearchTargetIndex, resolveSearchWindowSize } from '@/modules/chat/utils/searchTargetLocator';
+import { buildPromptPreview } from '@/modules/chat/utils/promptNavigator';
+import type { PromptEntry } from '@/modules/chat/utils/promptNavigator';
 import { readSelectedProvider } from '@/shared/selectedProvider';
 import type { SearchTarget } from '@/modules/chat/utils/searchTargetLocator';
 
@@ -200,6 +202,7 @@ export function useChatSessionState({
   const [totalMessages, setTotalMessages] = useState(0);
   const [isUserScrolledUp, setIsUserScrolledUp] = useState(false);
   const [tokenBudget, setTokenBudget] = useState<Record<string, unknown> | null>(null);
+  const [turnStats, setTurnStats] = useState<TurnStats | null>(null);
   const [visibleMessageCount, setVisibleMessageCount] = useState(INITIAL_VISIBLE_MESSAGES);
   const [allMessagesLoaded, setAllMessagesLoaded] = useState(false);
   const [isLoadingAllMessages, setIsLoadingAllMessages] = useState(false);
@@ -227,6 +230,16 @@ export function useChatSessionState({
   const isUserScrolledUpRef = useRef(false);
   const isLoadingMoreRef = useRef(false);
   const allMessagesLoadedRef = useRef(false);
+  /**
+   * Per-session outcome of the prompt navigator's full-transcript prefetch:
+   * 'inflight' while the unbounded fetch runs, 'complete' once the store holds
+   * the whole transcript, 'unsupported' when the provider refused the
+   * unbounded page (so we stop hammering it and let "load older" walk instead).
+   * 'complete' is re-checked against the slot on every activation: a bounded
+   * reload that shrank the cache again must re-arm the prefetch instead of
+   * being trusted forever.
+   */
+  const promptNavigatorPrefetchRef = useRef(new Map<string, 'inflight' | 'complete' | 'unsupported'>());
   const topLoadLockRef = useRef(false);
   const pendingScrollRestoreRef = useRef<ScrollRestoreState | null>(null);
   const pendingInitialScrollRef = useRef(true);
@@ -278,6 +291,7 @@ export function useChatSessionState({
     setTotalMessages(0);
     
     setTokenBudget(null);
+    setTurnStats(null);
     setVisibleMessageCount(INITIAL_VISIBLE_MESSAGES);
     setAllMessagesLoaded(false);
     allMessagesLoadedRef.current = false;
@@ -330,8 +344,14 @@ export function useChatSessionState({
     async () => true,
   );
   latestRefreshExecutorRef.current = async (sessionId: string) => {
+    // Once the prompt navigator's prefetch has hydrated the whole transcript,
+    // every refresh must re-request the whole transcript. A bounded 20-row
+    // tail page cannot bridge against the full cache (no overlap), and the
+    // store would fall back to keeping — effectively shrinking the rail back
+    // to one page.
+    const limit = allMessagesLoadedRef.current ? null : SESSION_MESSAGES_PAGE_SIZE;
     const result = await sessionStore.refreshLatestFromServer(sessionId, {
-      limit: SESSION_MESSAGES_PAGE_SIZE,
+      limit,
       canRequest: () => (
         isActiveRef.current
         && activeSessionIdRef.current === sessionId
@@ -344,6 +364,9 @@ export function useChatSessionState({
       messagesOffsetRef.current = slot.offset;
       if (slot.tokenUsage !== undefined) {
         setTokenBudget((slot.tokenUsage as Record<string, unknown> | null) ?? null);
+        // The turn bill has no transcript backing (the jsonl never stores the
+        // provider's result) — a session switch must not carry the old one.
+        setTurnStats(null);
       }
     }
     return !result.deferred;
@@ -483,6 +506,9 @@ export function useChatSessionState({
         messagesOffsetRef.current = slot.offset;
         if (slot.tokenUsage !== undefined) {
           setTokenBudget((slot.tokenUsage as Record<string, unknown> | null) ?? null);
+        // The turn bill has no transcript backing (the jsonl never stores the
+        // provider's result) — a session switch must not carry the old one.
+        setTurnStats(null);
         }
 
         if (prependedCount === 0) {
@@ -556,8 +582,21 @@ export function useChatSessionState({
       }
       const didLoad = await loadOlderMessages(container);
       if (didLoad) topLoadLockRef.current = true;
+      return;
     }
-  }, [hasMoreMessages, isActive, isNearBottom, loadOlderMessages]);
+
+    // Everything is in the store (prefetch finished, or load-all ran), yet the
+    // render window still clips older rows. Reaching the top widens it another
+    // page — scrolling up keeps yielding history without a "load 100" click.
+    // The same lock pattern re-arms after the user scrolls away from the top
+    // and back, so one arrival at the top reveals one page, not all of it.
+    if (visibleMessageCount >= chatMessages.length) return;
+    // No anchor restore here (unlike the server path): the user is at the
+    // top, nothing exists above them to shift, and the prepended rows mount
+    // into view from the top of the container.
+    setVisibleMessageCount((prev) => Math.min(chatMessages.length, prev + SESSION_MESSAGES_PAGE_SIZE * 5));
+    topLoadLockRef.current = true;
+  }, [chatMessages.length, hasMoreMessages, isActive, isNearBottom, loadOlderMessages, visibleMessageCount]);
 
   const wasChatActiveRef = useRef(isActive);
   useLayoutEffect(() => {
@@ -698,6 +737,7 @@ export function useChatSessionState({
       setHasMoreMessages(false);
       setTotalMessages(0);
       setTokenBudget(null);
+      setTurnStats(null);
       lastLoadedSessionKeyRef.current = null;
       return;
     }
@@ -745,6 +785,7 @@ export function useChatSessionState({
 
     if (sessionChanged) {
       setTokenBudget(null);
+      setTurnStats(null);
     }
 
     setCurrentSessionId(selectedSessionId);
@@ -753,6 +794,24 @@ export function useChatSessionState({
 
     // Fetch from server → store updates → chatMessages re-derives automatically
     setIsLoadingSessionMessages(true);
+    // A session whose transcript the prompt navigator already hydrated does
+    // not re-enter through fetchFromServer: that replaces the cache wholesale,
+    // so re-downloading everything to catch a few new rows wastes the whole
+    // transcript. Reconcile instead — the latest-page refresh reads from the
+    // newest cached row and only bridges the rows added since.
+    if (
+      promptNavigatorPrefetchRef.current.get(selectedSessionId) === 'complete'
+      && existingSlot
+      && existingSlot.serverMessages.length > 0
+    ) {
+      void requestLatestMessages(selectedSessionId).finally(() => {
+        if (activeSessionIdRef.current === selectedSessionId) {
+          setIsLoadingSessionMessages(false);
+        }
+      });
+      return;
+    }
+
     sessionStore.fetchFromServer(selectedSessionId, {
       limit: SESSION_MESSAGES_PAGE_SIZE,
       offset: 0,
@@ -765,8 +824,19 @@ export function useChatSessionState({
         setHasMoreMessages(slot.hasMore);
         setTotalMessages(slot.total);
         messagesOffsetRef.current = slot.offset;
+        // Only trust a reported end-of-history when the page could actually
+        // hold it; a bounded page claiming hasMore=false over a larger total
+        // is a provider lie, and flagging it as loaded would strand the rail
+        // on one page (the prefetch would see hasMore=false and stand down).
+        if (!slot.hasMore && slot.total <= slot.offset) {
+          allMessagesLoadedRef.current = true;
+          setAllMessagesLoaded(true);
+        }
         if (slot.tokenUsage !== undefined) {
           setTokenBudget((slot.tokenUsage as Record<string, unknown> | null) ?? null);
+        // The turn bill has no transcript backing (the jsonl never stores the
+        // provider's result) — a session switch must not carry the old one.
+        setTurnStats(null);
         }
       }
       setIsLoadingSessionMessages(false);
@@ -954,6 +1024,7 @@ export function useChatSessionState({
   useEffect(() => {
     if (!selectedSession?.id) {
       setTokenBudget(null);
+      setTurnStats(null);
       return;
     }
     const fetchInitialTokenUsage = async () => {
@@ -965,6 +1036,7 @@ export function useChatSessionState({
           setTokenBudget(payload.data ?? null);
         } else {
           setTokenBudget(null);
+      setTurnStats(null);
         }
       } catch (error) {
         console.error('Failed to fetch initial token usage:', error);
@@ -1098,6 +1170,163 @@ export function useChatSessionState({
     setVisibleMessageCount((prev) => prev + 100);
   }, []);
 
+  /* ------------------------------------------------------------------ */
+  /*  Full-transcript prefetch (prompt navigator)                        */
+  /* ------------------------------------------------------------------ */
+
+  // The rail is a map of the whole conversation, not of the loaded page: its
+  // ticks and jump targets must exist before the user scrolls there. Once a
+  // session's first page lands, pull the rest of the transcript into the store
+  // in the background. Rendering stays windowed (rows lazy-mount near the
+  // viewport), so this grows the data, never the visible DOM.
+  useEffect(() => {
+    if (!isActive) return;
+    const sessionId = selectedSession?.id;
+    if (!sessionId || isLoadingSessionMessages || chatMessages.length === 0) return;
+    const prefetchState = promptNavigatorPrefetchRef.current.get(sessionId);
+    if (prefetchState === 'inflight' || prefetchState === 'unsupported') return;
+    const slot = sessionStore.getSessionSlot(sessionId);
+    if (!slot || !slot.hasMore) return;
+
+    promptNavigatorPrefetchRef.current.set(sessionId, 'inflight');
+    void sessionStore
+      .fetchFromServer(sessionId, {
+        limit: null,
+        offset: 0,
+        canRequest: () => isActiveRef.current && activeSessionIdRef.current === sessionId,
+      })
+      .then((refreshed) => {
+        if (!refreshed) {
+          // Cancelled mid-flight (session switched away); let a later
+          // re-select retry instead of caching a no-op as complete.
+          promptNavigatorPrefetchRef.current.delete(sessionId);
+          return;
+        }
+        if (!refreshed.hasMore) {
+          promptNavigatorPrefetchRef.current.set(sessionId, 'complete');
+          if (activeSessionIdRef.current === sessionId) {
+            setHasMoreMessages(false);
+            setTotalMessages(refreshed.total);
+            messagesOffsetRef.current = refreshed.offset;
+            // The store now owns the whole transcript, so scrolling to the top
+            // switches from "fetch older" to "widen the render window" in
+            // handleScroll. Without this the flag stays false forever and the
+            // widening branch is unreachable.
+            allMessagesLoadedRef.current = true;
+            setAllMessagesLoaded(true);
+          }
+        } else {
+          // The provider could not serve the unbounded page; stop retrying the
+          // unbounded fetch and let a scroll-to-top "load older" walk the
+          // history instead.
+          promptNavigatorPrefetchRef.current.set(sessionId, 'unsupported');
+        }
+      })
+      .catch(() => {
+        // The rail just covers what is loaded until a retry succeeds.
+        promptNavigatorPrefetchRef.current.delete(sessionId);
+      });
+  }, [isActive, isLoadingSessionMessages, chatMessages.length, sessionStore, selectedSession?.id]);
+
+  /**
+   * Server-side "load older": fetches the previous page of history, the same
+   * path scroll-to-top triggers. The prompt navigator's load-more button calls
+   * this so ticks for not-yet-loaded prompts can appear.
+   */
+  const requestOlderMessages = useCallback(() => {
+    const container = scrollContainerRef.current;
+    if (container) {
+      return loadOlderMessages(container);
+    }
+    return Promise.resolve(false);
+  }, [loadOlderMessages]);
+
+  /**
+   * Widens the render window so the tail slice covers `requiredCount` messages.
+   * The prompt navigator jumps to prompts outside the current window; covering
+   * an index means rendering everything after it.
+   */
+  const expandVisibleWindow = useCallback((requiredCount: number) => {
+    setVisibleMessageCount((prev) => Math.max(prev, requiredCount));
+  }, []);
+
+  /**
+   * Scrolls the transcript to a prompt-navigator entry, widening the render
+   * window first when the target sits above it. Used by the prompt navigator
+   * rail; it mirrors the sidebar-search jump (retry on DOM commit, then flash).
+   * The processed preview disambiguates repeated timestamps.
+   */
+  const scrollToPromptEntry = useCallback((entry: PromptEntry) => {
+    if (!isActive) return;
+
+    const targetTimestamp = String(entry.timestamp);
+    const matches = (message: ChatMessage, withHint: boolean) =>
+      String(message.timestamp) === targetTimestamp &&
+      (!withHint || buildPromptPreview(message.displayText ?? message.content) === entry.preview);
+
+    let targetIndex = -1;
+    if (entry.preview) {
+      targetIndex = chatMessages.findIndex((message) => matches(message, true));
+    }
+    if (targetIndex < 0) {
+      targetIndex = chatMessages.findIndex((message) => matches(message, false));
+    }
+    if (targetIndex < 0) return;
+
+    // Widen the window so the target is rendered; covering index N means
+    // rendering everything after it.
+    expandVisibleWindow(resolveSearchWindowSize(
+      chatMessages.length,
+      targetIndex,
+      SEARCH_TARGET_CONTEXT_MESSAGES,
+    ));
+
+    // Suppress the follow-bottom auto-scroll while the jump settles.
+    searchScrollActiveRef.current = true;
+    if (searchScrollTimerRef.current !== null) {
+      clearTimeout(searchScrollTimerRef.current);
+    }
+
+    const scrollToRenderedTarget = (retriesLeft: number) => {
+      const container = scrollContainerRef.current;
+      if (!container) {
+        searchScrollActiveRef.current = false;
+        return;
+      }
+
+      const targetElement = findRenderedMessageElement(
+        container,
+        targetTimestamp,
+        retriesLeft === 0,
+      );
+
+      if (targetElement) {
+        targetElement.scrollIntoView({ block: 'center', behavior: 'smooth' });
+        targetElement.classList.add('search-highlight-flash');
+        setTimeout(() => targetElement.classList.remove('search-highlight-flash'), 4000);
+        searchScrollTimerRef.current = null;
+        searchScrollActiveRef.current = false;
+        return;
+      }
+
+      if (retriesLeft > 0) {
+        searchScrollTimerRef.current = setTimeout(
+          () => scrollToRenderedTarget(retriesLeft - 1),
+          SEARCH_SCROLL_RETRY_DELAY_MS,
+        );
+        return;
+      }
+
+      searchScrollTimerRef.current = null;
+      searchScrollActiveRef.current = false;
+    };
+
+    searchScrollTimerRef.current = setTimeout(
+      () => scrollToRenderedTarget(SEARCH_SCROLL_RETRIES),
+      150,
+    );
+  }, [chatMessages, expandVisibleWindow, isActive]);
+
   return {
     chatMessages,
     addMessage,
@@ -1114,11 +1343,16 @@ export function useChatSessionState({
     setIsUserScrolledUp,
     tokenBudget,
     setTokenBudget,
+    turnStats,
+    setTurnStats,
     visibleMessageCount,
     visibleMessages,
     loadEarlierMessages,
     loadAllMessages,
     loadFullTranscript,
+    requestOlderMessages,
+    expandVisibleWindow,
+    scrollToPromptEntry,
     allMessagesLoaded,
     isLoadingAllMessages,
     loadAllJustFinished,

--- a/src/modules/chat/hooks/useElementWidth.ts
+++ b/src/modules/chat/hooks/useElementWidth.ts
@@ -1,0 +1,24 @@
+import { useEffect, useState } from 'react';
+import type { RefObject } from 'react';
+
+/**
+ * Tracks the element's layout width, so the pane can tell when the viewport
+ * (or a panel resize) has shrunk the transcript below the room the navigator
+ * rail needs beside the message column.
+ */
+export function useElementWidth(ref: RefObject<HTMLElement | null>): number {
+  const [width, setWidth] = useState(0);
+  useEffect(() => {
+    const element = ref.current;
+    if (!element) return undefined;
+    const observer = new ResizeObserver((entries) => {
+      for (const entry of entries) {
+        setWidth(entry.target.getBoundingClientRect().width);
+      }
+    });
+    observer.observe(element);
+    setWidth(element.getBoundingClientRect().width);
+    return () => observer.disconnect();
+  }, [ref]);
+  return width;
+}

--- a/src/modules/chat/hooks/useSessionInfoPanel.ts
+++ b/src/modules/chat/hooks/useSessionInfoPanel.ts
@@ -1,0 +1,105 @@
+import { useCallback, useEffect, useState } from 'react';
+
+import { api } from '@/shared/api';
+import type { LLMProvider } from '@/shared/types';
+import {
+  readStoredSessionInfoPanelPrefs,
+  withSectionCollapsed,
+  type SessionInfoPanelPrefs,
+  type SessionInfoPanelSection,
+} from '@/shared/sessionInfoPanelPrefs';
+import { writeUserPreference, subscribeToUserPreferences } from '@/shared/userSettings';
+
+/** The provider's context-window snapshot; null when the CLI has no live handle. */
+export type ContextInfoSnapshot = {
+  totalTokens: number | null;
+  maxTokens: number | null;
+  percentage: number | null;
+  model: string | null;
+  categories: Array<{ name: string; tokens: number; kind: string }>;
+  agents: Array<{ agentType: string; tokens: number }>;
+  mcpTools: Array<{ name: string; serverName: string; tokens: number }>;
+  memoryFiles: Array<{ path: string; tokens: number }>;
+  slashCommands: { totalCommands: number; includedCommands: number } | null;
+};
+
+type UseSessionInfoPanelArgs = {
+  provider: LLMProvider;
+  /** App session id; null while a brand-new conversation has no id yet. */
+  sessionId: string | null;
+  /** Provider integration offers the subagent/context/CLI-backed sections. */
+  supportsInsights: boolean;
+};
+
+/**
+ * Owns the info panel's layout preferences and the REST reads it makes when
+ * opened. Streamed data (tokenBudget, turnStats, merged messages) is NOT
+ * fetched here — it already lives in session state, and the panel receives it
+ * by props so both views update from the same source.
+ *
+ * Reading (contextInfo, MCP, skills) happens on open and on session/project
+ * change; a closed panel never polls.
+ */
+export function useSessionInfoPanel({ provider, sessionId, supportsInsights }: UseSessionInfoPanelArgs) {
+  const [prefs, setPrefs] = useState<SessionInfoPanelPrefs>(() => readStoredSessionInfoPanelPrefs());
+  const [contextInfo, setContextInfo] = useState<ContextInfoSnapshot | null>(null);
+
+  // Follow preference changes made elsewhere (another tab, the header button
+  // before this panel mounted) through the shared change notification.
+  useEffect(() => {
+    const sync = () => setPrefs(readStoredSessionInfoPanelPrefs());
+    return subscribeToUserPreferences(sync);
+  }, []);
+
+  const setOpen = useCallback((open: boolean) => {
+    setPrefs((current) => {
+      if (current.open === open) return current;
+      const next = { ...current, open };
+      writeUserPreference('sessionInfoPanel', next);
+      return next;
+    });
+  }, []);
+
+  const toggleSection = useCallback((section: SessionInfoPanelSection) => {
+    setPrefs((current) => {
+      const next = withSectionCollapsed(current, section, !current.collapsedSections[section]);
+      writeUserPreference('sessionInfoPanel', next);
+      return next;
+    });
+  }, []);
+
+  // The CLI answers context questions only while it holds the session, so a
+  // failed/absent answer simply means "fall back to streamed usage". Re-read
+  // on session change and whenever the panel (re)opens.
+  useEffect(() => {
+    if (!prefs.open || !sessionId || !supportsInsights) {
+      setContextInfo(null);
+      return;
+    }
+
+    let cancelled = false;
+    const load = async () => {
+      try {
+        const response = await api.providers.sessionContextInfo(sessionId);
+        if (!response.ok) {
+          if (!cancelled) setContextInfo(null);
+          return;
+        }
+
+        const payload = (await response.json()) as { data?: ContextInfoSnapshot | null };
+        if (!cancelled) {
+          setContextInfo(payload.data ?? null);
+        }
+      } catch {
+        if (!cancelled) setContextInfo(null);
+      }
+    };
+
+    void load();
+    return () => {
+      cancelled = true;
+    };
+  }, [prefs.open, sessionId, provider, supportsInsights]);
+
+  return { prefs, setOpen, toggleSection, contextInfo };
+}

--- a/src/modules/chat/hooks/useSessionMcpServers.ts
+++ b/src/modules/chat/hooks/useSessionMcpServers.ts
@@ -8,8 +8,10 @@ type UseSessionMcpServersArgs = {
   provider: LLMProvider;
   /** Workspace whose project-scoped servers join the global ones. */
   projectPath: string | null;
-  /** Panel open AND the runtime honors the switches (capability-gated). */
+  /** Panel open — the list is worth reading (the sources section uses it too). */
   enabled: boolean;
+  /** Whether the runtime honors the disabled set; switches otherwise read-only. */
+  canToggle: boolean;
 };
 
 /** Server shapes the MCP routes can answer with: grouped by scope, or flat. */
@@ -54,7 +56,7 @@ export function flattenMcpServers(payload: McpServersPayload): ProviderMcpServer
  * hydrate. Toggling writes both the server (immediately, for the runtime) and
  * the mirror (debounced), and a failed write rolls the row back.
  */
-export function useSessionMcpServers({ provider, projectPath, enabled }: UseSessionMcpServersArgs) {
+export function useSessionMcpServers({ provider, projectPath, enabled, canToggle }: UseSessionMcpServersArgs) {
   const [servers, setServers] = useState<ProviderMcpServer[]>([]);
   const [loading, setLoading] = useState(false);
   // Names the PUT is still in flight for, so the switch cannot be flipped
@@ -105,6 +107,11 @@ export function useSessionMcpServers({ provider, projectPath, enabled }: UseSess
 
   /** Flip one server's global switch; returns whether the server accepted it. */
   const toggleServer = useCallback(async (name: string): Promise<boolean> => {
+    // A provider whose runtime ignores the set shows rows read-only: the
+    // switch would change what the panel says without changing what runs.
+    if (!canToggle) {
+      return false;
+    }
     const trimmed = name.trim();
     if (!trimmed || pendingNames.has(trimmed)) {
       return false;
@@ -142,7 +149,7 @@ export function useSessionMcpServers({ provider, projectPath, enabled }: UseSess
         return copy;
       });
     }
-  }, [pendingNames]);
+  }, [pendingNames, canToggle]);
 
-  return { servers, loading, disabledSet, toggleServer, pendingNames };
+  return { servers, loading, disabledSet, toggleServer, pendingNames, canToggle };
 }

--- a/src/modules/chat/hooks/useSessionMcpServers.ts
+++ b/src/modules/chat/hooks/useSessionMcpServers.ts
@@ -1,0 +1,148 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+
+import { api } from '@/shared/api';
+import type { LLMProvider, McpScope, ProviderMcpServer } from '@/shared/types';
+import { subscribeToUserPreferences, readUserPreference, writeUserPreference } from '@/shared/userSettings';
+
+type UseSessionMcpServersArgs = {
+  provider: LLMProvider;
+  /** Workspace whose project-scoped servers join the global ones. */
+  projectPath: string | null;
+  /** Panel open AND the runtime honors the switches (capability-gated). */
+  enabled: boolean;
+};
+
+/** Server shapes the MCP routes can answer with: grouped by scope, or flat. */
+type McpServersPayload = {
+  data?: {
+    scopes?: Partial<Record<McpScope, ProviderMcpServer[]>>;
+    servers?: ProviderMcpServer[];
+  };
+};
+
+/**
+ * Flattens either response shape to one list, deduplicated by name.
+ *
+ * The panel shows one row per recognizable server; the same name defined at
+ * two scopes is one switch, so the first scope's entry wins and the
+ * user-scoped definition is what the row describes.
+ */
+export function flattenMcpServers(payload: McpServersPayload): ProviderMcpServer[] {
+  const grouped = payload.data?.scopes;
+  const rows = grouped
+    ? (['project', 'local', 'user'] as McpScope[]).flatMap((scope) => grouped[scope] ?? [])
+    : payload.data?.servers ?? [];
+
+  const byName = new Map<string, ProviderMcpServer>();
+  for (const server of rows) {
+    const name = typeof server?.name === 'string' ? server.name.trim() : '';
+    if (name && !byName.has(name)) {
+      byName.set(name, { ...server, name });
+    }
+  }
+  return [...byName.values()].sort((a, b) => a.name.localeCompare(b.name));
+}
+
+/**
+ * The panel's MCP section data: every server visible to the provider, plus
+ * the user's disabled-name set, plus the optimistic toggle.
+ *
+ * The disabled set is read through the shared user-preference mirror rather
+ * than fetched from the settings route on its own: the server stores it under
+ * the same key either way, so the mirror is already the freshest local copy,
+ * and a change made on another device arrives through the preference
+ * hydrate. Toggling writes both the server (immediately, for the runtime) and
+ * the mirror (debounced), and a failed write rolls the row back.
+ */
+export function useSessionMcpServers({ provider, projectPath, enabled }: UseSessionMcpServersArgs) {
+  const [servers, setServers] = useState<ProviderMcpServer[]>([]);
+  const [loading, setLoading] = useState(false);
+  // Names the PUT is still in flight for, so the switch cannot be flipped
+  // twice before the server answers.
+  const [pendingNames, setPendingNames] = useState<Set<string>>(() => new Set());
+  const [mirror, setMirror] = useState<string[]>(() =>
+    readUserPreference<string[]>('mcpDisabledServers', []),
+  );
+
+  useEffect(() => {
+    const sync = () => setMirror(readUserPreference<string[]>('mcpDisabledServers', []));
+    return subscribeToUserPreferences(sync);
+  }, []);
+
+  useEffect(() => {
+    if (!enabled) {
+      setServers([]);
+      return;
+    }
+
+    let cancelled = false;
+    setLoading(true);
+    void (async () => {
+      try {
+        const response = await api.providers.mcpServers(provider, {
+          scope: undefined,
+          workspacePath: projectPath ?? undefined,
+        });
+        if (!response.ok) {
+          if (!cancelled) setServers([]);
+          return;
+        }
+        const payload = (await response.json()) as McpServersPayload;
+        if (!cancelled) setServers(flattenMcpServers(payload));
+      } catch {
+        if (!cancelled) setServers([]);
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [enabled, provider, projectPath]);
+
+  const disabledSet = useMemo(() => new Set(mirror), [mirror]);
+
+  /** Flip one server's global switch; returns whether the server accepted it. */
+  const toggleServer = useCallback(async (name: string): Promise<boolean> => {
+    const trimmed = name.trim();
+    if (!trimmed || pendingNames.has(trimmed)) {
+      return false;
+    }
+
+    const current = readUserPreference<string[]>('mcpDisabledServers', []);
+    const wasDisabled = current.includes(trimmed);
+    const next = wasDisabled
+      ? current.filter((entry) => entry !== trimmed)
+      : [...current, trimmed];
+
+    setPendingNames((pending) => new Set(pending).add(trimmed));
+    // Optimistic: the row flips now and the mirror follows, so the next turn's
+    // panel already reads the new truth even before the PUT resolves.
+    writeUserPreference('mcpDisabledServers', next);
+
+    try {
+      const response = await api.settings.saveMcpDisabledServers(next);
+      if (!response.ok) {
+        throw new Error(`mcp-disabled-servers PUT ${response.status}`);
+      }
+      // Confirm with the server's normalized list rather than the local one.
+      const payload = (await response.json()) as { servers?: string[] };
+      writeUserPreference('mcpDisabledServers', payload.servers ?? next);
+      return true;
+    } catch {
+      // Roll the row (and the mirror, and thus any other component reading it)
+      // back to what the server still believes.
+      writeUserPreference('mcpDisabledServers', current);
+      return false;
+    } finally {
+      setPendingNames((pending) => {
+        const copy = new Set(pending);
+        copy.delete(trimmed);
+        return copy;
+      });
+    }
+  }, [pendingNames]);
+
+  return { servers, loading, disabledSet, toggleServer, pendingNames };
+}

--- a/src/modules/chat/hooks/useSessionSkills.ts
+++ b/src/modules/chat/hooks/useSessionSkills.ts
@@ -1,0 +1,58 @@
+import { useEffect, useState } from 'react';
+
+import { api } from '@/shared/api';
+import type { LLMProvider, ProviderSkill } from '@/shared/types';
+
+type UseSessionSkillsArgs = {
+  provider: LLMProvider;
+  /** Workspace whose project-scoped skills join the global ones. */
+  projectPath: string | null;
+  /** Only fetches while the info panel is open. */
+  enabled: boolean;
+};
+
+/**
+ * The skills visible to one provider, for the panel's sources section.
+ *
+ * Read through the existing skills endpoint (the same one the skills manager
+ * uses) — no parallel data path. Like the panel's other REST reads, a closed
+ * panel never polls; the list refreshes when it (re)opens or the
+ * provider/workspace changes.
+ */
+export function useSessionSkills({ provider, projectPath, enabled }: UseSessionSkillsArgs) {
+  const [skills, setSkills] = useState<ProviderSkill[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (!enabled) {
+      setSkills([]);
+      return;
+    }
+
+    let cancelled = false;
+    setLoading(true);
+    void (async () => {
+      try {
+        const response = await api.providers.skills(provider, {
+          workspacePath: projectPath ?? undefined,
+        });
+        if (!response.ok) {
+          if (!cancelled) setSkills([]);
+          return;
+        }
+        const payload = (await response.json()) as { data?: { skills?: ProviderSkill[] } };
+        if (!cancelled) setSkills(payload.data?.skills ?? []);
+      } catch {
+        if (!cancelled) setSkills([]);
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [enabled, provider, projectPath]);
+
+  return { skills, loading };
+}

--- a/src/modules/chat/hooks/useSessionStore.ts
+++ b/src/modules/chat/hooks/useSessionStore.ts
@@ -281,10 +281,50 @@ function dedupeAdjacentAssistantEchoes(merged: NormalizedMessage[]): NormalizedM
           continue;
         }
       }
+      // Same story for reasoning: the streamed thinking row finalizes under a
+      // synthetic id, and the provider's complete message re-emits the same
+      // text as a fresh `thinking` row beside it. Collapse onto the latter.
+      if (prev.kind === 'thinking' && m.kind === 'thinking') {
+        const ms = (m.content || '').trim();
+        if (ms.length > 0 && ms === (prev.content || '').trim()) {
+          out[out.length - 1] = m;
+          continue;
+        }
+      }
     }
     out.push(m);
   }
   return out;
+}
+
+/**
+ * Thinking counterpart of the assistant-echo check: a live reasoning row (or
+ * its frozen finalization) is superseded once the persisted transcript carries
+ * the same reasoning inside the same user turn. Without this the streamed
+ * thinking bubble stacks on top of the reloaded one until realtime clears.
+ */
+function isThinkingEchoedInSameTurnOnServer(
+  message: NormalizedMessage,
+  serverMessages: NormalizedMessage[],
+  realtimeMessages: NormalizedMessage[],
+): boolean {
+  const thinkingText = (message.content || '').trim();
+  if (!thinkingText) {
+    return false;
+  }
+
+  const turnOrdinal = getUserTurnOrdinalBefore(message, serverMessages, realtimeMessages);
+  const turnRange = findServerTurnRangeByOrdinal(serverMessages, turnOrdinal);
+  if (!turnRange) {
+    return false;
+  }
+
+  return serverMessages
+    .slice(turnRange.start + 1, turnRange.end)
+    .some((serverMessage) =>
+      serverMessage.kind === 'thinking'
+      && (serverMessage.content || '').trim() === thinkingText,
+    );
 }
 
 /**
@@ -313,6 +353,21 @@ function pruneRealtimeSupersededByServer(
       if (isAssistantTextEchoedInSameTurnOnServer(message, serverMessages, realtimeMessages)) {
         return false;
       }
+      return true;
+    }
+
+    if (
+      message.kind === 'thinking'
+      || message.kind === 'thinking_delta'
+      || message.id === `__streaming_thinking_${message.sessionId}`
+    ) {
+      if (isThinkingEchoedInSameTurnOnServer(message, serverMessages, realtimeMessages)) {
+        return false;
+      }
+      // A thinking_delta that got no finalization tick (aborted run) must not
+      // linger as an orphan streaming row once the turn is on disk either —
+      // but while nothing is persisted it is the only view of the reasoning,
+      // so it survives exactly like the text stream row above.
       return true;
     }
 
@@ -754,7 +809,18 @@ export function useSessionStore() {
       msg.sessionId === sessionId
         ? msg
         : { ...msg, sessionId };
-    let updated = [...slot.realtimeMessages, normalizedMessage];
+    // A live provider event that repeats an id already in the transcript is
+    // an update to that row, not a new one — the Codex SDK pushes `item.updated`
+    // ticks for the same item, and appending them stacked one bubble per tick.
+    // Replace in place, keeping the row's position.
+    const existingIdx = slot.realtimeMessages.findIndex(m => m.id === normalizedMessage.id);
+    let updated: NormalizedMessage[];
+    if (existingIdx >= 0) {
+      updated = [...slot.realtimeMessages];
+      updated[existingIdx] = normalizedMessage;
+    } else {
+      updated = [...slot.realtimeMessages, normalizedMessage];
+    }
     if (updated.length > MAX_REALTIME_MESSAGES) {
       updated = updated.slice(-MAX_REALTIME_MESSAGES);
     }
@@ -853,6 +919,57 @@ export function useSessionStore() {
   }, [notify]);
 
   /**
+   * Thinking counterpart of `updateStreaming`: one well-known row carrying the
+   * accumulated reasoning text, replaced in place on every throttled tick.
+   * Separate from the text sentinel because a turn streams both at once
+   * (reasoning first, then the answer) and one buffer would clobber the other.
+   */
+  const updateStreamingThinking = useCallback((sessionId: string, accumulatedText: string, msgProvider: LLMProvider) => {
+    const slot = getSlot(sessionId);
+    const streamId = `__streaming_thinking_${sessionId}`;
+    const msg: NormalizedMessage = {
+      id: streamId,
+      sessionId,
+      timestamp: new Date().toISOString(),
+      provider: msgProvider,
+      kind: 'thinking_delta',
+      content: accumulatedText,
+    };
+    const idx = slot.realtimeMessages.findIndex(m => m.id === streamId);
+    if (idx >= 0) {
+      slot.realtimeMessages = [...slot.realtimeMessages];
+      slot.realtimeMessages[idx] = msg;
+    } else {
+      slot.realtimeMessages = [...slot.realtimeMessages, msg];
+    }
+    recomputeMergedIfNeeded(slot);
+    notify(sessionId);
+  }, [getSlot, notify]);
+
+  /**
+   * Finalize thinking streaming: freeze the accumulated row into a regular
+   * `thinking` message so it renders as the finished reasoning bubble and
+   * survives until the persisted-history refresh retires it.
+   */
+  const finalizeStreamingThinking = useCallback((sessionId: string) => {
+    const slot = storeRef.current.get(sessionId);
+    if (!slot) return;
+    const streamId = `__streaming_thinking_${sessionId}`;
+    const idx = slot.realtimeMessages.findIndex(m => m.id === streamId);
+    if (idx >= 0) {
+      const stream = slot.realtimeMessages[idx];
+      slot.realtimeMessages = [...slot.realtimeMessages];
+      slot.realtimeMessages[idx] = {
+        ...stream,
+        id: `thinking_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`,
+        kind: 'thinking',
+      };
+      recomputeMergedIfNeeded(slot);
+      notify(sessionId);
+    }
+  }, [notify]);
+
+  /**
    * Get merged messages for a session (for rendering).
    */
   const getMessages = useCallback((sessionId: string): NormalizedMessage[] => {
@@ -876,11 +993,14 @@ export function useSessionStore() {
     isStale,
     updateStreaming,
     finalizeStreaming,
+    updateStreamingThinking,
+    finalizeStreamingThinking,
     getMessages,
     getSessionSlot,
   }), [
     fetchFromServer, fetchMore, appendRealtime, truncateAt, refreshLatestFromServer,
     setActiveSession, isStale, updateStreaming, finalizeStreaming,
+    updateStreamingThinking, finalizeStreamingThinking,
     getMessages, getSessionSlot,
   ]);
 }

--- a/src/modules/chat/hooks/useSessionStore.ts
+++ b/src/modules/chat/hooks/useSessionStore.ts
@@ -477,7 +477,7 @@ function olderPagePrecedesCachedHistory(
 async function refreshLatestSlotFromServer(
   sessionId: string,
   slot: SessionSlot,
-  limit: number,
+  limit: number | null,
   canRequest: CanRequestHistory = () => true,
 ): Promise<LatestHistoryRefreshResult> {
   if (!canRequest()) {
@@ -495,9 +495,15 @@ async function refreshLatestSlotFromServer(
   let nextServerMessages: NormalizedMessage[] | null = null;
   let nextHasMore = previousHasMore;
 
-  // A page with no older rows is the complete authoritative transcript. This
-  // also removes cached rows after a provider-side truncation.
-  if (!latestPage.hasMore) {
+  // A page with no older rows is the complete authoritative transcript — but
+  // only when it can actually hold the whole thing. Providers have been seen
+  // to answer a bounded tail page with hasMore=false on a 100+ row transcript;
+  // trusting that replaced the full cache with one page and shrank the prompt
+  // navigator rail. A bounded page whose total exceeds its rows falls through
+  // to the bridge/merge path, which keeps the older cached rows.
+  const pageIsWholeTranscript =
+    !latestPage.hasMore && latestPage.total <= latestPage.messages.length;
+  if (pageIsWholeTranscript) {
     nextServerMessages = latestPage.messages;
     nextHasMore = false;
   } else if (previousServerMessages.length === 0) {
@@ -837,7 +843,7 @@ export function useSessionStore() {
   const refreshLatestFromServer = useCallback(async (
     sessionId: string,
     opts: {
-      limit?: number;
+      limit?: number | null;
       canRequest?: CanRequestHistory;
     } = {},
   ) => {
@@ -845,10 +851,17 @@ export function useSessionStore() {
 
     return enqueueHistoryMutation(slot, async () => {
       try {
+        // `undefined` → bounded tail page; `null` → the whole transcript.
+        // Callers that have already hydrated the full history refresh with
+        // `null`: a bounded 20-row page would fail to bridge against the
+        // full cache (no overlapping rows) and shrink it back to one page.
+        const limit = 'limit' in opts && opts.limit !== undefined
+          ? opts.limit
+          : SESSION_MESSAGES_PAGE_SIZE;
         const result = await refreshLatestSlotFromServer(
           sessionId,
           slot,
-          opts.limit ?? SESSION_MESSAGES_PAGE_SIZE,
+          limit,
           opts.canRequest,
         );
         if (result.changed) notify(sessionId);

--- a/src/modules/chat/hooks/useSessionSubagents.ts
+++ b/src/modules/chat/hooks/useSessionSubagents.ts
@@ -1,0 +1,111 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+import { api } from '@/shared/api';
+import type { LLMProvider, SubagentSummary } from '@/shared/types';
+
+/** How long a roster with a running agent waits before asking the server again. */
+const RUNNING_POLL_MS = 5_000;
+
+type UseSessionSubagentsArgs = {
+  provider: LLMProvider;
+  /** App session id; null while a brand-new conversation has no id yet. */
+  sessionId: string | null;
+  /** The panel is open — a closed panel never polls. */
+  enabled: boolean;
+  /** Provider integration answers the roster endpoint. */
+  supportsInsights: boolean;
+  /** The parent conversation is streaming right now. */
+  parentRunning: boolean;
+};
+
+type SessionSubagentsState = {
+  subagents: SubagentSummary[];
+  loading: boolean;
+  /** Re-pull the roster now (retry after an error, or after the run ends). */
+  refresh: () => void;
+};
+
+/**
+ * The info panel's roster of the session's spawned agents.
+ *
+ * The server composes each row from the CLI's subagents directory plus the
+ * parent's task notifications, so the list survives reloads; polling only
+ * matters while something runs. Once every row is terminal the timer stops
+ * and only explicit refreshes (or the parent's run ending) re-read — a
+ * crashed run's leftover then settles within one poll instead of spinning
+ * forever. Realtime per-row streaming does NOT come from here; the modal
+ * derives it from the parent's live message slot.
+ */
+export function useSessionSubagents({
+  provider,
+  sessionId,
+  enabled,
+  supportsInsights,
+  parentRunning,
+}: UseSessionSubagentsArgs): SessionSubagentsState {
+  const [subagents, setSubagents] = useState<SubagentSummary[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [reloadToken, setReloadToken] = useState(0);
+
+  const refresh = useCallback(() => setReloadToken((token) => token + 1), []);
+
+  // Clearing is synchronous with the session identity: showing the previous
+  // session's roster for one frame after a switch reads as a wrong answer.
+  const lastKeyRef = useRef<string | null>(null);
+  const key = enabled && supportsInsights ? `${provider}:${sessionId ?? ''}` : null;
+  if (key !== lastKeyRef.current) {
+    lastKeyRef.current = key;
+    if (subagents.length > 0) setSubagents([]);
+  }
+
+  useEffect(() => {
+    if (!key || !sessionId) {
+      return;
+    }
+
+    let cancelled = false;
+    let timer: ReturnType<typeof setTimeout> | null = null;
+
+    const load = async (initial: boolean) => {
+      if (initial) setLoading(true);
+      try {
+        const response = await api.providers.sessionSubagents(sessionId);
+        if (!response.ok) {
+          if (!cancelled && initial) setSubagents([]);
+          return;
+        }
+        const payload = (await response.json()) as { data?: { subagents?: SubagentSummary[] } };
+        if (cancelled) return;
+        const next = payload.data?.subagents ?? [];
+        setSubagents(next);
+        // Only a running row justifies the next automatic read; the parent's
+        // own run ending triggers a refresh from the outside as well.
+        if (next.some((entry) => entry.status === 'running')) {
+          timer = setTimeout(() => void load(false), RUNNING_POLL_MS);
+        }
+      } catch {
+        // Keep the last known roster; a transient failure should not blank the panel.
+      } finally {
+        if (!cancelled && initial) setLoading(false);
+      }
+    };
+
+    void load(true);
+    return () => {
+      cancelled = true;
+      if (timer) clearTimeout(timer);
+    };
+  }, [key, sessionId, reloadToken]);
+
+  // The heuristic that calls a fresh file "running" needs the parent's state
+  // to settle; one re-read when the run flips false pins every row's truth.
+  const wasRunningRef = useRef(false);
+  useEffect(() => {
+    if (wasRunningRef.current && !parentRunning) {
+      refresh();
+    }
+    wasRunningRef.current = parentRunning;
+  }, [parentRunning, refresh]);
+
+  return { subagents, loading, refresh };
+}

--- a/src/modules/chat/hooks/useTranscriptVirtualization.ts
+++ b/src/modules/chat/hooks/useTranscriptVirtualization.ts
@@ -1,0 +1,192 @@
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import type { RefObject } from 'react';
+
+import {
+  TRANSCRIPT_FULL_RENDER_ROWS,
+  TRANSCRIPT_OVERSCAN_PX,
+  estimateItemHeightPx,
+} from '@/modules/chat/utils/transcriptWindow';
+import type { MessageListItem } from '@/modules/chat/utils/toolGrouping';
+
+/** Key under which rendered row heights are cached. Stable rows only. */
+export type VirtualizedRowKey = string;
+
+type UseTranscriptVirtualizationArgs = {
+  scrollContainerRef: RefObject<HTMLDivElement>;
+  /** The grouped rows the pane renders, in order. */
+  items: MessageListItem[];
+  /** Pane-level key for each item; the height cache is keyed by it. */
+  getKey: (item: MessageListItem, index: number) => string;
+  /**
+   * Freezes the window on an explicit range while a jump animates to its
+   * target: the target's rows must exist (and the rows under the animation
+   * must not collapse into a spacer) until the scroll lands. Cleared when
+   * the jump completes; the scroll-driven window re-arms from the settled
+   * position.
+   */
+  forcedRange: { start: number; end: number } | null;
+  /**
+   * Renders everything with no spacers. Test/inspection escape hatch; the
+   * jump flow uses forcedRange, not this.
+   */
+  disabled: boolean;
+};
+
+type TranscriptVirtualization = {
+  /** Index range of `items` to render, inclusive-exclusive. */
+  range: { start: number; end: number };
+  /** Spacer heights (px) above and below the rendered slice. */
+  spacerHeights: { top: number; bottom: number };
+  virtualized: boolean;
+  /**
+   * Called with each row's element after React commits the slice; measures
+   * and caches its height so the window math uses real geometry for any row
+   * that has been on screen at least once.
+   */
+  registerRendered: (element: HTMLDivElement | null, key: VirtualizedRowKey) => void;
+};
+
+/**
+ * Windowing for the transcript: only the rows inside the viewport band render,
+ * and everything above/below collapses into two spacers.
+ *
+ * The previous scheme kept every loaded row in the DOM as a placeholder — a
+ * 1500-row session produced a 1500-node, ~150k-px scroller, and Chrome's
+ * compositor gave up painting it: selectable-but-invisible text until the
+ * user shook it with a scroll. DOM nodes now track the viewport, not the
+ * transcript.
+ */
+export function useTranscriptVirtualization({
+  scrollContainerRef,
+  items,
+  getKey,
+  forcedRange,
+  disabled,
+}: UseTranscriptVirtualizationArgs): TranscriptVirtualization {
+  const heightsRef = useRef(new Map<VirtualizedRowKey, number>());
+  // Bumped whenever a row gets newly measured, so the bounds memo recomputes
+  // against the freshest cache.
+  const [measureVersion, setMeasureVersion] = useState(0);
+  // Nothing until the layout pass has measured the scroll position — the
+  // first frame of a long transcript renders zero rows plus the spacers
+  // rather than the whole list.
+  const [range, setRange] = useState({ start: 0, end: 0 });
+
+  // A session switch empties the list before filling it with another
+  // transcript's rows; the cache must not outlive its transcript. The key
+  // carries the session identity implicitly: an empty list means the old
+  // rows are gone.
+  const lastNonEmptyRef = useRef(0);
+  if (items.length === 0 && lastNonEmptyRef.current > 0) {
+    lastNonEmptyRef.current = 0;
+    heightsRef.current.clear();
+  } else if (items.length > 0) {
+    lastNonEmptyRef.current = items.length;
+  }
+
+  const virtualized = !disabled && items.length > TRANSCRIPT_FULL_RENDER_ROWS;
+  const bounds = useMemo(() => {
+    const heights = heightsRef.current;
+    const result = new Array<number>(items.length + 1);
+    result[0] = 0;
+    for (let index = 0; index < items.length; index++) {
+      const key = getKey(items[index], index);
+      const measured = heights.get(key);
+      const height = measured ?? estimateItemHeightPx(items[index]);
+      result[index + 1] = result[index] + height;
+    }
+    return result;
+  }, [items, getKey, measureVersion]);
+
+  const itemsRef = useRef(items);
+  itemsRef.current = items;
+  const boundsRef = useRef(bounds);
+  boundsRef.current = bounds;
+
+  const computeRange = useCallback(() => {
+    const container = scrollContainerRef.current;
+    const list = itemsRef.current;
+    const boundsList = boundsRef.current;
+    if (!container || list.length === 0) {
+      setRange({ start: 0, end: list.length });
+      return;
+    }
+    const scrollTop = container.scrollTop;
+    const bandTop = Math.max(0, scrollTop - TRANSCRIPT_OVERSCAN_PX);
+    const bandBottom = scrollTop + container.clientHeight + TRANSCRIPT_OVERSCAN_PX;
+
+    // First bound at or after the band edge; steps of ±1 row bracket it so a
+    // row straddling the band edge is included.
+    const lowerBound = (target: number) => {
+      let low = 0;
+      let high = boundsList.length - 1;
+      while (low < high) {
+        const mid = (low + high) >> 1;
+        if (boundsList[mid] < target) low = mid + 1;
+        else high = mid;
+      }
+      return low;
+    };
+    const start = Math.max(0, lowerBound(bandTop) - 1);
+    const end = Math.min(list.length, lowerBound(bandBottom) + 1);
+    setRange((previous) => (
+      previous.start === start && previous.end === end ? previous : { start, end }
+    ));
+  }, [scrollContainerRef]);
+
+  useLayoutEffect(() => {
+    if (forcedRange) {
+      setRange((previous) => (
+        previous.start === forcedRange.start && previous.end === forcedRange.end
+          ? previous
+          : { start: forcedRange.start, end: forcedRange.end }
+      ));
+      // A jump is animating; re-windowing off the in-flight scroll position
+      // would yank rows out from under the animation.
+      return undefined;
+    }
+    if (disabled) {
+      setRange((previous) => (
+        previous.start === 0 && previous.end === itemsRef.current.length
+          ? previous
+          : { start: 0, end: itemsRef.current.length }
+      ));
+      return undefined;
+    }
+    const container = scrollContainerRef.current;
+    if (!container) return undefined;
+    computeRange();
+    let frame = 0;
+    const onScroll = () => {
+      if (frame !== 0) return;
+      frame = requestAnimationFrame(() => {
+        frame = 0;
+        computeRange();
+      });
+    };
+    container.addEventListener('scroll', onScroll, { passive: true });
+    return () => {
+      container.removeEventListener('scroll', onScroll);
+      if (frame !== 0) cancelAnimationFrame(frame);
+    };
+  }, [computeRange, disabled, forcedRange, items, measureVersion, scrollContainerRef]);
+
+  const registerRendered = useCallback((element: HTMLDivElement | null, key: VirtualizedRowKey) => {
+    if (!element) return;
+    const height = element.offsetHeight;
+    if (height <= 0) return;
+    const heights = heightsRef.current;
+    if (heights.get(key) === height) return;
+    heights.set(key, height);
+    setMeasureVersion((current) => current + 1);
+  }, []);
+
+  const spacerHeights = virtualized
+    ? {
+      top: bounds[range.start] ?? 0,
+      bottom: Math.max(0, (bounds[items.length] ?? 0) - (bounds[range.end] ?? 0)),
+    }
+    : { top: 0, bottom: 0 };
+
+  return { range, spacerHeights, virtualized, registerRendered };
+}

--- a/src/modules/chat/panel/ContextRingSection.tsx
+++ b/src/modules/chat/panel/ContextRingSection.tsx
@@ -1,0 +1,77 @@
+import { memo } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import type { ProviderContextInfo } from '@/shared/types';
+
+type ContextRingSectionProps = {
+  /** From the provider's live CLI (its `/context` answer), when available. */
+  contextInfo: ProviderContextInfo | null;
+  /** Fallback: the streamed usage frame, same source as the composer counter. */
+  tokenBudget: Record<string, unknown> | null;
+  onShowDetails?: () => void;
+};
+
+/**
+ * Context-window occupancy as ring + percentage + bar. The provider's own
+ * answer wins (it classifies cached/deferred content the streamed frames
+ * cannot); the streamed usage frame is the fallback so an idle session still
+ * shows something. Click opens the existing token-detail modal.
+ */
+export const ContextRingSection = memo(({ contextInfo, tokenBudget, onShowDetails }: ContextRingSectionProps) => {
+  const { t } = useTranslation('chat');
+  const budget = (tokenBudget ?? {}) as Record<string, unknown>;
+  const used = typeof budget.used === 'number' ? budget.used : null;
+  const total = typeof budget.total === 'number' ? budget.total : null;
+
+  const percent = contextInfo?.percentage ?? (used !== null && total ? (used / total) * 100 : null);
+  const label = percent === null ? '—' : `${(Math.round(percent * 10) / 10).toFixed(1)}%`;
+  const barWidth = percent === null ? 0 : Math.min(100, Math.max(0, percent));
+
+  return (
+    <button
+      type="button"
+      onClick={onShowDetails}
+      className="flex w-full items-center gap-2.5 text-left disabled:cursor-default"
+      disabled={!onShowDetails}
+    >
+      <ContextRing percent={percent} />
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center justify-between">
+          <span className="text-xs text-muted-foreground">{t('sessionInfoPanel.context')}</span>
+          <span className="font-mono text-xs text-foreground/80">{label}</span>
+        </div>
+        <div className="mt-1 h-1 w-full overflow-hidden rounded-full bg-muted">
+          <div
+            className="h-full rounded-full bg-green-500 transition-[width]"
+            style={{ width: `${barWidth}%` }}
+          />
+        </div>
+      </div>
+    </button>
+  );
+});
+ContextRingSection.displayName = 'ContextRingSection';
+
+/** SVG ring whose filled arc tracks the percentage; a gauge glyph at rest. */
+const ContextRing = memo(({ percent }: { percent: number | null }) => {
+  const radius = 12;
+  const circumference = 2 * Math.PI * radius;
+  const filled = percent === null ? 0 : Math.min(100, Math.max(0, percent));
+
+  return (
+    <svg viewBox="0 0 32 32" className="h-8 w-8 flex-shrink-0 -rotate-90" aria-hidden="true">
+      <circle cx="16" cy="16" r={radius} fill="none" strokeWidth="3" className="stroke-muted" />
+      <circle
+        cx="16"
+        cy="16"
+        r={radius}
+        fill="none"
+        strokeWidth="3"
+        strokeLinecap="round"
+        className="stroke-green-500 transition-[stroke-dashoffset]"
+        strokeDasharray={`${(filled / 100) * circumference} ${circumference}`}
+      />
+    </svg>
+  );
+});
+ContextRing.displayName = 'ContextRing';

--- a/src/modules/chat/panel/ContextSourcesSection.tsx
+++ b/src/modules/chat/panel/ContextSourcesSection.tsx
@@ -1,0 +1,75 @@
+import { memo } from 'react';
+import { useTranslation } from 'react-i18next';
+import { BookText, Plug } from 'lucide-react';
+
+import type { ProviderMcpServer, ProviderSkill } from '@/shared/types';
+
+type ContextSourcesSectionProps = {
+  skills: ProviderSkill[];
+  skillsLoading: boolean;
+  /** Same rows the MCP section renders — one fetch feeds both. */
+  mcpServers: ProviderMcpServer[];
+  mcpLoading: boolean;
+};
+
+/**
+ * The sources feeding the context window: how many skills and MCP servers the
+ * provider currently sees, each expandable to the names behind the count.
+ *
+ * MCP rows are the MCP section's own list passed straight through (no second
+ * fetch, so the two sections can never disagree); skills read the existing
+ * skills endpoint. Names truncate with the scope tag so an override across
+ * scopes is still legible.
+ */
+export const ContextSourcesSection = memo(({
+  skills,
+  skillsLoading,
+  mcpServers,
+  mcpLoading,
+}: ContextSourcesSectionProps) => {
+  const { t } = useTranslation('chat');
+
+  const group = (
+    icon: React.ReactNode,
+    label: string,
+    count: number,
+    loading: boolean,
+    rows: Array<{ key: string; name: string; tag?: string }>,
+  ) => (
+    <div className="flex flex-col gap-0.5 py-1">
+      <div className="flex items-center gap-2 px-1 text-xs text-muted-foreground">
+        {icon}
+        <span className="flex-1">{label}</span>
+        <span className="tabular-nums">{loading ? '…' : count}</span>
+      </div>
+      {rows.map((row) => (
+        <div key={row.key} className="flex items-center gap-2 pl-6 pr-1">
+          <span className="min-w-0 flex-1 truncate text-xs text-foreground">{row.name}</span>
+          {row.tag && (
+            <span className="flex-shrink-0 text-[10px] uppercase text-muted-foreground/70">{row.tag}</span>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+
+  return (
+    <div className="flex flex-col">
+      {group(
+        <BookText className="h-3.5 w-3.5 flex-shrink-0" />,
+        t('sessionInfoPanel.sourcesSkills'),
+        skills.length,
+        skillsLoading,
+        skills.map((skill) => ({ key: `${skill.provider}:${skill.command}`, name: skill.name, tag: skill.scope })),
+      )}
+      {group(
+        <Plug className="h-3.5 w-3.5 flex-shrink-0" />,
+        t('sessionInfoPanel.sourcesMcp'),
+        mcpServers.length,
+        mcpLoading,
+        mcpServers.map((server) => ({ key: `${server.provider}:${server.name}`, name: server.name, tag: server.scope })),
+      )}
+    </div>
+  );
+});
+ContextSourcesSection.displayName = 'ContextSourcesSection';

--- a/src/modules/chat/panel/InfoSection.tsx
+++ b/src/modules/chat/panel/InfoSection.tsx
@@ -1,0 +1,35 @@
+import { memo, type ReactNode } from 'react';
+import { ChevronRight } from 'lucide-react';
+
+import { cn } from '@/shared/utils';
+
+type InfoSectionProps = {
+  title: string;
+  /** Small trailing label in the header row (a count, e.g. "3/5"). */
+  countLabel?: string;
+  collapsed: boolean;
+  onToggle: () => void;
+  children: ReactNode;
+};
+
+/**
+ * One collapsible section of the session info panel: a header row (title,
+ * optional count, rotating chevron) that mounts its body only while expanded
+ * — the same rule SubagentPanel follows for long agent timelines.
+ */
+export const InfoSection = memo(({ title, countLabel, collapsed, onToggle, children }: InfoSectionProps) => (
+  <section className="border-b border-border/40 last:border-b-0">
+    <button
+      type="button"
+      onClick={onToggle}
+      aria-expanded={!collapsed}
+      className="flex w-full items-center gap-1.5 px-3 py-2 text-left text-xs font-medium text-foreground/80 hover:bg-muted/40"
+    >
+      <ChevronRight className={cn('h-3 w-3 flex-shrink-0 text-muted-foreground transition-transform', !collapsed && 'rotate-90')} />
+      <span className="min-w-0 flex-1 truncate">{title}</span>
+      {countLabel && <span className="flex-shrink-0 text-[11px] text-muted-foreground">{countLabel}</span>}
+    </button>
+    {!collapsed && <div className="px-3 pb-2.5">{children}</div>}
+  </section>
+));
+InfoSection.displayName = 'InfoSection';

--- a/src/modules/chat/panel/McpServersSection.tsx
+++ b/src/modules/chat/panel/McpServersSection.tsx
@@ -11,6 +11,8 @@ type McpServersSectionProps = {
   disabledSet: Set<string>;
   pendingNames: Set<string>;
   onToggle: (name: string) => Promise<boolean>;
+  /** False when the runtime ignores the set — rows render read-only. */
+  canToggle?: boolean;
 };
 
 /**
@@ -29,6 +31,7 @@ export const McpServersSection = memo(({
   disabledSet,
   pendingNames,
   onToggle,
+  canToggle = true,
 }: McpServersSectionProps) => {
   const { t } = useTranslation('chat');
 
@@ -55,7 +58,7 @@ export const McpServersSection = memo(({
               role="switch"
               aria-checked={!disabled}
               aria-label={t('sessionInfoPanel.mcpToggleAria', { name: server.name })}
-              disabled={pending}
+              disabled={!canToggle || pending}
               onClick={() => void onToggle(server.name)}
               className={cn(
                 'relative h-4 w-7 flex-shrink-0 rounded-full transition-colors disabled:opacity-50',
@@ -88,7 +91,7 @@ export const McpServersSection = memo(({
         );
       })}
       <p className="mt-1 px-1 text-[10px] leading-snug text-muted-foreground/70">
-        {t('sessionInfoPanel.mcpToggleHint')}
+        {canToggle ? t('sessionInfoPanel.mcpToggleHint') : t('sessionInfoPanel.mcpReadOnlyHint')}
       </p>
     </div>
   );

--- a/src/modules/chat/panel/McpServersSection.tsx
+++ b/src/modules/chat/panel/McpServersSection.tsx
@@ -1,0 +1,96 @@
+import { memo } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Loader } from 'lucide-react';
+
+import { cn } from '@/shared/utils';
+import type { ProviderMcpServer } from '@/shared/types';
+
+type McpServersSectionProps = {
+  servers: ProviderMcpServer[];
+  loading: boolean;
+  disabledSet: Set<string>;
+  pendingNames: Set<string>;
+  onToggle: (name: string) => Promise<boolean>;
+};
+
+/**
+ * One row per MCP server with a switch that writes the user's global
+ * disabled-name set. The Claude runtime consults that set when it assembles
+ * the NEXT turn's MCP config — a running session keeps its already-spawned
+ * servers, which is what the footer note says.
+ *
+ * Switches are optimistic: the row flips on click, and a failed PUT rolls it
+ * back (the parent hook owns the roll-back so the shared preference mirror —
+ * which every other reader follows — is what reverts, not just local state).
+ */
+export const McpServersSection = memo(({
+  servers,
+  loading,
+  disabledSet,
+  pendingNames,
+  onToggle,
+}: McpServersSectionProps) => {
+  const { t } = useTranslation('chat');
+
+  if (loading && servers.length === 0) {
+    return <div className="py-1 text-xs text-muted-foreground">{t('sessionInfoPanel.mcpLoading')}</div>;
+  }
+  if (servers.length === 0) {
+    return <div className="py-1 text-xs text-muted-foreground">{t('sessionInfoPanel.empty')}</div>;
+  }
+
+  return (
+    <div className="flex flex-col gap-0.5 py-1">
+      {servers.map((server) => {
+        const disabled = disabledSet.has(server.name);
+        const pending = pendingNames.has(server.name);
+        return (
+          <div
+            key={server.name}
+            className="flex items-center gap-2 rounded px-1 py-1 hover:bg-muted/40"
+            title={server.command ? `${server.command} ${(server.args ?? []).join(' ')}`.trim() : server.url}
+          >
+            <button
+              type="button"
+              role="switch"
+              aria-checked={!disabled}
+              aria-label={t('sessionInfoPanel.mcpToggleAria', { name: server.name })}
+              disabled={pending}
+              onClick={() => void onToggle(server.name)}
+              className={cn(
+                'relative h-4 w-7 flex-shrink-0 rounded-full transition-colors disabled:opacity-50',
+                disabled ? 'bg-muted-foreground/40' : 'bg-primary',
+              )}
+            >
+              <span
+                className={cn(
+                  'absolute top-0.5 h-3 w-3 rounded-full bg-background transition-all',
+                  disabled ? 'left-0.5' : 'left-3.5',
+                )}
+              />
+            </button>
+            <span
+              className={cn(
+                'min-w-0 flex-1 truncate text-xs',
+                disabled ? 'text-muted-foreground line-through' : 'text-foreground',
+              )}
+            >
+              {server.name}
+            </span>
+            {pending ? (
+              <Loader className="h-3 w-3 flex-shrink-0 animate-spin text-muted-foreground" />
+            ) : (
+              <span className="flex-shrink-0 text-[10px] uppercase text-muted-foreground/70">
+                {server.scope}
+              </span>
+            )}
+          </div>
+        );
+      })}
+      <p className="mt-1 px-1 text-[10px] leading-snug text-muted-foreground/70">
+        {t('sessionInfoPanel.mcpToggleHint')}
+      </p>
+    </div>
+  );
+});
+McpServersSection.displayName = 'McpServersSection';

--- a/src/modules/chat/panel/SessionInfoPanel.tsx
+++ b/src/modules/chat/panel/SessionInfoPanel.tsx
@@ -2,13 +2,14 @@ import { memo, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { cn } from '@/shared/utils';
-import type { NormalizedMessage, ProviderContextInfo, SubagentSummary, TurnStats } from '@/shared/types';
+import type { NormalizedMessage, ProviderContextInfo, ProviderMcpServer, SubagentSummary, TurnStats } from '@/shared/types';
 import type { SessionInfoPanelSection } from '@/shared/sessionInfoPanelPrefs';
 import { InfoSection } from '@/modules/chat/panel/InfoSection';
 import { ContextRingSection } from '@/modules/chat/panel/ContextRingSection';
 import { TurnStatsSection } from '@/modules/chat/panel/TurnStatsSection';
 import { TasksSection } from '@/modules/chat/panel/TasksSection';
 import { SubagentsSection } from '@/modules/chat/panel/SubagentsSection';
+import { McpServersSection } from '@/modules/chat/panel/McpServersSection';
 import { buildSessionTaskLedger } from '@/modules/chat/utils/sessionTaskList';
 
 type SessionInfoPanelProps = {
@@ -22,11 +23,14 @@ type SessionInfoPanelProps = {
   subagents: SubagentSummary[];
   subagentsLoading: boolean;
   onSelectSubagent: (summary: SubagentSummary) => void;
+  mcpServers: ProviderMcpServer[];
+  mcpLoading: boolean;
+  mcpDisabledSet: Set<string>;
+  mcpPendingNames: Set<string>;
+  onToggleMcpServer: (name: string) => Promise<boolean>;
   isMobile: boolean;
   onClose: () => void;
 };
-
-const SECTION_KEYS = ['context', 'turnStats', 'subagents', 'tasks', 'mcp', 'sources'] as const;
 
 /**
  * The right-hand conversation sidebar: six collapsible sections covering
@@ -45,6 +49,11 @@ export const SessionInfoPanel = memo(({
   subagents,
   subagentsLoading,
   onSelectSubagent,
+  mcpServers,
+  mcpLoading,
+  mcpDisabledSet,
+  mcpPendingNames,
+  onToggleMcpServer,
   isMobile,
   onClose,
 }: SessionInfoPanelProps) => {
@@ -108,16 +117,28 @@ export const SessionInfoPanel = memo(({
         <TasksSection tasks={taskLedger.tasks} />
       </InfoSection>
 
-      {SECTION_KEYS.filter((section) => section === 'mcp' || section === 'sources').map((section) => (
-        <InfoSection
-          key={section}
-          title={t(`sessionInfoPanel.${section}`)}
-          collapsed={collapsed[section] ?? false}
-          onToggle={() => onToggleSection(section)}
-        >
-          <div className="py-1 text-xs text-muted-foreground">{t('sessionInfoPanel.empty')}</div>
-        </InfoSection>
-      ))}
+      <InfoSection
+        title={t('sessionInfoPanel.mcp')}
+        countLabel={mcpServers.length > 0 ? String(mcpServers.length) : undefined}
+        collapsed={collapsed.mcp ?? false}
+        onToggle={() => onToggleSection('mcp')}
+      >
+        <McpServersSection
+          servers={mcpServers}
+          loading={mcpLoading}
+          disabledSet={mcpDisabledSet}
+          pendingNames={mcpPendingNames}
+          onToggle={onToggleMcpServer}
+        />
+      </InfoSection>
+
+      <InfoSection
+        title={t('sessionInfoPanel.sources')}
+        collapsed={collapsed.sources ?? false}
+        onToggle={() => onToggleSection('sources')}
+      >
+        <div className="py-1 text-xs text-muted-foreground">{t('sessionInfoPanel.empty')}</div>
+      </InfoSection>
     </aside>
   );
 });

--- a/src/modules/chat/panel/SessionInfoPanel.tsx
+++ b/src/modules/chat/panel/SessionInfoPanel.tsx
@@ -1,4 +1,4 @@
-import { memo } from 'react';
+import { memo, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { cn } from '@/shared/utils';
@@ -7,6 +7,8 @@ import type { SessionInfoPanelSection } from '@/shared/sessionInfoPanelPrefs';
 import { InfoSection } from '@/modules/chat/panel/InfoSection';
 import { ContextRingSection } from '@/modules/chat/panel/ContextRingSection';
 import { TurnStatsSection } from '@/modules/chat/panel/TurnStatsSection';
+import { TasksSection } from '@/modules/chat/panel/TasksSection';
+import { buildSessionTaskLedger } from '@/modules/chat/utils/sessionTaskList';
 
 type SessionInfoPanelProps = {
   collapsed: Partial<Record<SessionInfoPanelSection, boolean>>;
@@ -40,6 +42,10 @@ export const SessionInfoPanel = memo(({
   onClose,
 }: SessionInfoPanelProps) => {
   const { t } = useTranslation('chat');
+
+  // Rebuilt from the merged transcript on each stream change; the replay is
+  // linear over tool rows, and the panel only renders it while open.
+  const taskLedger = useMemo(() => buildSessionTaskLedger(mergedMessages), [mergedMessages]);
 
   return (
     <aside
@@ -77,7 +83,16 @@ export const SessionInfoPanel = memo(({
         <TurnStatsSection mergedMessages={mergedMessages} turnStats={turnStats} tokenBudget={tokenBudget} />
       </InfoSection>
 
-      {SECTION_KEYS.filter((section) => section !== 'context' && section !== 'turnStats').map((section) => (
+      <InfoSection
+        title={t('sessionInfoPanel.tasks')}
+        countLabel={taskLedger.total > 0 ? `${taskLedger.completed}/${taskLedger.total}` : undefined}
+        collapsed={collapsed.tasks ?? false}
+        onToggle={() => onToggleSection('tasks')}
+      >
+        <TasksSection tasks={taskLedger.tasks} />
+      </InfoSection>
+
+      {SECTION_KEYS.filter((section) => section !== 'context' && section !== 'turnStats' && section !== 'tasks').map((section) => (
         <InfoSection
           key={section}
           title={t(`sessionInfoPanel.${section}`)}

--- a/src/modules/chat/panel/SessionInfoPanel.tsx
+++ b/src/modules/chat/panel/SessionInfoPanel.tsx
@@ -1,0 +1,93 @@
+import { memo } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { cn } from '@/shared/utils';
+import type { NormalizedMessage, ProviderContextInfo, TurnStats } from '@/shared/types';
+import type { SessionInfoPanelSection } from '@/shared/sessionInfoPanelPrefs';
+import { InfoSection } from '@/modules/chat/panel/InfoSection';
+import { ContextRingSection } from '@/modules/chat/panel/ContextRingSection';
+import { TurnStatsSection } from '@/modules/chat/panel/TurnStatsSection';
+
+type SessionInfoPanelProps = {
+  collapsed: Partial<Record<SessionInfoPanelSection, boolean>>;
+  onToggleSection: (section: SessionInfoPanelSection) => void;
+  mergedMessages: NormalizedMessage[];
+  turnStats: TurnStats | null;
+  tokenBudget: Record<string, unknown> | null;
+  contextInfo: ProviderContextInfo | null;
+  onShowTokenDetails?: () => void;
+  isMobile: boolean;
+  onClose: () => void;
+};
+
+const SECTION_KEYS = ['context', 'turnStats', 'subagents', 'tasks', 'mcp', 'sources'] as const;
+
+/**
+ * The right-hand conversation sidebar: six collapsible sections covering
+ * context occupancy, the turn bill, subagents, the task ledger, MCP servers,
+ * and the sources feeding the window. A desktop rail beside the transcript;
+ * a full-height drawer on phones.
+ */
+export const SessionInfoPanel = memo(({
+  collapsed,
+  onToggleSection,
+  mergedMessages,
+  turnStats,
+  tokenBudget,
+  contextInfo,
+  onShowTokenDetails,
+  isMobile,
+  onClose,
+}: SessionInfoPanelProps) => {
+  const { t } = useTranslation('chat');
+
+  return (
+    <aside
+      className={cn(
+        'flex h-full min-h-0 flex-col overflow-y-auto border-l border-border/60 bg-background/95 backdrop-blur',
+        isMobile ? 'fixed inset-y-0 right-0 z-40 w-[85%] max-w-sm shadow-xl' : 'w-72 flex-shrink-0',
+      )}
+      aria-label={t('sessionInfoPanel.title')}
+    >
+      <div className="sticky top-0 z-10 flex items-center justify-between border-b border-border/40 bg-background/95 px-3 py-2">
+        <h2 className="text-sm font-semibold text-foreground">{t('sessionInfoPanel.title')}</h2>
+        <button
+          type="button"
+          onClick={onClose}
+          className="rounded p-1 text-muted-foreground hover:bg-muted hover:text-foreground"
+          aria-label={t('sessionInfoPanel.close')}
+        >
+          ✕
+        </button>
+      </div>
+
+      <InfoSection
+        title={t('sessionInfoPanel.context')}
+        collapsed={collapsed.context ?? false}
+        onToggle={() => onToggleSection('context')}
+      >
+        <ContextRingSection contextInfo={contextInfo} tokenBudget={tokenBudget} onShowDetails={onShowTokenDetails} />
+      </InfoSection>
+
+      <InfoSection
+        title={t('sessionInfoPanel.turnStats')}
+        collapsed={collapsed.turnStats ?? false}
+        onToggle={() => onToggleSection('turnStats')}
+      >
+        <TurnStatsSection mergedMessages={mergedMessages} turnStats={turnStats} tokenBudget={tokenBudget} />
+      </InfoSection>
+
+      {SECTION_KEYS.filter((section) => section !== 'context' && section !== 'turnStats').map((section) => (
+        <InfoSection
+          key={section}
+          title={t(`sessionInfoPanel.${section}`)}
+          collapsed={collapsed[section] ?? false}
+          onToggle={() => onToggleSection(section)}
+        >
+          <div className="py-1 text-xs text-muted-foreground">{t('sessionInfoPanel.empty')}</div>
+        </InfoSection>
+      ))}
+    </aside>
+  );
+});
+SessionInfoPanel.displayName = 'SessionInfoPanel';

--- a/src/modules/chat/panel/SessionInfoPanel.tsx
+++ b/src/modules/chat/panel/SessionInfoPanel.tsx
@@ -2,7 +2,7 @@ import { memo, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { cn } from '@/shared/utils';
-import type { NormalizedMessage, ProviderContextInfo, ProviderMcpServer, SubagentSummary, TurnStats } from '@/shared/types';
+import type { NormalizedMessage, ProviderContextInfo, ProviderMcpServer, ProviderSkill, SubagentSummary, TurnStats } from '@/shared/types';
 import type { SessionInfoPanelSection } from '@/shared/sessionInfoPanelPrefs';
 import { InfoSection } from '@/modules/chat/panel/InfoSection';
 import { ContextRingSection } from '@/modules/chat/panel/ContextRingSection';
@@ -10,6 +10,7 @@ import { TurnStatsSection } from '@/modules/chat/panel/TurnStatsSection';
 import { TasksSection } from '@/modules/chat/panel/TasksSection';
 import { SubagentsSection } from '@/modules/chat/panel/SubagentsSection';
 import { McpServersSection } from '@/modules/chat/panel/McpServersSection';
+import { ContextSourcesSection } from '@/modules/chat/panel/ContextSourcesSection';
 import { buildSessionTaskLedger } from '@/modules/chat/utils/sessionTaskList';
 
 type SessionInfoPanelProps = {
@@ -28,6 +29,9 @@ type SessionInfoPanelProps = {
   mcpDisabledSet: Set<string>;
   mcpPendingNames: Set<string>;
   onToggleMcpServer: (name: string) => Promise<boolean>;
+  mcpCanToggle: boolean;
+  skills: ProviderSkill[];
+  skillsLoading: boolean;
   isMobile: boolean;
   onClose: () => void;
 };
@@ -54,6 +58,9 @@ export const SessionInfoPanel = memo(({
   mcpDisabledSet,
   mcpPendingNames,
   onToggleMcpServer,
+  mcpCanToggle,
+  skills,
+  skillsLoading,
   isMobile,
   onClose,
 }: SessionInfoPanelProps) => {
@@ -129,6 +136,7 @@ export const SessionInfoPanel = memo(({
           disabledSet={mcpDisabledSet}
           pendingNames={mcpPendingNames}
           onToggle={onToggleMcpServer}
+          canToggle={mcpCanToggle}
         />
       </InfoSection>
 
@@ -137,7 +145,12 @@ export const SessionInfoPanel = memo(({
         collapsed={collapsed.sources ?? false}
         onToggle={() => onToggleSection('sources')}
       >
-        <div className="py-1 text-xs text-muted-foreground">{t('sessionInfoPanel.empty')}</div>
+        <ContextSourcesSection
+          skills={skills}
+          skillsLoading={skillsLoading}
+          mcpServers={mcpServers}
+          mcpLoading={mcpLoading}
+        />
       </InfoSection>
     </aside>
   );

--- a/src/modules/chat/panel/SessionInfoPanel.tsx
+++ b/src/modules/chat/panel/SessionInfoPanel.tsx
@@ -2,12 +2,13 @@ import { memo, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { cn } from '@/shared/utils';
-import type { NormalizedMessage, ProviderContextInfo, TurnStats } from '@/shared/types';
+import type { NormalizedMessage, ProviderContextInfo, SubagentSummary, TurnStats } from '@/shared/types';
 import type { SessionInfoPanelSection } from '@/shared/sessionInfoPanelPrefs';
 import { InfoSection } from '@/modules/chat/panel/InfoSection';
 import { ContextRingSection } from '@/modules/chat/panel/ContextRingSection';
 import { TurnStatsSection } from '@/modules/chat/panel/TurnStatsSection';
 import { TasksSection } from '@/modules/chat/panel/TasksSection';
+import { SubagentsSection } from '@/modules/chat/panel/SubagentsSection';
 import { buildSessionTaskLedger } from '@/modules/chat/utils/sessionTaskList';
 
 type SessionInfoPanelProps = {
@@ -18,6 +19,9 @@ type SessionInfoPanelProps = {
   tokenBudget: Record<string, unknown> | null;
   contextInfo: ProviderContextInfo | null;
   onShowTokenDetails?: () => void;
+  subagents: SubagentSummary[];
+  subagentsLoading: boolean;
+  onSelectSubagent: (summary: SubagentSummary) => void;
   isMobile: boolean;
   onClose: () => void;
 };
@@ -38,6 +42,9 @@ export const SessionInfoPanel = memo(({
   tokenBudget,
   contextInfo,
   onShowTokenDetails,
+  subagents,
+  subagentsLoading,
+  onSelectSubagent,
   isMobile,
   onClose,
 }: SessionInfoPanelProps) => {
@@ -84,6 +91,15 @@ export const SessionInfoPanel = memo(({
       </InfoSection>
 
       <InfoSection
+        title={t('sessionInfoPanel.subagents')}
+        countLabel={subagents.length > 0 ? String(subagents.length) : undefined}
+        collapsed={collapsed.subagents ?? false}
+        onToggle={() => onToggleSection('subagents')}
+      >
+        <SubagentsSection subagents={subagents} loading={subagentsLoading} onSelect={onSelectSubagent} />
+      </InfoSection>
+
+      <InfoSection
         title={t('sessionInfoPanel.tasks')}
         countLabel={taskLedger.total > 0 ? `${taskLedger.completed}/${taskLedger.total}` : undefined}
         collapsed={collapsed.tasks ?? false}
@@ -92,7 +108,7 @@ export const SessionInfoPanel = memo(({
         <TasksSection tasks={taskLedger.tasks} />
       </InfoSection>
 
-      {SECTION_KEYS.filter((section) => section !== 'context' && section !== 'turnStats' && section !== 'tasks').map((section) => (
+      {SECTION_KEYS.filter((section) => section === 'mcp' || section === 'sources').map((section) => (
         <InfoSection
           key={section}
           title={t(`sessionInfoPanel.${section}`)}

--- a/src/modules/chat/panel/SubagentChatModal.tsx
+++ b/src/modules/chat/panel/SubagentChatModal.tsx
@@ -1,0 +1,287 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Loader, X } from 'lucide-react';
+
+import { api } from '@/shared/api';
+import { cn } from '@/shared/utils';
+import type { LLMProvider, NormalizedMessage, Project, SubagentSummary } from '@/shared/types';
+import { normalizedToChatMessages } from '@/modules/chat/hooks/useChatMessages';
+import MessageComponent from '@/modules/chat/transcript/MessageComponent';
+import { createCachedDiffCalculator } from '@/modules/chat/utils/messageTransforms';
+import {
+  buildSubagentContinuationPrompt,
+  extractLiveSubagentMessages,
+  mergeSubagentMessages,
+} from '@/modules/chat/utils/sessionSubagents';
+
+/** Rows per history page — the agent's log is read tail-first, oldest upward. */
+const HISTORY_PAGE_SIZE = 50;
+
+type SubagentChatModalProps = {
+  parentSessionId: string;
+  summary: SubagentSummary;
+  /** The parent session's live store rows; the agent's rows hide among them. */
+  parentLiveMessages: NormalizedMessage[];
+  provider: LLMProvider;
+  selectedProject: Project | null;
+  onClose: () => void;
+  /** Starts the continuation session and navigates the workspace to it. */
+  onContinue: (prompt: string) => Promise<boolean>;
+};
+
+/**
+ * One agent's own conversation, opened from the info panel's roster.
+ *
+ * History comes from the dedicated endpoint (the parent's folded timeline
+ * caps what it transmits; this is the complete record). Live rows are
+ * derived from the parent's message slot by their spawn stamp and stamped
+ * off before conversion, so they render as this agent's own messages rather
+ * than folding back into the parent's Task card. Reading an agent is live
+ * for free this way — the parent's websocket already carries every row.
+ *
+ * "Continue" cannot message the finished agent in place (it ran inside the
+ * parent's SDK process, with no external input channel), so it opens a
+ * brand-new session seeded with the agent's identity and its work log.
+ */
+export const SubagentChatModal = ({
+  parentSessionId,
+  summary,
+  parentLiveMessages,
+  provider,
+  selectedProject,
+  onClose,
+  onContinue,
+}: SubagentChatModalProps) => {
+  const { t } = useTranslation('chat');
+  const [history, setHistory] = useState<NormalizedMessage[]>([]);
+  const [offset, setOffset] = useState(0);
+  const [historyLoading, setHistoryLoading] = useState(true);
+  const [draft, setDraft] = useState('');
+  const [sending, setSending] = useState(false);
+  const scrollRef = useRef<HTMLDivElement | null>(null);
+  const createDiff = useMemo(() => createCachedDiffCalculator(), []);
+
+  // The newest page on open, then "load earlier" walks upward from there.
+  useEffect(() => {
+    let cancelled = false;
+    setHistoryLoading(true);
+    void (async () => {
+      try {
+        const response = await api.providers.sessionSubagentMessages(parentSessionId, summary.agentId, {
+          limit: HISTORY_PAGE_SIZE,
+          offset: 0,
+        });
+        if (!response.ok) {
+          if (!cancelled) {
+            setHistory([]);
+            setOffset(0);
+          }
+          return;
+        }
+        const payload = (await response.json()) as {
+          data?: { messages?: NormalizedMessage[]; total?: number; offset?: number };
+        };
+        if (cancelled) return;
+        const messages = payload.data?.messages ?? [];
+        const totalCount = payload.data?.total ?? messages.length;
+        setHistory(messages);
+        // Rows already in hand are the tail; earlier pages start before them.
+        setOffset(Math.max(0, totalCount - messages.length));
+      } catch {
+        if (!cancelled) {
+          setHistory([]);
+          setOffset(0);
+        }
+      } finally {
+        if (!cancelled) setHistoryLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [parentSessionId, summary.agentId]);
+
+  const live = useMemo(
+    () => extractLiveSubagentMessages(parentLiveMessages, summary.toolUseId),
+    [parentLiveMessages, summary.toolUseId],
+  );
+  const merged = useMemo(() => mergeSubagentMessages(history, live), [history, live]);
+  const chatMessages = useMemo(() => normalizedToChatMessages(merged), [merged]);
+
+  // Follow the newest row while it is at the bottom, the same courtesy the
+  // main transcript extends to its own stream.
+  const lastCountRef = useRef(0);
+  useEffect(() => {
+    if (chatMessages.length > lastCountRef.current) {
+      const container = scrollRef.current;
+      if (container) container.scrollTop = container.scrollHeight;
+    }
+    lastCountRef.current = chatMessages.length;
+  }, [chatMessages.length]);
+
+  const loadEarlier = useCallback(async () => {
+    if (offset <= 0 || historyLoading) return;
+    setHistoryLoading(true);
+    try {
+      const from = Math.max(0, offset - HISTORY_PAGE_SIZE);
+      const response = await api.providers.sessionSubagentMessages(parentSessionId, summary.agentId, {
+        limit: HISTORY_PAGE_SIZE,
+        offset: from,
+      });
+      if (!response.ok) return;
+      const payload = (await response.json()) as { data?: { messages?: NormalizedMessage[] } };
+      const older = payload.data?.messages ?? [];
+      if (older.length > 0) {
+        // Prepending shifts the viewport; keep the reader on the row they had.
+        const container = scrollRef.current;
+        const previousHeight = container?.scrollHeight ?? 0;
+        setHistory((current) => [...older, ...current]);
+        setOffset(from);
+        requestAnimationFrame(() => {
+          if (container) container.scrollTop += container.scrollHeight - previousHeight;
+        });
+      } else {
+        setOffset(0);
+      }
+    } finally {
+      setHistoryLoading(false);
+    }
+  }, [offset, historyLoading, parentSessionId, summary.agentId]);
+
+  const handleSend = useCallback(async () => {
+    const text = draft.trim();
+    if (!text || sending) return;
+    setSending(true);
+    try {
+      const prompt = buildSubagentContinuationPrompt({
+        summary,
+        history,
+        userText: text,
+        copy: {
+          identity: summary.agentType
+            ? summary.description
+              ? t('sessionInfoPanel.subagentsContinueIdentityWithDescription', {
+                type: summary.agentType,
+                description: summary.description,
+              })
+              : t('sessionInfoPanel.subagentsContinueIdentity', { type: summary.agentType })
+            : summary.description
+              ? t('sessionInfoPanel.subagentsContinueIdentityBare', { description: summary.description })
+              : t('sessionInfoPanel.subagentsContinueIdentityPlain'),
+          logIntro: t('sessionInfoPanel.subagentsContinueLogIntro'),
+          askIntro: t('sessionInfoPanel.subagentsContinueAskIntro'),
+        },
+      });
+      const launched = await onContinue(prompt);
+      // The workspace took the packaged message; the overlay's job is done.
+      if (launched) onClose();
+    } finally {
+      setSending(false);
+    }
+  }, [draft, sending, onContinue, onClose, summary, history, t]);
+
+  // Escape closes the overlay, matching every other modal in the app.
+  useEffect(() => {
+    const onKey = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') onClose();
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [onClose]);
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4" onClick={onClose} role="presentation">
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-label={summary.description || summary.agentType || summary.agentId}
+        className="flex h-[85%] w-full max-w-2xl flex-col overflow-hidden rounded-lg border border-border/60 bg-background shadow-2xl"
+        onClick={(event) => event.stopPropagation()}
+      >
+        <header className="flex items-center gap-2 border-b border-border/40 px-3 py-2">
+          <h3 className="min-w-0 flex-1 truncate text-sm font-semibold text-foreground">
+            {summary.agentType || t('sessionInfoPanel.subagentsAgentLabel')}
+            {summary.description && (
+              <span className="ml-2 font-normal text-muted-foreground">{summary.description}</span>
+            )}
+          </h3>
+          {summary.status === 'running' && (
+            <span className="flex flex-shrink-0 items-center gap-1 text-[11px] text-purple-500">
+              <Loader className="h-3 w-3 animate-spin" />
+              {t('sessionInfoPanel.subagentsStatusRunning')}
+            </span>
+          )}
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded p-1 text-muted-foreground hover:bg-muted hover:text-foreground"
+            aria-label={t('sessionInfoPanel.subagentsCloseChat')}
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </header>
+
+        <div ref={scrollRef} className="min-h-0 flex-1 overflow-y-auto px-3 py-2">
+          {offset > 0 && (
+            <button
+              type="button"
+              onClick={() => void loadEarlier()}
+              disabled={historyLoading}
+              className="mb-2 w-full rounded py-1 text-xs text-muted-foreground hover:bg-muted/50 hover:text-foreground disabled:opacity-50"
+            >
+              {historyLoading ? t('sessionInfoPanel.subagentsLoading') : t('sessionInfoPanel.subagentsLoadEarlier')}
+            </button>
+          )}
+          {chatMessages.length === 0 && !historyLoading && (
+            <div className="py-6 text-center text-xs text-muted-foreground">{t('sessionInfoPanel.empty')}</div>
+          )}
+          {chatMessages.map((message, index) => (
+            <MessageComponent
+              key={String(message.id ?? `msg-${index}`)}
+              message={message}
+              prevMessage={index > 0 ? chatMessages[index - 1] : null}
+              createDiff={createDiff}
+              provider={provider}
+              selectedProject={selectedProject}
+              showRawParameters={false}
+              showThinking
+            />
+          ))}
+        </div>
+
+        <footer className="border-t border-border/40 p-2">
+          <div className="flex items-end gap-2">
+            <textarea
+              value={draft}
+              onChange={(event) => setDraft(event.target.value)}
+              onKeyDown={(event) => {
+                if (event.key === 'Enter' && !event.shiftKey) {
+                  event.preventDefault();
+                  void handleSend();
+                }
+              }}
+              rows={2}
+              placeholder={t('sessionInfoPanel.subagentsContinuePlaceholder')}
+              className="min-h-9 flex-1 resize-none rounded-md border border-border/60 bg-muted/30 px-2 py-1.5 text-sm text-foreground outline-none focus:border-primary/50"
+            />
+            <button
+              type="button"
+              onClick={() => void handleSend()}
+              disabled={!draft.trim() || sending}
+              className={cn(
+                'flex h-8 flex-shrink-0 items-center gap-1 rounded-md px-3 text-xs font-medium',
+                'bg-primary text-primary-foreground hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-50',
+              )}
+            >
+              {sending && <Loader className="h-3 w-3 animate-spin" />}
+              {t('sessionInfoPanel.subagentsContinueSend')}
+            </button>
+          </div>
+          <p className="mt-1 px-1 text-[10px] text-muted-foreground/70">
+            {t('sessionInfoPanel.subagentsContinueHint')}
+          </p>
+        </footer>
+      </div>
+    </div>
+  );
+};

--- a/src/modules/chat/panel/SubagentsSection.tsx
+++ b/src/modules/chat/panel/SubagentsSection.tsx
@@ -1,0 +1,66 @@
+import { memo } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Bot, CircleAlert, CircleCheck, Loader } from 'lucide-react';
+
+import { cn } from '@/shared/utils';
+import type { SubagentSummary } from '@/shared/types';
+
+type SubagentsSectionProps = {
+  subagents: SubagentSummary[];
+  loading: boolean;
+  /** Opens one agent's conversation overlay. */
+  onSelect: (summary: SubagentSummary) => void;
+};
+
+/**
+ * One row per agent the session spawned. The label leads with the agent type
+ * Claude presets (Explore, Plan) or the neutral word, and the task the parent
+ * assigned rides alongside it. Tapping a row opens the agent's own
+ * conversation in SubagentChatModal.
+ */
+export const SubagentsSection = memo(({ subagents, loading, onSelect }: SubagentsSectionProps) => {
+  const { t } = useTranslation('chat');
+
+  if (subagents.length === 0) {
+    return (
+      <div className="py-1 text-xs text-muted-foreground">
+        {loading ? t('sessionInfoPanel.subagentsLoading') : t('sessionInfoPanel.empty')}
+      </div>
+    );
+  }
+
+  return (
+    <ul className="space-y-0.5 py-0.5">
+      {subagents.map((agent) => (
+        <li key={agent.agentId}>
+          <button
+            type="button"
+            onClick={() => onSelect(agent)}
+            className="flex w-full items-center gap-1.5 rounded px-1 py-1 text-left text-xs hover:bg-muted/50"
+          >
+            {agent.status === 'running' ? (
+              <Loader className="h-3.5 w-3.5 flex-shrink-0 animate-spin text-purple-500" />
+            ) : agent.status === 'failed' ? (
+              <CircleAlert className="h-3.5 w-3.5 flex-shrink-0 text-red-500" />
+            ) : (
+              <CircleCheck className="h-3.5 w-3.5 flex-shrink-0 text-green-500" />
+            )}
+            <Bot className="h-3 w-3 flex-shrink-0 text-purple-500/80 dark:text-purple-400/80" />
+            <span className="flex-shrink-0 font-medium text-foreground">
+              {agent.agentType || t('sessionInfoPanel.subagentsAgentLabel')}
+            </span>
+            {agent.description && (
+              <span className="min-w-0 flex-1 truncate text-muted-foreground" title={agent.description}>
+                {agent.description}
+              </span>
+            )}
+            <span className={cn('ml-auto flex-shrink-0 text-[10px] tabular-nums', agent.status === 'running' ? 'text-purple-500' : 'text-muted-foreground/60')}>
+              {agent.activityCount}
+            </span>
+          </button>
+        </li>
+      ))}
+    </ul>
+  );
+});
+SubagentsSection.displayName = 'SubagentsSection';

--- a/src/modules/chat/panel/TasksSection.tsx
+++ b/src/modules/chat/panel/TasksSection.tsx
@@ -1,0 +1,50 @@
+import { memo } from 'react';
+import { useTranslation } from 'react-i18next';
+import { CircleCheck, CircleDashed, Loader } from 'lucide-react';
+
+import { cn } from '@/shared/utils';
+import type { SessionTask } from '@/modules/chat/utils/sessionTaskList';
+
+type TasksSectionProps = {
+  tasks: SessionTask[];
+};
+
+/**
+ * The task ledger the agent committed to this session, rebuilt from the
+ * transcript by buildSessionTaskLedger. An in-progress row shows the
+ * present-tense wording (activeForm) the agent created it with, which reads
+ * better than the imperative subject while the work is actually happening.
+ */
+export const TasksSection = memo(({ tasks }: TasksSectionProps) => {
+  const { t } = useTranslation('chat');
+
+  if (tasks.length === 0) {
+    return <div className="py-1 text-xs text-muted-foreground">{t('sessionInfoPanel.empty')}</div>;
+  }
+
+  return (
+    <ul className="space-y-1 py-0.5">
+      {tasks.map((task) => (
+        <li key={task.id} className="flex items-start gap-1.5 text-xs">
+          {task.status === 'completed' ? (
+            <CircleCheck className="mt-0.5 h-3.5 w-3.5 flex-shrink-0 text-green-500" />
+          ) : task.status === 'in_progress' ? (
+            <Loader className="mt-0.5 h-3.5 w-3.5 flex-shrink-0 animate-spin text-primary" />
+          ) : (
+            <CircleDashed className="mt-0.5 h-3.5 w-3.5 flex-shrink-0 text-muted-foreground/60" />
+          )}
+          <span
+            className={cn(
+              'min-w-0 flex-1 leading-snug',
+              task.status === 'completed' ? 'text-muted-foreground line-through' : 'text-foreground/90',
+            )}
+            title={task.content}
+          >
+            {task.status === 'in_progress' && task.activeForm ? task.activeForm : task.content}
+          </span>
+        </li>
+      ))}
+    </ul>
+  );
+});
+TasksSection.displayName = 'TasksSection';

--- a/src/modules/chat/panel/TurnStatsSection.tsx
+++ b/src/modules/chat/panel/TurnStatsSection.tsx
@@ -1,0 +1,57 @@
+import { memo } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import type { TurnStats } from '@/shared/types';
+import { deriveTurnMetrics, formatDuration, formatTokenCount, formatTokPerSec } from '@/modules/chat/utils/sessionTurnStats';
+
+type TurnStatsSectionProps = {
+  mergedMessages: Parameters<typeof deriveTurnMetrics>[0];
+  turnStats: TurnStats | null;
+  tokenBudget: Record<string, unknown> | null;
+};
+
+/** A right-aligned gray metric row, matching the reference panel's layout. */
+const StatRow = memo(({ label, value }: { label: string; value: string }) => (
+  <div className="flex items-center justify-between py-0.5 text-xs">
+    <span className="text-muted-foreground">{label}</span>
+    <span className="font-mono text-foreground/70">{value}</span>
+  </div>
+));
+StatRow.displayName = 'StatRow';
+
+/**
+ * The turn bill: speeds, durations, step count, token split, cache hit and
+ * cost. Metrics the provider could not report render `—` rather than a zero,
+ * so a mid-run or post-reload panel never claims a free or instant turn.
+ */
+export const TurnStatsSection = memo(({ mergedMessages, turnStats, tokenBudget }: TurnStatsSectionProps) => {
+  const { t } = useTranslation('chat');
+  const metrics = deriveTurnMetrics(mergedMessages, turnStats, tokenBudget);
+  // Durations come straight from the provider's result frame when present;
+  // without it the values are timestamp estimates, which the reference marks
+  // with `~`.
+  const exact = turnStats?.durationMs != null && turnStats?.apiDurationMs != null;
+
+  return (
+    <div>
+      <StatRow label={t('sessionInfoPanel.stats.answerSpeed')} value={formatTokPerSec(metrics.answerSpeedTokPerSec, !exact)} />
+      <StatRow label={t('sessionInfoPanel.stats.requestSpeed')} value={formatTokPerSec(metrics.requestSpeedTokPerSec, !exact)} />
+      <StatRow label={t('sessionInfoPanel.stats.modelTime')} value={formatDuration(metrics.modelDurationMs)} />
+      <StatRow label={t('sessionInfoPanel.stats.toolTime')} value={formatDuration(metrics.toolDurationMs)} />
+      <StatRow label={t('sessionInfoPanel.stats.steps')} value={metrics.steps === null ? '—' : String(metrics.steps)} />
+      <StatRow
+        label={t('sessionInfoPanel.stats.tokens')}
+        value={`${formatTokenCount(metrics.inputTokens)}↑ · ${formatTokenCount(metrics.outputTokens)}↓`}
+      />
+      <StatRow
+        label={t('sessionInfoPanel.stats.cacheHit')}
+        value={metrics.cacheHitPercent === null ? '—' : `${Math.round(metrics.cacheHitPercent)}%`}
+      />
+      <StatRow
+        label={t('sessionInfoPanel.stats.cost')}
+        value={metrics.costUsd === null ? '—' : `$${metrics.costUsd.toFixed(3)}`}
+      />
+    </div>
+  );
+});
+TurnStatsSection.displayName = 'TurnStatsSection';

--- a/src/modules/chat/tests/contextSourcesSection.test.tsx
+++ b/src/modules/chat/tests/contextSourcesSection.test.tsx
@@ -1,0 +1,66 @@
+import assert from 'node:assert/strict';
+
+import { render, screen } from '@testing-library/react';
+import { test, vi } from 'vitest';
+
+import { ContextSourcesSection } from '@/modules/chat/panel/ContextSourcesSection';
+import type { McpScope, ProviderMcpServer, ProviderSkill } from '@/shared/types';
+
+// Keys stand in for translations; the panel-level test covers the catalog.
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+const skill = (name: string, scope: ProviderSkill['scope'] = 'user'): ProviderSkill => ({
+  provider: 'claude',
+  name,
+  description: `${name} desc`,
+  command: `/${name}`,
+  scope,
+  sourcePath: `skills/${name}.md`,
+});
+
+const server = (name: string, scope: McpScope = 'user'): ProviderMcpServer => ({
+  provider: 'claude',
+  name,
+  scope,
+  transport: 'stdio',
+  command: `${name}-bin`,
+});
+
+test('each group counts and lists its rows with the scope tag', () => {
+  render(
+    <ContextSourcesSection
+      skills={[skill('commit'), skill('review', 'project')]}
+      skillsLoading={false}
+      mcpServers={[server('github')]}
+      mcpLoading={false}
+    />,
+  );
+
+  // Group headers carry the counts; loading would replace them with "…".
+  assert.ok(screen.getByText('sessionInfoPanel.sourcesSkills'));
+  assert.ok(screen.getByText('sessionInfoPanel.sourcesMcp'));
+  assert.ok(screen.getByText('2'));
+  assert.ok(screen.getByText('1'));
+
+  assert.ok(screen.getByText('commit'));
+  assert.ok(screen.getByText('review'));
+  assert.ok(screen.getByText('github'));
+  // The tag uppercases through CSS, so the DOM text is the raw scope value.
+  assert.ok(screen.getByText('project'));
+});
+
+test('a loading group shows the ellipsis instead of the count', () => {
+  render(
+    <ContextSourcesSection
+      skills={[]}
+      skillsLoading={true}
+      mcpServers={[]}
+      mcpLoading={false}
+    />,
+  );
+
+  assert.ok(screen.getByText('…'));
+  assert.ok(screen.getByText('0'));
+});

--- a/src/modules/chat/tests/mcpServersSection.test.tsx
+++ b/src/modules/chat/tests/mcpServersSection.test.tsx
@@ -1,0 +1,89 @@
+import assert from 'node:assert/strict';
+
+import { fireEvent, render, screen } from '@testing-library/react';
+import { test, vi } from 'vitest';
+
+import { McpServersSection } from '@/modules/chat/panel/McpServersSection';
+import { flattenMcpServers } from '@/modules/chat/hooks/useSessionMcpServers';
+import type { McpScope, ProviderMcpServer } from '@/shared/types';
+
+// Section body has no translated strings it asserts on; t() returning the key
+// keeps the mock trivial and the role-based queries locale-independent.
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+const server = (name: string, scope: McpScope = 'user'): ProviderMcpServer => ({
+  provider: 'claude',
+  name,
+  scope,
+  transport: 'stdio',
+  command: `${name}-bin`,
+});
+
+test('flattenMcpServers dedupes by name across scopes, first scope wins', () => {
+  const flat = flattenMcpServers({
+    data: {
+      scopes: {
+        project: [server('shared', 'project')],
+        user: [server('shared', 'user'), server('solo', 'user')],
+      } as Partial<Record<McpScope, ProviderMcpServer[]>>,
+    },
+  });
+
+  assert.deepEqual(flat.map((s) => [s.name, s.scope]), [
+    ['shared', 'project'],
+    ['solo', 'user'],
+  ]);
+});
+
+test('flattenMcpServers reads the flat servers shape and trims names', () => {
+  const flat = flattenMcpServers({
+    data: { servers: [server('  spaced  ') as never] },
+  });
+  assert.deepEqual(flat.map((s) => s.name), ['spaced']);
+});
+
+test('flattenMcpServers tolerates an empty or missing payload', () => {
+  assert.deepEqual(flattenMcpServers({}), []);
+  assert.deepEqual(flattenMcpServers({ data: {} }), []);
+});
+
+const renderSection = (overrides: Partial<Parameters<typeof McpServersSection>[0]> = {}) => {
+  const toggles: string[] = [];
+  render(
+    <McpServersSection
+      servers={[server('github'), server('fetch')]}
+      loading={false}
+      disabledSet={new Set(['fetch'])}
+      pendingNames={new Set<string>()}
+      onToggle={async (name) => { toggles.push(name); return true; }}
+      {...overrides}
+    />,
+  );
+  return { toggles };
+};
+
+test('a disabled server reads as an off switch and an enabled one as on', () => {
+  renderSection();
+  // Servers are sorted, so switches[0] is github (on) and switches[1] fetch (off).
+  const ordered = screen.getAllByRole('switch').map((el) => el.getAttribute('aria-checked'));
+  assert.deepEqual(ordered, ['true', 'false']);
+});
+
+test('clicking a switch asks the parent to toggle that name', () => {
+  const { toggles } = renderSection();
+  fireEvent.click(screen.getAllByRole('switch')[0]);
+  assert.deepEqual(toggles, ['github']);
+});
+
+test('a pending switch is disabled so it cannot be flipped twice', () => {
+  renderSection({ pendingNames: new Set(['github']) });
+  const first = screen.getAllByRole('switch')[0];
+  assert.equal(first.hasAttribute('disabled'), true);
+});
+
+test('a loading empty list shows the loading line, not the empty one', () => {
+  renderSection({ servers: [], loading: true });
+  assert.ok(screen.getByText('sessionInfoPanel.mcpLoading'));
+});

--- a/src/modules/chat/tests/mcpServersSection.test.tsx
+++ b/src/modules/chat/tests/mcpServersSection.test.tsx
@@ -87,3 +87,15 @@ test('a loading empty list shows the loading line, not the empty one', () => {
   renderSection({ servers: [], loading: true });
   assert.ok(screen.getByText('sessionInfoPanel.mcpLoading'));
 });
+
+test('canToggle=false renders read-only switches that swallow clicks', async () => {
+  const { toggles } = renderSection({ canToggle: false });
+  const first = screen.getAllByRole('switch')[0];
+  assert.equal(first.hasAttribute('disabled'), true);
+
+  fireEvent.click(first);
+  assert.deepEqual(toggles, []);
+
+  // The footer swaps to the read-only explanation.
+  assert.ok(screen.getByText('sessionInfoPanel.mcpReadOnlyHint'));
+});

--- a/src/modules/chat/tests/permissionPromptReplay.test.tsx
+++ b/src/modules/chat/tests/permissionPromptReplay.test.tsx
@@ -29,6 +29,7 @@ const renderHandlers = () => {
     selectedSession: { id: 'viewed-session' } as ProjectSession,
     currentSessionId: 'viewed-session',
     setTokenBudget: () => {},
+    setTurnStats: () => {},
     pendingPermissionRequests: [],
     setPendingPermissionRequests: (next) => {
       pending = typeof next === 'function' ? next(pending) : next;

--- a/src/modules/chat/tests/permissionPromptReplay.test.tsx
+++ b/src/modules/chat/tests/permissionPromptReplay.test.tsx
@@ -35,6 +35,8 @@ const renderHandlers = () => {
     },
     streamTimerRef: { current: null },
     accumulatedStreamRef: { current: '' },
+    thinkingStreamTimerRef: { current: null },
+    accumulatedThinkingStreamRef: { current: '' },
     lastSeqRef: { current: new Map() },
     statusCheckSentAtRef: { current: new Map() },
     requestLatestMessages: async () => {},

--- a/src/modules/chat/tests/promptNavigator.test.ts
+++ b/src/modules/chat/tests/promptNavigator.test.ts
@@ -1,0 +1,52 @@
+import assert from 'node:assert/strict';
+
+import { test } from 'vitest';
+
+import { buildPromptEntries, buildPromptPreview } from '@/modules/chat/utils/promptNavigator';
+import type { ChatMessage } from '@/shared/types';
+
+/**
+ * The prompt navigator rail offers one tick per user prompt. Messages that
+ * never appear as a prompt bubble (assistant replies, thinking placeholders,
+ * content-less local commands) must not produce entries, and the preview must
+ * be a single readable line regardless of what the raw markdown looked like.
+ */
+
+const message = (partial: Partial<ChatMessage> & { type: string }): ChatMessage => ({
+  timestamp: '2026-01-01T00:00:00.000Z',
+  ...partial,
+});
+
+test('collects only user prompts, in order', () => {
+  const entries = buildPromptEntries([
+    message({ type: 'user', content: '第一条', timestamp: '2026-01-01T00:00:01.000Z' }),
+    message({ type: 'assistant', content: '回复' }),
+    message({ type: 'user', isThinking: true, content: '思考中' }),
+    message({ type: 'user', isLocalCommand: true }),
+    message({ type: 'user', content: '/help 用法说明', isLocalCommand: true }),
+    message({ type: 'user', content: '第二条', timestamp: '2026-01-01T00:00:09.000Z' }),
+  ]);
+
+  assert.deepEqual(
+    entries.map((entry) => entry.preview),
+    ['第一条', '/help 用法说明', '第二条'],
+  );
+  assert.equal(entries[0].timestamp, '2026-01-01T00:00:01.000Z');
+  assert.equal(entries[1].message.isLocalCommand, true);
+  // Ids stay unique even when two prompts share a timestamp.
+  const dup = buildPromptEntries([
+    message({ type: 'user', content: '甲', timestamp: '2026-01-01T00:00:05.000Z' }),
+    message({ type: 'user', content: '乙', timestamp: '2026-01-01T00:00:05.000Z' }),
+  ]);
+  assert.notEqual(dup[0].id, dup[1].id);
+});
+
+test('preview collapses markdown to one line', () => {
+  assert.equal(
+    buildPromptPreview('## 标题\n\n```js\nconst a = 1;\n```\n\n看 [链接](http://x.y) 里的 `_代码_`'),
+    '标题 看 链接 里的 代码',
+  );
+  const long = buildPromptPreview('长'.repeat(400));
+  assert.ok(long.length <= 160);
+  assert.ok(long.endsWith('…'));
+});

--- a/src/modules/chat/tests/sessionInfoPanelRender.test.tsx
+++ b/src/modules/chat/tests/sessionInfoPanelRender.test.tsx
@@ -79,6 +79,29 @@ test('clicking a header asks the parent to toggle that section', () => {
   assert.deepEqual(toggles, ['tasks']);
 });
 
+test('the task section counts completed rows and shows activeForm while running', () => {
+  const taskRows: NormalizedMessage[] = [
+    {
+      id: 'tc1', sessionId: 's1', timestamp: '2026-09-12T00:00:00.000Z', provider: 'claude',
+      kind: 'tool_use', toolName: 'TaskCreate', toolId: 't1',
+      toolInput: { subject: 'Read notes', activeForm: 'Reading notes' },
+      toolResult: { content: 'ok', isError: false, toolUseResult: { task: { id: '1', status: 'completed' } } },
+    },
+    {
+      id: 'tc2', sessionId: 's1', timestamp: '2026-09-12T00:00:01.000Z', provider: 'claude',
+      kind: 'tool_use', toolName: 'TaskCreate', toolId: 't2',
+      toolInput: { subject: 'Ship it', activeForm: 'Shipping it' },
+      toolResult: { content: 'ok', isError: false, toolUseResult: { task: { id: '2', status: 'in_progress' } } },
+    },
+  ] as unknown as NormalizedMessage[];
+
+  renderPanel({ mergedMessages: taskRows });
+
+  assert.ok(screen.getByText('1/2'), 'header shows the completed/total count');
+  assert.ok(screen.getByText('Read notes'), 'a pending row shows its subject');
+  assert.ok(screen.getByText('Shipping it'), 'the running row uses its present-tense wording');
+});
+
 test('mobile renders as a fixed drawer with the close affordance', () => {
   const { toggles } = renderPanel({ isMobile: true });
 

--- a/src/modules/chat/tests/sessionInfoPanelRender.test.tsx
+++ b/src/modules/chat/tests/sessionInfoPanelRender.test.tsx
@@ -42,6 +42,11 @@ const renderPanel = (overrides: Partial<Parameters<typeof SessionInfoPanel>[0]> 
       subagents={[]}
       subagentsLoading={false}
       onSelectSubagent={() => undefined}
+      mcpServers={[]}
+      mcpLoading={false}
+      mcpDisabledSet={new Set()}
+      mcpPendingNames={new Set()}
+      onToggleMcpServer={async () => true}
       isMobile={false}
       onClose={() => toggles.push('close')}
       {...overrides}

--- a/src/modules/chat/tests/sessionInfoPanelRender.test.tsx
+++ b/src/modules/chat/tests/sessionInfoPanelRender.test.tsx
@@ -39,6 +39,9 @@ const renderPanel = (overrides: Partial<Parameters<typeof SessionInfoPanel>[0]> 
       turnStats={null}
       tokenBudget={null}
       contextInfo={null}
+      subagents={[]}
+      subagentsLoading={false}
+      onSelectSubagent={() => undefined}
       isMobile={false}
       onClose={() => toggles.push('close')}
       {...overrides}

--- a/src/modules/chat/tests/sessionInfoPanelRender.test.tsx
+++ b/src/modules/chat/tests/sessionInfoPanelRender.test.tsx
@@ -1,0 +1,109 @@
+import assert from 'node:assert/strict';
+
+import { fireEvent, render, screen } from '@testing-library/react';
+import { test, vi } from 'vitest';
+
+import zhChat from '@/modules/i18n/locales/zh-CN/chat.json';
+import enChat from '@/modules/i18n/locales/en/chat.json';
+
+// Mock t() against the real zh-CN catalog: the panel's section titles and
+// metric labels are the keys this test asserts on, so a key typo fails here
+// while the English parity check below guards the other locale.
+const panelMessages = (zhChat as Record<string, unknown>).sessionInfoPanel as Record<string, unknown>;
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => {
+      const [ns, ...rest] = key.split('.');
+      const root = ns === 'sessionInfoPanel' ? panelMessages : (zhChat as Record<string, unknown>)[ns];
+      let value: unknown = root;
+      for (const part of rest) {
+        value = (value as Record<string, unknown> | undefined)?.[part];
+      }
+      return typeof value === 'string' ? value : key;
+    },
+  }),
+}));
+
+const { SessionInfoPanel } = await import('@/modules/chat/panel/SessionInfoPanel');
+import type { NormalizedMessage } from '@/shared/types';
+
+const noMessages: NormalizedMessage[] = [];
+
+const renderPanel = (overrides: Partial<Parameters<typeof SessionInfoPanel>[0]> = {}) => {
+  const toggles: string[] = [];
+  const view = render(
+    <SessionInfoPanel
+      collapsed={{}}
+      onToggleSection={(section) => toggles.push(section)}
+      mergedMessages={noMessages}
+      turnStats={null}
+      tokenBudget={null}
+      contextInfo={null}
+      isMobile={false}
+      onClose={() => toggles.push('close')}
+      {...overrides}
+    />,
+  );
+
+  return { view, toggles };
+};
+
+test('the six sections render and one click collapses by request', () => {
+  renderPanel();
+
+  for (const heading of ['上下文', '轮次统计', '子代理', '任务', 'MCP', '上下文来源']) {
+    assert.ok(screen.getAllByText(heading).length >= 1, `missing section ${heading}`);
+  }
+});
+
+test('a collapsed section unmounts its body', () => {
+  renderPanel({ collapsed: { turnStats: true } });
+
+  // The header stays; the metric rows are gone.
+  assert.ok(screen.getByText('轮次统计'));
+  assert.equal(screen.queryByText('回答速度'), null);
+});
+
+test('an expanded section shows the metric labels', () => {
+  renderPanel();
+
+  assert.ok(screen.getByText('回答速度'));
+  assert.ok(screen.getByText('缓存命中率'));
+});
+
+test('clicking a header asks the parent to toggle that section', () => {
+  const { toggles } = renderPanel();
+
+  fireEvent.click(screen.getByText('任务'));
+
+  assert.deepEqual(toggles, ['tasks']);
+});
+
+test('mobile renders as a fixed drawer with the close affordance', () => {
+  const { toggles } = renderPanel({ isMobile: true });
+
+  const close = screen.getByLabelText('关闭会话面板');
+  fireEvent.click(close);
+
+  assert.deepEqual(toggles, ['close']);
+});
+
+test('the English catalog covers every key the panel reads', () => {
+  const enPanel = (enChat as Record<string, unknown>).sessionInfoPanel as Record<string, unknown>;
+  const collect = (value: unknown, prefix: string, into: string[]) => {
+    if (typeof value === 'string') {
+      into.push(prefix);
+      return;
+    }
+    for (const [key, child] of Object.entries(value as Record<string, unknown>)) {
+      collect(child, `${prefix}.${key}`, into);
+    }
+  };
+
+  const zhKeys: string[] = [];
+  collect(panelMessages, 'sessionInfoPanel', zhKeys);
+  const enKeys: string[] = [];
+  collect(enPanel, 'sessionInfoPanel', enKeys);
+
+  assert.deepEqual(zhKeys.sort(), enKeys.sort());
+});

--- a/src/modules/chat/tests/sessionInfoPanelRender.test.tsx
+++ b/src/modules/chat/tests/sessionInfoPanelRender.test.tsx
@@ -47,6 +47,9 @@ const renderPanel = (overrides: Partial<Parameters<typeof SessionInfoPanel>[0]> 
       mcpDisabledSet={new Set()}
       mcpPendingNames={new Set()}
       onToggleMcpServer={async () => true}
+      mcpCanToggle={true}
+      skills={[]}
+      skillsLoading={false}
       isMobile={false}
       onClose={() => toggles.push('close')}
       {...overrides}

--- a/src/modules/chat/tests/sessionSubagentsExtraction.test.ts
+++ b/src/modules/chat/tests/sessionSubagentsExtraction.test.ts
@@ -1,0 +1,139 @@
+import assert from 'node:assert/strict';
+
+import { test } from 'vitest';
+
+import type { NormalizedMessage, SubagentSummary } from '@/shared/types';
+import { normalizedToChatMessages } from '@/modules/chat/hooks/useChatMessages';
+import {
+  buildSubagentContinuationPrompt,
+  extractLiveSubagentMessages,
+  mergeSubagentMessages,
+} from '@/modules/chat/utils/sessionSubagents';
+
+/**
+ * The info panel's agent view reads one agent's rows out of the PARENT
+ * session's live slot. Two rules keep that honest: rows are selected by
+ * their spawn stamp (`parentToolUseId`), and the stamp is stripped before
+ * conversion — `normalizedToChatMessages` folds stamped rows into the
+ * parent's Task container, which is exactly what this view must not do.
+ */
+
+function message(id: string, overrides: Partial<NormalizedMessage> = {}): NormalizedMessage {
+  return {
+    id,
+    sessionId: 'parent-1',
+    timestamp: '2026-09-11T12:00:00.000Z',
+    provider: 'claude',
+    kind: 'text',
+    role: 'assistant',
+    content: id,
+    ...overrides,
+  };
+}
+
+const agentRow = (id: string, overrides: Partial<NormalizedMessage> = {}): NormalizedMessage =>
+  message(id, { parentToolUseId: 'toolu_launch', ...overrides });
+
+test('only the matching stamp survives, and the stamp is stripped', () => {
+  const rows = [
+    message('parent-text'),
+    agentRow('agent-text'),
+    agentRow('agent-tool', { kind: 'tool_use', toolId: 'b1', toolName: 'Bash', toolInput: { command: 'ls' } }),
+    message('other-agent', { parentToolUseId: 'toolu_other' }),
+  ];
+
+  const live = extractLiveSubagentMessages(rows, 'toolu_launch');
+  assert.deepEqual(live.map((row) => row.id), ['agent-text', 'agent-tool']);
+  assert.ok(live.every((row) => row.parentToolUseId === undefined), 'the stamp must be removed');
+
+  // Stripped rows convert to top-level chat messages, not a folded container.
+  const converted = normalizedToChatMessages(live);
+  assert.equal(converted.length, 2);
+  assert.ok(converted.every((entry) => !entry.isSubagentContainer));
+});
+
+test('the echoed prompt and run-control rows never join the agent view', () => {
+  const live = extractLiveSubagentMessages([
+    agentRow('echo', { role: 'user', content: 'do the task' }),
+    agentRow('note'),
+    agentRow('done', { kind: 'complete' }),
+    agentRow('frame', { kind: 'status' }),
+  ], 'toolu_launch');
+
+  assert.deepEqual(live.map((row) => row.id), ['note']);
+});
+
+test('an agent without a known tool id has no derivable live rows', () => {
+  assert.deepEqual(extractLiveSubagentMessages([agentRow('x')], undefined), []);
+});
+
+test('merge dedupes by id and by paired tool rows', () => {
+  const history = [
+    message('h1'),
+    agentRow('h-tool', { kind: 'tool_use', toolId: 'b1', toolName: 'Bash' }),
+  ];
+  const live = [
+    message('h1'), // same id already in the page
+    agentRow('live-tool', { kind: 'tool_result', toolId: 'b1', content: 'done' }), // paired row, different id
+    agentRow('fresh'),
+  ];
+
+  const merged = mergeSubagentMessages(history, live);
+  // h1 dedupes by id; live-tool dedupes against h-tool by (kind,toolId)…
+  // except it is a tool_RESULT and h-tool is a tool_USE — different keys, so
+  // it legitimately joins as the missing result half.
+  assert.deepEqual(merged.map((row) => row.id), ['h1', 'h-tool', 'live-tool', 'fresh']);
+
+  const resultDup = mergeSubagentMessages(
+    [...history, agentRow('h-result', { kind: 'tool_result', toolId: 'b1', content: 'done' })],
+    [agentRow('live-tool', { kind: 'tool_result', toolId: 'b1', content: 'done' })],
+  );
+  assert.equal(resultDup.length, 3, 'an already-paged tool_result must not reappear');
+});
+
+const summary: SubagentSummary = {
+  agentId: 'alpha', agentType: 'Explore', description: 'survey the repo',
+  toolUseId: 'toolu_launch', status: 'completed', activityCount: 3,
+};
+
+test('the continuation prompt carries identity, log, and the user’s words', () => {
+  const history = [
+    agentRow('think', { kind: 'thinking', content: 'checking entry points' }),
+    agentRow('call', { kind: 'tool_use', toolId: 'b1', toolName: 'Bash', toolInput: { command: 'ls src' } }),
+    agentRow('res', { kind: 'tool_result', toolId: 'b1', content: 'index.ts\nmain.ts' }),
+    agentRow('say', { content: 'the entry point is main.ts' }),
+  ];
+
+  const prompt = buildSubagentContinuationPrompt({ summary, history, userText: 'then what about tests?' });
+
+  assert.match(prompt, /「Explore」（survey the repo）/);
+  assert.match(prompt, /checking entry points/);
+  assert.match(prompt, /调用 Bash/);
+  assert.match(prompt, /index\.ts/);
+  assert.match(prompt, /main\.ts/);
+  assert.ok(prompt.trimEnd().endsWith('then what about tests?'), 'the user’s words come last');
+});
+
+test('injected copy replaces the prose seams', () => {
+  const prompt = buildSubagentContinuationPrompt({
+    summary,
+    history: [agentRow('say', { content: 'earlier finding' })],
+    userText: 'hello',
+    copy: { identity: 'You are "Explore".', logIntro: 'Your earlier record:', askIntro: 'Now answer:' },
+  });
+
+  assert.ok(prompt.startsWith('You are "Explore".'));
+  assert.match(prompt, /Your earlier record:.*earlier finding/s);
+  assert.match(prompt, /Now answer:\nhello/);
+});
+
+test('an oversized log keeps its tail', () => {
+  const history = Array.from({ length: 400 }, (_, index) =>
+    agentRow(`row-${index}`, { content: `line ${index} ${'x'.repeat(200)}` }));
+
+  const prompt = buildSubagentContinuationPrompt({ summary, history, userText: 'next?' });
+
+  assert.ok(prompt.includes('仅保留最近部分'), 'truncation is announced');
+  assert.ok(prompt.includes('line 399'), 'the newest rows survive');
+  assert.ok(!prompt.includes('line 0 xxx'), 'the oldest rows are dropped');
+});

--- a/src/modules/chat/tests/sessionTaskListReplay.test.ts
+++ b/src/modules/chat/tests/sessionTaskListReplay.test.ts
@@ -1,0 +1,141 @@
+import assert from 'node:assert/strict';
+import { test } from 'vitest';
+
+import type { NormalizedMessage } from '@/shared/types';
+import { buildSessionTaskLedger } from '@/modules/chat/utils/sessionTaskList';
+
+// Fixture shape mirrors server/shared/tests/message-unification.test.ts so the
+// replay rules stay checked against the same transcripts both sides read.
+
+const message = (overrides: Partial<NormalizedMessage>): NormalizedMessage => ({
+  id: `m-${Math.random().toString(36).slice(2)}`,
+  sessionId: 's1',
+  timestamp: '2026-09-12T00:00:00.000Z',
+  provider: 'claude',
+  kind: 'text',
+  ...overrides,
+} as NormalizedMessage);
+
+const taskCall = (
+  toolName: string,
+  toolId: string,
+  toolInput: unknown,
+  toolUseResult: unknown,
+): NormalizedMessage => message({
+  kind: 'tool_use',
+  toolName,
+  toolId,
+  toolInput,
+  toolResult: { content: 'ok', isError: false, toolUseResult },
+});
+
+const todoSnapshot = (toolId: string, todos: unknown[]): NormalizedMessage => message({
+  kind: 'tool_use',
+  toolName: 'TodoWrite',
+  toolId,
+  toolInput: { todos },
+});
+
+test('the task tracker replays creates, an id-keyed update, and counts', () => {
+  const ledger = buildSessionTaskLedger([
+    taskCall('TaskCreate', 't1', { subject: 'Read notes', activeForm: 'Reading notes' }, { task: { id: '1' } }),
+    taskCall('TaskCreate', 't2', { subject: 'Run tests', activeForm: 'Running tests' }, { task: { id: '2' } }),
+    taskCall('TaskUpdate', 't3', { taskId: '1', status: 'completed' }, { success: true }),
+  ]);
+
+  assert.deepEqual(ledger.tasks.map((task) => [task.id, task.status]), [['1', 'completed'], ['2', 'pending']]);
+  assert.equal(ledger.completed, 1);
+  assert.equal(ledger.pending, 1);
+  assert.equal(ledger.inProgress, 0);
+});
+
+test('a create whose result has not landed is keyed by the tool call id', () => {
+  const ledger = buildSessionTaskLedger([
+    message({ kind: 'tool_use', toolName: 'TaskCreate', toolId: 'pending-1', toolInput: { subject: 'Draft' } }),
+  ]);
+
+  assert.equal(ledger.tasks.length, 1);
+  assert.equal(ledger.tasks[0].id, 'pending-1');
+  assert.equal(ledger.tasks[0].content, 'Draft');
+});
+
+test('a TaskList restatement wins wholesale and keeps known activeForm', () => {
+  const ledger = buildSessionTaskLedger([
+    taskCall('TaskCreate', 't1', { subject: 'Read notes', activeForm: 'Reading notes' }, { task: { id: '1' } }),
+    taskCall('TaskList', 't2', {}, { tasks: [
+      { id: '1', subject: 'Read notes (edited)', status: 'in_progress' },
+      { id: '2', subject: 'Extra', status: 'pending' },
+    ] }),
+  ]);
+
+  assert.deepEqual(ledger.tasks.map((task) => [task.id, task.status]), [['1', 'in_progress'], ['2', 'pending']]);
+  assert.equal(ledger.tasks[0].activeForm, 'Reading notes');
+  assert.equal(ledger.inProgress, 1);
+});
+
+test('TodoWrite snapshots restate the whole ledger and the last one wins', () => {
+  const ledger = buildSessionTaskLedger([
+    todoSnapshot('w1', [{ content: 'One', status: 'pending' }, { content: 'Two', status: 'pending' }]),
+    todoSnapshot('w2', [{ content: 'One', status: 'completed' }, { content: 'Two', status: 'in_progress' }]),
+  ]);
+
+  assert.deepEqual(ledger.tasks.map((task) => task.status), ['completed', 'in_progress']);
+  assert.equal(ledger.total, 2);
+});
+
+test('repeated identical snapshots collapse and later creates own the ledger', () => {
+  const ledger = buildSessionTaskLedger([
+    todoSnapshot('w1', [{ content: 'Ship it', status: 'pending' }]),
+    todoSnapshot('w2', [{ content: 'Ship it', status: 'pending' }]),
+    todoSnapshot('w3', [{ content: 'Ship it', status: 'pending' }]),
+    taskCall('TaskCreate', 't1', { subject: 'Follow-up' }, { task: { id: '9' } }),
+  ]);
+
+  // The tracker wrote last, so it owns the ledger regardless of the snapshots.
+  assert.deepEqual(ledger.tasks.map((task) => task.id), ['9']);
+});
+
+test('whichever source wrote last owns the ledger', () => {
+  const trackerThenSnapshot = buildSessionTaskLedger([
+    taskCall('TaskCreate', 't1', { subject: 'Stale', activeForm: 'Staling' }, { task: { id: '1' } }),
+    todoSnapshot('w1', [{ content: 'Fresh', status: 'in_progress' }]),
+  ]);
+  assert.deepEqual(trackerThenSnapshot.tasks.map((task) => task.content), ['Fresh']);
+
+  const snapshotThenTracker = buildSessionTaskLedger([
+    todoSnapshot('w1', [{ content: 'Fresh', status: 'in_progress' }]),
+    taskCall('TaskCreate', 't1', { subject: 'Stale', activeForm: 'Staling' }, { task: { id: '1' } }),
+  ]);
+  assert.deepEqual(snapshotThenTracker.tasks.map((task) => task.content), ['Stale']);
+});
+
+test('subagent rows are kept out of the main ledger', () => {
+  const ledger = buildSessionTaskLedger([
+    taskCall('TaskCreate', 't1', { subject: 'Child work' }, { task: { id: '1' } }),
+    message({
+      kind: 'tool_use',
+      toolName: 'TaskCreate',
+      toolId: 't2',
+      toolInput: { subject: 'Subagent private' },
+      toolResult: { content: 'ok', isError: false, toolUseResult: { task: { id: '2' } } },
+      parentToolUseId: 'toolu-parent-1',
+    }),
+    message({
+      kind: 'tool_use',
+      toolName: 'TodoWrite',
+      toolId: 'w1',
+      toolInput: { todos: [{ content: 'Child snapshot', status: 'pending' }] },
+      parentToolUseId: 'toolu-parent-1',
+    }),
+  ]);
+
+  assert.deepEqual(ledger.tasks.map((task) => task.content), ['Child work']);
+});
+
+test('non-ledger traffic and empty transcripts yield an empty ledger', () => {
+  assert.equal(buildSessionTaskLedger([]).total, 0);
+  assert.equal(buildSessionTaskLedger([
+    message({ kind: 'text', role: 'assistant', content: 'hello' } as Partial<NormalizedMessage>),
+    message({ kind: 'tool_use', toolName: 'Bash', toolId: 'b1', toolInput: { command: 'ls' } }),
+  ]).total, 0);
+});

--- a/src/modules/chat/tests/sessionTurnStats.test.ts
+++ b/src/modules/chat/tests/sessionTurnStats.test.ts
@@ -1,0 +1,115 @@
+import assert from 'node:assert/strict';
+import { test } from 'vitest';
+
+import type { NormalizedMessage, TurnStats } from '@/shared/types';
+import {
+  deriveTurnMetrics,
+  formatDuration,
+  formatTokenCount,
+  selectCurrentTurn,
+} from '@/modules/chat/utils/sessionTurnStats';
+
+const msg = (partial: Partial<NormalizedMessage> & { kind: NormalizedMessage['kind'] }): NormalizedMessage => ({
+  id: Math.random().toString(36).slice(2),
+  sessionId: 's1',
+  timestamp: '2026-09-11T10:00:00.000Z',
+  provider: 'claude',
+  ...partial,
+});
+
+const frame = (overrides: Partial<TurnStats> = {}): TurnStats => ({
+  costUsd: 0.042,
+  durationMs: 181_000,
+  apiDurationMs: 61_000,
+  numTurns: 9,
+  usage: { inputTokens: 18, outputTokens: 1900, cacheReadTokens: 40_460, cacheCreationTokens: 8_138 },
+  ...overrides,
+});
+
+test('the turn is everything after the last main-thread user text', () => {
+  const merged = [
+    msg({ kind: 'text', role: 'user', content: 'first' }),
+    msg({ kind: 'text', role: 'assistant', content: 'a1' }),
+    msg({ kind: 'text', role: 'user', content: 'second' }),
+    msg({ kind: 'tool_use', toolName: 'Bash', toolId: 't1' }),
+    msg({ kind: 'tool_result', toolId: 't1' }),
+  ];
+
+  const turn = selectCurrentTurn(merged);
+  assert.equal(turn.length, 2);
+  assert.equal(turn[0].kind, 'tool_use');
+});
+
+test('a subagent user echo does not start a new turn', () => {
+  const merged = [
+    msg({ kind: 'text', role: 'user', content: 'ask' }),
+    msg({ kind: 'text', role: 'user', content: 'sub prompt', parentToolUseId: 'toolu_1' }),
+    msg({ kind: 'text', role: 'assistant', content: 'a1' }),
+  ];
+
+  assert.equal(selectCurrentTurn(merged).length, 2);
+});
+
+test('the frame drives speed, durations and cost', () => {
+  const merged = [
+    msg({ kind: 'text', role: 'user', content: 'go' }),
+    msg({ kind: 'tool_use', toolName: 'Bash', toolId: 't1' }),
+    msg({ kind: 'tool_use', toolName: 'Read', toolId: 't2' }),
+  ];
+
+  const metrics = deriveTurnMetrics(merged, frame(), { used: 49_000, cacheReadTokens: 40_460 });
+
+  assert.equal(metrics.steps, 2);
+  assert.equal(metrics.modelDurationMs, 61_000);
+  assert.equal(metrics.toolDurationMs, 181_000 - 61_000);
+  assert.equal(metrics.costUsd, 0.042);
+  // 1900 output tokens over 61s of model time.
+  assert.ok(metrics.answerSpeedTokPerSec !== null);
+  assert.ok(Math.abs(metrics.answerSpeedTokPerSec - 1900 / 61) < 0.01);
+  assert.equal(metrics.outputTokens, 1900);
+  assert.equal(metrics.inputTokens, 49_000);
+  assert.ok(metrics.cacheHitPercent !== null);
+  assert.ok(Math.abs(metrics.cacheHitPercent - (40_460 / 49_000) * 100) < 0.01);
+});
+
+test('subagent tool calls are not main-thread steps', () => {
+  const merged = [
+    msg({ kind: 'text', role: 'user', content: 'go' }),
+    msg({ kind: 'tool_use', toolName: 'Agent', toolId: 't1' }),
+    msg({ kind: 'tool_use', toolName: 'Read', toolId: 't2', parentToolUseId: 't1' }),
+  ];
+
+  const metrics = deriveTurnMetrics(merged, frame(), null);
+  assert.equal(metrics.steps, 1);
+});
+
+test('without the frame, metrics degrade instead of lying', () => {
+  const merged = [msg({ kind: 'text', role: 'user', content: 'go' })];
+
+  const metrics = deriveTurnMetrics(merged, null, null);
+
+  assert.equal(metrics.costUsd, null);
+  assert.equal(metrics.modelDurationMs, null);
+  assert.equal(metrics.answerSpeedTokPerSec, null);
+  assert.equal(metrics.requestSpeedTokPerSec, null);
+});
+
+test('tool duration pairs tool_use with tool_result timestamps', () => {
+  const merged = [
+    msg({ kind: 'text', role: 'user', content: 'go' }),
+    msg({ kind: 'tool_use', toolName: 'Bash', toolId: 't1', timestamp: '2026-09-11T10:00:00.000Z' }),
+    msg({ kind: 'tool_result', toolId: 't1', timestamp: '2026-09-11T10:00:03.500Z' }),
+  ];
+
+  // No frame durations -> pairing fallback must produce 3.5s.
+  const metrics = deriveTurnMetrics(merged, frame({ durationMs: null, apiDurationMs: null }), null);
+  assert.equal(metrics.toolDurationMs, 3500);
+});
+
+test('formatters render the reference screenshot style', () => {
+  assert.equal(formatDuration(61_000), '1m1s');
+  assert.equal(formatDuration(170_000), '2m50s');
+  assert.equal(formatDuration(null), '—');
+  assert.equal(formatTokenCount(55_700), '55.7K');
+  assert.equal(formatTokenCount(null), '—');
+});

--- a/src/modules/chat/tests/thinkingStreaming.test.tsx
+++ b/src/modules/chat/tests/thinkingStreaming.test.tsx
@@ -1,0 +1,161 @@
+import assert from 'node:assert/strict';
+
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, it, vi } from 'vitest';
+
+import type { NormalizedMessage } from '@/shared/types';
+
+/**
+ * Live reasoning has to appear token-by-token, so the store keeps a
+ * well-known thinking row that updateStreamingThinking replaces in place, and
+ * finalizeStreamingThinking freezes it into a regular `thinking` row — the
+ * same contract the text stream pair already honors.
+ */
+
+const sessionMessages = vi.fn();
+
+vi.mock('@/shared/api', () => ({
+  api: {
+    providers: {
+      sessionMessages: (...args: unknown[]) => sessionMessages(...args),
+    },
+  },
+}));
+
+const row = (id: string, content: string, kind: NormalizedMessage['kind'] = 'text'): NormalizedMessage => ({
+  id,
+  kind,
+  role: kind === 'text' ? (id.startsWith('u') ? 'user' : 'assistant') : undefined,
+  provider: 'claude',
+  sessionId: 'session-1',
+  content,
+  timestamp: '2026-01-01T00:00:00.000Z',
+} as NormalizedMessage);
+
+const HISTORY = [
+  row('u1', 'first prompt'),
+  row('a1', 'first answer'),
+];
+
+beforeEach(() => {
+  sessionMessages.mockReset();
+  sessionMessages.mockResolvedValue({
+    ok: true,
+    json: async () => ({ data: { messages: HISTORY, total: HISTORY.length, hasMore: false } }),
+  });
+});
+
+afterEach(() => {
+  vi.resetModules();
+});
+
+async function loadedStore() {
+  const { useSessionStore } = await import('@/modules/chat/hooks/useSessionStore');
+  const view = renderHook(() => useSessionStore());
+  await act(async () => {
+    await view.result.current.fetchFromServer('session-1', { limit: 20, offset: 0 });
+  });
+  return view;
+}
+
+describe('thinking streaming', () => {
+  it('replaces the same accumulated row instead of appending one per tick', async () => {
+    const { result } = await loadedStore();
+
+    act(() => {
+      result.current.updateStreamingThinking('session-1', '想', 'claude');
+    });
+    act(() => {
+      result.current.updateStreamingThinking('session-1', '想一想', 'claude');
+    });
+
+    const streamed = result.current.getMessages('session-1').filter(
+      (message) => message.kind === 'thinking_delta',
+    );
+    assert.equal(streamed.length, 1);
+    assert.equal(streamed[0]?.content, '想一想');
+  });
+
+  it('keeps thinking and text streams as separate rows', async () => {
+    const { result } = await loadedStore();
+
+    act(() => {
+      result.current.updateStreamingThinking('session-1', 'thinking text', 'claude');
+      result.current.updateStreaming('session-1', 'answer text', 'claude');
+    });
+
+    const messages = result.current.getMessages('session-1');
+    const thinkingRow = messages.find((message) => message.kind === 'thinking_delta');
+    const textRow = messages.find((message) => message.kind === 'stream_delta');
+    assert.equal(thinkingRow?.content, 'thinking text');
+    assert.equal(textRow?.content, 'answer text');
+  });
+
+  it('finalizes the thinking row into a regular thinking message', async () => {
+    const { result } = await loadedStore();
+
+    act(() => {
+      result.current.updateStreamingThinking('session-1', 'final thought', 'claude');
+      result.current.finalizeStreamingThinking('session-1');
+    });
+
+    const messages = result.current.getMessages('session-1');
+    assert.equal(messages.some((message) => message.kind === 'thinking_delta'), false);
+    const finished = messages.find((message) => message.kind === 'thinking');
+    assert.equal(finished?.content, 'final thought');
+  });
+
+  it('prunes the finalized thinking row once the server transcript carries it', async () => {
+    const { result } = await loadedStore();
+
+    act(() => {
+      result.current.updateStreamingThinking('session-1', 'final thought', 'claude');
+      result.current.finalizeStreamingThinking('session-1');
+    });
+    assert.equal(result.current.getMessages('session-1').some((m) => m.kind === 'thinking'), true);
+
+    // Simulate the complete-triggered refresh bringing the same reasoning back
+    // from the persisted transcript under fresh ids.
+    sessionMessages.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        data: {
+          messages: [
+            ...HISTORY,
+            row('srv_think', 'final thought', 'thinking'),
+          ],
+          total: HISTORY.length + 1,
+          hasMore: false,
+        },
+      }),
+    });
+    await act(async () => {
+      await result.current.refreshLatestFromServer('session-1', { limit: 20 });
+    });
+
+    const thinkingRows = result.current.getMessages('session-1').filter(
+      (message) => message.kind === 'thinking',
+    );
+    assert.equal(thinkingRows.length, 1);
+    assert.equal(thinkingRows[0]?.id, 'srv_think');
+  });
+});
+
+describe('appendRealtime same-id updates', () => {
+  it('replaces an existing row instead of stacking a duplicate', async () => {
+    const { result } = await loadedStore();
+
+    act(() => {
+      result.current.appendRealtime('session-1', row('item_1', 'partial reasoning', 'thinking'));
+    });
+    act(() => {
+      result.current.appendRealtime('session-1', row('item_1', 'fuller reasoning', 'thinking'));
+    });
+
+    const rows = result.current.getMessages('session-1').filter(
+      (message) => message.id === 'item_1',
+    );
+    assert.equal(rows.length, 1);
+    assert.equal(rows[0]?.content, 'fuller reasoning');
+  });
+});

--- a/src/modules/chat/tests/tokenBudgetSessionScope.test.tsx
+++ b/src/modules/chat/tests/tokenBudgetSessionScope.test.tsx
@@ -33,6 +33,8 @@ const renderHandlers = () => {
     setPendingPermissionRequests: () => {},
     streamTimerRef: { current: null },
     accumulatedStreamRef: { current: '' },
+    thinkingStreamTimerRef: { current: null },
+    accumulatedThinkingStreamRef: { current: '' },
     lastSeqRef: { current: new Map() },
     statusCheckSentAtRef: { current: new Map() },
     requestLatestMessages: async () => {},

--- a/src/modules/chat/tests/tokenBudgetSessionScope.test.tsx
+++ b/src/modules/chat/tests/tokenBudgetSessionScope.test.tsx
@@ -29,6 +29,7 @@ const renderHandlers = () => {
     selectedSession: { id: 'viewed-session' } as ProjectSession,
     currentSessionId: 'viewed-session',
     setTokenBudget: (budget) => budgets.push(budget),
+    setTurnStats: () => {},
     pendingPermissionRequests: [],
     setPendingPermissionRequests: () => {},
     streamTimerRef: { current: null },

--- a/src/modules/chat/tests/toolResultImages.test.ts
+++ b/src/modules/chat/tests/toolResultImages.test.ts
@@ -1,0 +1,104 @@
+import assert from 'node:assert/strict';
+
+import { test } from 'vitest';
+
+import {
+  extractToolResultImages,
+  hasToolResultImages,
+  withoutImageBlocks,
+} from '@/modules/chat/utils/toolResultImages';
+import { getToolConfig } from '@/modules/chat/tools/configs/toolConfigs';
+
+/**
+ * Tool results that carry image blocks (screenshots, image reads, MCP image
+ * content) must surface as pictures, not as a base64 wall dumped into the
+ * text renderer. The extraction has to survive every shape the providers
+ * actually produce — including the JSON.stringified array form that
+ * useChatMessages produces for any non-string content.
+ */
+
+const base64Data = 'A'.repeat(96);
+
+test('extracts the bare base64 source block', () => {
+  const payload = [{ type: 'base64', media_type: 'image/png', data: base64Data }];
+  assert.deepEqual(extractToolResultImages(payload), [
+    { mediaType: 'image/png', data: base64Data },
+  ]);
+});
+
+test('extracts the anthropic image content block', () => {
+  const payload = [{
+    type: 'image',
+    source: { type: 'base64', media_type: 'image/jpeg', data: base64Data },
+  }];
+  assert.deepEqual(extractToolResultImages(payload), [
+    { mediaType: 'image/jpeg', data: base64Data },
+  ]);
+});
+
+test('extracts the MCP image block', () => {
+  const payload = [{ type: 'image', mimeType: 'image/webp', data: base64Data }];
+  assert.deepEqual(extractToolResultImages(payload), [
+    { mediaType: 'image/webp', data: base64Data },
+  ]);
+});
+
+test('extracts from a JSON-stringified array (useChatMessages format)', () => {
+  const payload = JSON.stringify([
+    { type: 'text', text: 'screenshot taken' },
+    { type: 'base64', media_type: 'image/png', data: base64Data },
+  ]);
+  assert.equal(extractToolResultImages(payload).length, 1);
+  assert.ok(hasToolResultImages(payload));
+});
+
+test('extracts through the tool result wrapper', () => {
+  const payload = {
+    content: JSON.stringify([{ type: 'base64', media_type: 'image/png', data: base64Data }]),
+    isError: false,
+  };
+  assert.equal(extractToolResultImages(payload).length, 1);
+});
+
+test('ignores plain text and short non-image payloads', () => {
+  assert.deepEqual(extractToolResultImages('{"ok": true}'), []);
+  assert.deepEqual(extractToolResultImages([{ type: 'text', text: 'hello' }]), []);
+  // Too short to be a real image payload — likely a false-shape object.
+  assert.deepEqual(extractToolResultImages([{ type: 'base64', media_type: 'image/png', data: 'abc' }]), []);
+  assert.equal(hasToolResultImages('plain output'), false);
+});
+
+test('default config keeps text and drops image base64', () => {
+  const config = getToolConfig('SomeUnknownTool').result!;
+  const props = config.getContentProps!({
+    content: JSON.stringify([
+      { type: 'text', text: '第一行' },
+      { type: 'base64', media_type: 'image/png', data: base64Data },
+    ]),
+  });
+  assert.equal(props.content, '第一行');
+});
+
+test('default config renders nothing but the image when there is no text', () => {
+  const config = getToolConfig('SomeUnknownTool').result!;
+  const props = config.getContentProps!({
+    content: JSON.stringify([{ type: 'base64', media_type: 'image/png', data: base64Data }]),
+  });
+  assert.equal(props.content, '');
+});
+
+test('default config still shows plain output verbatim', () => {
+  const config = getToolConfig('SomeUnknownTool').result!;
+  const props = config.getContentProps!({ content: '命令输出正常文本' });
+  assert.equal(props.content, '命令输出正常文本');
+});
+
+test('withoutImageBlocks removes image blocks and keeps the rest', () => {
+  const blocks = [
+    { type: 'text', text: '保留' },
+    { type: 'base64', media_type: 'image/png', data: base64Data },
+  ];
+  assert.deepEqual(withoutImageBlocks(blocks), [{ type: 'text', text: '保留' }]);
+  assert.deepEqual(withoutImageBlocks(JSON.stringify(blocks)), [{ type: 'text', text: '保留' }]);
+  assert.equal(withoutImageBlocks('普通字符串'), '普通字符串');
+});

--- a/src/modules/chat/tests/turnStatsSessionScope.test.tsx
+++ b/src/modules/chat/tests/turnStatsSessionScope.test.tsx
@@ -1,0 +1,78 @@
+import assert from 'node:assert/strict';
+
+import { renderHook } from '@testing-library/react';
+import { test } from 'vitest';
+
+import { useChatRealtimeHandlers } from '@/modules/chat/hooks/useChatRealtimeHandlers';
+import type { ServerEvent, ProjectSession, TurnStats } from '@/shared/types';
+import type { SessionStore } from '@/modules/chat/hooks/useSessionStore';
+
+/**
+ * The turn bill (cost/duration/tokens) arrives on a `status`/`turn_stats`
+ * frame stamped with its own session id. The panel shows the viewed session's
+ * bill, so a result from another concurrently running session must not
+ * overwrite it — the same session-scoping rule the composer's context counter
+ * already follows for `token_budget`.
+ */
+
+const renderHandlers = () => {
+  let listener: ((event: ServerEvent) => void) | null = null;
+  const stats: Array<TurnStats | null> = [];
+
+  renderHook(() => useChatRealtimeHandlers({
+    isActive: true,
+    subscribe: (fn) => {
+      listener = fn;
+      return () => { listener = null; };
+    },
+    provider: 'claude',
+    selectedSession: { id: 'viewed-session' } as ProjectSession,
+    currentSessionId: 'viewed-session',
+    setTokenBudget: () => {},
+    setTurnStats: (next) => stats.push(next),
+    pendingPermissionRequests: [],
+    setPendingPermissionRequests: () => {},
+    streamTimerRef: { current: null },
+    accumulatedStreamRef: { current: '' },
+    thinkingStreamTimerRef: { current: null },
+    accumulatedThinkingStreamRef: { current: '' },
+    lastSeqRef: { current: new Map() },
+    statusCheckSentAtRef: { current: new Map() },
+    requestLatestMessages: async () => {},
+    sessionStore: {} as SessionStore,
+  }));
+
+  const dispatch = (event: ServerEvent) => listener?.(event);
+  return { stats, dispatch };
+};
+
+const statsEvent = (sessionId: string): ServerEvent => ({
+  kind: 'status',
+  text: 'turn_stats',
+  sessionId,
+  turnStats: {
+    costUsd: 0.04,
+    durationMs: 12_000,
+    apiDurationMs: 4_000,
+    numTurns: 3,
+    usage: { inputTokens: 10, outputTokens: 220, cacheReadTokens: 900, cacheCreationTokens: 20 },
+  },
+} as unknown as ServerEvent);
+
+test('adopts turn stats stamped with the viewed session', () => {
+  const { stats, dispatch } = renderHandlers();
+
+  dispatch(statsEvent('viewed-session'));
+
+  assert.equal(stats.length, 1);
+  assert.equal(stats[0]?.costUsd, 0.04);
+  assert.equal(stats[0]?.numTurns, 3);
+});
+
+test('ignores turn stats from other running sessions', () => {
+  const { stats, dispatch } = renderHandlers();
+
+  dispatch(statsEvent('some-other-session'));
+
+  assert.equal(stats.length, 0);
+});

--- a/src/modules/chat/tools/ContentRenderers/ToolResultImages.tsx
+++ b/src/modules/chat/tools/ContentRenderers/ToolResultImages.tsx
@@ -1,0 +1,56 @@
+import React, { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { ImageLightbox } from '@/modules/chat/transcript/ChatMessageImages';
+import type { ToolResultImage } from '@/modules/chat/utils/toolResultImages';
+
+type ToolResultImagesProps = {
+  images: ToolResultImage[];
+};
+
+/**
+ * Images returned inside a tool result (screenshots, image reads, MCP image
+ * content) shown as clickable thumbnails that expand to a fullscreen lightbox.
+ *
+ * Rendered by chat's ToolRenderer beneath a tool result's text so a base64
+ * image block reads as a picture rather than a wall of base64 characters.
+ */
+export const ToolResultImages: React.FC<ToolResultImagesProps> = ({ images }) => {
+  const { t } = useTranslation();
+  const [expanded, setExpanded] = useState<number | null>(null);
+
+  if (images.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="mt-1 flex flex-wrap gap-2">
+      {images.map((image, index) => {
+        const src = `data:${image.mediaType};base64,${image.data}`;
+        const alt = `Tool result image ${index + 1}`;
+        return (
+          <button
+            key={index}
+            type="button"
+            onClick={() => setExpanded(index)}
+            aria-label={t('chat:misc.expandImage', { name: alt })}
+            className="block max-w-full overflow-hidden rounded-lg border border-gray-200/50 bg-gray-50 focus:outline-none focus:ring-2 focus:ring-primary/60 dark:border-gray-700/50 dark:bg-gray-800/50"
+          >
+            <img
+              src={src}
+              alt={alt}
+              className="max-h-64 cursor-zoom-in rounded-lg object-contain"
+            />
+          </button>
+        );
+      })}
+      {expanded !== null && (
+        <ImageLightbox
+          src={`data:${images[expanded].mediaType};base64,${images[expanded].data}`}
+          alt={`Tool result image ${expanded + 1}`}
+          onClose={() => setExpanded(null)}
+        />
+      )}
+    </div>
+  );
+};

--- a/src/modules/chat/tools/ToolRenderer.tsx
+++ b/src/modules/chat/tools/ToolRenderer.tsx
@@ -11,11 +11,13 @@ import { FileListContent } from '@/modules/chat/tools/ContentRenderers/FileListC
 import { TodoListContent } from '@/modules/chat/tools/ContentRenderers/TodoListContent';
 import { TaskListContent } from '@/modules/chat/tools/ContentRenderers/TaskListContent';
 import { TextContent } from '@/modules/chat/tools/ContentRenderers/TextContent';
+import { ToolResultImages } from '@/modules/chat/tools/ContentRenderers/ToolResultImages';
 import { QuestionAnswerContent } from '@/modules/chat/tools/ContentRenderers/QuestionAnswerContent';
 import { PlanDisplay } from '@/modules/chat/tools/PlanDisplay';
 import { ToolStatusBadge } from '@/modules/chat/tools/ToolStatusBadge';
 import { DiffStatsBadge } from '@/modules/chat/tools/DiffStatsBadge';
 import { parseToolPayload, summarizeDiff } from '@/modules/chat/utils/messageTransforms';
+import { extractToolResultImages } from '@/modules/chat/utils/toolResultImages';
 
 type ToolRendererProps = {
   toolName: string;
@@ -213,6 +215,10 @@ export const ToolRenderer: React.FC<ToolRendererProps> = memo(({
       onFileOpen
     }) || {};
 
+    // A tool result can carry image blocks next to its text; they render as
+    // thumbnails under the text instead of as base64 noise.
+    const resultImages = mode === 'result' ? extractToolResultImages(toolResult) : [];
+
     let contentComponent: React.ReactNode = null;
 
     switch (displayConfig.contentType) {
@@ -268,10 +274,15 @@ export const ToolRenderer: React.FC<ToolRendererProps> = memo(({
 
       case 'text':
         contentComponent = (
-          <TextContent
-            content={contentProps.content || ''}
-            format={contentProps.format || 'plain'}
-          />
+          <>
+            {contentProps.content && (
+              <TextContent
+                content={contentProps.content}
+                format={contentProps.format || 'plain'}
+              />
+            )}
+            {resultImages.length > 0 && <ToolResultImages images={resultImages} />}
+          </>
         );
         break;
 

--- a/src/modules/chat/tools/configs/toolConfigs.ts
+++ b/src/modules/chat/tools/configs/toolConfigs.ts
@@ -1,7 +1,9 @@
 /**
  * Centralized tool configuration registry
- * Defines display behavior for all tool types 
+ * Defines display behavior for all tool types
  */
+
+import { extractToolResultImages, withoutImageBlocks } from '@/modules/chat/utils/toolResultImages';
 
 export type ToolDisplayConfig = {
   input: {
@@ -752,32 +754,39 @@ export const TOOL_CONFIGS: Record<string, ToolDisplayConfig> = {
       title: 'Output',
       contentType: 'text',
       getContentProps: (result) => {
-        let content = result?.content || '';
+        // ToolRenderer hands the parsed tool-result object ({ content, isError })
+        // or, for other call sites, the blocks themselves — unwrap to the payload.
+        if (result && typeof result === 'object' && !Array.isArray(result) && 'content' in result) {
+          result = result.content;
+        }
+
+        // Image blocks render as pictures through ToolResultImages; drop them
+        // from the text pass so their base64 payload is not dumped as JSON.
+        let content = withoutImageBlocks(result ?? '');
+
+        const collectText = (blocks: unknown[]) =>
+          blocks
+            .filter((p: any) => p && p.type === 'text' && p.text)
+            .map((p: any) => p.text);
 
         // Handle MCP format: array of objects with type and text fields
         if (typeof content === 'string') {
           try {
             const parsed = JSON.parse(content);
             if (Array.isArray(parsed)) {
-              const textParts = parsed
-                .filter((p: any) => p.type === 'text' && p.text)
-                .map((p: any) => p.text);
+              const textParts = collectText(parsed);
               if (textParts.length > 0) {
                 content = textParts.join('\n');
+              } else if (extractToolResultImages(parsed).length > 0) {
+                content = '';
               }
             }
           } catch {
             // Not JSON or not MCP format, use as-is
           }
         } else if (Array.isArray(content)) {
-          const textParts = content
-            .filter((p: any) => p.type === 'text' && p.text)
-            .map((p: any) => p.text);
-          if (textParts.length > 0) {
-            content = textParts.join('\n');
-          } else {
-            content = JSON.stringify(content, null, 2);
-          }
+          const textParts = collectText(content);
+          content = textParts.length > 0 ? textParts.join('\n') : '';
         } else if (typeof content === 'object' && content !== null) {
           content = JSON.stringify(content, null, 2);
         }

--- a/src/modules/chat/transcript/ChatMessageImages.tsx
+++ b/src/modules/chat/transcript/ChatMessageImages.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { createPortal } from 'react-dom';
 import { X } from 'lucide-react';
@@ -84,13 +84,29 @@ function useChatImageSrc(image: ChatImage, projectId?: string | null): { src: st
 
 /**
  * Fullscreen image overlay in the claude.ai style: dark backdrop, centered
- * image, closes on backdrop click, close button, or Escape.
+ * image, closes on backdrop click, close button, or Escape. The image itself
+ * zooms with the mouse wheel, a trackpad pinch (which arrives as ctrl+wheel),
+ * or a two-finger touch pinch, and pans by dragging (one finger when zoomed,
+ * two fingers anytime).
  *
  * Used by chat's ChatMessageImages and ComposerAttachment to expand a
- * thumbnail to full size.
+ * thumbnail to full size, and by chat's ToolResultImages for images carried
+ * inside a tool result.
  */
 export function ImageLightbox({ src, alt, onClose }: { src: string; alt: string; onClose: () => void }) {
   const { t } = useTranslation();
+  const [scale, setScale] = useState(1);
+  const [offset, setOffset] = useState({ x: 0, y: 0 });
+  const [dragging, setDragging] = useState(false);
+  const dragRef = useRef<{ startX: number; startY: number; originX: number; originY: number } | null>(null);
+  const pointersRef = useRef(new Map<number, { x: number; y: number }>());
+  const pinchRef = useRef<{ startDist: number; startMid: { x: number; y: number }; startScale: number; startOffset: { x: number; y: number } } | null>(null);
+  const scaleRef = useRef(1);
+  scaleRef.current = scale;
+  const offsetRef = useRef(offset);
+  offsetRef.current = offset;
+  const viewportRef = useRef<HTMLDivElement>(null);
+
   useEffect(() => {
     const handleKeyDown = (event: globalThis.KeyboardEvent) => {
       if (event.key === 'Escape') {
@@ -102,9 +118,128 @@ export function ImageLightbox({ src, alt, onClose }: { src: string; alt: string;
     return () => document.removeEventListener('keydown', handleKeyDown, true);
   }, [onClose]);
 
+  // Wheel zoom has to preventDefault (the backdrop would otherwise scroll /
+  // the browser would page-zoom on ctrl+wheel), and React's synthetic onWheel
+  // is passive — register natively with the flag instead.
+  useEffect(() => {
+    const viewport = viewportRef.current;
+    if (!viewport) {
+      return;
+    }
+
+    const handleWheel = (event: WheelEvent) => {
+      event.preventDefault();
+      event.stopPropagation();
+      setScale((current) => {
+        const factor = Math.exp(-event.deltaY * 0.0015);
+        return Math.min(10, Math.max(1, current * factor));
+      });
+    };
+
+    viewport.addEventListener('wheel', handleWheel, { passive: false });
+    return () => viewport.removeEventListener('wheel', handleWheel);
+  }, []);
+
+  // Zooming back out to 1 re-centers; a stale offset would park the image
+  // off-screen until the next zoom.
+  useEffect(() => {
+    if (scale === 1) {
+      setOffset({ x: 0, y: 0 });
+    }
+  }, [scale]);
+
+  const handlePointerDown = useCallback((event: React.PointerEvent<HTMLImageElement>) => {
+    const pointers = pointersRef.current;
+    pointers.set(event.pointerId, { x: event.clientX, y: event.clientY });
+    // Capture can throw for a pointer that ended between dispatch and here;
+    // the gesture must survive that (a lifted finger mid-pinch is routine).
+    try {
+      (event.target as HTMLElement).setPointerCapture(event.pointerId);
+    } catch {
+      // fall through
+    }
+
+    if (pointers.size === 2) {
+      // A second finger starts a pinch; the single-finger drag ends.
+      dragRef.current = null;
+      setDragging(false);
+      const [a, b] = [...pointers.values()];
+      pinchRef.current = {
+        startDist: Math.hypot(a.x - b.x, a.y - b.y) || 1,
+        startMid: { x: (a.x + b.x) / 2, y: (a.y + b.y) / 2 },
+        startScale: scaleRef.current,
+        startOffset: { ...offsetRef.current },
+      };
+      return;
+    }
+
+    if (pointers.size === 1 && scaleRef.current > 1) {
+      event.stopPropagation();
+      dragRef.current = {
+        startX: event.clientX, startY: event.clientY,
+        originX: offsetRef.current.x, originY: offsetRef.current.y,
+      };
+      setDragging(true);
+    }
+  }, []);
+
+  const handlePointerMove = useCallback((event: React.PointerEvent<HTMLImageElement>) => {
+    const pointers = pointersRef.current;
+    if (!pointers.has(event.pointerId)) {
+      return;
+    }
+    pointers.set(event.pointerId, { x: event.clientX, y: event.clientY });
+
+    const pinch = pinchRef.current;
+    if (pinch && pointers.size >= 2) {
+      const [a, b] = [...pointers.values()];
+      const dist = Math.hypot(a.x - b.x, a.y - b.y) || 1;
+      const mid = { x: (a.x + b.x) / 2, y: (a.y + b.y) / 2 };
+      const next = Math.min(10, Math.max(1, pinch.startScale * (dist / pinch.startDist)));
+      setScale(next);
+      // Pan follows the pinch midpoint so two fingers also slide the image
+      // around, anchored to where the gesture started.
+      setOffset(next === 1
+        ? { x: 0, y: 0 }
+        : {
+          x: pinch.startOffset.x + (mid.x - pinch.startMid.x),
+          y: pinch.startOffset.y + (mid.y - pinch.startMid.y),
+        });
+      return;
+    }
+
+    const drag = dragRef.current;
+    if (drag) {
+      setOffset({
+        x: drag.originX + event.clientX - drag.startX,
+        y: drag.originY + event.clientY - drag.startY,
+      });
+    }
+  }, []);
+
+  const handlePointerUp = useCallback((event: React.PointerEvent<HTMLImageElement>) => {
+    pointersRef.current.delete(event.pointerId);
+    if (pointersRef.current.size < 2) {
+      pinchRef.current = null;
+    }
+    if (pointersRef.current.size === 0) {
+      dragRef.current = null;
+      setDragging(false);
+    }
+  }, []);
+
+  const handleImageClick = useCallback((event: React.MouseEvent<HTMLImageElement>) => {
+    event.stopPropagation();
+    // A finished pinch or drag must not read as a tap-to-close.
+    if (scaleRef.current <= 1 && pointersRef.current.size === 0) {
+      onClose();
+    }
+  }, [onClose]);
+
   return createPortal(
     <div
-      className="fixed inset-0 z-[100] flex items-center justify-center bg-black/80 backdrop-blur-sm"
+      ref={viewportRef}
+      className="fixed inset-0 z-[100] flex items-center justify-center overflow-hidden bg-black/80 backdrop-blur-sm"
       onClick={onClose}
       role="dialog"
       aria-modal="true"
@@ -114,15 +249,25 @@ export function ImageLightbox({ src, alt, onClose }: { src: string; alt: string;
         type="button"
         onClick={onClose}
         aria-label={t('chat:misc.closeImagePreview')}
-        className="absolute right-4 top-4 rounded-full bg-white/10 p-2 text-white transition-colors hover:bg-white/20"
+        className="absolute right-4 top-4 z-[101] rounded-full bg-white/10 p-2 text-white transition-colors hover:bg-white/20"
       >
         <X className="h-5 w-5" />
       </button>
       <img
         src={src}
         alt={alt}
-        onClick={(event) => event.stopPropagation()}
-        className="max-h-[90vh] max-w-[92vw] rounded-lg object-contain shadow-2xl"
+        onClick={handleImageClick}
+        onPointerDown={handlePointerDown}
+        onPointerMove={handlePointerMove}
+        onPointerUp={handlePointerUp}
+        onPointerCancel={handlePointerUp}
+        style={{
+          transform: `translate(${offset.x}px, ${offset.y}px) scale(${scale})`,
+          cursor: scale > 1 ? (dragging ? 'grabbing' : 'grab') : 'zoom-in',
+          touchAction: 'none',
+        }}
+        className="max-h-[90vh] max-w-[92vw] select-none rounded-lg object-contain shadow-2xl will-change-transform"
+        draggable={false}
       />
     </div>,
     document.body,

--- a/src/modules/chat/transcript/ChatMessagesPane.tsx
+++ b/src/modules/chat/transcript/ChatMessagesPane.tsx
@@ -1,6 +1,8 @@
 import { useTranslation } from 'react-i18next';
-import { memo, useCallback, useMemo } from 'react';
-import type { Dispatch, RefObject, SetStateAction } from 'react';
+import { memo, useCallback, useLayoutEffect, useMemo, useState } from 'react';
+import type { CSSProperties, Dispatch, RefObject, SetStateAction } from 'react';
+
+import { cn } from '@/shared/utils';
 
 import type { ChatMessage,
   Project,
@@ -15,6 +17,7 @@ import { buildPromptEntries } from '@/modules/chat/utils/promptNavigator';
 import type { PromptEntry } from '@/modules/chat/utils/promptNavigator';
 import { useLazyRowObserver } from '@/modules/chat/hooks/useLazyRowObserver';
 import { useActivePromptEntry } from '@/modules/chat/hooks/useActivePromptEntry';
+import { useElementWidth } from '@/modules/chat/hooks/useElementWidth';
 import { useTranscriptVirtualization } from '@/modules/chat/hooks/useTranscriptVirtualization';
 import LazyMessageRow from '@/modules/chat/transcript/LazyMessageRow';
 import MessageComponent from '@/modules/chat/transcript/MessageComponent';
@@ -229,6 +232,19 @@ function ChatMessagesPane({
     disabled: false,
   });
 
+  // The rail hangs OUTSIDE the message column (left:100%), into the pane
+  // margin. Once the pane shrinks below the column's max width plus the rail
+  //'s gutter, there is no margin left to hang into and the rail falls past
+  // the pane's clipped edge — invisible. Below that threshold (phones always,
+  // narrow desktop windows too) the rail docks inside the gutter the message
+  // column gives up on its right instead. Measured on the pane, not the
+  // viewport: split views and resizable panels change the room without
+  // changing the window width.
+  const MESSAGE_COLUMN_MAX_PX = 54.25 * 16;
+  const RAIL_GUTTER_PX = 48;
+  const paneWidth = useElementWidth(scrollContainerRef);
+  const railDockedInside = paneWidth > 0 && paneWidth < MESSAGE_COLUMN_MAX_PX + RAIL_GUTTER_PX;
+
   const getMessageKey = useCallback(
     (message: ChatMessage) =>
       rowKeysData.messageKeys.get(message) ?? getIntrinsicMessageKey(message) ?? 'message-generated',
@@ -246,7 +262,7 @@ function ChatMessagesPane({
       }`}
     >
       {chatMessages.length > 0 && (
-        <div className="pointer-events-none sticky right-4 top-3 z-10 mb-2 flex justify-end sm:px-4">
+        <div className="pointer-events-none sticky right-4 top-3 z-10 mb-2 flex justify-end sm:right-[calc(1rem+20px)] sm:px-4">
           <div className="pointer-events-auto">
             <ChatExportMenu
               messages={chatMessages}
@@ -259,11 +275,18 @@ function ChatMessagesPane({
           </div>
         </div>
       )}
-      {/* On phones the pane is narrower than the rail's desktop margin can
-          offer, so the column gives up a rail-width gutter on its right and
-          the rail's positioning layer matches — the ticks then sit inside the
-          viewport instead of past its edge. */}
-      <div className="mx-auto w-full max-w-[54.25rem] space-y-3 px-4 sm:space-y-4 max-sm:pr-10">
+      {/* The rail needs a rail-width gutter on the column's right: on phones
+          (always docked) and on any pane too narrow for the rail to hang
+          outside the column, the column gives up `pr-10` (+ the scrollbar
+          inset on desktop) and the docked rail sits inside it; on a wide pane
+          the rail hangs into the pane margin instead and the column only
+          keeps the 30px scrollbar clearance. */}
+      <div className={cn(
+        'mx-auto w-full max-w-[54.25rem] space-y-3 px-4 sm:space-y-4',
+        railDockedInside
+          ? 'pr-10 sm:pr-[calc(2.5rem+30px)]'
+          : 'sm:pr-[calc(1rem+30px)]',
+      )}>
       {(isLoadingSessionMessages || isProcessing) && chatMessages.length === 0 ? (
         <div className="mt-8 text-center text-gray-500 dark:text-gray-400">
           <div className="flex items-center justify-center space-x-2">
@@ -416,6 +439,7 @@ function ChatMessagesPane({
               isLoadingOlder={isLoadingMoreMessages}
               onLoadEarlier={onRequestOlderMessages ?? loadAllMessages}
               scrollContainerRef={scrollContainerRef}
+              dockedInside={railDockedInside}
               loadMoreLabel={t('session.messages.loadEarlier')}
               emptyPreviewLabel={t('promptNavigator.noTextContent', {
                 defaultValue: '(no text content)',

--- a/src/modules/chat/transcript/ChatMessagesPane.tsx
+++ b/src/modules/chat/transcript/ChatMessagesPane.tsx
@@ -10,13 +10,19 @@ import type { ChatMessage,
   ProviderModelsDefinition } from '@/shared/types';
 import { getIntrinsicMessageKey } from '@/modules/chat/utils/messageKeys';
 import { groupConsecutiveTools, isToolGroupItem } from '@/modules/chat/utils/toolGrouping';
+import type { MessageListItem } from '@/modules/chat/utils/toolGrouping';
+import { buildPromptEntries } from '@/modules/chat/utils/promptNavigator';
+import type { PromptEntry } from '@/modules/chat/utils/promptNavigator';
 import { useLazyRowObserver } from '@/modules/chat/hooks/useLazyRowObserver';
+import { useActivePromptEntry } from '@/modules/chat/hooks/useActivePromptEntry';
+import { useTranscriptVirtualization } from '@/modules/chat/hooks/useTranscriptVirtualization';
 import LazyMessageRow from '@/modules/chat/transcript/LazyMessageRow';
 import MessageComponent from '@/modules/chat/transcript/MessageComponent';
 import ProviderSelectionEmptyState from '@/modules/chat/transcript/ProviderSelectionEmptyState';
 import ToolGroupContainer from '@/modules/chat/transcript/ToolGroupContainer';
 import LoadAllMessagesOverlay from '@/modules/chat/transcript/LoadAllMessagesOverlay';
 import ChatExportMenu from '@/modules/chat/transcript/ChatExportMenu';
+import { PromptNavigatorRail } from '@/modules/chat/transcript/PromptNavigatorRail';
 
 /**
  * How many of the newest rows mount with real content on the first commit,
@@ -53,9 +59,6 @@ type ChatMessagesPaneProps = {
   hasMoreMessages: boolean;
   totalMessages: number;
   sessionMessagesCount: number;
-  visibleMessageCount: number;
-  visibleMessages: ChatMessage[];
-  loadEarlierMessages: () => void;
   loadAllMessages: () => void;
   allMessagesLoaded: boolean;
   isLoadingAllMessages: boolean;
@@ -74,6 +77,16 @@ type ChatMessagesPaneProps = {
   onForkFromMessage?: (message: ChatMessage) => void;
   /** Fetches the whole transcript for an export, which otherwise only sees the loaded page. */
   onLoadFullTranscript?: () => Promise<ChatMessage[]>;
+  /** Jumps the transcript to a prompt chosen on the navigator rail. */
+  onSelectPrompt?: (entry: PromptEntry) => void;
+  /** Fetches the previous page of history from the server (rail's load-more). */
+  onRequestOlderMessages?: () => void;
+  /**
+   * While a search/rail jump animates, the transcript window freezes on the
+   * target's neighbourhood (message-index range) so its rows exist for the
+   * scroll-pin; null when no jump is in flight.
+   */
+  jumpMessageRange?: { start: number; end: number } | null;
 };
 
 /**
@@ -107,9 +120,6 @@ function ChatMessagesPane({
   hasMoreMessages,
   totalMessages,
   sessionMessagesCount,
-  visibleMessageCount,
-  visibleMessages,
-  loadEarlierMessages,
   loadAllMessages,
   allMessagesLoaded,
   isLoadingAllMessages,
@@ -119,6 +129,9 @@ function ChatMessagesPane({
   onEditMessage,
   onForkFromMessage,
   onLoadFullTranscript,
+  onSelectPrompt,
+  onRequestOlderMessages,
+  jumpMessageRange,
   onFileOpen,
   onShowSettings,
   onGrantToolPermission,
@@ -128,44 +141,102 @@ function ChatMessagesPane({
 }: ChatMessagesPaneProps) {
   const { t } = useTranslation('chat');
   const lazyRows = useLazyRowObserver(scrollContainerRef);
-  const groupedVisibleMessages = useMemo(
-    () => groupConsecutiveTools(visibleMessages, Boolean(showThinking)),
-    [visibleMessages, showThinking],
+  const promptEntries = useMemo(() => buildPromptEntries(chatMessages), [chatMessages]);
+  const activePromptId = useActivePromptEntry(scrollContainerRef, promptEntries);
+  // Grouping runs over the WHOLE transcript, not a loaded slice: the
+  // virtualization window must be able to start at any row, and a window cut
+  // mid-tool-run would render half a collapsed group. Grouping is a linear
+  // pass over plain objects — over a few thousand rows it costs far less
+  // than the markdown pipeline it protects against.
+  const groupedItems = useMemo(
+    () => groupConsecutiveTools(chatMessages, Boolean(showThinking)),
+    [chatMessages, showThinking],
   );
 
-  // Stable, deterministic keys for the messages rendered this pass.
+  // Stable, deterministic keys for every grouped row this pass.
   //
   // A server refresh can replace source records with equivalent new objects, so
   // object identity is not a durable React key across pagination or hydration.
-  // Deriving keys from this render's ordered messages (intrinsic key,
+  // Deriving keys from this pass's ordered messages (intrinsic key,
   // disambiguated by occurrence index on collision) preserves existing DOM
-  // nodes and component state when older history is prepended.
-  const messageKeyMap = useMemo(() => {
-    const keys = new WeakMap<ChatMessage, string>();
+  // nodes and component state when older history is prepended — and doubles
+  // as the transcript's virtualization height-cache key.
+  const rowKeysData = useMemo(() => {
+    const keys: string[] = [];
+    const messageKeys = new WeakMap<ChatMessage, string>();
     const occurrences = new Map<string, number>();
-    const assign = (message: ChatMessage) => {
+    const keyFor = (message: ChatMessage) => {
+      const cached = messageKeys.get(message);
+      if (cached) return cached;
       const intrinsicKey = getIntrinsicMessageKey(message) ?? 'message-generated';
       const seen = occurrences.get(intrinsicKey) ?? 0;
       occurrences.set(intrinsicKey, seen + 1);
-      keys.set(message, seen === 0 ? intrinsicKey : `${intrinsicKey}__${seen}`);
+      const key = seen === 0 ? intrinsicKey : `${intrinsicKey}__${seen}`;
+      messageKeys.set(message, key);
+      return key;
     };
-    for (const item of groupedVisibleMessages) {
+    for (const item of groupedItems) {
       if (isToolGroupItem(item)) {
-        item.messages.forEach(assign);
+        keys.push(`tool-group-${keyFor(item.messages[0])}`);
+        item.messages.forEach(keyFor);
       } else {
-        assign(item);
+        keys.push(keyFor(item));
       }
     }
-    return keys;
-  }, [groupedVisibleMessages]);
+    return { keys, messageKeys };
+  }, [groupedItems]);
+  const rowKeys = rowKeysData.keys;
+
+  const getKey = useCallback(
+    (_item: MessageListItem, index: number) => rowKeys[index] ?? `row-${index}`,
+    [rowKeys],
+  );
+
+  // A rail/search jump addresses rows by MESSAGE index; the virtualization
+  // window speaks GROUPED-row index. Map the frozen message range onto the
+  // grouped list via each group's first-message index (chatMessages order and
+  // groupedItems order agree because grouping only merges neighbours).
+  const groupedItemSpans = useMemo(() => {
+    const spans: Array<{ start: number; length: number }> = [];
+    let messageCursor = 0;
+    for (const item of groupedItems) {
+      const length = isToolGroupItem(item) ? item.messages.length : 1;
+      spans.push({ start: messageCursor, length });
+      messageCursor += length;
+    }
+    return spans;
+  }, [groupedItems]);
+
+  const forcedRange = useMemo(() => {
+    if (!jumpMessageRange || groupedItems.length === 0) return null;
+    let start = groupedItems.length;
+    let end = 0;
+    for (let index = 0; index < groupedItemSpans.length; index++) {
+      const span = groupedItemSpans[index];
+      if (span.start + span.length > jumpMessageRange.start && span.start < jumpMessageRange.end) {
+        start = Math.min(start, index);
+        end = Math.max(end, index + 1);
+      }
+    }
+    return end > start ? { start, end } : null;
+  }, [groupedItems, groupedItemSpans, jumpMessageRange]);
+
+  const { range, spacerHeights, virtualized, registerRendered } = useTranscriptVirtualization({
+    scrollContainerRef,
+    items: groupedItems,
+    getKey,
+    forcedRange,
+    disabled: false,
+  });
 
   const getMessageKey = useCallback(
     (message: ChatMessage) =>
-      messageKeyMap.get(message) ?? getIntrinsicMessageKey(message) ?? 'message-generated',
-    [messageKeyMap],
+      rowKeysData.messageKeys.get(message) ?? getIntrinsicMessageKey(message) ?? 'message-generated',
+    [rowKeysData],
   );
 
   return (
+    <div className="relative flex min-h-0 flex-1 flex-col">
     <div
       ref={scrollContainerRef}
       onWheel={onWheel}
@@ -188,7 +259,11 @@ function ChatMessagesPane({
           </div>
         </div>
       )}
-      <div className="mx-auto w-full max-w-[54.25rem] space-y-3 px-4 sm:space-y-4">
+      {/* On phones the pane is narrower than the rail's desktop margin can
+          offer, so the column gives up a rail-width gutter on its right and
+          the rail's positioning layer matches — the ticks then sit inside the
+          viewport instead of past its edge. */}
+      <div className="mx-auto w-full max-w-[54.25rem] space-y-3 px-4 sm:space-y-4 max-sm:pr-10">
       {(isLoadingSessionMessages || isProcessing) && chatMessages.length === 0 ? (
         <div className="mt-8 text-center text-gray-500 dark:text-gray-400">
           <div className="flex items-center justify-center space-x-2">
@@ -245,28 +320,21 @@ function ChatMessagesPane({
             onLoadAllMessages={loadAllMessages}
           />
 
-          {/* Legacy message count indicator (for non-paginated view) */}
-          {!hasMoreMessages && chatMessages.length > visibleMessageCount && (
+          {/* Legacy message count indicator (for non-paginated view). The rows
+              beyond the window load themselves as the user scrolls up (see
+              handleScroll's window widening), so there are no manual buttons
+              here anymore. */}
+          {!hasMoreMessages && range.end < groupedItems.length && (
             <div className="border-b border-gray-200 py-2 text-center text-sm text-gray-500 dark:border-gray-700 dark:text-gray-400">
-              {t('session.messages.showingLast', { count: visibleMessageCount, total: chatMessages.length })} |
-              <button className="ml-1 text-blue-600 underline hover:text-blue-700" onClick={loadEarlierMessages}>
-                {t('session.messages.loadEarlier')}
-              </button>
-              {' | '}
-              <button
-                className="text-blue-600 underline hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300"
-                onClick={loadAllMessages}
-              >
-                {t('session.messages.loadAll')}
-              </button>
+              {t('session.messages.showingLast', { count: range.end, total: groupedItems.length })}
             </div>
           )}
 
           {(() => {
             let prevMessage: ChatMessage | null = null;
-            const rowCount = groupedVisibleMessages.length;
+            const rowCount = groupedItems.length;
 
-            return groupedVisibleMessages.map((item, index) => {
+            return groupedItems.map((item, index) => {
               // Rows near the tail mount their content on first commit so the
               // initial scroll-to-bottom measures real heights; older rows
               // start as placeholders and mount when scrolled toward.
@@ -331,6 +399,34 @@ function ChatMessagesPane({
         </>
       )}
       </div>
+    </div>
+      {promptEntries.length > 0 && onSelectPrompt && (
+        /* Positioning layer matching the message column width, so the rail
+           hugs the right edge of the conversation column rather than the
+           window edge (where it collided with the scrollbar and the export
+           menu). The layer stays click-through; only the rail itself is
+           interactive. */
+        <div className="pointer-events-none absolute inset-0 flex justify-center">
+          <div className="relative h-full w-full max-w-[54.25rem]">
+            <PromptNavigatorRail
+              prompts={promptEntries}
+              activeId={activePromptId}
+              onSelect={onSelectPrompt}
+              canLoadEarlier={hasMoreMessages && !allMessagesLoaded}
+              isLoadingOlder={isLoadingMoreMessages}
+              onLoadEarlier={onRequestOlderMessages ?? loadAllMessages}
+              scrollContainerRef={scrollContainerRef}
+              loadMoreLabel={t('session.messages.loadEarlier')}
+              emptyPreviewLabel={t('promptNavigator.noTextContent', {
+                defaultValue: '(no text content)',
+              })}
+              navigatorLabel={t('promptNavigator.aria', {
+                defaultValue: 'Prompt navigator',
+              })}
+            />
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/modules/chat/transcript/LazyMessageRow.tsx
+++ b/src/modules/chat/transcript/LazyMessageRow.tsx
@@ -34,6 +34,13 @@ type LazyMessageRowProps = {
    * placeholder and mounts when scrolled toward.
    */
   initiallyNearViewport: boolean;
+  /**
+   * Receives the row element (and its windowing key) on mount/unmount so the
+   * transcript virtualization can cache the row's real height.
+   */
+  onElement?: (element: HTMLDivElement | null, key: string) => void;
+  /** Stable identity for the height cache; `onElement` is keyed by it. */
+  heightKey?: string;
   children: ReactNode;
 };
 
@@ -41,6 +48,8 @@ export default function LazyMessageRow({
   lazyRows,
   timestamp,
   initiallyNearViewport,
+  onElement,
+  heightKey,
   children,
 }: LazyMessageRowProps) {
   const [isNearViewport, setIsNearViewport] = useState(initiallyNearViewport);
@@ -54,10 +63,13 @@ export default function LazyMessageRow({
       const height = elementRef.current?.offsetHeight ?? 0;
       if (height > 0) {
         setMeasuredHeight(height);
+        if (onElement && heightKey) {
+          onElement(elementRef.current, heightKey);
+        }
       }
     }
     setIsNearViewport(nextIsNearViewport);
-  }, []);
+  }, [onElement, heightKey]);
 
   useEffect(() => {
     const element = elementRef.current;
@@ -67,9 +79,16 @@ export default function LazyMessageRow({
 
   const isMounted = lazyRows === null || isNearViewport;
 
+  const attachRef = useCallback((element: HTMLDivElement | null) => {
+    elementRef.current = element;
+    if (element && onElement && heightKey) {
+      onElement(element, heightKey);
+    }
+  }, [onElement, heightKey]);
+
   return (
     <div
-      ref={elementRef}
+      ref={attachRef}
       data-message-timestamp={timestamp || undefined}
       style={isMounted ? undefined : { height: measuredHeight ?? ESTIMATED_ROW_HEIGHT_PX }}
     >

--- a/src/modules/chat/transcript/MessageComponent.tsx
+++ b/src/modules/chat/transcript/MessageComponent.tsx
@@ -271,8 +271,13 @@ const MessageComponent = memo(({ message, prevMessage, createDiff, onFileOpen, s
                 )}
               </>
             ) : message.isThinking ? (
-              /* Thinking messages — Reasoning component (ai-elements pattern) */
-              <Reasoning defaultOpen={isExporting}>
+              /* Thinking messages — Reasoning component (ai-elements pattern).
+                 A streamed row (isStreaming) auto-opens and shimmers; the
+                 finalized row lands collapsed as before. */
+              <Reasoning
+                defaultOpen={isExporting || Boolean(message.isStreaming)}
+                isStreaming={Boolean(message.isStreaming)}
+              >
                 <ReasoningTrigger />
                 <ReasoningContent>
                   <Markdown className="prose prose-sm prose-gray max-w-none font-serif dark:prose-invert">

--- a/src/modules/chat/transcript/PromptNavigatorRail.tsx
+++ b/src/modules/chat/transcript/PromptNavigatorRail.tsx
@@ -58,6 +58,13 @@ type PromptNavigatorRailProps = {
    * history. The gutter forwards its wheel here instead.
    */
   scrollContainerRef: React.RefObject<HTMLDivElement>;
+  /**
+   * Park the rail INSIDE the pane's right edge (in the gutter the message
+   * column gave up) instead of hanging it outside the message column. The
+   * pane sets this once it is too narrow for the outside hang to stay inside
+   * the pane's clipped edge.
+   */
+  dockedInside?: boolean;
   loadMoreLabel: string;
   emptyPreviewLabel: string;
   navigatorLabel: string;
@@ -82,6 +89,7 @@ export function PromptNavigatorRail({
   isLoadingOlder,
   onLoadEarlier,
   scrollContainerRef,
+  dockedInside = false,
   loadMoreLabel,
   emptyPreviewLabel,
   navigatorLabel,
@@ -544,13 +552,20 @@ export function PromptNavigatorRail({
   return (
     <nav
       aria-label={navigatorLabel}
-      // The rail's left edge sits on the message column's right edge: the
-      // column wrapper's right:100% anchor pushes the whole gutter outward
-      // into the pane margin instead of overlapping the bubbles. On phones
-      // there is no pane margin to push into (the column spans the viewport),
-      // so it instead sits inside the gutter the column's `max-sm:pr-10`
-      // gave up, aligned to the layer's right edge.
-      className="pointer-events-none absolute left-full top-1/2 z-20 -translate-y-1/2 pl-1.5 max-sm:left-auto max-sm:right-0 max-sm:pl-0"
+      // Docked (the pane is too narrow to hang into): the rail sits INSIDE the
+      // layer's right edge, in the gutter the message column gives up — with a
+      // 20px desktop inset so the ticks clear the classic scrollbar, no inset
+      // on phones where the scrollbar is an overlay. Hung (wide pane): the
+      // rail's left edge sits on the message column's right edge — the
+      // right:100%/left-full anchor pushes the whole gutter outward into the
+      // pane margin instead of overlapping the bubbles, stepping 20px back on
+      // desktop to clear the scrollbar.
+      className={cn(
+        'pointer-events-none absolute top-1/2 z-20 -translate-y-1/2',
+        dockedInside
+          ? 'right-0 pl-0 sm:right-5'
+          : 'left-full pl-1.5 sm:-ml-5',
+      )}
     >
       <div className="pointer-events-auto flex flex-col items-end" onWheel={handleGutterWheel}>
         {canLoadEarlier ? (

--- a/src/modules/chat/transcript/PromptNavigatorRail.tsx
+++ b/src/modules/chat/transcript/PromptNavigatorRail.tsx
@@ -1,0 +1,746 @@
+import React from 'react';
+
+import type { PromptEntry } from '@/modules/chat/utils/promptNavigator';
+import { cn } from '@/shared/utils';
+
+// The whole gutter is one hover/click target: the cursor's vertical position
+// maps to the nearest tick, so tick density never demands pointer precision.
+const GUTTER_WIDTH_PX = 28;
+// The rail shows at most a window of ticks; hovering the gutter edges
+// carousels the window through the rest of the prompts.
+const MAX_VISIBLE_TICKS = 30;
+const TICK_PITCH_PX = 12;
+const EDGE_ZONE_PX = 18;
+const CAROUSEL_INTERVAL_MS = 80;
+const TICK_OVERSCAN = 4;
+// Tick lengths for the proximity wave around the cursor.
+const TICK_BASE_WIDTH_PX = 10;
+const TICK_ACTIVE_WIDTH_PX = 14;
+const TICK_FOCUS_WIDTH_PX = 20;
+// The hover preview is a scrolling mini-list of all prompts: the highlighted
+// row stays centered while the list glides, and the panel itself is
+// interactive so imprecise gutter hits can be corrected inside the list.
+const PANEL_ROW_HEIGHT_PX = 54;
+const PANEL_ROW_INSET_Y_PX = 4;
+const PANEL_MAX_ROWS = 8;
+const PANEL_SCROLL_MARGIN_ROWS = 2;
+const PANEL_HIDE_DELAY_MS = 160;
+
+// Codex-style wave: the highlighted tick stretches, neighbours taper off.
+const PROXIMITY_FALLOFF = [1, 0.6, 0.35, 0.15];
+
+const resolveTickWidth = (
+  index: number,
+  highlightedIndex: number | null,
+  isActive: boolean,
+): number => {
+  const base = isActive ? TICK_ACTIVE_WIDTH_PX : TICK_BASE_WIDTH_PX;
+  if (highlightedIndex === null) {
+    return base;
+  }
+  const distance = Math.abs(index - highlightedIndex);
+  const factor = PROXIMITY_FALLOFF[distance] ?? 0;
+  return Math.round(base + (TICK_FOCUS_WIDTH_PX - base) * factor);
+};
+
+type PromptNavigatorRailProps = {
+  prompts: PromptEntry[];
+  /** Entry id of the prompt the viewport is currently reading. */
+  activeId: string | null;
+  onSelect: (entry: PromptEntry) => void;
+  canLoadEarlier: boolean;
+  isLoadingOlder: boolean;
+  onLoadEarlier: () => void;
+  /**
+   * The transcript's scroll container. The gutter is a pointer-events island
+   * over it, so a wheel over the rail would otherwise be swallowed and the
+   * transcript could not scroll — and scroll-to-top is what pages in older
+   * history. The gutter forwards its wheel here instead.
+   */
+  scrollContainerRef: React.RefObject<HTMLDivElement>;
+  loadMoreLabel: string;
+  emptyPreviewLabel: string;
+  navigatorLabel: string;
+};
+
+/**
+ * The right-edge prompt navigator: a tape of ticks, one per user prompt, that
+ * previews each prompt on hover and jumps the transcript to it on click.
+ *
+ * Ported from openchamber's `PromptNavigatorRail` (packages/ui/src/components/
+ * chat/components/PromptNavigatorRail.tsx): pointer position over the gutter
+ * maps to the nearest tick (a wave stretches the tick under the cursor), the
+ * gutter carousels through long transcripts when the pointer parks on its
+ * edges, and an adjacent panel lists every prompt as a card, gliding so the
+ * highlighted row stays centered.
+ */
+export function PromptNavigatorRail({
+  prompts,
+  activeId,
+  onSelect,
+  canLoadEarlier,
+  isLoadingOlder,
+  onLoadEarlier,
+  scrollContainerRef,
+  loadMoreLabel,
+  emptyPreviewLabel,
+  navigatorLabel,
+}: PromptNavigatorRailProps) {
+  const gutterRef = React.useRef<HTMLDivElement | null>(null);
+  // Declared early: the gutter's pointer handlers below must be able to tell
+  // whether a pointer event bubbled up from inside the preview panel.
+  const panelRef = React.useRef<HTMLDivElement | null>(null);
+  const [highlightedIndex, setHighlightedIndex] = React.useState<number | null>(null);
+  const [windowStart, setWindowStart] = React.useState(0);
+
+  // The rail floats outside the scroll container, so a wheel over the gutter
+  // would scroll nothing; hand the delta to the transcript instead (and let
+  // scroll-to-top page in older history from there).
+  const handleGutterWheel = React.useCallback((event: React.WheelEvent<HTMLDivElement>) => {
+    scrollContainerRef.current?.scrollBy({ top: event.deltaY });
+  }, [scrollContainerRef]);
+
+  const visibleCount = Math.min(prompts.length, MAX_VISIBLE_TICKS);
+  const maxWindowStart = Math.max(0, prompts.length - visibleCount);
+  const clampedWindowStart = Math.min(windowStart, maxWindowStart);
+  const windowEnd = clampedWindowStart + visibleCount;
+  const hasMoreAbove = clampedWindowStart > 0;
+  const hasMoreBelow = windowEnd < prompts.length;
+
+  const activeIndex = React.useMemo(() => {
+    if (!activeId) {
+      return -1;
+    }
+    return prompts.findIndex((prompt) => prompt.id === activeId);
+  }, [activeId, prompts]);
+
+  // Refs mirroring hot values so the carousel interval reads fresh state.
+  const windowStartRef = React.useRef(clampedWindowStart);
+  windowStartRef.current = clampedWindowStart;
+  const promptsLengthRef = React.useRef(prompts.length);
+  promptsLengthRef.current = prompts.length;
+  const pointerYRef = React.useRef<number | null>(null);
+  const carouselTimerRef = React.useRef<number | null>(null);
+  const carouselDirRef = React.useRef<0 | 1 | -1>(0);
+
+  const ensureWindowContains = React.useCallback((index: number) => {
+    setWindowStart((start) => {
+      const length = promptsLengthRef.current;
+      const count = Math.min(length, MAX_VISIBLE_TICKS);
+      const maxStart = Math.max(0, length - count);
+      const clamped = Math.min(start, maxStart);
+      if (index < clamped) {
+        return index;
+      }
+      if (index >= clamped + count) {
+        return Math.min(maxStart, index - count + 1);
+      }
+      return clamped;
+    });
+  }, []);
+
+  // Load-earlier prepends shift every index; move the window with them so the
+  // visible ticks (and the active one) don't jump around.
+  const firstIdRef = React.useRef<string | undefined>(prompts[0]?.id);
+  const prevLengthRef = React.useRef(prompts.length);
+  React.useLayoutEffect(() => {
+    const prevFirst = firstIdRef.current;
+    const prevLength = prevLengthRef.current;
+    const added = prompts.length - prevLength;
+    if (added > 0 && prevLength > 0 && prevFirst && prompts[0]?.id !== prevFirst) {
+      setWindowStart((start) => start + added);
+      setHighlightedIndex((index) => (index === null ? null : index + added));
+    }
+    firstIdRef.current = prompts[0]?.id;
+    prevLengthRef.current = prompts.length;
+  }, [prompts]);
+
+  // While the user isn't interacting with the rail, the tape glides so the
+  // active prompt stays centered — the scale moves, not the marker.
+  React.useEffect(() => {
+    if (highlightedIndex !== null) {
+      return;
+    }
+    const target = activeIndex >= 0 ? activeIndex : prompts.length - 1;
+    setWindowStart(() => {
+      const length = promptsLengthRef.current;
+      const count = Math.min(length, MAX_VISIBLE_TICKS);
+      const maxStart = Math.max(0, length - count);
+      return Math.max(0, Math.min(maxStart, target - Math.floor(count / 2)));
+    });
+  }, [activeIndex, highlightedIndex, prompts.length]);
+
+  const relativeIndexFromPointer = React.useCallback((clientY: number): number | null => {
+    const gutter = gutterRef.current;
+    if (!gutter) {
+      return null;
+    }
+    const rect = gutter.getBoundingClientRect();
+    const raw = Math.floor((clientY - rect.top) / TICK_PITCH_PX);
+    const count = Math.min(promptsLengthRef.current, MAX_VISIBLE_TICKS);
+    if (count === 0) {
+      return null;
+    }
+    return Math.max(0, Math.min(count - 1, raw));
+  }, []);
+
+  const stopCarousel = React.useCallback(() => {
+    carouselDirRef.current = 0;
+    if (carouselTimerRef.current !== null) {
+      window.clearInterval(carouselTimerRef.current);
+      carouselTimerRef.current = null;
+    }
+  }, []);
+
+  const carouselStep = React.useCallback(() => {
+    const dir = carouselDirRef.current;
+    if (dir === 0) {
+      stopCarousel();
+      return;
+    }
+    const length = promptsLengthRef.current;
+    const count = Math.min(length, MAX_VISIBLE_TICKS);
+    const maxStart = Math.max(0, length - count);
+    const current = Math.min(windowStartRef.current, maxStart);
+    const next = Math.max(0, Math.min(maxStart, current + dir));
+    if (next === current) {
+      stopCarousel();
+      return;
+    }
+    windowStartRef.current = next;
+    setWindowStart(next);
+    const pointerY = pointerYRef.current;
+    if (pointerY !== null) {
+      const relative = relativeIndexFromPointer(pointerY);
+      if (relative !== null) {
+        setHighlightedIndex(Math.min(length - 1, next + relative));
+      }
+    }
+  }, [relativeIndexFromPointer, stopCarousel]);
+
+  const updateCarousel = React.useCallback((clientY: number) => {
+    const gutter = gutterRef.current;
+    if (!gutter) {
+      return;
+    }
+    const rect = gutter.getBoundingClientRect();
+    const y = clientY - rect.top;
+    let dir: 0 | 1 | -1 = 0;
+    if (y <= EDGE_ZONE_PX && hasMoreAbove) {
+      dir = -1;
+    } else if (y >= rect.height - EDGE_ZONE_PX && hasMoreBelow) {
+      dir = 1;
+    }
+    carouselDirRef.current = dir;
+    if (dir === 0) {
+      stopCarousel();
+      return;
+    }
+    if (carouselTimerRef.current === null) {
+      carouselTimerRef.current = window.setInterval(carouselStep, CAROUSEL_INTERVAL_MS);
+    }
+  }, [carouselStep, hasMoreAbove, hasMoreBelow, stopCarousel]);
+
+  React.useEffect(() => () => {
+    if (carouselTimerRef.current !== null) {
+      window.clearInterval(carouselTimerRef.current);
+    }
+  }, []);
+
+  // Leaving the gutter hides the panel after a short grace period so the
+  // pointer can travel into the panel and interact with the list directly.
+  const hideTimerRef = React.useRef<number | null>(null);
+  const cancelScheduledHide = React.useCallback(() => {
+    if (hideTimerRef.current !== null) {
+      window.clearTimeout(hideTimerRef.current);
+      hideTimerRef.current = null;
+    }
+  }, []);
+  const scheduleHide = React.useCallback(() => {
+    cancelScheduledHide();
+    hideTimerRef.current = window.setTimeout(() => {
+      hideTimerRef.current = null;
+      setHighlightedIndex(null);
+    }, PANEL_HIDE_DELAY_MS);
+  }, [cancelScheduledHide]);
+  React.useEffect(() => () => {
+    if (hideTimerRef.current !== null) {
+      window.clearTimeout(hideTimerRef.current);
+    }
+  }, []);
+
+  // Shared by mouse hover and touch scrub: highlight the tick under the
+  // pointer and run the edge carousel.
+  const applyPointer = React.useCallback((clientY: number) => {
+    cancelScheduledHide();
+    pointerYRef.current = clientY;
+    const relative = relativeIndexFromPointer(clientY);
+    if (relative !== null) {
+      setHighlightedIndex(
+        Math.min(promptsLengthRef.current - 1, windowStartRef.current + relative),
+      );
+    }
+    updateCarousel(clientY);
+  }, [cancelScheduledHide, relativeIndexFromPointer, updateCarousel]);
+
+  // The preview panel renders inside the gutter, so its pointer events reach
+  // the gutter's handlers by bubbling. The panel's cursor Y projected onto
+  // the gutter's scale is meaningless — feeding it to applyPointer fought the
+  // panel's own row highlighting (flicker) and could trip the edge carousel
+  // (tape auto-scrolling while the pointer was only reading the list). The
+  // container's stopPropagation only covers mousemove/click, and these run on
+  // pointer events, which sail through it.
+  const isInsidePanel = React.useCallback((target: EventTarget | null): boolean => (
+    target instanceof Node && panelRef.current !== null && panelRef.current.contains(target)
+  ), []);
+
+  const handlePointerLeave = React.useCallback(() => {
+    pointerYRef.current = null;
+    stopCarousel();
+    scheduleHide();
+  }, [scheduleHide, stopCarousel]);
+
+  // The pointer is reading the list, not the tape: keep the panel open, but
+  // drop the gutter-side pointer state (carousel, last pointer Y) so nothing
+  // keeps re-driving the tape from a cursor that left it.
+  const handlePanelEnter = React.useCallback(() => {
+    cancelScheduledHide();
+    pointerYRef.current = null;
+    stopCarousel();
+  }, [cancelScheduledHide, stopCarousel]);
+
+  /* Touch parity: a finger press on the gutter does what hover does on a
+     mouse — wave + preview panel — then drag scrubs the ticks and release
+     selects the highlighted one. Pointer events carry both input types; the
+     gutter sets `touch-action: none` so the browser delivers the drag as
+     pointermove instead of stealing it for transcript scrolling. */
+  const scrubbingRef = React.useRef(false);
+  const suppressGutterClickRef = React.useRef(false);
+  // Fresh-value reads for the scrub-completion callback, which stays stable.
+  const highlightedIndexRefForSelect = React.useRef<number | null>(highlightedIndex);
+  highlightedIndexRefForSelect.current = highlightedIndex;
+  const handleSelectRef = React.useRef<((index: number | null) => void) | null>(null);
+
+  const handleGutterPointerDown = React.useCallback((event: React.PointerEvent<HTMLDivElement>) => {
+    if (isInsidePanel(event.target)) {
+      return;
+    }
+    if (event.pointerType !== 'touch') {
+      return;
+    }
+    event.preventDefault();
+    event.currentTarget.setPointerCapture(event.pointerId);
+    scrubbingRef.current = true;
+    applyPointer(event.clientY);
+  }, [applyPointer, isInsidePanel]);
+
+  const handleGutterPointerMove = React.useCallback((event: React.PointerEvent<HTMLDivElement>) => {
+    if (isInsidePanel(event.target)) {
+      // Reading the list keeps the panel open (the row's own onMouseMove
+      // owns the highlight) but must not re-derive the tick from the
+      // pointer's Y or arm the edge carousel.
+      cancelScheduledHide();
+      return;
+    }
+    if (event.pointerType === 'touch') {
+      if (scrubbingRef.current) {
+        applyPointer(event.clientY);
+      }
+      return;
+    }
+    applyPointer(event.clientY);
+  }, [applyPointer, cancelScheduledHide, isInsidePanel]);
+
+  const endTouchScrub = React.useCallback((event: React.PointerEvent<HTMLDivElement>, select: boolean) => {
+    if (!scrubbingRef.current) {
+      return;
+    }
+    scrubbingRef.current = false;
+    suppressGutterClickRef.current = true;
+    if (event.currentTarget.hasPointerCapture(event.pointerId)) {
+      event.currentTarget.releasePointerCapture(event.pointerId);
+    }
+    if (select) {
+      const index = highlightedIndexRefForSelect.current;
+      if (index !== null && handleSelectRef.current) {
+        handleSelectRef.current(index);
+        return;
+      }
+    }
+    pointerYRef.current = null;
+    stopCarousel();
+    scheduleHide();
+  }, [scheduleHide, stopCarousel]);
+
+  const handleGutterPointerUp = React.useCallback(
+    (event: React.PointerEvent<HTMLDivElement>) => endTouchScrub(event, true),
+    [endTouchScrub],
+  );
+  const handleGutterPointerCancel = React.useCallback(
+    (event: React.PointerEvent<HTMLDivElement>) => endTouchScrub(event, false),
+    [endTouchScrub],
+  );
+
+  const handleSelect = React.useCallback((index: number | null) => {
+    if (index === null) {
+      return;
+    }
+    const prompt = prompts[index];
+    if (!prompt) {
+      return;
+    }
+    onSelect(prompt);
+    stopCarousel();
+    setHighlightedIndex(null);
+    gutterRef.current?.blur();
+  }, [onSelect, prompts, stopCarousel]);
+  handleSelectRef.current = handleSelect;
+
+  const handleGutterClick = React.useCallback((event: React.MouseEvent<HTMLDivElement>) => {
+    // A touch scrub selects on pointerup; the click synthesized afterwards
+    // would select the pointer-up position again (or double-fire elsewhere).
+    if (suppressGutterClickRef.current) {
+      suppressGutterClickRef.current = false;
+      return;
+    }
+    const relative = relativeIndexFromPointer(event.clientY);
+    if (relative === null) {
+      return;
+    }
+    handleSelect(Math.min(prompts.length - 1, windowStartRef.current + relative));
+  }, [handleSelect, prompts.length, relativeIndexFromPointer]);
+
+  const handleKeyDown = React.useCallback((event: React.KeyboardEvent<HTMLDivElement>) => {
+    if (prompts.length === 0) {
+      return;
+    }
+    const current = highlightedIndex ?? (activeIndex >= 0 ? activeIndex : prompts.length - 1);
+
+    const moveTo = (index: number) => {
+      const next = Math.max(0, Math.min(prompts.length - 1, index));
+      ensureWindowContains(next);
+      setHighlightedIndex(next);
+    };
+
+    if (event.key === 'ArrowUp' || event.key === 'ArrowDown') {
+      event.preventDefault();
+      moveTo(current + (event.key === 'ArrowUp' ? -1 : 1));
+      return;
+    }
+    if (event.key === 'Home') {
+      event.preventDefault();
+      moveTo(0);
+      return;
+    }
+    if (event.key === 'End') {
+      event.preventDefault();
+      moveTo(prompts.length - 1);
+      return;
+    }
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      handleSelect(current);
+      return;
+    }
+    if (event.key === 'Escape') {
+      event.preventDefault();
+      setHighlightedIndex(null);
+      gutterRef.current?.blur();
+    }
+  }, [activeIndex, ensureWindowContains, handleSelect, highlightedIndex, prompts.length]);
+
+  const handleBlur = React.useCallback(() => {
+    stopCarousel();
+    setHighlightedIndex(null);
+  }, [stopCarousel]);
+
+  // Wheel over the panel steps the highlight instead of scrolling the chat
+  // underneath; a native non-passive listener is required for preventDefault.
+  const highlightedIndexRef = React.useRef(highlightedIndex);
+  highlightedIndexRef.current = highlightedIndex;
+  const isPanelVisible = highlightedIndex !== null;
+  const wheelRemainderRef = React.useRef(0);
+  React.useEffect(() => {
+    const panel = panelRef.current;
+    if (!panel) {
+      return;
+    }
+    const handleWheel = (event: WheelEvent) => {
+      event.preventDefault();
+      event.stopPropagation();
+      wheelRemainderRef.current += event.deltaY;
+      const steps = Math.trunc(wheelRemainderRef.current / PANEL_ROW_HEIGHT_PX);
+      if (steps === 0) {
+        return;
+      }
+      wheelRemainderRef.current -= steps * PANEL_ROW_HEIGHT_PX;
+      const current = highlightedIndexRef.current;
+      if (current === null) {
+        return;
+      }
+      const next = Math.max(0, Math.min(promptsLengthRef.current - 1, current + steps));
+      if (next !== current) {
+        ensureWindowContains(next);
+        setHighlightedIndex(next);
+      }
+    };
+    panel.addEventListener('wheel', handleWheel, { passive: false });
+    return () => panel.removeEventListener('wheel', handleWheel);
+  }, [ensureWindowContains, isPanelVisible]);
+
+  const highlightedPrompt = highlightedIndex !== null ? prompts[highlightedIndex] : undefined;
+  // Panel list geometry: centered on the highlight when the panel opens, then
+  // a dead zone — the list only glides when the highlighted row gets within a
+  // couple of rows of the window edge, so small pointer moves don't scroll.
+  const panelVisibleRows = Math.min(prompts.length, PANEL_MAX_ROWS);
+  const panelHeight = panelVisibleRows * PANEL_ROW_HEIGHT_PX;
+  const panelMaxOffset = prompts.length * PANEL_ROW_HEIGHT_PX - panelHeight;
+  const clampPanelOffset = (offset: number) => Math.max(0, Math.min(panelMaxOffset, offset));
+  const panelOffsetRef = React.useRef<number | null>(null);
+  let panelScrollOffset = 0;
+  if (highlightedIndex === null) {
+    panelOffsetRef.current = null;
+  } else if (panelOffsetRef.current === null) {
+    panelScrollOffset = clampPanelOffset(
+      highlightedIndex * PANEL_ROW_HEIGHT_PX - (panelHeight - PANEL_ROW_HEIGHT_PX) / 2,
+    );
+    panelOffsetRef.current = panelScrollOffset;
+  } else {
+    let offset = panelOffsetRef.current;
+    const highestAllowed = (highlightedIndex - PANEL_SCROLL_MARGIN_ROWS) * PANEL_ROW_HEIGHT_PX;
+    const lowestAllowed =
+      (highlightedIndex + 1 + PANEL_SCROLL_MARGIN_ROWS) * PANEL_ROW_HEIGHT_PX - panelHeight;
+    if (offset > highestAllowed) {
+      offset = highestAllowed;
+    } else if (offset < lowestAllowed) {
+      offset = lowestAllowed;
+    }
+    panelScrollOffset = clampPanelOffset(offset);
+    panelOffsetRef.current = panelScrollOffset;
+  }
+  // Only rows near the visible window are rendered; extra rows slide in under
+  // the mask during the glide instead of popping in at the edges.
+  const panelFirstVisibleRow = Math.floor(panelScrollOffset / PANEL_ROW_HEIGHT_PX);
+  const panelSliceStart = Math.max(0, panelFirstVisibleRow - TICK_OVERSCAN);
+  const panelSliceEnd = Math.min(prompts.length, panelFirstVisibleRow + panelVisibleRows + TICK_OVERSCAN);
+  const panelClippedAbove = panelScrollOffset > 0;
+  const panelClippedBelow = panelScrollOffset < panelMaxOffset;
+  const panelMask = panelClippedAbove || panelClippedBelow
+    ? `linear-gradient(to bottom, ${panelClippedAbove ? 'transparent, black 10%' : 'black'}, ${panelClippedBelow ? 'black 90%, transparent' : 'black'})`
+    : undefined;
+  // Overscan a few ticks beyond the window so they slide in under the gradient
+  // mask instead of popping into existence at the edges.
+  const overscanStart = Math.max(0, clampedWindowStart - TICK_OVERSCAN);
+  const overscanEnd = Math.min(prompts.length, windowEnd + TICK_OVERSCAN);
+  const visiblePrompts = prompts.slice(overscanStart, overscanEnd);
+  const gutterMask = hasMoreAbove || hasMoreBelow
+    ? `linear-gradient(to bottom, ${hasMoreAbove ? 'transparent, black 14%' : 'black'}, ${hasMoreBelow ? 'black 86%, transparent' : 'black'})`
+    : undefined;
+
+  if (prompts.length === 0) {
+    return null;
+  }
+
+  return (
+    <nav
+      aria-label={navigatorLabel}
+      // The rail's left edge sits on the message column's right edge: the
+      // column wrapper's right:100% anchor pushes the whole gutter outward
+      // into the pane margin instead of overlapping the bubbles. On phones
+      // there is no pane margin to push into (the column spans the viewport),
+      // so it instead sits inside the gutter the column's `max-sm:pr-10`
+      // gave up, aligned to the layer's right edge.
+      className="pointer-events-none absolute left-full top-1/2 z-20 -translate-y-1/2 pl-1.5 max-sm:left-auto max-sm:right-0 max-sm:pl-0"
+    >
+      <div className="pointer-events-auto flex flex-col items-end" onWheel={handleGutterWheel}>
+        {canLoadEarlier ? (
+          <button
+            type="button"
+            tabIndex={-1}
+            className={cn(
+              // Nudge so the icon centers over the tick column
+              // (ticks sit at right-1 with a 10px base width).
+              '-mr-px mb-1.5 flex size-5 shrink-0 items-center justify-center rounded-full',
+              'text-gray-400 transition-colors hover:bg-gray-200/60 hover:text-gray-700',
+              'dark:hover:bg-gray-700/60 dark:hover:text-gray-200',
+              isLoadingOlder ? 'cursor-wait opacity-70' : undefined,
+            )}
+            aria-label={loadMoreLabel}
+            title={loadMoreLabel}
+            disabled={isLoadingOlder}
+            onClick={(event) => {
+              event.stopPropagation();
+              if (!isLoadingOlder) {
+                onLoadEarlier();
+              }
+            }}
+          >
+            {isLoadingOlder ? (
+              <span className="block size-3.5 animate-spin rounded-full border-b-2 border-gray-400" />
+            ) : (
+              <span aria-hidden="true" className="block text-xs leading-none">↑</span>
+            )}
+          </button>
+        ) : null}
+        <div
+          ref={gutterRef}
+          role="listbox"
+          tabIndex={-1}
+          aria-activedescendant={
+            highlightedPrompt ? `prompt-rail-tick-${highlightedPrompt.id}` : undefined
+          }
+          className="relative cursor-pointer outline-none"
+          style={{
+            width: `${GUTTER_WIDTH_PX}px`,
+            height: `${visibleCount * TICK_PITCH_PX}px`,
+            // Touch drags over the gutter scrub the ticks (like mouse hover)
+            // instead of panning the transcript; the gutter is a 28px island,
+            // so the transcript still scrolls freely everywhere else.
+            touchAction: 'none',
+          }}
+          onMouseLeave={handlePointerLeave}
+          onPointerDown={handleGutterPointerDown}
+          onPointerMove={handleGutterPointerMove}
+          onPointerUp={handleGutterPointerUp}
+          onPointerCancel={handleGutterPointerCancel}
+          onClick={handleGutterClick}
+          onKeyDown={handleKeyDown}
+          onBlur={handleBlur}
+        >
+          <div
+            className="absolute inset-0 overflow-hidden"
+            style={gutterMask ? { maskImage: gutterMask, WebkitMaskImage: gutterMask } : undefined}
+          >
+            {/* The tape: ticks keep their absolute position on the strip, and
+                the strip itself glides. */}
+            <div
+              // Remount on prepend so the index shift doesn't play as a
+              // spurious slide animation.
+              key={prompts[0]?.id}
+              className="absolute inset-x-0 top-0 transition-transform duration-300 ease-out"
+              style={{ transform: `translateY(-${clampedWindowStart * TICK_PITCH_PX}px)` }}
+            >
+              {visiblePrompts.map((prompt, slot) => {
+                const index = overscanStart + slot;
+                const isActive = prompt.id === activeId;
+                const isHighlighted = highlightedIndex === index;
+                const tickWidth = resolveTickWidth(index, highlightedIndex, isActive);
+
+                return (
+                  <div
+                    key={prompt.id}
+                    id={`prompt-rail-tick-${prompt.id}`}
+                    role="option"
+                    aria-selected={isHighlighted}
+                    aria-current={isActive ? 'true' : undefined}
+                    aria-label={prompt.preview.trim() || emptyPreviewLabel}
+                    className="pointer-events-none absolute right-1 flex items-center justify-end"
+                    style={{ top: `${index * TICK_PITCH_PX}px`, height: `${TICK_PITCH_PX}px` }}
+                  >
+                    <span
+                      aria-hidden="true"
+                      className={cn(
+                        'block h-0.5 rounded-full transition-all duration-200 ease-out',
+                        isActive
+                          ? 'bg-gray-900 dark:bg-gray-100'
+                          : isHighlighted
+                            ? 'bg-gray-900/80 dark:bg-gray-100/80'
+                            : 'bg-gray-900/30 dark:bg-gray-100/30',
+                      )}
+                      style={{ width: `${tickWidth}px` }}
+                    />
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+          {highlightedPrompt && highlightedIndex !== null ? (
+            <div
+              ref={panelRef}
+              className={cn(
+                'pointer-events-auto absolute right-full top-1/2 z-30 mr-3 -translate-y-1/2',
+                'w-[min(20rem,calc(100vw-6rem))] overflow-hidden rounded-xl',
+                'border border-gray-200/60 bg-white py-1 shadow-md',
+                'dark:border-gray-700/60 dark:bg-gray-800',
+              )}
+              onMouseEnter={handlePanelEnter}
+              onMouseLeave={scheduleHide}
+              onMouseMove={(event) => event.stopPropagation()}
+              onClick={(event) => event.stopPropagation()}
+            >
+              <div
+                className="relative overflow-hidden"
+                style={{
+                  height: `${panelVisibleRows * PANEL_ROW_HEIGHT_PX}px`,
+                  maskImage: panelMask,
+                  WebkitMaskImage: panelMask,
+                }}
+              >
+                {/* The list glides so the highlighted row stays centered while
+                    scrubbing the rail. */}
+                <div
+                  className="absolute inset-x-0 top-0 transition-transform duration-200 ease-out"
+                  style={{
+                    height: `${prompts.length * PANEL_ROW_HEIGHT_PX}px`,
+                    transform: `translateY(-${panelScrollOffset}px)`,
+                  }}
+                >
+                  {prompts.slice(panelSliceStart, panelSliceEnd).map((prompt, slot) => {
+                    const index = panelSliceStart + slot;
+                    const isActive = prompt.id === activeId;
+                    const isHighlighted = highlightedIndex === index;
+                    return (
+                      <div
+                        key={prompt.id}
+                        role="option"
+                        aria-selected={isHighlighted}
+                        aria-current={isActive ? 'true' : undefined}
+                        className="absolute inset-x-0 cursor-pointer px-1.5"
+                        style={{
+                          top: `${index * PANEL_ROW_HEIGHT_PX + PANEL_ROW_INSET_Y_PX}px`,
+                          height: `${PANEL_ROW_HEIGHT_PX - PANEL_ROW_INSET_Y_PX * 2}px`,
+                        }}
+                        onMouseMove={() => {
+                          cancelScheduledHide();
+                          if (highlightedIndexRef.current !== index) {
+                            ensureWindowContains(index);
+                            setHighlightedIndex(index);
+                          }
+                        }}
+                        onClick={() => handleSelect(index)}
+                      >
+                        <div
+                          className={cn(
+                            'flex h-full items-center rounded-lg border px-2 transition-colors',
+                            isActive
+                              ? 'border-transparent bg-gray-900 dark:bg-gray-100'
+                              : isHighlighted
+                                ? 'border-gray-200/60 bg-gray-100 dark:border-gray-700/60 dark:bg-gray-700'
+                                : 'border-gray-200/40 dark:border-gray-700/40',
+                          )}
+                        >
+                          <span
+                            className={cn(
+                              // Fill both clamp lines to the edge instead of
+                              // leaving a ragged gap before a long next word.
+                              'min-w-0 flex-1 line-clamp-2 break-words text-xs leading-snug [overflow-wrap:anywhere]',
+                              isActive
+                                ? 'text-white dark:text-gray-900'
+                                : 'text-gray-500 dark:text-gray-400',
+                            )}
+                          >
+                            {prompt.preview.trim() || emptyPreviewLabel}
+                          </span>
+                        </div>
+                      </div>
+                    );
+                  })}
+                </div>
+              </div>
+            </div>
+          ) : null}
+        </div>
+      </div>
+    </nav>
+  );
+}

--- a/src/modules/chat/utils/promptNavigator.ts
+++ b/src/modules/chat/utils/promptNavigator.ts
@@ -1,0 +1,50 @@
+import type { ChatMessage } from '@/shared/types';
+
+const PREVIEW_MAX_CHARS = 160;
+
+export type PromptEntry = {
+  /** Identity used as the React key and for active-tick matching. */
+  id: string;
+  /** The message's own timestamp, used to find the rendered DOM row to jump to. */
+  timestamp: ChatMessage['timestamp'];
+  preview: string;
+  /** The source message, for callers that need to match rows back to entries. */
+  message: ChatMessage;
+};
+
+/** Collapse a message's text into a single-line snippet for the preview list. */
+export const buildPromptPreview = (content: string | undefined): string => {
+  const collapsed = (content ?? '')
+    .replace(/```[\s\S]*?```/g, ' ')
+    .replace(/[#>*_`~]/g, ' ')
+    .replace(/\[([^\]]*)\]\([^)]*\)/g, '$1')
+    .replace(/\s+/g, ' ')
+    .trim();
+  return collapsed.length > PREVIEW_MAX_CHARS
+    ? `${collapsed.slice(0, PREVIEW_MAX_CHARS - 1)}…`
+    : collapsed;
+};
+
+/**
+ * Collect the user prompts of a transcript into navigator entries, in order.
+ * The prompt navigator rail shows one tick per entry; the jump handler matches
+ * the same processed preview when disambiguating repeated timestamps.
+ */
+export const buildPromptEntries = (messages: ChatMessage[]): PromptEntry[] => {
+  const entries: PromptEntry[] = [];
+  messages.forEach((message, index) => {
+    if (message.type !== 'user' || message.isThinking) {
+      return;
+    }
+    if (message.isLocalCommand && !message.content) {
+      return;
+    }
+    entries.push({
+      id: `${String(message.timestamp)}-${index}`,
+      timestamp: message.timestamp,
+      preview: buildPromptPreview(message.displayText ?? message.content),
+      message,
+    });
+  });
+  return entries;
+};

--- a/src/modules/chat/utils/sessionSubagents.ts
+++ b/src/modules/chat/utils/sessionSubagents.ts
@@ -1,0 +1,164 @@
+import type { NormalizedMessage, SubagentSummary } from '@/shared/types';
+
+/**
+ * Pure helpers behind the info panel's subagent section and its chat modal.
+ *
+ * While an agent runs, its rows stream into the PARENT session's store
+ * stamped with `parentToolUseId` (the spawning tool call). The main timeline
+ * folds them into the Task card, but the panel's agent view must show them
+ * top-level — so they are filtered by their parent stamp and the stamp is
+ * stripped before conversion, otherwise `normalizedToChatMessages` folds them
+ * away again. History and live rows are keyed apart by id.
+ */
+
+/** The agent's own rows from the parent's stream, with the parent stamp removed. */
+export function extractLiveSubagentMessages(
+  messages: NormalizedMessage[],
+  toolUseId: string | undefined,
+): NormalizedMessage[] {
+  if (!toolUseId) return [];
+
+  const live: NormalizedMessage[] = [];
+  for (const message of messages) {
+    if (message.parentToolUseId !== toolUseId) continue;
+    // The echoed task prompt arrives as a user-role row under the same stamp;
+    // it is the parent's question, not the agent's own voice.
+    if (message.kind === 'text' && message.role === 'user') continue;
+    if (message.kind === 'complete' || message.kind === 'status') continue;
+    const copy = { ...message };
+    delete copy.parentToolUseId;
+    live.push(copy);
+  }
+  return live;
+}
+
+/**
+ * Append live rows to the paged history without duplicating what the server
+ * already shipped. Transcript ids are stable across REST and websocket
+ * normalization, so id is the join key; tool rows additionally dedupe by
+ * toolId because a tool_result can land from the live stream before the
+ * REST page that carries its pair.
+ */
+export function mergeSubagentMessages(
+  history: NormalizedMessage[],
+  live: NormalizedMessage[],
+): NormalizedMessage[] {
+  if (live.length === 0) return history;
+
+  const seenIds = new Set<string>();
+  const seenToolIds = new Set<string>();
+  for (const message of history) {
+    seenIds.add(message.id);
+    if ((message.kind === 'tool_use' || message.kind === 'tool_result') && message.toolId) {
+      seenToolIds.add(`${message.kind}:${message.toolId}`);
+    }
+  }
+
+  const merged = [...history];
+  for (const message of live) {
+    if (seenIds.has(message.id)) continue;
+    const isToolRow = message.kind === 'tool_use' || message.kind === 'tool_result';
+    const toolKey = isToolRow && message.toolId ? `${message.kind}:${message.toolId}` : null;
+    if (toolKey && seenToolIds.has(toolKey)) continue;
+    seenIds.add(message.id);
+    if (toolKey) seenToolIds.add(toolKey);
+    merged.push(message);
+  }
+  return merged;
+}
+
+/** Working log of one agent, compressed for the continuation prompt. */
+function summarizeWorkLog(messages: NormalizedMessage[]): string {
+  const lines: string[] = [];
+  for (const message of messages) {
+    switch (message.kind) {
+      case 'text':
+      case 'thinking':
+        if (message.content?.trim()) {
+          lines.push(message.kind === 'thinking' ? `[思考] ${message.content.trim()}` : message.content.trim());
+        }
+        break;
+      case 'tool_use': {
+        const input = typeof message.toolInput === 'string'
+          ? message.toolInput
+          : JSON.stringify(message.toolInput ?? {});
+        lines.push(`[调用 ${message.toolName ?? 'Tool'}(${clip(input, 200)})]`);
+        break;
+      }
+      case 'tool_result': {
+        const text = typeof message.content === 'string' ? message.content : JSON.stringify(message.content ?? '');
+        lines.push(`[结果${message.isError ? '（失败）' : ''}] ${clip(text, 200)}`);
+        break;
+      }
+      default:
+        break;
+    }
+  }
+  return lines.join('\n');
+}
+
+function clip(text: string, max: number): string {
+  const single = text.replace(/\s+/g, ' ').trim();
+  return single.length > max ? `${single.slice(0, max)}…` : single;
+}
+
+/** Ceiling on how much of the agent's log rides along in the new session. */
+const MAX_WORK_LOG_CHARS = 24_000;
+
+/** Pre-translated sentences the prompt is assembled from (empty = built-in). */
+export type ContinuationPromptCopy = {
+  /** e.g. `你是「{{type}}」（{{description}}）。` */
+  identity: string;
+  /** Sentence before the log body, e.g. `以下是你…的工作记录：`. */
+  logIntro: string;
+  /** Sentence before the user's words, e.g. `用户现在要继续与你对话…：`. */
+  askIntro: string;
+};
+
+const DEFAULT_COPY: ContinuationPromptCopy = {
+  identity: '',
+  logIntro: '以下是你作为该子智能体在先前会话中的工作记录',
+  askIntro: '用户现在要继续与你对话，请基于上述上下文回应：',
+};
+
+/**
+ * The "continue as this agent" first message for a brand-new session.
+ *
+ * A finished subagent has no external input channel — it ran inside the
+ * parent's SDK process — so conversing means starting an independent session
+ * seeded with the agent's identity (its type and task) and a compressed
+ * record of what it already did. The user's own words come last. The three
+ * prose seams are injected translated copy so the payload matches the UI
+ * language; structure (identity line, fenced log, ask) stays here.
+ */
+export function buildSubagentContinuationPrompt(input: {
+  summary: SubagentSummary;
+  history: NormalizedMessage[];
+  userText: string;
+  copy?: Partial<ContinuationPromptCopy>;
+}): string {
+  const { summary, history, userText } = input;
+  const copy = { ...DEFAULT_COPY, ...input.copy };
+
+  const identity = copy.identity.trim()
+    || (summary.agentType
+      ? `你是「${summary.agentType}」${summary.description ? `（${summary.description}）` : ''}。`
+      : summary.description
+        ? `你是一名子智能体，此前的任务是：${summary.description}。`
+        : '你是一名子智能体。');
+
+  let log = summarizeWorkLog(history);
+  let truncated = false;
+  if (log.length > MAX_WORK_LOG_CHARS) {
+    // Keep the END of the log — the most recent work is the most relevant
+    // to a follow-up question.
+    log = log.slice(log.length - MAX_WORK_LOG_CHARS);
+    truncated = true;
+  }
+
+  const logSection = log
+    ? `${copy.logIntro}${truncated ? '（超长，仅保留最近部分）' : ''}：\n---\n${log}\n---`
+    : '（此前没有可携带的工作记录。）';
+
+  return [identity, logSection, `${copy.askIntro}\n${userText}`].join('\n\n');
+}

--- a/src/modules/chat/utils/sessionTaskList.ts
+++ b/src/modules/chat/utils/sessionTaskList.ts
@@ -1,0 +1,230 @@
+import type { NormalizedMessage } from '@/shared/types';
+
+/**
+ * Rebuilds the session's task ledger from the transcript.
+ *
+ * Two shapes feed the same ledger, and both arrive as `tool_use` rows:
+ * - a whole-list snapshot — Claude's `TodoWrite` (and Codex's `update_plan`,
+ *   which the Codex adapter already normalizes into the TodoWrite shape) —
+ *   restates every step, so the latest one wins;
+ * - the incremental task tracker — `TaskCreate`/`TaskUpdate`/`TaskList`/
+ *   `TaskGet` — where each call moves one row, keyed by the id the tracker
+ *   assigned in the call's result.
+ *
+ * This is the read-side twin of `server/shared/message-unification.ts`'s
+ * `ChecklistState`, kept in sync by the shared test fixtures; change the
+ * replay rules there and mirror them here. Subagent tool rows
+ * (`parentToolUseId` set) belong to a child transcript, not this ledger.
+ */
+
+export type SessionTaskStatus = 'pending' | 'in_progress' | 'completed';
+
+export type SessionTask = {
+  id: string;
+  content: string;
+  status: SessionTaskStatus;
+  activeForm?: string;
+};
+
+export type SessionTaskLedger = {
+  tasks: SessionTask[];
+  total: number;
+  completed: number;
+  inProgress: number;
+  pending: number;
+};
+
+const CHECKLIST_TOOL = 'TodoWrite';
+const TASK_TOOLS = new Set(['TaskCreate', 'TaskUpdate', 'TaskList', 'TaskGet']);
+
+type AnyRecord = Record<string, unknown>;
+
+function readObjectRecord(value: unknown): AnyRecord | null {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+    ? (value as AnyRecord)
+    : null;
+}
+
+function readToolPayload(value: unknown): AnyRecord | null {
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    if (!trimmed.startsWith('{')) {
+      return null;
+    }
+    try {
+      return readObjectRecord(JSON.parse(trimmed));
+    } catch {
+      return null;
+    }
+  }
+
+  return readObjectRecord(value);
+}
+
+function readNonEmptyString(value: unknown): string {
+  return typeof value === 'string' && value.trim() ? value : '';
+}
+
+/** Claude's task statuses already match the todo vocabulary; anything else is pending. */
+function readTaskStatus(value: unknown): SessionTaskStatus {
+  const status = readNonEmptyString(value);
+  return status === 'in_progress' || status === 'completed' ? status : 'pending';
+}
+
+/** True for a tool row that already carries a whole checklist in its input. */
+function isChecklistSnapshot(message: NormalizedMessage): boolean {
+  return message.kind === 'tool_use' && message.toolName === CHECKLIST_TOOL;
+}
+
+/**
+ * Identity of a checklist as it is drawn: the steps and their states, and
+ * nothing else. Consecutive snapshots with the same signature replay as one.
+ */
+function readChecklistSignature(message: NormalizedMessage): string {
+  const todos = readToolPayload(message.toolInput)?.todos;
+  if (!Array.isArray(todos)) {
+    return '';
+  }
+
+  return JSON.stringify(todos.map((todo) => {
+    const entry = readObjectRecord(todo);
+    return [readNonEmptyString(entry?.content), readTaskStatus(entry?.status)];
+  }));
+}
+
+/** Replays the incremental tracker calls into the list they describe. */
+class TrackerState {
+  private readonly entries = new Map<string, SessionTask>();
+
+  applyTaskCall(message: NormalizedMessage): void {
+    const input = readToolPayload(message.toolInput) ?? {};
+    const result = readObjectRecord(message.toolResult?.toolUseResult);
+
+    // A listing restates the whole tracker — adopt it wholesale, carrying the
+    // present-tense wording already known for ids the listing omits.
+    const listed = result?.tasks;
+    if (Array.isArray(listed)) {
+      const known = new Map(this.entries);
+      this.entries.clear();
+      for (const entry of listed) {
+        const task = readObjectRecord(entry);
+        const activeForm = known.get(readNonEmptyString(task?.id))?.activeForm ?? '';
+        this.upsertTask(task, { content: '', activeForm });
+      }
+      return;
+    }
+
+    const single = readObjectRecord(result?.task);
+    if (single) {
+      this.upsertTask(single, {
+        content: readNonEmptyString(input.subject),
+        activeForm: readNonEmptyString(input.activeForm),
+      });
+      return;
+    }
+
+    const id = readNonEmptyString(input.taskId) || readNonEmptyString(message.toolId);
+    if (!id) {
+      return;
+    }
+
+    const existing = this.entries.get(id);
+    this.entries.set(id, {
+      id,
+      content: readNonEmptyString(input.subject) || existing?.content || id,
+      status: input.status === undefined ? existing?.status ?? 'pending' : readTaskStatus(input.status),
+      activeForm: readNonEmptyString(input.activeForm) || existing?.activeForm,
+    });
+  }
+
+  private upsertTask(task: AnyRecord | null, defaults: { content: string; activeForm: string } = { content: '', activeForm: '' }): void {
+    const id = readNonEmptyString(task?.id);
+    if (!id) {
+      return;
+    }
+
+    const existing = this.entries.get(id);
+    this.entries.set(id, {
+      id,
+      content: readNonEmptyString(task?.subject) || defaults.content || existing?.content || id,
+      status: task?.status === undefined ? existing?.status ?? 'pending' : readTaskStatus(task.status),
+      activeForm: defaults.activeForm || existing?.activeForm,
+    });
+  }
+
+  snapshot(): SessionTask[] {
+    return [...this.entries.values()].map((entry) => ({ ...entry }));
+  }
+}
+
+/**
+ * Replays the transcript into the task ledger. `TodoWrite` snapshots and the
+ * incremental tracker calls both write the same ledger: snapshots replace it
+ * wholesale (signatures collapse replay churn), tracker calls move one row.
+ */
+export function buildSessionTaskLedger(messages: NormalizedMessage[]): SessionTaskLedger {
+  const tracker = new TrackerState();
+  let snapshotTasks: SessionTask[] | null = null;
+  let lastSignature = '';
+  // Whichever source wrote the ledger last owns it — providers do not mix the
+  // snapshot and tracker styles, but a resumed/edited transcript can contain
+  // both, and the later write is the fresher truth.
+  let lastWriter: 'snapshot' | 'tracker' | null = null;
+
+  for (const message of messages) {
+    // A subagent's checklist is the child's own work; the panel's ledger
+    // tracks what the main agent committed to.
+    if (message.parentToolUseId) {
+      continue;
+    }
+
+    if (message.kind !== 'tool_use' || !message.toolName) {
+      continue;
+    }
+
+    if (isChecklistSnapshot(message)) {
+      const signature = readChecklistSignature(message);
+      if (signature && signature === lastSignature) {
+        lastWriter = 'snapshot';
+        continue;
+      }
+      lastSignature = signature;
+
+      const todos = readToolPayload(message.toolInput)?.todos;
+      snapshotTasks = Array.isArray(todos)
+        ? todos.flatMap((todo, index) => {
+            const entry = readObjectRecord(todo);
+            const content = readNonEmptyString(entry?.content);
+            if (!content) {
+              return [];
+            }
+            return [{
+              id: readNonEmptyString(entry?.id) || `todo-${index}`,
+              content,
+              status: readTaskStatus(entry?.status),
+              activeForm: readNonEmptyString(entry?.activeForm) || undefined,
+            } satisfies SessionTask];
+          })
+        : [];
+      lastWriter = 'snapshot';
+      continue;
+    }
+
+    if (TASK_TOOLS.has(message.toolName)) {
+      tracker.applyTaskCall(message);
+      lastWriter = 'tracker';
+    }
+  }
+
+  const tasks = lastWriter === 'tracker' ? tracker.snapshot() : lastWriter === 'snapshot' ? (snapshotTasks ?? []) : [];
+
+  const completed = tasks.filter((task) => task.status === 'completed').length;
+  const inProgress = tasks.filter((task) => task.status === 'in_progress').length;
+  return {
+    tasks,
+    total: tasks.length,
+    completed,
+    inProgress,
+    pending: tasks.length - completed - inProgress,
+  };
+}

--- a/src/modules/chat/utils/sessionTurnStats.ts
+++ b/src/modules/chat/utils/sessionTurnStats.ts
@@ -1,0 +1,173 @@
+import type { NormalizedMessage, TurnStats } from '@/shared/types';
+
+/**
+ * The seven metrics the info panel's "turn statistics" section shows, derived
+ * from the viewed session's merged transcript plus the latest `turn_stats`
+ * frame (the provider's turn bill — cost/duration only ever arrive there).
+ *
+ * "This turn" is everything after the last user text message, which is how the
+ * panel answers "what did the model just do" for both a finished and a running
+ * turn. Missing inputs render `—` (null) rather than a fabricated zero.
+ */
+export type TurnMetrics = {
+  /** Output tokens per second while the model was answering. */
+  answerSpeedTokPerSec: number | null;
+  /** Output tokens per second for the whole request, tools included. */
+  requestSpeedTokPerSec: number | null;
+  /** Wall time the model itself spent, in ms. */
+  modelDurationMs: number | null;
+  /** Wall time spent outside the model (tool execution), in ms. */
+  toolDurationMs: number | null;
+  /** Main-thread tool calls made this turn. */
+  steps: number | null;
+  /** Current context size (the ↑ number) and this turn's output (the ↓ number). */
+  inputTokens: number | null;
+  outputTokens: number | null;
+  /** Share of input tokens served from cache, 0-100. */
+  cacheHitPercent: number | null;
+  /** Session cost in USD — cumulative across the session, from the latest frame. */
+  costUsd: number | null;
+};
+
+const toMs = (value: string | number | Date | null | undefined): number | null => {
+  if (value === null || value === undefined) return null;
+  const ms = value instanceof Date ? value.getTime() : typeof value === 'number' ? value : Date.parse(value);
+  return Number.isFinite(ms) ? ms : null;
+};
+
+/** Everything after the last user text message — the turn the panel describes. */
+export const selectCurrentTurn = (merged: NormalizedMessage[]): NormalizedMessage[] => {
+  let start = 0;
+  for (let index = merged.length - 1; index >= 0; index -= 1) {
+    const message = merged[index];
+    if (message.kind === 'text' && message.role === 'user' && !message.parentToolUseId) {
+      start = index + 1;
+      break;
+    }
+  }
+
+  return merged.slice(start);
+};
+
+const sumTurnOutputTokens = (turn: NormalizedMessage[]): number | null => {
+  // Assistant usage is not carried on NormalizedMessage, so speed metrics fall
+  // back to the turn bill's output tokens; with neither source, stay null.
+  let total = 0;
+  let seen = false;
+  for (const message of turn) {
+    const usage = (message as { usage?: { outputTokens?: unknown } }).usage;
+    const output = usage?.outputTokens;
+    if (typeof output === 'number' && Number.isFinite(output)) {
+      total += output;
+      seen = true;
+    }
+  }
+
+  return seen ? total : null;
+};
+
+const sumToolDurationMs = (turn: NormalizedMessage[]): number | null => {
+  const openedAt = new Map<string, number>();
+  let total = 0;
+  let pairs = 0;
+
+  for (const message of turn) {
+    if (message.parentToolUseId) continue;
+    if (message.kind === 'tool_use' && message.toolId) {
+      const at = toMs(message.timestamp);
+      if (at !== null) openedAt.set(message.toolId, at);
+    } else if (message.kind === 'tool_result' && message.toolId) {
+      const started = openedAt.get(message.toolId);
+      const ended = toMs(message.timestamp);
+      if (started !== undefined && ended !== null && ended >= started) {
+        total += ended - started;
+        pairs += 1;
+        openedAt.delete(message.toolId);
+      }
+    }
+  }
+
+  return pairs > 0 ? total : null;
+};
+
+export const deriveTurnMetrics = (
+  merged: NormalizedMessage[],
+  turnStats: TurnStats | null,
+  tokenBudget: Record<string, unknown> | null,
+): TurnMetrics => {
+  const turn = selectCurrentTurn(merged);
+
+  const mainThreadToolCalls = turn.filter(
+    (message) => message.kind === 'tool_use' && !message.parentToolUseId,
+  ).length;
+
+  const outputFromFrame = turnStats?.usage?.outputTokens ?? null;
+  const outputTokens = outputFromFrame ?? sumTurnOutputTokens(turn);
+
+  const apiMs = turnStats?.apiDurationMs ?? null;
+  const totalMs = turnStats?.durationMs ?? null;
+  // Prefer the provider's accounting; estimate from message timestamps only
+  // when the frame has not arrived (mid-run) so the panel still fills in.
+  const fallbackModelMs = (() => {
+    if (apiMs !== null) return null;
+    const stamps = turn
+      .filter((message) => (message.kind === 'text' && message.role === 'assistant') || message.kind === 'thinking')
+      .map((message) => toMs(message.timestamp))
+      .filter((value): value is number => value !== null);
+    if (stamps.length < 2) return null;
+    return stamps[stamps.length - 1] - stamps[0];
+  })();
+
+  const modelDurationMs = apiMs ?? fallbackModelMs;
+  const toolDurationMs = totalMs !== null && apiMs !== null
+    ? Math.max(0, totalMs - apiMs)
+    : sumToolDurationMs(turn);
+
+  const speed = (tokens: number | null, ms: number | null): number | null =>
+    tokens !== null && ms !== null && ms > 0 ? tokens / (ms / 1000) : null;
+
+  const budget = (tokenBudget ?? {}) as Record<string, unknown>;
+  const readNum = (key: string): number | null => {
+    const value = budget[key];
+    return typeof value === 'number' && Number.isFinite(value) ? value : null;
+  };
+  const inputTokens = readNum('used');
+  const cacheRead = readNum('cacheReadTokens');
+  const cacheHitPercent = inputTokens !== null && cacheRead !== null && inputTokens > 0
+    ? Math.min(100, (cacheRead / inputTokens) * 100)
+    : null;
+
+  return {
+    answerSpeedTokPerSec: speed(outputTokens, modelDurationMs),
+    requestSpeedTokPerSec: speed(outputTokens, totalMs),
+    modelDurationMs,
+    toolDurationMs,
+    steps: turn.length > 0 ? mainThreadToolCalls : null,
+    inputTokens,
+    outputTokens,
+    cacheHitPercent,
+    costUsd: turnStats?.costUsd ?? null,
+  };
+};
+
+/** Formats a ms duration as `1m1s` / `2m50s` / `850ms`. */
+export const formatDuration = (ms: number | null): string => {
+  if (ms === null) return '—';
+  if (ms < 1000) return `${Math.round(ms)}ms`;
+  const seconds = Math.round(ms / 1000);
+  const minutes = Math.floor(seconds / 60);
+  return minutes > 0 ? `${minutes}m${seconds % 60}s` : `${seconds}s`;
+};
+
+/** Formats a token count as `55.7K`. */
+export const formatTokenCount = (tokens: number | null): string => {
+  if (tokens === null) return '—';
+  if (tokens < 1000) return String(tokens);
+  return `${(tokens / 1000).toFixed(1)}K`;
+};
+
+/** Formats a tok/s speed, prefixing estimates with `~`. */
+export const formatTokPerSec = (value: number | null, estimated: boolean): string => {
+  if (value === null) return '—';
+  return `${estimated ? '~' : ''}${Math.round(value)} tok/s`;
+};

--- a/src/modules/chat/utils/toolResultImages.ts
+++ b/src/modules/chat/utils/toolResultImages.ts
@@ -1,0 +1,108 @@
+/**
+ * Pulls image blocks out of a tool result payload.
+ *
+ * Providers disagree on the shape of an image inside a tool result — the
+ * Anthropic content-block form (`{ type: 'image', source: { type: 'base64', … } }`),
+ * the bare base64 source (`{ type: 'base64', media_type, data }`), and the MCP
+ * form (`{ type: 'image', data, mimeType }`) all show up depending on which
+ * provider and which tool produced the result. `useChatMessages` also
+ * JSON.stringifies anything non-string before it reaches the renderer, so a
+ * stringified array has to be parsed back before scanning.
+ */
+
+export type ToolResultImage = {
+  mediaType: string;
+  data: string;
+};
+
+const BASE64_PATTERN = /^[A-Za-z0-9+/]+={0,2}$/;
+
+const isBase64Data = (value: unknown): value is string =>
+  typeof value === 'string' && value.length > 64 && BASE64_PATTERN.test(value);
+
+const isImageBlock = (block: any): block is ToolResultImage => {
+  if (!block || typeof block !== 'object') {
+    return false;
+  }
+
+  // Anthropic content block: { type: 'image', source: { type: 'base64', media_type, data } }
+  if (block.type === 'image' && block.source?.type === 'base64'
+    && typeof block.source.media_type === 'string' && isBase64Data(block.source.data)) {
+    return true;
+  }
+
+  // Bare base64 source: { type: 'base64', media_type, data }
+  if (block.type === 'base64'
+    && typeof block.media_type === 'string' && isBase64Data(block.data)) {
+    return true;
+  }
+
+  // MCP content block: { type: 'image', data, mimeType }
+  if (block.type === 'image'
+    && typeof block.mimeType === 'string' && isBase64Data(block.data)) {
+    return true;
+  }
+
+  return false;
+};
+
+const toImage = (block: any): ToolResultImage => {
+  if (block.source) {
+    return { mediaType: block.source.media_type, data: block.source.data };
+  }
+  return { mediaType: block.media_type || block.mimeType, data: block.data };
+};
+
+const parseBlocks = (payload: unknown): unknown => {
+  if (typeof payload === 'string') {
+    try {
+      return JSON.parse(payload);
+    } catch {
+      return null;
+    }
+  }
+  return payload;
+};
+
+/**
+ * Collect every image block found in a tool result payload (string, array, or
+ * an object carrying a `content` array). Returns data URLs plus their media
+ * types, ready for an `<img src>`.
+ */
+export const extractToolResultImages = (payload: unknown): ToolResultImage[] => {
+  if (payload == null) {
+    return [];
+  }
+
+  // A tool result wrapper ({ content, isError }) is as common as the bare array.
+  const blocks = parseBlocks(
+    payload && typeof payload === 'object' && !Array.isArray(payload) && 'content' in (payload as any)
+      ? (payload as any).content
+      : payload,
+  );
+
+  if (!Array.isArray(blocks)) {
+    return [];
+  }
+
+  return blocks.filter(isImageBlock).map(toImage);
+};
+
+/** True when the result carries at least one renderable image. */
+export const hasToolResultImages = (toolResult: unknown): boolean =>
+  extractToolResultImages(toolResult).length > 0;
+
+/**
+ * Drops the image blocks from a tool result payload so the remaining text can
+ * be rendered without dragging a wall of base64 characters along with it.
+ */
+export const withoutImageBlocks = (payload: unknown): unknown => {
+  if (typeof payload === 'string') {
+    const parsed = parseBlocks(payload);
+    return Array.isArray(parsed) ? withoutImageBlocks(parsed) : payload;
+  }
+  if (Array.isArray(payload)) {
+    return payload.filter((block) => !isImageBlock(block));
+  }
+  return payload;
+};

--- a/src/modules/chat/utils/transcriptWindow.ts
+++ b/src/modules/chat/utils/transcriptWindow.ts
@@ -1,0 +1,41 @@
+import type { ChatMessage } from '@/shared/types';
+import { isToolGroupItem } from '@/modules/chat/utils/toolGrouping';
+import type { MessageListItem } from '@/modules/chat/utils/toolGrouping';
+
+/** Rows at or below this count render without virtualization (no spacers). */
+export const TRANSCRIPT_FULL_RENDER_ROWS = 60;
+
+/** Render band beyond the viewport on each side, so fast scrolls stay covered. */
+export const TRANSCRIPT_OVERSCAN_PX = 900;
+
+/** Per-row vertical gap (the list's space-y margin) charged onto every row. */
+export const TRANSCRIPT_ROW_GAP_PX = 14;
+
+/**
+ * Estimated rendered height of a single transcript row, gap included.
+ *
+ * Same per-kind numbers as the old placeholder scheme, with collapsed tool
+ * runs priced as one summary line. Measured heights replace these as soon
+ * as a row has been near the screen; the estimate only has to keep the
+ * scrollbar and the two spacers sane.
+ */
+export function estimateItemHeightPx(item: MessageListItem): number {
+  let base: number;
+  if (isToolGroupItem(item)) {
+    base = 240;
+  } else {
+    const message = item as ChatMessage;
+    if (message.isThinking) {
+      base = 70;
+    } else if (message.type === 'error') {
+      base = 120;
+    } else if (message.type === 'user') {
+      base = 110;
+    } else if ((message as { isTaskNotification?: boolean }).isTaskNotification) {
+      base = 90;
+    } else {
+      base = 200;
+    }
+  }
+  return base + TRANSCRIPT_ROW_GAP_PX;
+}

--- a/src/modules/i18n/locales/en/chat.json
+++ b/src/modules/i18n/locales/en/chat.json
@@ -357,5 +357,28 @@
   "promptNavigator": {
     "aria": "Prompt navigator",
     "noTextContent": "(no text content)"
+  },
+  "sessionInfoPanel": {
+    "title": "Session",
+    "close": "Close session panel",
+    "empty": "Nothing to show yet",
+    "context": "Context",
+    "turnStats": "Turn stats",
+    "subagents": "Subagents",
+    "tasks": "Tasks",
+    "mcp": "MCP",
+    "sources": "Context sources",
+    "stats": {
+      "answerSpeed": "Answer speed",
+      "requestSpeed": "Whole request",
+      "modelTime": "Model time",
+      "toolTime": "Tool time",
+      "steps": "Steps",
+      "tokens": "Tokens",
+      "cacheHit": "Cache hit",
+      "cost": "Cost"
+    },
+    "openButton": "Show session panel",
+    "closeButton": "Hide session panel"
   }
 }

--- a/src/modules/i18n/locales/en/chat.json
+++ b/src/modules/i18n/locales/en/chat.json
@@ -379,6 +379,20 @@
       "cost": "Cost"
     },
     "openButton": "Show session panel",
-    "closeButton": "Hide session panel"
+    "closeButton": "Hide session panel",
+    "subagentsAgentLabel": "Agent",
+    "subagentsLoading": "Loading…",
+    "subagentsStatusRunning": "running",
+    "subagentsCloseChat": "Close agent conversation",
+    "subagentsLoadEarlier": "Load earlier messages",
+    "subagentsContinuePlaceholder": "Continue the conversation with this agent…",
+    "subagentsContinueSend": "Continue",
+    "subagentsContinueHint": "Sends as a new session carrying this agent's identity and work log.",
+    "subagentsContinueIdentity": "You are \"{{type}}\".",
+    "subagentsContinueIdentityWithDescription": "You are \"{{type}}\" ({{description}}).",
+    "subagentsContinueIdentityBare": "You are a subagent whose previous task was: {{description}}.",
+    "subagentsContinueIdentityPlain": "You are a subagent.",
+    "subagentsContinueLogIntro": "Below is your own working record from the earlier session as this subagent",
+    "subagentsContinueAskIntro": "The user now wants to continue the conversation. Respond based on the context above:"
   }
 }

--- a/src/modules/i18n/locales/en/chat.json
+++ b/src/modules/i18n/locales/en/chat.json
@@ -396,6 +396,9 @@
     "subagentsContinueAskIntro": "The user now wants to continue the conversation. Respond based on the context above:",
     "mcpLoading": "Loading servers…",
     "mcpToggleAria": "Enable {{name}}",
-    "mcpToggleHint": "Switches apply to new sessions."
+    "mcpToggleHint": "Switches apply to new sessions.",
+    "mcpReadOnlyHint": "This provider's runtime does not read the disabled list, so the switches are display-only.",
+    "sourcesSkills": "Skills",
+    "sourcesMcp": "MCP servers"
   }
 }

--- a/src/modules/i18n/locales/en/chat.json
+++ b/src/modules/i18n/locales/en/chat.json
@@ -393,6 +393,9 @@
     "subagentsContinueIdentityBare": "You are a subagent whose previous task was: {{description}}.",
     "subagentsContinueIdentityPlain": "You are a subagent.",
     "subagentsContinueLogIntro": "Below is your own working record from the earlier session as this subagent",
-    "subagentsContinueAskIntro": "The user now wants to continue the conversation. Respond based on the context above:"
+    "subagentsContinueAskIntro": "The user now wants to continue the conversation. Respond based on the context above:",
+    "mcpLoading": "Loading servers…",
+    "mcpToggleAria": "Enable {{name}}",
+    "mcpToggleHint": "Switches apply to new sessions."
   }
 }

--- a/src/modules/i18n/locales/en/chat.json
+++ b/src/modules/i18n/locales/en/chat.json
@@ -353,5 +353,9 @@
     "tokensLabel_other": "tokens",
     "escClosesModal": "Esc closes the modal.",
     "close": "Close"
+  },
+  "promptNavigator": {
+    "aria": "Prompt navigator",
+    "noTextContent": "(no text content)"
   }
 }

--- a/src/modules/i18n/locales/zh-CN/chat.json
+++ b/src/modules/i18n/locales/zh-CN/chat.json
@@ -276,5 +276,9 @@
     "failed": "未发送 — {{reason}}",
     "cancel": "取消定时消息",
     "dismiss": "关闭失败提示"
+  },
+  "promptNavigator": {
+    "aria": "提示词导航",
+    "noTextContent": "（无文本内容）"
   }
 }

--- a/src/modules/i18n/locales/zh-CN/chat.json
+++ b/src/modules/i18n/locales/zh-CN/chat.json
@@ -302,6 +302,20 @@
       "cost": "费用"
     },
     "openButton": "打开会话面板",
-    "closeButton": "收起会话面板"
+    "closeButton": "收起会话面板",
+    "subagentsAgentLabel": "智能体",
+    "subagentsLoading": "加载中…",
+    "subagentsStatusRunning": "运行中",
+    "subagentsCloseChat": "关闭智能体对话",
+    "subagentsLoadEarlier": "加载更早的消息",
+    "subagentsContinuePlaceholder": "继续与该智能体对话…",
+    "subagentsContinueSend": "继续",
+    "subagentsContinueHint": "将作为携带该智能体身份与工作记录的新会话发出。",
+    "subagentsContinueIdentity": "你是「{{type}}」。",
+    "subagentsContinueIdentityWithDescription": "你是「{{type}}」（{{description}}）。",
+    "subagentsContinueIdentityBare": "你是一名子智能体，此前的任务是：{{description}}。",
+    "subagentsContinueIdentityPlain": "你是一名子智能体。",
+    "subagentsContinueLogIntro": "以下是你作为该子智能体在先前会话中的工作记录",
+    "subagentsContinueAskIntro": "用户现在要继续与你对话，请基于上述上下文回应："
   }
 }

--- a/src/modules/i18n/locales/zh-CN/chat.json
+++ b/src/modules/i18n/locales/zh-CN/chat.json
@@ -280,5 +280,28 @@
   "promptNavigator": {
     "aria": "提示词导航",
     "noTextContent": "（无文本内容）"
+  },
+  "sessionInfoPanel": {
+    "title": "会话",
+    "close": "关闭会话面板",
+    "empty": "暂无内容",
+    "context": "上下文",
+    "turnStats": "轮次统计",
+    "subagents": "子代理",
+    "tasks": "任务",
+    "mcp": "MCP",
+    "sources": "上下文来源",
+    "stats": {
+      "answerSpeed": "回答速度",
+      "requestSpeed": "整个请求",
+      "modelTime": "模型耗时",
+      "toolTime": "工具耗时",
+      "steps": "步骤",
+      "tokens": "Token",
+      "cacheHit": "缓存命中率",
+      "cost": "费用"
+    },
+    "openButton": "打开会话面板",
+    "closeButton": "收起会话面板"
   }
 }

--- a/src/modules/i18n/locales/zh-CN/chat.json
+++ b/src/modules/i18n/locales/zh-CN/chat.json
@@ -319,6 +319,9 @@
     "subagentsContinueAskIntro": "用户现在要继续与你对话，请基于上述上下文回应：",
     "mcpLoading": "正在加载服务器…",
     "mcpToggleAria": "启用 {{name}}",
-    "mcpToggleHint": "开关对新会话生效。"
+    "mcpToggleHint": "开关对新会话生效。",
+    "mcpReadOnlyHint": "该供应商的运行器不读取禁用列表，开关仅作展示。",
+    "sourcesSkills": "技能",
+    "sourcesMcp": "MCP 服务器"
   }
 }

--- a/src/modules/i18n/locales/zh-CN/chat.json
+++ b/src/modules/i18n/locales/zh-CN/chat.json
@@ -316,6 +316,9 @@
     "subagentsContinueIdentityBare": "你是一名子智能体，此前的任务是：{{description}}。",
     "subagentsContinueIdentityPlain": "你是一名子智能体。",
     "subagentsContinueLogIntro": "以下是你作为该子智能体在先前会话中的工作记录",
-    "subagentsContinueAskIntro": "用户现在要继续与你对话，请基于上述上下文回应："
+    "subagentsContinueAskIntro": "用户现在要继续与你对话，请基于上述上下文回应：",
+    "mcpLoading": "正在加载服务器…",
+    "mcpToggleAria": "启用 {{name}}",
+    "mcpToggleHint": "开关对新会话生效。"
   }
 }

--- a/src/modules/project-workspace/WorkspaceHeader.tsx
+++ b/src/modules/project-workspace/WorkspaceHeader.tsx
@@ -1,9 +1,11 @@
-import { ChevronLeft, ChevronRight } from 'lucide-react';
+import { ChevronLeft, ChevronRight, PanelRightClose, PanelRightOpen } from 'lucide-react';
 import { useCallback, useEffect, useRef, useState, type Dispatch, type SetStateAction } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import type { AppTab, Project, ProjectSession } from '@/shared/types';
 import { cn } from '@/shared/utils';
+import { readStoredSessionInfoPanelPrefs } from '@/shared/sessionInfoPanelPrefs';
+import { writeUserPreference, USER_PREFERENCES_CHANGED_EVENT } from '@/shared/userSettings';
 import MobileMenuButton from '@/modules/project-workspace/MobileMenuButton';
 import WorkspaceTabs from '@/modules/project-workspace/WorkspaceTabs';
 import WorkspaceTitle from '@/modules/project-workspace/WorkspaceTitle';
@@ -35,6 +37,22 @@ export default function WorkspaceHeader({
   const [canScrollLeft, setCanScrollLeft] = useState(false);
   const [canScrollRight, setCanScrollRight] = useState(false);
   const hasOverflow = canScrollLeft || canScrollRight;
+
+  // Mirrors the shared preference the chat panel itself owns; the change
+  // event keeps the icon in sync while another tab's panel toggles it.
+  const [infoPanelOpen, setInfoPanelOpen] = useState(() => readStoredSessionInfoPanelPrefs().open);
+  useEffect(() => {
+    const sync = () => setInfoPanelOpen(readStoredSessionInfoPanelPrefs().open);
+    window.addEventListener(USER_PREFERENCES_CHANGED_EVENT, sync);
+    return () => window.removeEventListener(USER_PREFERENCES_CHANGED_EVENT, sync);
+  }, []);
+
+  const toggleInfoPanel = useCallback(() => {
+    const current = readStoredSessionInfoPanelPrefs();
+    const open = !current.open;
+    writeUserPreference('sessionInfoPanel', { ...current, open });
+    setInfoPanelOpen(open);
+  }, []);
 
   const updateScrollState = useCallback(() => {
     const el = scrollRef.current;
@@ -150,6 +168,26 @@ export default function WorkspaceHeader({
             )}
           </div>
         </div>
+
+        {activeTab === 'chat' && selectedSession && (
+          <button
+            type="button"
+            onClick={toggleInfoPanel}
+            aria-label={infoPanelOpen
+              ? t('sessionInfoPanel.closeButton', { defaultValue: 'Hide session panel' })
+              : t('sessionInfoPanel.openButton', { defaultValue: 'Show session panel' })}
+            aria-pressed={infoPanelOpen}
+            title={infoPanelOpen
+              ? t('sessionInfoPanel.closeButton', { defaultValue: 'Hide session panel' })
+              : t('sessionInfoPanel.openButton', { defaultValue: 'Show session panel' })}
+            className={cn(
+              'hidden h-7 w-7 flex-shrink-0 items-center justify-center rounded-md border border-border/70 text-muted-foreground outline-none hover:bg-accent hover:text-foreground focus-visible:ring-2 focus-visible:ring-primary/60 sm:flex',
+              infoPanelOpen && 'bg-accent/60 text-foreground',
+            )}
+          >
+            {infoPanelOpen ? <PanelRightClose className="h-4 w-4" /> : <PanelRightOpen className="h-4 w-4" />}
+          </button>
+        )}
       </div>
     </header>
   );

--- a/src/modules/quick-settings-panel/hooks/useQuickSettingsDrag.ts
+++ b/src/modules/quick-settings-panel/hooks/useQuickSettingsDrag.ts
@@ -3,9 +3,13 @@ import type { MouseEvent as ReactMouseEvent, TouchEvent as ReactTouchEvent } fro
 
 import type { QuickSettingsHandleStyle } from '@/shared/types';
 
-const HANDLE_POSITION_STORAGE_KEY = 'quickSettingsHandlePosition';
+// Versioned so an older persisted position does not outlive a changed default.
+const HANDLE_POSITION_STORAGE_KEY = 'quickSettingsHandlePosition.v2';
+const LEGACY_HANDLE_POSITION_STORAGE_KEY = 'quickSettingsHandlePosition';
 
-const DEFAULT_HANDLE_POSITION = 50;
+// A quarter down the edge: high enough to clear the composer activity tab and
+// the bottom of the transcript, low enough to stay thumb-reachable.
+const DEFAULT_HANDLE_POSITION = 25;
 const HANDLE_POSITION_MIN = 10;
 const HANDLE_POSITION_MAX = 90;
 const DRAG_THRESHOLD_PX = 5;
@@ -27,7 +31,8 @@ const readHandlePosition = (): number => {
     return DEFAULT_HANDLE_POSITION;
   }
 
-  const saved = localStorage.getItem(HANDLE_POSITION_STORAGE_KEY);
+  const saved = localStorage.getItem(HANDLE_POSITION_STORAGE_KEY)
+    ?? localStorage.getItem(LEGACY_HANDLE_POSITION_STORAGE_KEY);
   if (!saved) {
     return DEFAULT_HANDLE_POSITION;
   }
@@ -39,6 +44,7 @@ const readHandlePosition = (): number => {
     }
   } catch {
     localStorage.removeItem(HANDLE_POSITION_STORAGE_KEY);
+    localStorage.removeItem(LEGACY_HANDLE_POSITION_STORAGE_KEY);
     return DEFAULT_HANDLE_POSITION;
   }
 

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -146,6 +146,17 @@ export const sessionMessagesUrl = (
     : `${base}${query({ limit, offset: offset ?? 0 })}`;
 };
 
+export const subagentMessagesUrl = (
+  sessionId: string,
+  agentId: string,
+  { limit = null, offset = 0 }: { limit?: number | null; offset?: number } = {},
+): string => {
+  const base = `/api/providers/sessions/${encodeURIComponent(sessionId)}/subagents/${encodeURIComponent(agentId)}/messages`;
+  return limit === null || limit === undefined
+    ? base
+    : `${base}${query({ limit, offset: offset ?? 0 })}`;
+};
+
 const fileContentPath = (projectId: string, filePath: string) =>
   `/api/file-tree/projects/${projectId}/files/content${query({ path: filePath })}`;
 
@@ -378,6 +389,14 @@ export const api = {
       get(`/api/providers/sessions/${encodeURIComponent(sessionId)}/token-usage`),
     sessionContextInfo: (sessionId: string) =>
       get(`/api/providers/sessions/${encodeURIComponent(sessionId)}/context-info`),
+    sessionSubagents: (sessionId: string) =>
+      get(`/api/providers/sessions/${encodeURIComponent(sessionId)}/subagents`),
+    sessionSubagentMessages: (
+      sessionId: string,
+      agentId: string,
+      pagination: { limit?: number | null; offset?: number } = {},
+      options: ApiRequestOptions = {},
+    ) => get(subagentMessagesUrl(sessionId, agentId, pagination), options),
     sessionActiveModel: (provider: string, sessionId: string) =>
       get(`/api/providers/${provider}/sessions/${encodeURIComponent(sessionId)}/active-model`),
     setSessionActiveModel: (provider: string, sessionId: string, model: string) =>

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -376,6 +376,8 @@ export const api = {
     ) => get(sessionMessagesUrl(sessionId, pagination), options),
     sessionTokenUsage: (sessionId: string) =>
       get(`/api/providers/sessions/${encodeURIComponent(sessionId)}/token-usage`),
+    sessionContextInfo: (sessionId: string) =>
+      get(`/api/providers/sessions/${encodeURIComponent(sessionId)}/context-info`),
     sessionActiveModel: (provider: string, sessionId: string) =>
       get(`/api/providers/${provider}/sessions/${encodeURIComponent(sessionId)}/active-model`),
     setSessionActiveModel: (provider: string, sessionId: string, model: string) =>

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -410,7 +410,7 @@ export const api = {
 
     mcpServers: (
       provider: string,
-      { scope, workspacePath }: { scope: string; workspacePath?: string },
+      { scope, workspacePath }: { scope?: string; workspacePath?: string },
     ) => get(`/api/providers/${provider}/mcp/servers${query({ scope, workspacePath })}`),
     saveMcpServer: (provider: string, payload: unknown) =>
       post(`/api/providers/${provider}/mcp/servers`, payload),
@@ -510,6 +510,12 @@ export const api = {
     notificationPreferences: () => get('/api/settings/notification-preferences'),
     saveNotificationPreferences: (preferences: unknown) =>
       put('/api/settings/notification-preferences', preferences),
+
+    // The session info panel's MCP switches; the Claude runtime consults this
+    // set when it assembles each turn's MCP config.
+    mcpDisabledServers: () => get('/api/settings/mcp-disabled-servers'),
+    saveMcpDisabledServers: (servers: string[]) =>
+      put('/api/settings/mcp-disabled-servers', { servers }),
 
     push: {
       vapidPublicKey: () => get('/api/settings/push/vapid-public-key'),

--- a/src/shared/sessionInfoPanelPrefs.ts
+++ b/src/shared/sessionInfoPanelPrefs.ts
@@ -1,0 +1,88 @@
+import { readUserPreference } from '@/shared/userSettings';
+
+/**
+ * The session info panel's layout preferences, stored in `auth.db` through the
+ * preference store (the same route `uiPreferences` uses), so the panel opens
+ * the same way on every device.
+ *
+ * Kept separate from the boolean `uiPreferences` blob because this one holds
+ * an object (`collapsedSections`) and evolves its own shape.
+ */
+export type SessionInfoPanelSection =
+  | 'context'
+  | 'turnStats'
+  | 'subagents'
+  | 'tasks'
+  | 'mcp'
+  | 'sources';
+
+export type SessionInfoPanelPrefs = {
+  open: boolean;
+  collapsedSections: Partial<Record<SessionInfoPanelSection, boolean>>;
+};
+
+const DEFAULTS: SessionInfoPanelPrefs = {
+  open: false,
+  collapsedSections: {},
+};
+
+const VALID_SECTIONS: ReadonlySet<string> = new Set<SessionInfoPanelSection>([
+  'context',
+  'turnStats',
+  'subagents',
+  'tasks',
+  'mcp',
+  'sources',
+]);
+
+const parseBoolean = (value: unknown, fallback: boolean): boolean => {
+  if (typeof value === 'boolean') return value;
+  if (value === 'true') return true;
+  if (value === 'false') return false;
+  return fallback;
+};
+
+/**
+ * Reads the stored panel layout, filling defaults for anything never touched.
+ * Synchronous against the localStorage mirror, like the other preferences.
+ */
+export const readStoredSessionInfoPanelPrefs = (): SessionInfoPanelPrefs => {
+  const stored = readUserPreference<Record<string, unknown>>('sessionInfoPanel', {});
+
+  const collapsedSource = stored.collapsedSections;
+  const collapsedSections: Partial<Record<SessionInfoPanelSection, boolean>> = {};
+  if (collapsedSource && typeof collapsedSource === 'object' && !Array.isArray(collapsedSource)) {
+    for (const [key, value] of Object.entries(collapsedSource as Record<string, unknown>)) {
+      // A section is either collapsed (present, true) or absent; a stored
+      // `false` is normalized away so the shape stays canonical.
+      if (VALID_SECTIONS.has(key) && parseBoolean(value, false)) {
+        collapsedSections[key as SessionInfoPanelSection] = true;
+      }
+    }
+  }
+
+  return {
+    open: parseBoolean(stored.open, DEFAULTS.open),
+    collapsedSections,
+  };
+};
+
+/** Immutably flips one section's collapsed flag. */
+export const withSectionCollapsed = (
+  prefs: SessionInfoPanelPrefs,
+  section: SessionInfoPanelSection,
+  collapsed: boolean,
+): SessionInfoPanelPrefs => {
+  if (Boolean(prefs.collapsedSections[section]) === collapsed) {
+    return prefs;
+  }
+
+  const collapsedSections = { ...prefs.collapsedSections };
+  if (collapsed) {
+    collapsedSections[section] = true;
+  } else {
+    delete collapsedSections[section];
+  }
+
+  return { ...prefs, collapsedSections };
+};

--- a/src/shared/tests/sessionInfoPanelPrefs.test.ts
+++ b/src/shared/tests/sessionInfoPanelPrefs.test.ts
@@ -1,0 +1,53 @@
+import assert from 'node:assert/strict';
+
+import { beforeEach, test } from 'vitest';
+
+import {
+  readStoredSessionInfoPanelPrefs,
+  withSectionCollapsed,
+} from '@/shared/sessionInfoPanelPrefs';
+import { writeUserPreference, resetUserPreferences } from '@/shared/userSettings';
+
+beforeEach(() => {
+  localStorage.clear();
+  resetUserPreferences();
+});
+
+test('a fresh install opens closed with nothing collapsed', () => {
+  assert.deepEqual(readStoredSessionInfoPanelPrefs(), { open: false, collapsedSections: {} });
+});
+
+test('the stored blob round-trips through the preference store', () => {
+  writeUserPreference('sessionInfoPanel', { open: true, collapsedSections: { tasks: true, mcp: false } });
+
+  const prefs = readStoredSessionInfoPanelPrefs();
+  assert.equal(prefs.open, true);
+  assert.deepEqual(prefs.collapsedSections, { tasks: true });
+});
+
+test('junk is filtered, strings coerced, unknown sections dropped', () => {
+  writeUserPreference('sessionInfoPanel', {
+    open: 'true',
+    collapsedSections: { tasks: 'true', bogus: true, mcp: false, context: 42 },
+  });
+
+  const prefs = readStoredSessionInfoPanelPrefs();
+  assert.equal(prefs.open, true);
+  assert.deepEqual(prefs.collapsedSections, { tasks: true });
+});
+
+test('withSectionCollapsed is immutable and idempotent', () => {
+  const start = readStoredSessionInfoPanelPrefs();
+
+  const closed = withSectionCollapsed(start, 'tasks', true);
+  assert.deepEqual(start.collapsedSections, {});
+  assert.deepEqual(closed.collapsedSections, { tasks: true });
+
+  // Re-collapsing an already-collapsed section returns the same object.
+  assert.equal(withSectionCollapsed(closed, 'tasks', true), closed);
+
+  // Uncollapsing removes the key entirely rather than storing false.
+  const reopened = withSectionCollapsed(closed, 'tasks', false);
+  assert.deepEqual(reopened.collapsedSections, {});
+  assert.equal('tasks' in reopened.collapsedSections, false);
+});

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -275,6 +275,20 @@ export type SubagentInfo = {
   activityCount?: number;
 };
 
+/** A running session's context-window snapshot, answered by the provider's own tooling; null fields mean that category could not be classified and render as `—`. */
+export type ProviderContextInfo = {
+  totalTokens: number | null;
+  maxTokens: number | null;
+  /** 0-100, as the provider itself computed it. */
+  percentage: number | null;
+  model: string | null;
+  categories: Array<{ name: string; tokens: number; kind: string }>;
+  agents: Array<{ agentType: string; tokens: number }>;
+  mcpTools: Array<{ name: string; serverName: string; tokens: number }>;
+  memoryFiles: Array<{ path: string; tokens: number }>;
+  slashCommands: { totalCommands: number; includedCommands: number } | null;
+};
+
 /**
  * The turn's bill, forwarded from the provider's turn-complete signal on a
  * `status`/`turn_stats` frame. `usage` covers this turn's main loop only;

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -275,6 +275,20 @@ export type SubagentInfo = {
   activityCount?: number;
 };
 
+/** One row of the info panel's subagent roster, composed server-side from the CLI's subagents directory plus the parent's task notifications. */
+export type SubagentSummary = {
+  agentId: string;
+  agentType?: string;
+  description?: string;
+  /** The parent's tool call that spawned this agent; the live stream keys off it. */
+  toolUseId?: string;
+  status: 'running' | 'completed' | 'failed';
+  activityCount: number;
+  startedAt?: string;
+  lastActivityAt?: string;
+  model?: string;
+};
+
 /** A running session's context-window snapshot, answered by the provider's own tooling; null fields mean that category could not be classified and render as `—`. */
 export type ProviderContextInfo = {
   totalTokens: number | null;

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -491,6 +491,7 @@ type MessageKind =
   | 'tool_use'
   | 'tool_result'
   | 'thinking'
+  | 'thinking_delta'
   | 'stream_delta'
   | 'stream_end'
   | 'error'

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -275,6 +275,25 @@ export type SubagentInfo = {
   activityCount?: number;
 };
 
+/**
+ * The turn's bill, forwarded from the provider's turn-complete signal on a
+ * `status`/`turn_stats` frame. `usage` covers this turn's main loop only;
+ * `costUsd` and the token totals are cumulative across the session, so
+ * consumers read the latest frame rather than summing across frames.
+ */
+export type TurnStats = {
+  costUsd: number | null;
+  durationMs: number | null;
+  apiDurationMs: number | null;
+  numTurns: number | null;
+  usage: {
+    inputTokens: number | null;
+    outputTokens: number | null;
+    cacheReadTokens: number | null;
+    cacheCreationTokens: number | null;
+  } | null;
+};
+
 /** One rendered entry in a chat transcript — user turn, assistant turn, tool call and result, local command output, or subagent container — and the shape the chat message list and message components consume. */
 export type ChatMessage = {
   type: string;
@@ -464,6 +483,8 @@ export type NormalizedMessage = {
   tokens?: number;
   canInterrupt?: boolean;
   tokenBudget?: unknown;
+  /** The turn's bill from a `status`/`turn_stats` frame; absent on every other message. */
+  turnStats?: TurnStats;
   requestId?: string;
   input?: unknown;
   context?: unknown;

--- a/src/shared/userSettings.ts
+++ b/src/shared/userSettings.ts
@@ -28,6 +28,8 @@ export type UserPreferences = {
   codeEditorSettings: unknown;
   uiPreferences: unknown;
   sessionInfoPanel: unknown;
+  /** MCP server names the info panel switched off; the Claude runtime drops them. */
+  mcpDisabledServers: string[];
   selectedProvider: string;
 };
 
@@ -69,6 +71,8 @@ const LEGACY_STORAGE_KEYS: Record<UserPreferenceKey, string> = {
   uiPreferences: 'uiPreferences',
   // Panel layout is new; nothing to migrate from localStorage.
   sessionInfoPanel: '',
+  // Also new, and only ever set from the panel; no legacy key exists.
+  mcpDisabledServers: '',
   selectedProvider: 'selected-provider',
 };
 

--- a/src/shared/userSettings.ts
+++ b/src/shared/userSettings.ts
@@ -27,6 +27,7 @@ export type UserPreferences = {
   opencodePermissions: unknown;
   codeEditorSettings: unknown;
   uiPreferences: unknown;
+  sessionInfoPanel: unknown;
   selectedProvider: string;
 };
 
@@ -66,6 +67,8 @@ const LEGACY_STORAGE_KEYS: Record<UserPreferenceKey, string> = {
   // read by readLegacyCodeEditorSettings instead.
   codeEditorSettings: '',
   uiPreferences: 'uiPreferences',
+  // Panel layout is new; nothing to migrate from localStorage.
+  sessionInfoPanel: '',
   selectedProvider: 'selected-provider',
 };
 


### PR DESCRIPTION
## What

Two transcript layout fixes, plus a follow-bottom scroll fix found while testing them:

**1. Narrow screens clip the transcript (missing `min-w-0`)**
The chat column was a `flex-1` item without `min-w-0`, so its automatic minimum size let one wide message (a long code line, a wide table) inflate the whole transcript column past the viewport; the pane's overflow-x then clipped the right-hand content out of view. With the minimum width released, the column compresses to the viewport and wide content scrolls inside its own overflow box.

**2. The prompt navigator rail was invisible at narrow desktop widths**
The rail hung outside the message column (`left: 100%`), which falls past the pane's clipped edge once the pane shrinks below the column's max width plus the rail's gutter (e.g. a 1000px window with the sidebar open). It now docks inside the gutter the message column gives up, decided from the measured pane width — not the viewport — so split views and resizable panels track correctly too.

On desktop the classic scrollbar owns ~15px at the pane's right edge, so the message column, the export menu, and the rail all step back there to stay clear of it.

**3. Streaming follow-bottom snapped back over the user**
The follow-bottom timer reads the scrolled-up flag through a ref at fire time, but the ref was only synced from a state effect; during heavy streaming renders the state→effect round-trip lags past the 50ms timer and yanked the view back down right after the user dragged up. The ref is now mirrored where the flag is computed, and the timer's effect keys on the array identity instead of `.length` so it re-runs while a streaming row grows without changing the message count.

## Tested

Via Chrome DevTools at 390px mobile, 1000px and 1280px desktop viewports: column/pane/scroll widths all collapse to the viewport with no overflowing descendants; the rail is visible and clear of the scrollbar at every width; `tsc --noEmit` and oxlint (via lint-staged) are clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a session information panel with context usage, turn statistics, tasks, subagents, context sources, and MCP server controls.
  * Added prompt navigation, subagent conversation viewing, and continuation support.
  * Model pickers now reflect live Claude, Codex, and OpenCode availability.
  * Added streamed reasoning output and tool-result image previews with zoomable lightboxes.
  * Added session forking support for OpenCode and improved anchor handling across providers.

* **Bug Fixes**
  * Improved API error messages, transcript rendering, image preservation, and large-transcript performance.
  * Added support for disabling individual MCP servers per user.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->