### PR TITLE
feat(plugins): recommend GLM Usage plugin

### DIFF
--- a/src/modules/i18n/locales/en/settings.json
+++ b/src/modules/i18n/locales/en/settings.json
@@ -591,6 +591,12 @@
       "description": "Track live Codex plan limits, reset timing, and 30-day account token activity.",
       "install": "Install"
     },
+    "glmUsagePlugin": {
+      "name": "GLM Usage",
+      "badge": "unofficial",
+      "description": "Track live GLM/Zhipu coding-plan quotas and 30-day token history.",
+      "install": "Install"
+    },
     "morePlugins": "More",
     "enable": "Enable",
     "disable": "Disable",

--- a/src/modules/plugins/PluginSettingsTab.tsx
+++ b/src/modules/plugins/PluginSettingsTab.tsx
@@ -35,6 +35,7 @@ const TASK_QUEUE_PLUGIN_URL = 'https://github.com/TadMSTR/cloudcli-plugin-task-q
 const GITHUB_ISSUES_BOARD_PLUGIN_URL = 'https://github.com/szmidtpiotr/claude-github-issue';
 const CLAUDE_USAGE_PLUGIN_URL = 'https://github.com/HandyS11/cloudcli-plugin-claude-usage';
 const CODEX_USAGE_PLUGIN_URL = 'https://github.com/dongwook-chan/cloudcli-plugin-codex-usage';
+const GLM_USAGE_PLUGIN_URL = 'https://github.com/realjustinwu/CloudCLI-GLM-Usage';
 
 type PluginRecommendation = {
   id: string;
@@ -134,6 +135,14 @@ const UNOFFICIAL_PLUGIN_RECOMMENDATIONS: PluginRecommendation[] = [
     translationKey: 'codexUsagePlugin',
     repoUrl: CODEX_USAGE_PLUGIN_URL,
     installedNames: ['codex-usage'],
+    icon: BarChart3,
+    source: 'unofficial',
+  },
+  {
+    id: 'glm-usage',
+    translationKey: 'glmUsagePlugin',
+    repoUrl: GLM_USAGE_PLUGIN_URL,
+    installedNames: ['glm-usage'],
     icon: BarChart3,
     source: 'unofficial',
   },


### PR DESCRIPTION
Adds realjustinwu/CloudCLI-GLM-Usage to the unofficial plugin recommendations: live GLM/Zhipu coding-plan quota gauges plus 30-day token history parsed from local Claude Code transcripts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an unofficial GLM Usage plugin recommendation to the plugin settings.
  * Added localized plugin details, including its name, badge, description, and installation text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->