### PR TITLE
feat: add pi as fifth agent provider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -147,3 +147,7 @@ tasks/
 cloudcli-sidebar-app-source.tar.gz
 cloudcli-sidebar.html
 electron/*.tar.gz
+
+# pi provider fork working notes (not for upstream PR)
+docs/pi-notes.md
+docs/pi-e2e-checklist.md

--- a/public/api-docs.html
+++ b/public/api-docs.html
@@ -489,7 +489,7 @@
                                 <span class="endpoint-path"><span class="api-url">http://localhost:3001</span>/api/agent</span>
                             </div>
 
-                            <p>Trigger an AI agent (Claude, Cursor, Codex, or OpenCode) to work on a project.</p>
+                            <p>Trigger an AI agent (Claude, Cursor, Codex, OpenCode, or Pi) to work on a project.</p>
 
                             <h4>Request Body Parameters</h4>
                             <table>
@@ -524,7 +524,7 @@
                                         <td><code>provider</code></td>
                                         <td>string</td>
                                         <td><span class="badge badge-optional">Optional</span></td>
-                                        <td><code>claude</code>, <code>cursor</code>, <code>codex</code>, or <code>opencode</code> (default: <code>claude</code>)</td>
+                                        <td><code>claude</code>, <code>cursor</code>, <code>codex</code>, <code>opencode</code>, or <code>pi</code> (default: <code>claude</code>)</td>
                                     </tr>
                                     <tr>
                                         <td><code>stream</code></td>
@@ -839,6 +839,7 @@ data: {"type":"done"}</code></pre>
             { id: 'codex',    name: 'OpenAI' },
             { id: 'cursor',   name: 'Cursor' },
             { id: 'opencode', name: 'OpenCode' },
+            { id: 'pi',       name: 'Pi' },
         ];
 
         async function populateModels() {

--- a/server/index.ts
+++ b/server/index.ts
@@ -87,6 +87,7 @@ const queryClaude = providerRuntimeService.getRunner('claude');
 const queryCursor = providerRuntimeService.getRunner('cursor');
 const queryCodex = providerRuntimeService.getRunner('codex');
 const queryOpenCode = providerRuntimeService.getRunner('opencode');
+const queryPi = providerRuntimeService.getRunner('pi');
 const gitRoutes = createGitModule({
     queryClaude,
     queryCursor,
@@ -96,6 +97,7 @@ const agentRoutes = createAgentModule({
     queryCursor,
     queryCodex,
     queryOpenCode,
+    queryPi,
 });
 
 // Single WebSocket server that handles chat, shell, and plugin proxy paths.

--- a/server/modules/agent/agent.module.ts
+++ b/server/modules/agent/agent.module.ts
@@ -18,7 +18,7 @@ import { createAgentRouter } from './agent.routes.js';
 
 type AgentExternalDependencies = Pick<
   Parameters<typeof createAgentRouter>[0],
-  'queryClaude' | 'queryCursor' | 'queryCodex' | 'queryOpenCode'
+  'queryClaude' | 'queryCursor' | 'queryCodex' | 'queryOpenCode' | 'queryPi'
 >;
 
 /**

--- a/server/modules/agent/agent.routes.ts
+++ b/server/modules/agent/agent.routes.ts
@@ -22,6 +22,7 @@ type AgentRouterDependencies = {
   queryCursor: ProviderRunFunction;
   queryCodex: ProviderRunFunction;
   queryOpenCode: ProviderRunFunction;
+  queryPi: ProviderRunFunction;
   GithubClient: typeof import('@octokit/rest').Octokit;
 };
 
@@ -44,6 +45,7 @@ export function createAgentRouter(dependencies: AgentRouterDependencies): expres
   const spawnCursor = dependencies.queryCursor;
   const queryCodex = dependencies.queryCodex;
   const spawnOpenCode = dependencies.queryOpenCode;
+  const spawnPi = dependencies.queryPi;
   const Octokit = dependencies.GithubClient;
   const router = express.Router();
 
@@ -662,7 +664,7 @@ export function createAgentRouter(dependencies: AgentRouterDependencies): expres
    *                          - Source for auto-generated branch names (if createBranch=true and no branchName)
    *                          - Fallback for PR title if no commits are made
    *
-   * @param {string} provider - (Optional) AI provider to use. Options: 'claude' | 'cursor' | 'codex' | 'opencode'
+   * @param {string} provider - (Optional) AI provider to use. Options: 'claude' | 'cursor' | 'codex' | 'opencode' | 'pi'
    *                           Default: 'claude'
    *
    * @param {boolean} stream - (Optional) Enable Server-Sent Events (SSE) streaming for real-time updates.
@@ -785,7 +787,7 @@ export function createAgentRouter(dependencies: AgentRouterDependencies): expres
    * Input Validations (400 Bad Request):
    *   - Either githubUrl OR projectPath must be provided (not neither)
    *   - message must be non-empty string
-   *   - provider must be 'claude', 'cursor', 'codex', or 'opencode'
+   *   - provider must be 'claude', 'cursor', 'codex', 'opencode', or 'pi'
    *   - createBranch/createPR requires githubUrl OR projectPath (not neither)
    *   - branchName must pass Git naming rules (if provided)
    *
@@ -896,8 +898,8 @@ export function createAgentRouter(dependencies: AgentRouterDependencies): expres
       return res.status(400).json({ error: 'message is required' });
     }
 
-    if (!['claude', 'cursor', 'codex', 'opencode'].includes(provider)) {
-      return res.status(400).json({ error: 'provider must be "claude", "cursor", "codex", or "opencode"' });
+    if (!['claude', 'cursor', 'codex', 'opencode', 'pi'].includes(provider)) {
+      return res.status(400).json({ error: 'provider must be "claude", "cursor", "codex", "opencode", or "pi"' });
     }
 
     // Validate GitHub branch/PR creation requirements
@@ -980,6 +982,7 @@ export function createAgentRouter(dependencies: AgentRouterDependencies): expres
 
       const codexModels = await providerModelsService.getProviderModels('codex');
       const opencodeModels = await providerModelsService.getProviderModels('opencode');
+      const piModels = await providerModelsService.getProviderModels('pi');
 
       // Start the appropriate session
       if (provider === 'claude') {
@@ -1023,6 +1026,17 @@ export function createAgentRouter(dependencies: AgentRouterDependencies): expres
           cwd: finalProjectPath,
           sessionId: sessionId || null,
           model: model || opencodeModels.DEFAULT,
+          effort,
+          permissionMode: 'bypassPermissions' // Agent runs are non-interactive, like the other providers above
+        }, writer);
+      } else if (provider === 'pi') {
+        console.log('Starting Pi CLI session');
+
+        await spawnPi(message.trim(), {
+          projectPath: finalProjectPath,
+          cwd: finalProjectPath,
+          sessionId: sessionId || null,
+          model: model || piModels.DEFAULT,
           effort,
           permissionMode: 'bypassPermissions' // Agent runs are non-interactive, like the other providers above
         }, writer);

--- a/server/modules/agent/tests/agent.routes.test.ts
+++ b/server/modules/agent/tests/agent.routes.test.ts
@@ -34,6 +34,7 @@ function createDependencies(
     queryCursor: unexpectedProviderCall as AgentDependencies['queryCursor'],
     queryCodex: unexpectedProviderCall as AgentDependencies['queryCodex'],
     queryOpenCode: unexpectedProviderCall as AgentDependencies['queryOpenCode'],
+    queryPi: unexpectedProviderCall as AgentDependencies['queryPi'],
     GithubClient: class {} as unknown as AgentDependencies['GithubClient'],
     ...overrides,
   };

--- a/server/modules/commands/commands.routes.ts
+++ b/server/modules/commands/commands.routes.ts
@@ -28,13 +28,14 @@ const providerModelsService = dependencies.models;
 const process = dependencies.runtime;
 const router = express.Router();
 
-const MODEL_PROVIDERS = ["claude", "cursor", "codex", "opencode"];
+const MODEL_PROVIDERS = ["claude", "cursor", "codex", "opencode", "pi"];
 
 const MODEL_PROVIDER_LABELS = {
   claude: "Claude",
   cursor: "Cursor",
   codex: "Codex",
   opencode: "OpenCode",
+  pi: "Pi",
 };
 
 const readModelProvider = (value) => {

--- a/server/modules/database/migrations.ts
+++ b/server/modules/database/migrations.ts
@@ -393,21 +393,30 @@ const rebuildSessionsTableWithProjectSchema = (db: Database): void => {
  * provider. SQLite exposes CHECK constraints only through the stored schema
  * text, so the cheapest exact test is to attempt the very insert the
  * constraint must allow and roll the probe row back.
+ *
+ * A CHECK rejection is the only answer that means "rebuild me": any other
+ * failure (locked database, full disk, ...) is surfaced instead of pushing an
+ * otherwise healthy install through a copy-the-whole-table migration.
  */
 const providerModelsTableAcceptsPi = (db: Database): boolean => {
   db.exec('SAVEPOINT provider_models_pi_probe');
   try {
+    // The random suffix keeps the probe row clear of the UNIQUE(provider,
+    // model_id) index no matter what a user has stored.
     db.prepare(`
       INSERT INTO provider_models (provider, model_id, model_name)
-      VALUES ('pi', '__pi_migration_probe__', '__pi_migration_probe__')
+      VALUES ('pi', '__pi_migration_probe__' || lower(hex(randomblob(16))), '__pi_migration_probe__')
     `).run();
     db.exec('ROLLBACK TO provider_models_pi_probe');
     db.exec('RELEASE provider_models_pi_probe');
     return true;
-  } catch {
+  } catch (error: any) {
     db.exec('ROLLBACK TO provider_models_pi_probe');
     db.exec('RELEASE provider_models_pi_probe');
-    return false;
+    if (error?.code === 'SQLITE_CONSTRAINT_CHECK') {
+      return false;
+    }
+    throw error;
   }
 };
 

--- a/server/modules/database/migrations.ts
+++ b/server/modules/database/migrations.ts
@@ -389,6 +389,99 @@ const rebuildSessionsTableWithProjectSchema = (db: Database): void => {
 };
 
 /**
+ * Detects whether the installed provider_models table already accepts the pi
+ * provider. SQLite exposes CHECK constraints only through the stored schema
+ * text, so the cheapest exact test is to attempt the very insert the
+ * constraint must allow and roll the probe row back.
+ */
+const providerModelsTableAcceptsPi = (db: Database): boolean => {
+  db.exec('SAVEPOINT provider_models_pi_probe');
+  try {
+    db.prepare(`
+      INSERT INTO provider_models (provider, model_id, model_name)
+      VALUES ('pi', '__pi_migration_probe__', '__pi_migration_probe__')
+    `).run();
+    db.exec('ROLLBACK TO provider_models_pi_probe');
+    db.exec('RELEASE provider_models_pi_probe');
+    return true;
+  } catch {
+    db.exec('ROLLBACK TO provider_models_pi_probe');
+    db.exec('RELEASE provider_models_pi_probe');
+    return false;
+  }
+};
+
+/**
+ * Rebuilds provider_models so its provider CHECK constraint accepts 'pi'.
+ *
+ * SQLite cannot edit a CHECK constraint in place — the provider list is baked
+ * into the table's CREATE TABLE text — so a legacy table is copied into a new
+ * one that allows 'pi' and swapped back in under the same name. Rows keep
+ * their ids because the Providers module addresses custom models by record id.
+ * New installs already create the table with 'pi' allowed and skip the copy.
+ */
+const rebuildProviderModelsWithPiSchema = (db: Database): void => {
+  if (!tableExists(db, 'provider_models')) {
+    db.exec(PROVIDER_MODELS_TABLE_SCHEMA_SQL);
+    return;
+  }
+
+  if (providerModelsTableAcceptsPi(db)) {
+    return;
+  }
+
+  console.log('Running migration: Rebuilding provider_models to accept the pi provider');
+
+  db.exec('PRAGMA foreign_keys = OFF');
+  try {
+    db.exec('BEGIN TRANSACTION');
+    db.exec('DROP TABLE IF EXISTS provider_models__new');
+    // Mirrors PROVIDER_MODELS_TABLE_SCHEMA_SQL with 'pi' added; the schema
+    // constant names the real table, so the rebuilt one is spelled out here.
+    db.exec(`
+      CREATE TABLE provider_models__new (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        provider TEXT NOT NULL CHECK (provider IN ('claude', 'cursor', 'codex', 'opencode', 'pi')),
+        model_id TEXT NOT NULL,
+        model_name TEXT NOT NULL,
+        sort_order INTEGER NOT NULL DEFAULT 0,
+        created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+        updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+        UNIQUE(provider, model_id)
+      )
+    `);
+    db.exec(`
+      INSERT INTO provider_models__new (
+        id,
+        provider,
+        model_id,
+        model_name,
+        sort_order,
+        created_at,
+        updated_at
+      )
+      SELECT
+        id,
+        provider,
+        model_id,
+        model_name,
+        sort_order,
+        created_at,
+        updated_at
+      FROM provider_models
+    `);
+    db.exec('DROP TABLE provider_models');
+    db.exec('ALTER TABLE provider_models__new RENAME TO provider_models');
+    db.exec('COMMIT');
+  } catch (migrationError) {
+    db.exec('ROLLBACK');
+    throw migrationError;
+  } finally {
+    db.exec('PRAGMA foreign_keys = ON');
+  }
+};
+
+/**
  * Adds the `provider_session_id` mapping column used by the session gateway.
  *
  * Rows that existed before this migration were always keyed directly by the
@@ -500,6 +593,9 @@ export const runMigrations = (db: Database) => {
     db.exec('CREATE INDEX IF NOT EXISTS idx_notification_channel_endpoints_user_channel ON notification_channel_endpoints(user_id, channel)');
     db.exec('CREATE INDEX IF NOT EXISTS idx_notification_channel_endpoints_enabled ON notification_channel_endpoints(enabled)');
     db.exec(PROVIDER_MODELS_TABLE_SCHEMA_SQL);
+    // Rebuilds before the index below is created: dropping the legacy table
+    // would drop a just-created index along with it.
+    rebuildProviderModelsWithPiSchema(db);
     db.exec(`
       CREATE INDEX IF NOT EXISTS idx_provider_models_provider_order
       ON provider_models(provider, sort_order, id)

--- a/server/modules/database/schema.ts
+++ b/server/modules/database/schema.ts
@@ -178,7 +178,7 @@ CREATE TABLE IF NOT EXISTS app_config (
 export const PROVIDER_MODELS_TABLE_SCHEMA_SQL = `
 CREATE TABLE IF NOT EXISTS provider_models (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
-    provider TEXT NOT NULL CHECK (provider IN ('claude', 'cursor', 'codex', 'opencode')),
+    provider TEXT NOT NULL CHECK (provider IN ('claude', 'cursor', 'codex', 'opencode', 'pi')),
     model_id TEXT NOT NULL,
     model_name TEXT NOT NULL,
     sort_order INTEGER NOT NULL DEFAULT 0,

--- a/server/modules/database/tests/pi-provider-models-migration.test.ts
+++ b/server/modules/database/tests/pi-provider-models-migration.test.ts
@@ -1,0 +1,161 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, rm } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+
+import {
+  closeConnection,
+  getConnection,
+  initializeDatabase,
+  providerModelsDb,
+} from '@/modules/database/index.js';
+import { runMigrations } from '@/modules/database/migrations.js';
+
+// The provider_models shape shipped before the pi provider existed. Legacy
+// installs carry this exact table, and its CHECK constraint is what kept
+// 'pi' rows out of the database until the rebuild migration runs.
+const LEGACY_PROVIDER_MODELS_SCHEMA_SQL = `
+CREATE TABLE provider_models (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    provider TEXT NOT NULL CHECK (provider IN ('claude', 'cursor', 'codex', 'opencode')),
+    model_id TEXT NOT NULL,
+    model_name TEXT NOT NULL,
+    sort_order INTEGER NOT NULL DEFAULT 0,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE(provider, model_id)
+);
+`;
+
+async function withIsolatedDatabase(runTest: () => void | Promise<void>): Promise<void> {
+  const previousDatabasePath = process.env.DATABASE_PATH;
+  const tempDirectory = await mkdtemp(path.join(os.tmpdir(), 'pi-provider-models-db-'));
+  const databasePath = path.join(tempDirectory, 'auth.db');
+
+  closeConnection();
+  process.env.DATABASE_PATH = databasePath;
+
+  try {
+    await initializeDatabase();
+    await runTest();
+  } finally {
+    closeConnection();
+    if (previousDatabasePath === undefined) {
+      delete process.env.DATABASE_PATH;
+    } else {
+      process.env.DATABASE_PATH = previousDatabasePath;
+    }
+    await rm(tempDirectory, { recursive: true, force: true });
+  }
+}
+
+test('provider_models accepts pi rows on a fresh install', async () => {
+  await withIsolatedDatabase(() => {
+    const db = getConnection();
+
+    db.prepare(`
+      INSERT INTO provider_models (provider, model_id, model_name, sort_order)
+      VALUES ('pi', 'pi/local-model', 'Local pi Model', 3)
+    `).run();
+
+    const stored = providerModelsDb.listCustomProviderModels('pi');
+    assert.equal(stored.length, 1);
+    assert.equal(stored[0].provider, 'pi');
+    assert.equal(stored[0].modelId, 'pi/local-model');
+    assert.equal(stored[0].model, 'Local pi Model');
+    assert.equal(stored[0].sortOrder, 3);
+
+    // Legacy providers keep working, and the constraint still rejects
+    // providers outside the list instead of letting anything through.
+    db.prepare(`
+      INSERT INTO provider_models (provider, model_id, model_name)
+      VALUES ('codex', 'codex/local-model', 'Local codex Model')
+    `).run();
+    assert.equal(providerModelsDb.listCustomProviderModels('codex').length, 1);
+    assert.throws(
+      () => db.prepare(`
+        INSERT INTO provider_models (provider, model_id, model_name)
+        VALUES ('not-a-provider', 'x/y', 'X')
+      `).run(),
+      /CHECK constraint failed/,
+    );
+  });
+});
+
+test('migration rebuilds a legacy provider_models table without losing rows', async () => {
+  await withIsolatedDatabase(() => {
+    const db = getConnection();
+
+    // Simulate a pre-pi install: the table exists with the old CHECK and
+    // holds user-created rows that must survive the rebuild.
+    db.exec('DROP TABLE provider_models');
+    db.exec(LEGACY_PROVIDER_MODELS_SCHEMA_SQL);
+    const legacyRows = [
+      { id: 7, provider: 'claude', model_id: 'claude/custom-model', model_name: 'Custom Claude Model', sort_order: 1 },
+      { id: 9, provider: 'codex', model_id: 'codex/gateway-model', model_name: 'Gateway Codex Model', sort_order: 2 },
+    ];
+    for (const row of legacyRows) {
+      db.prepare(`
+        INSERT INTO provider_models (id, provider, model_id, model_name, sort_order)
+        VALUES (@id, @provider, @model_id, @model_name, @sort_order)
+      `).run(row);
+    }
+
+    assert.throws(
+      () => db.prepare(`
+        INSERT INTO provider_models (provider, model_id, model_name)
+        VALUES ('pi', 'pi/local-model', 'Local pi Model')
+      `).run(),
+      /CHECK constraint failed/,
+    );
+
+    runMigrations(db);
+
+    // Old rows survive with their ids, names and ordering intact.
+    for (const row of legacyRows) {
+      assert.deepEqual(
+        db.prepare(`
+          SELECT id, provider, model_id, model_name, sort_order
+          FROM provider_models
+          WHERE provider = ? AND model_id = ?
+        `).get(row.provider, row.model_id),
+        row,
+      );
+    }
+
+    // 'pi' rows are accepted after the rebuild and read back through the
+    // repository like any other provider's models.
+    db.prepare(`
+      INSERT INTO provider_models (provider, model_id, model_name, sort_order)
+      VALUES ('pi', 'pi/local-model', 'Local pi Model', 3)
+    `).run();
+    const piModels = providerModelsDb.listCustomProviderModels('pi');
+    assert.equal(piModels.length, 1);
+    assert.equal(piModels[0].modelId, 'pi/local-model');
+
+    // The provider-order index is recreated on the rebuilt table, and the
+    // remaining constraints are untouched.
+    const indexedColumns = (db
+      .prepare('PRAGMA index_info(idx_provider_models_provider_order)')
+      .all() as Array<{ name: string }>)
+      .map((column) => column.name);
+    assert.deepEqual(indexedColumns, ['provider', 'sort_order', 'id']);
+    assert.throws(
+      () => db.prepare(`
+        INSERT INTO provider_models (provider, model_id, model_name)
+        VALUES ('pi', 'pi/local-model', 'Local pi Model')
+      `).run(),
+      /UNIQUE constraint failed/,
+    );
+
+    // A second pass over an already-migrated table is a no-op that keeps
+    // every row exactly where it was.
+    runMigrations(db);
+    assert.equal(
+      (db.prepare('SELECT COUNT(*) AS count FROM provider_models').get() as { count: number }).count,
+      3,
+    );
+    assert.equal(providerModelsDb.listCustomProviderModels('pi').length, 1);
+  });
+});

--- a/server/modules/providers/README.md
+++ b/server/modules/providers/README.md
@@ -45,6 +45,7 @@ Current provider ids in this repo are:
 - `codex`
 - `cursor`
 - `opencode`
+- `pi`
 
 Those ids are mirrored in backend unions and frontend provider constants. If
 adding a new provider, update every place that hardcodes this list.
@@ -65,7 +66,8 @@ server/modules/providers/list/<provider>/
   <provider>-session-synchronizer.provider.ts
 ```
 
-The existing provider folders are `claude`, `codex`, `cursor`, and `opencode`.
+The existing provider folders are `claude`, `codex`, `cursor`, `opencode`, and
+`pi`.
 
 Each provider wrapper owns its SDK/CLI runtime alongside its auth, model, and
 session facets. Runtime adapters receive registry-backed model and session
@@ -96,7 +98,7 @@ import the service from `server/modules/providers/index.ts`.
 1. Add the provider id everywhere it is part of the contract.
 
 - Update `server/shared/types.ts` `LLMProvider`.
-- Update `src/types/app.ts` `LLMProvider` if the frontend should know about it.
+- Update `src/shared/types.ts` `LLMProvider` if the frontend should know about it.
 - Update `server/modules/providers/provider.routes.ts`.
 - Update `server/modules/agent/agent.routes.ts` if the provider is launchable from the agent runtime.
 - Update `server/index.ts` if the provider needs runtime boot or shutdown wiring.
@@ -143,6 +145,9 @@ Current MCP formats in this repo are:
 | Codex | `.codex/config.toml` | `user`, `project` | `stdio`, `http` |
 | Cursor | `.cursor/mcp.json` | `user`, `project` | `stdio`, `http` |
 | OpenCode | `~/.config/opencode/opencode.json` or `<workspace>/opencode.json` (`.jsonc` is read when present) | `user`, `project` | `stdio`, `http` |
+| pi | not applicable | none | none |
+
+pi has no MCP integration; every facet method answers `NOT_SUPPORTED`.
 
 5. Implement skills.
 
@@ -163,6 +168,7 @@ Current skill discovery roots are:
 | Codex | `~/.agents/skills`, `~/.codex/skills/.system`, `/etc/codex/skills` | `<workspace>/.agents/skills`, `path.dirname(workspacePath)/.agents/skills`, topmost git root `.agents/skills` | `$` | Overlapping roots are deduplicated before scanning. |
 | Cursor | `~/.cursor/skills` | `<workspace>/.cursor/skills`, `<workspace>/.agents/skills` | `/` | Uses slash-style commands. |
 | OpenCode | `~/.config/opencode/skills`, `~/.claude/skills`, `~/.agents/skills` | Cwd-to-topmost-git-root `.opencode/skills`, `.claude/skills`, and `.agents/skills` | `/` | Reuses OpenCode, Claude, and Agents skill locations. Overlapping roots are deduplicated before scanning. |
+| pi | `~/.pi/agent/skills`, plus every directory listed in the `skills` array of `~/.pi/agent/settings.json` | `<workspace>/.pi/skills` | `/` | Non-existent directories from the settings `skills` array are skipped. |
 
 Command forms currently used by the providers are:
 
@@ -171,6 +177,7 @@ Command forms currently used by the providers are:
 - Codex skills: `$skill-name`
 - Cursor skills: `/skill-name`
 - OpenCode skills: `/skill-name`
+- pi skills: `/skill-name`
 
 6. Implement sessions.
 
@@ -208,6 +215,7 @@ Current session sync roots are:
 | Codex | `~/.codex/sessions/**/*.jsonl` | Uses `~/.codex/session_index.jsonl` for title lookup and the last `task_complete` message for a fallback title. |
 | Cursor | `~/.cursor/projects/**/*.jsonl` | Uses sibling `worker.log` to recover `workspacePath`, then derives the session title from the first user prompt. |
 | OpenCode | `~/.local/share/opencode/opencode.db` | Reads active sessions/messages/parts from OpenCode's shared SQLite database and stores `jsonl_path` as `null` so deleting one app session cannot remove the shared DB. |
+| pi | `~/.pi/agent/sessions/**/*.jsonl` | Derives `workspacePath` from the transcript header's `cwd`; the title prefers an explicit `session_info` name and falls back to the first user prompt. |
 
 8. Register the provider.
 
@@ -230,7 +238,7 @@ If the provider is visible in the UI, update:
 - `src/components/chat/hooks/useChatProviderState.ts`
 - `src/components/chat/view/subcomponents/ProviderSelectionEmptyState.tsx`
 - `src/components/provider-auth/view/ProviderLoginModal.tsx`
-- `src/components/mcp/constants.ts`
+- `src/shared/constants.ts`
 
 ## Minimal Wrapper Template
 
@@ -331,7 +339,7 @@ Requirements:
     - server/modules/providers/provider.registry.ts
     - server/modules/providers/provider.routes.ts
    - server/shared/types.ts LLMProvider
-   - src/types/app.ts LLMProvider
+   - src/shared/types.ts LLMProvider
 3) Mirror the nearest existing provider implementation for file naming, style,
    and error handling.
 4) Implement skills support with SkillsProvider and the current skill roots.
@@ -339,7 +347,7 @@ Requirements:
 6) Ensure sessions use unique ids, safe path handling, and correct pagination.
 7) Keep `sessions` and `sessionSynchronizer` separate.
 8) Run:
-   - npx eslint <touched files>
+   - npx oxlint <touched files>
    - npx tsc --noEmit -p server/tsconfig.json
 ```
 
@@ -348,7 +356,7 @@ Requirements:
 After adding or changing a provider, run the relevant checks:
 
 ```bash
-npx eslint server/modules/providers/**/*.ts server/shared/types.ts server/shared/interfaces.ts
+npx oxlint server/modules/providers server/shared/types.ts server/shared/interfaces.ts
 npx tsc --noEmit -p server/tsconfig.json
 ```
 
@@ -357,6 +365,11 @@ Useful tests in this repo:
 - `server/modules/providers/tests/mcp.test.ts`
 - `server/modules/providers/tests/skills.test.ts`
 - `server/modules/providers/tests/opencode-sessions.test.ts`
+- `server/modules/providers/tests/pi-registry.test.ts`
+- `server/modules/providers/tests/pi-facets.test.ts`
+- `server/modules/providers/tests/pi-session-synchronizer.test.ts`
+- `server/modules/providers/list/pi/pi-runtime.provider.test.js`
+- `server/modules/providers/list/pi/pi-sessions.provider.test.ts`
 
 If you touch sessions or session synchronization, add or update focused tests
 alongside the implementation.
@@ -366,7 +379,7 @@ alongside the implementation.
 - Adding provider files but forgetting `provider.registry.ts` or
   `provider.routes.ts`.
 - Adding a live runtime without exposing it from the provider wrapper.
-- Updating backend provider ids but not `src/types/app.ts` or the frontend
+- Updating backend provider ids but not `src/shared/types.ts` or the frontend
   provider constants.
 - Omitting `runtime`, `skills`, or `sessionSynchronizer` from the wrapper.
 - Returning duplicate normalized message ids for split content.

--- a/server/modules/providers/list/pi/pi-auth.provider.ts
+++ b/server/modules/providers/list/pi/pi-auth.provider.ts
@@ -1,24 +1,78 @@
+import { access } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+import spawn from 'cross-spawn';
+
 import type { IProviderAuth } from '@/shared/interfaces.js';
 import type { ProviderAuthStatus } from '@/shared/types.js';
 
-/**
- * Phase 1 auth placeholder for Pi.
- *
- * Pi has no login subcommand — credentials come from its own `models.json` or
- * environment variables — so this reports the conservative "not installed /
- * not authenticated" state instead of probing a credential store that has no
- * stable layout yet. The real readiness check (`pi auth check`) lands with the
- * auth facet.
- */
+type PiCredentialsStatus = {
+  authenticated: boolean;
+  email: string | null;
+  method: string | null;
+};
+
+/** Provider API keys pi reads straight from the environment. */
+const PI_ENV_CREDENTIAL_KEYS = [
+  'ANTHROPIC_API_KEY',
+  'ANTHROPIC_AUTH_TOKEN',
+  'OPENAI_API_KEY',
+  'GOOGLE_GENERATIVE_AI_API_KEY',
+  'ZAI_CODING_CN_API_KEY',
+];
+
 export class PiProviderAuth implements IProviderAuth {
+  /**
+   * Checks whether the pi CLI is available to the server process.
+   */
+  private checkInstalled(): boolean {
+    try {
+      const result = spawn.sync('pi', ['--version'], { stdio: 'ignore', timeout: 5000 });
+      return !result.error && result.status === 0;
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Returns pi CLI installation and credential status.
+   *
+   * Unauthenticated is pi's normal first-run state rather than a failure, so no
+   * error string is reported for it.
+   */
   async getStatus(): Promise<ProviderAuthStatus> {
+    const installed = this.checkInstalled();
+    const credentials = await this.checkCredentials();
+
     return {
-      installed: false,
+      installed,
       provider: 'pi',
-      authenticated: false,
-      email: null,
-      method: null,
-      error: 'Pi not configured',
+      authenticated: credentials.authenticated,
+      // pi has no account identity: credentials are a local auth store or an
+      // API key, so there is never an email to show.
+      email: credentials.email,
+      method: credentials.method,
     };
+  }
+
+  /**
+   * Probes pi's credentials: its own auth store first, then the environment.
+   */
+  private async checkCredentials(): Promise<PiCredentialsStatus> {
+    try {
+      const authPath = path.join(os.homedir(), '.pi', 'agent', 'auth.json');
+      await access(authPath);
+      return { authenticated: true, email: null, method: 'oauth' };
+    } catch {
+      // No auth store — fall through to the environment keys.
+    }
+
+    const envCredential = PI_ENV_CREDENTIAL_KEYS.find((key) => process.env[key]?.trim());
+    if (envCredential) {
+      return { authenticated: true, email: null, method: 'env' };
+    }
+
+    return { authenticated: false, email: null, method: null };
   }
 }

--- a/server/modules/providers/list/pi/pi-auth.provider.ts
+++ b/server/modules/providers/list/pi/pi-auth.provider.ts
@@ -13,12 +13,16 @@ type PiCredentialsStatus = {
   method: string | null;
 };
 
-/** Provider API keys pi reads straight from the environment. */
+/**
+ * Provider API keys pi reads straight from the environment. The names follow
+ * pi's own env-api-keys mapping (packages/ai/src/env-api-keys.ts in pi-mono),
+ * which resolves its `google` provider from `GEMINI_API_KEY`.
+ */
 const PI_ENV_CREDENTIAL_KEYS = [
   'ANTHROPIC_API_KEY',
   'ANTHROPIC_AUTH_TOKEN',
   'OPENAI_API_KEY',
-  'GOOGLE_GENERATIVE_AI_API_KEY',
+  'GEMINI_API_KEY',
   'ZAI_CODING_CN_API_KEY',
 ];
 

--- a/server/modules/providers/list/pi/pi-auth.provider.ts
+++ b/server/modules/providers/list/pi/pi-auth.provider.ts
@@ -1,0 +1,24 @@
+import type { IProviderAuth } from '@/shared/interfaces.js';
+import type { ProviderAuthStatus } from '@/shared/types.js';
+
+/**
+ * Phase 1 auth placeholder for Pi.
+ *
+ * Pi has no login subcommand — credentials come from its own `models.json` or
+ * environment variables — so this reports the conservative "not installed /
+ * not authenticated" state instead of probing a credential store that has no
+ * stable layout yet. The real readiness check (`pi auth check`) lands with the
+ * auth facet.
+ */
+export class PiProviderAuth implements IProviderAuth {
+  async getStatus(): Promise<ProviderAuthStatus> {
+    return {
+      installed: false,
+      provider: 'pi',
+      authenticated: false,
+      email: null,
+      method: null,
+      error: 'Pi not configured',
+    };
+  }
+}

--- a/server/modules/providers/list/pi/pi-mcp.provider.ts
+++ b/server/modules/providers/list/pi/pi-mcp.provider.ts
@@ -1,37 +1,54 @@
 import { McpProvider } from '@/modules/providers/shared/mcp/mcp.provider.js';
-import type { ProviderMcpServer, UpsertProviderMcpServerInput } from '@/shared/types.js';
+import type { McpScope, ProviderMcpServer, UpsertProviderMcpServerInput } from '@/shared/types.js';
 import { AppError } from '@/shared/utils.js';
 
 /**
- * MCP adapter for Pi.
+ * MCP adapter for pi.
  *
- * Pi has no MCP integration, so the facet registers with no supported scopes
- * or transports: reads resolve to the empty set, and the shared base rejects
- * every upsert/removal through its own scope guards. The remaining write hooks
- * throw for the same reason should future base behavior ever reach them.
+ * pi has no MCP integration at all: the facet registers with no supported
+ * scopes or transports, so the shared base answers reads with the empty set.
+ * Every read/write hook and both public write entry points reject with
+ * `NOT_SUPPORTED` so nothing can mistake "no servers configured" for "pi
+ * cannot do MCP".
  */
 export class PiMcpProvider extends McpProvider {
   constructor() {
     super('pi', [], []);
   }
 
-  protected async readScopedServers(): Promise<Record<string, unknown>> {
-    return {};
+  async upsertServer(_input: UpsertProviderMcpServerInput): Promise<ProviderMcpServer> {
+    throw new AppError('Pi does not support MCP', { code: 'NOT_SUPPORTED' });
   }
 
-  protected async writeScopedServers(): Promise<void> {
-    throw new AppError('Pi does not support MCP server configuration.', {
-      code: 'NOT_SUPPORTED',
-    });
+  async removeServer(_input: {
+    name: string;
+    scope?: McpScope;
+    workspacePath?: string;
+  }): Promise<{ removed: boolean; provider: 'pi'; name: string; scope: McpScope }> {
+    throw new AppError('Pi does not support MCP', { code: 'NOT_SUPPORTED' });
+  }
+
+  protected async readScopedServers(_scope: McpScope, _workspacePath: string): Promise<Record<string, unknown>> {
+    throw new AppError('Pi does not support MCP', { code: 'NOT_SUPPORTED' });
+  }
+
+  protected async writeScopedServers(
+    _scope: McpScope,
+    _workspacePath: string,
+    _servers: Record<string, unknown>,
+  ): Promise<void> {
+    throw new AppError('Pi does not support MCP', { code: 'NOT_SUPPORTED' });
   }
 
   protected buildServerConfig(_input: UpsertProviderMcpServerInput): Record<string, unknown> {
-    throw new AppError('Pi does not support MCP server configuration.', {
-      code: 'NOT_SUPPORTED',
-    });
+    throw new AppError('Pi does not support MCP', { code: 'NOT_SUPPORTED' });
   }
 
-  protected normalizeServerConfig(): ProviderMcpServer | null {
-    return null;
+  protected normalizeServerConfig(
+    _scope: McpScope,
+    _name: string,
+    _rawConfig: unknown,
+  ): ProviderMcpServer | null {
+    throw new AppError('Pi does not support MCP', { code: 'NOT_SUPPORTED' });
   }
 }

--- a/server/modules/providers/list/pi/pi-mcp.provider.ts
+++ b/server/modules/providers/list/pi/pi-mcp.provider.ts
@@ -1,0 +1,37 @@
+import { McpProvider } from '@/modules/providers/shared/mcp/mcp.provider.js';
+import type { ProviderMcpServer, UpsertProviderMcpServerInput } from '@/shared/types.js';
+import { AppError } from '@/shared/utils.js';
+
+/**
+ * MCP adapter for Pi.
+ *
+ * Pi has no MCP integration, so the facet registers with no supported scopes
+ * or transports: reads resolve to the empty set, and the shared base rejects
+ * every upsert/removal through its own scope guards. The remaining write hooks
+ * throw for the same reason should future base behavior ever reach them.
+ */
+export class PiMcpProvider extends McpProvider {
+  constructor() {
+    super('pi', [], []);
+  }
+
+  protected async readScopedServers(): Promise<Record<string, unknown>> {
+    return {};
+  }
+
+  protected async writeScopedServers(): Promise<void> {
+    throw new AppError('Pi does not support MCP server configuration.', {
+      code: 'NOT_SUPPORTED',
+    });
+  }
+
+  protected buildServerConfig(_input: UpsertProviderMcpServerInput): Record<string, unknown> {
+    throw new AppError('Pi does not support MCP server configuration.', {
+      code: 'NOT_SUPPORTED',
+    });
+  }
+
+  protected normalizeServerConfig(): ProviderMcpServer | null {
+    return null;
+  }
+}

--- a/server/modules/providers/list/pi/pi-models.provider.ts
+++ b/server/modules/providers/list/pi/pi-models.provider.ts
@@ -1,0 +1,30 @@
+import type { IProviderModels } from '@/shared/interfaces.js';
+import type {
+  ProviderCurrentActiveModel,
+  ProviderModelsDefinition,
+} from '@/shared/types.js';
+import { buildDefaultProviderCurrentActiveModel } from '@/shared/utils.js';
+
+/**
+ * Curated Pi catalog shipped as immutable CloudCLI defaults.
+ *
+ * Pi resolves models through its own `models.json` provider/model pairs, so the
+ * skeleton ships an empty catalog: whatever the user's Pi installation can
+ * reach stays the source of truth until the catalog adapter lands. The default
+ * mirrors the frontend fallback in `useChatProviderState` so both layers agree
+ * while the catalog is still empty.
+ */
+export const PI_PREDEFINED_MODELS: ProviderModelsDefinition = {
+  OPTIONS: [],
+  DEFAULT: 'anthropic/claude-sonnet-4',
+};
+
+export class PiProviderModels implements IProviderModels {
+  async getSupportedModels(): Promise<ProviderModelsDefinition> {
+    return PI_PREDEFINED_MODELS;
+  }
+
+  async getCurrentActiveModel(): Promise<ProviderCurrentActiveModel> {
+    return buildDefaultProviderCurrentActiveModel(PI_PREDEFINED_MODELS);
+  }
+}

--- a/server/modules/providers/list/pi/pi-models.provider.ts
+++ b/server/modules/providers/list/pi/pi-models.provider.ts
@@ -6,25 +6,45 @@ import type {
 import { buildDefaultProviderCurrentActiveModel } from '@/shared/utils.js';
 
 /**
- * Curated Pi catalog shipped as immutable CloudCLI defaults.
+ * Curated pi catalog shipped as immutable CloudCLI defaults.
  *
- * Pi resolves models through its own `models.json` provider/model pairs, so the
- * skeleton ships an empty catalog: whatever the user's Pi installation can
- * reach stays the source of truth until the catalog adapter lands. The default
- * mirrors the frontend fallback in `useChatProviderState` so both layers agree
- * while the catalog is still empty.
+ * pi routes by `<providerID>/<modelID>` exactly like OpenCode, but Phase 1 has
+ * no `pi models`-style discovery to read a live registry from, so this list is
+ * the curated intersection of the providers pi can address: Anthropic, the
+ * Z.ai Coding CN gateway, and OpenAI. Every entry declares an empty effort list
+ * until pi exposes per-model reasoning levels through its CLI.
+ *
+ * The default mirrors the frontend fallback in `useChatProviderState` so both
+ * layers agree on what a fresh pi session runs with.
  */
 export const PI_PREDEFINED_MODELS: ProviderModelsDefinition = {
-  OPTIONS: [],
+  OPTIONS: [
+    { value: 'anthropic/claude-sonnet-4-5', label: 'Claude Sonnet 4.5', description: 'Anthropic', effort: { values: [] } },
+    { value: 'anthropic/claude-sonnet-4', label: 'Claude Sonnet 4', description: 'Anthropic', effort: { values: [] } },
+    { value: 'anthropic/claude-haiku-4-5', label: 'Claude Haiku 4.5', description: 'Anthropic', effort: { values: [] } },
+    { value: 'anthropic/claude-haiku-3-5', label: 'Claude Haiku 3.5', description: 'Anthropic', effort: { values: [] } },
+    { value: 'anthropic/claude-opus-4-5', label: 'Claude Opus 4.5', description: 'Anthropic', effort: { values: [] } },
+    { value: 'anthropic/claude-opus-4-1', label: 'Claude Opus 4.1', description: 'Anthropic', effort: { values: [] } },
+    { value: 'zai-coding-cn/glm-5.3', label: 'GLM 5.3', description: 'Z.ai Coding CN', effort: { values: [] } },
+    { value: 'zai-coding-cn/glm-5.3-flash', label: 'GLM 5.3 Flash', description: 'Z.ai Coding CN', effort: { values: [] } },
+    { value: 'zai-coding-cn/glm-5.2', label: 'GLM 5.2', description: 'Z.ai Coding CN', effort: { values: [] } },
+    { value: 'openai/gpt-5.6', label: 'GPT-5.6', description: 'OpenAI', effort: { values: [] } },
+    { value: 'openai/gpt-5.4', label: 'GPT-5.4', description: 'OpenAI', effort: { values: [] } },
+    { value: 'openai/gpt-5.4-mini', label: 'GPT-5.4 mini', description: 'OpenAI', effort: { values: [] } },
+  ],
   DEFAULT: 'anthropic/claude-sonnet-4',
 };
 
+/** Provider registry model adapter for pi predefined models. */
 export class PiProviderModels implements IProviderModels {
   async getSupportedModels(): Promise<ProviderModelsDefinition> {
     return PI_PREDEFINED_MODELS;
   }
 
-  async getCurrentActiveModel(): Promise<ProviderCurrentActiveModel> {
+  async getCurrentActiveModel(_sessionId?: string): Promise<ProviderCurrentActiveModel> {
+    // Phase 1: pi's per-session model lives in the JSONL transcript, which the
+    // sessions facet already surfaces; the registry keeps answering with the
+    // curated default instead of reading runtime state.
     return buildDefaultProviderCurrentActiveModel(PI_PREDEFINED_MODELS);
   }
 }

--- a/server/modules/providers/list/pi/pi-runtime.provider.js
+++ b/server/modules/providers/list/pi/pi-runtime.provider.js
@@ -1,0 +1,424 @@
+import crossSpawn from 'cross-spawn';
+
+import {
+  appendFilesInputTag,
+  appendImagesInputTag,
+  normalizeAttachmentDescriptors
+} from '@/shared/image-attachments.js';
+import { notifyRunFailed, notifyRunStopped } from '@/modules/notifications/index.js';
+import { AppError, createCompleteMessage, createNormalizedMessage, flattenPromptForWindowsShell } from '@/shared/utils.js';
+
+// cross-spawn resolves .cmd shims/PATHEXT on Windows and delegates to
+// child_process.spawn everywhere else.
+const spawnFunction = crossSpawn;
+
+const activePiProcesses = new Map();
+
+/**
+ * Builds the `pi -p --mode json` argument vector for one run.
+ *
+ * Verified against pi 0.85.1 (docs/pi-notes.md):
+ * - the prompt is the final positional argument (print mode reads it, no stdin);
+ * - `--session` resumes a provider session with its full uuid (resumed runs
+ *   keep the same session id and append to the same session file);
+ * - `--model` accepts a bare model id or a `provider/model` pair;
+ * - there is no `--dir`/`--cwd` flag — the working directory is the spawn
+ *   `cwd` option.
+ *
+ * Exported for tests only.
+ */
+export function buildPiArgs({ providerSessionId, model, prompt }) {
+  const args = ['-p', '--mode', 'json'];
+  if (providerSessionId) {
+    args.push('--session', providerSessionId);
+  }
+  if (model) {
+    args.push('--model', model);
+  }
+  if (prompt && prompt.trim()) {
+    args.push(flattenPromptForWindowsShell(prompt));
+  }
+  return args;
+}
+
+/**
+ * Reads the provider-native session id out of one parsed stdout event.
+ *
+ * Only the `session` header carries an id; the streaming events reference
+ * messages and tool calls, never the session.
+ */
+function readPiSessionId(event) {
+  if (!event || typeof event !== 'object') {
+    return null;
+  }
+
+  return event.type === 'session' && typeof event.id === 'string' ? event.id : null;
+}
+
+/**
+ * Maps pi's cumulative usage counters onto the token-budget shape the chat
+ * composer reads (`inputTokens`/`outputTokens`/`used`/`breakdown`, mirroring
+ * the opencode runtime), keeping pi's own totals and cost as extra fields.
+ *
+ * pi reports cache reads separately; like opencode, they count as input.
+ */
+function readPiTokenBudget(usage) {
+  if (!usage || typeof usage !== 'object') {
+    return null;
+  }
+
+  const inputTokens = Number(usage.input || 0) + Number(usage.cacheRead || 0);
+  const outputTokens = Number(usage.output || 0);
+  const used = Number(usage.totalTokens || 0) || inputTokens + outputTokens;
+  if (used <= 0) {
+    return null;
+  }
+
+  return {
+    used,
+    inputTokens,
+    outputTokens,
+    breakdown: {
+      input: inputTokens,
+      output: outputTokens,
+    },
+    totalTokens: Number(usage.totalTokens || 0),
+    cost: usage.cost && typeof usage.cost === 'object' ? usage.cost.total : undefined,
+  };
+}
+
+/**
+ * Parses one stdout line from `pi -p --mode json` and forwards what it yields.
+ *
+ * Exported for tests only; the runtime passes a ctx bag because the mutable
+ * state (captured session id, last usage) lives in the run closure.
+ *
+ * - Unparseable lines (pi's own warnings mixed into stdout) stream through as
+ *   deltas rather than killing the run.
+ * - The `session` header registers the provider-native id (contract: new
+ *   provider sessions announce `session_created` once, and the writer learns
+ *   the id before any content event).
+ * - Every event's top-level `usage` is cumulative, so the last one seen wins.
+ * - Event-to-message mapping is `context.normalizeMessage`; the runtime never
+ *   interprets event contents itself.
+ */
+export function processPiOutputLine(line, ctx) {
+  if (!line || !line.trim()) {
+    return;
+  }
+
+  let event;
+  try {
+    event = JSON.parse(line);
+  } catch {
+    ctx.ws.send(createNormalizedMessage({
+      kind: 'stream_delta',
+      content: line,
+      sessionId: ctx.getCapturedSessionId() || ctx.sessionId || null,
+      provider: 'pi',
+    }));
+    return;
+  }
+
+  try {
+    const nextSessionId = readPiSessionId(event);
+    if (nextSessionId) {
+      ctx.registerSession(nextSessionId);
+    }
+    if (event && typeof event === 'object' && event.usage && typeof event.usage === 'object') {
+      ctx.setUsage(event.usage);
+    }
+    const normalized = ctx.normalizeMessage(event, ctx.getCapturedSessionId() || ctx.sessionId || null);
+    for (const msg of normalized) {
+      ctx.ws.send(msg);
+    }
+  } catch (error) {
+    const errorContent = error instanceof Error ? error.message : String(error);
+    console.error('[Pi] Failed to process JSON output:', errorContent);
+    ctx.ws.send(createNormalizedMessage({
+      kind: 'error',
+      content: errorContent,
+      sessionId: ctx.getCapturedSessionId() || ctx.sessionId || null,
+      provider: 'pi',
+    }));
+  }
+}
+
+async function spawnPi(command, options = {}, ws, context) {
+  return new Promise((resolve, reject) => {
+    const {
+      sessionId,
+      projectPath,
+      cwd,
+      model,
+      sessionSummary,
+      images,
+      files
+      // `permissionMode` and `effort` are deliberately NOT destructured: pi
+      // has no permission system and no reasoning-effort lever (see the pi
+      // capabilities), so neither option maps to any CLI flag or env var.
+    } = options;
+    // Callers pass the stable app session id; the CLI resumes with the
+    // provider-native id recorded on the session row.
+    const providerSessionId = context.resolveProviderSessionId(sessionId);
+    const workingDir = cwd || projectPath || process.cwd();
+    // Process-map key: the app session id when the caller supplied one, so
+    // abort-by-app-id always works.
+    const processKey = sessionId || Date.now().toString();
+    let capturedSessionId = providerSessionId;
+    let sessionCreatedSent = false;
+    let lastUsage = null;
+    let stdoutLineBuffer = '';
+    let terminalNotificationSent = false;
+    let piProcess = null;
+    // Unified lifecycle contract: exactly one terminal `complete` per run
+    // (close and error handlers can both fire for spawn failures).
+    let completeSent = false;
+
+    const notifyTerminalState = ({ code = null, error = null } = {}) => {
+      if (terminalNotificationSent) {
+        return;
+      }
+
+      terminalNotificationSent = true;
+      // Notifications are app-facing, so they carry the app session id.
+      const finalSessionId = sessionId || capturedSessionId || processKey;
+      if (code === 0 && !error) {
+        notifyRunStopped({
+          userId: ws?.userId || null,
+          provider: 'pi',
+          sessionId: finalSessionId,
+          sessionName: sessionSummary,
+          stopReason: 'completed',
+        });
+        return;
+      }
+
+      notifyRunFailed({
+        userId: ws?.userId || null,
+        provider: 'pi',
+        sessionId: finalSessionId,
+        sessionName: sessionSummary,
+        error: error || `Pi CLI exited with code ${code}`,
+      });
+    };
+
+    const registerSession = (nextSessionId) => {
+      if (!nextSessionId || capturedSessionId === nextSessionId) {
+        return;
+      }
+
+      capturedSessionId = nextSessionId;
+      // Legacy/direct callers without an app session id re-key the process
+      // under the provider-native id once it is known.
+      if (!sessionId && processKey !== capturedSessionId && piProcess) {
+        activePiProcesses.delete(processKey);
+        activePiProcesses.set(capturedSessionId, piProcess);
+      }
+      if (piProcess) {
+        piProcess.sessionId = capturedSessionId;
+      }
+
+      if (ws.setSessionId && typeof ws.setSessionId === 'function') {
+        ws.setSessionId(capturedSessionId);
+      }
+
+      if (!providerSessionId && !sessionCreatedSent) {
+        sessionCreatedSent = true;
+        ws.send(createNormalizedMessage({
+          kind: 'session_created',
+          newSessionId: capturedSessionId,
+          sessionId: capturedSessionId,
+          provider: 'pi',
+        }));
+      }
+    };
+
+    const processCtx = {
+      ws,
+      sessionId,
+      getCapturedSessionId: () => capturedSessionId,
+      registerSession,
+      setUsage: (usage) => {
+        lastUsage = usage;
+      },
+      normalizeMessage: (raw, normalizedSessionId) => context.normalizeMessage(raw, normalizedSessionId),
+    };
+
+    void context.resolveResumeModel(sessionId, model).then(async (resolvedModel) => {
+      const args = buildPiArgs({ providerSessionId, model: resolvedModel });
+      const hasAttachments =
+        normalizeAttachmentDescriptors(images).length > 0
+        || normalizeAttachmentDescriptors(files).length > 0;
+      if ((command && command.trim()) || hasAttachments) {
+        // Attachment paths ride along as <images_input>/<files_input> blocks
+        // appended to the prompt; the session history reader strips the tags
+        // back out. pi is a .cmd shim on Windows, so the whole argument must
+        // be newline-free or cmd.exe silently truncates it.
+        const promptWithAttachments = appendFilesInputTag(
+          appendImagesInputTag(command?.trim() || '', images),
+          files
+        );
+        args.push(flattenPromptForWindowsShell(promptWithAttachments));
+      }
+
+      piProcess = spawnFunction('pi', args, {
+        cwd: workingDir,
+        stdio: ['pipe', 'pipe', 'pipe'],
+        // pi has no permission levers, so unlike opencode there is no env
+        // override to merge here — the user's own pi config governs.
+        env: { ...process.env },
+      });
+
+      activePiProcesses.set(processKey, piProcess);
+      piProcess.sessionId = processKey;
+      piProcess.stdin.end();
+
+      piProcess.stdout.on('data', (data) => {
+        stdoutLineBuffer += data.toString();
+        const completeLines = stdoutLineBuffer.split(/\r?\n/);
+        stdoutLineBuffer = completeLines.pop() || '';
+
+        completeLines.forEach((line) => {
+          processPiOutputLine(line.trim(), processCtx);
+        });
+      });
+
+      piProcess.stderr.on('data', (data) => {
+        const stderrText = data.toString();
+        if (!stderrText.trim()) {
+          return;
+        }
+
+        ws.send(createNormalizedMessage({
+          kind: 'error',
+          content: stderrText,
+          sessionId: capturedSessionId || sessionId || null,
+          provider: 'pi',
+        }));
+      });
+
+      piProcess.on('close', async (code) => {
+        const finalSessionId = sessionId || capturedSessionId || processKey;
+        activePiProcesses.delete(finalSessionId);
+        activePiProcesses.delete(processKey);
+
+        if (stdoutLineBuffer.trim()) {
+          processPiOutputLine(stdoutLineBuffer.trim(), processCtx);
+          stdoutLineBuffer = '';
+        }
+
+        // pi reports cumulative usage on every event; the last one seen is
+        // the run's final accounting.
+        const tokenBudget = readPiTokenBudget(lastUsage);
+        if (tokenBudget) {
+          ws.send(createNormalizedMessage({
+            kind: 'status',
+            text: 'token_budget',
+            tokenBudget,
+            sessionId: finalSessionId,
+            provider: 'pi',
+          }));
+        }
+
+        // Terminal complete — skipped for aborted runs (abort-session
+        // already sent the aborted complete on this run's behalf).
+        if (!completeSent && !piProcess.aborted) {
+          completeSent = true;
+          ws.send(createCompleteMessage({
+            provider: 'pi',
+            sessionId: finalSessionId,
+            actualSessionId: capturedSessionId || null,
+            exitCode: code,
+          }));
+        }
+
+        if (code === 0) {
+          notifyTerminalState({ code });
+          resolve();
+          return;
+        }
+
+        if (code === 127 || code === null) {
+          const installed = await context.isProviderInstalled();
+          if (!installed) {
+            ws.send(createNormalizedMessage({
+              kind: 'error',
+              content: 'Pi CLI is not installed. Install it from https://pi.dev/',
+              sessionId: finalSessionId,
+              provider: 'pi',
+            }));
+          }
+        }
+
+        notifyTerminalState({ code });
+        reject(new Error(code === null ? 'pi process was terminated' : `pi exited with code ${code}`));
+      });
+
+      piProcess.on('error', async (error) => {
+        const finalSessionId = sessionId || capturedSessionId || processKey;
+        activePiProcesses.delete(finalSessionId);
+        activePiProcesses.delete(processKey);
+
+        const installed = await context.isProviderInstalled();
+        const notInstalled = error.code === 'ENOENT' && !installed;
+        const errorContent = !installed
+          ? 'Pi CLI is not installed. Install it from https://pi.dev/'
+          : error.message;
+
+        ws.send(createNormalizedMessage({
+          kind: 'error',
+          content: errorContent,
+          sessionId: finalSessionId,
+          provider: 'pi',
+        }));
+        if (!completeSent && !piProcess.aborted) {
+          completeSent = true;
+          ws.send(createCompleteMessage({ provider: 'pi', sessionId: finalSessionId, exitCode: 1 }));
+        }
+        notifyTerminalState({ error });
+        if (notInstalled) {
+          reject(new AppError('Pi CLI is not installed. Install it from https://pi.dev/', {
+            code: 'PROVIDER_NOT_INSTALLED',
+          }));
+          return;
+        }
+        reject(error);
+      });
+    }).catch(reject);
+  });
+}
+
+function abortPiSession(sessionId) {
+  const process = activePiProcesses.get(sessionId);
+  if (!process) {
+    return false;
+  }
+
+  // The abort handler sends the terminal complete (aborted: true); flag the
+  // process so its close handler does not emit a second one.
+  process.aborted = true;
+  process.kill('SIGTERM');
+  activePiProcesses.delete(sessionId);
+  return true;
+}
+
+function isPiSessionActive(sessionId) {
+  return activePiProcesses.has(sessionId);
+}
+
+function getActivePiSessions() {
+  return Array.from(activePiProcesses.keys());
+}
+
+export const piRuntime = {
+  run: spawnPi,
+  abort: abortPiSession,
+};
+
+export {
+  spawnPi,
+  abortPiSession,
+  isPiSessionActive,
+  getActivePiSessions,
+};

--- a/server/modules/providers/list/pi/pi-runtime.provider.test.js
+++ b/server/modules/providers/list/pi/pi-runtime.provider.test.js
@@ -14,33 +14,16 @@ import {
   piRuntime,
   processPiOutputLine,
 } from './pi-runtime.provider.js';
+import { mapPiEventToMessages } from './pi-sessions.provider.js';
 
 // The runtime contract only cares that normalizeMessage maps one raw pi event
-// onto zero or more normalized messages; the real mapping is Task 6's
-// `mapPiEventToMessages`. This inline stub is the smallest mapping that lets
-// the runtime tests observe a live stream delta.
-const piNormalizeStub = (raw, sessionId) => {
-  if (
-    raw
-    && typeof raw === 'object'
-    && raw.type === 'message_update'
-    && raw.assistantMessageEvent?.type === 'text_delta'
-  ) {
-    return [{
-      kind: 'stream_delta',
-      content: raw.assistantMessageEvent.delta,
-      sessionId,
-      provider: 'pi',
-    }];
-  }
-  return [];
-};
-
+// onto zero or more normalized messages, so the context wires the sessions
+// facet's real mapping — the same one the live provider registry serves.
 const makeRuntimeContext = (overrides = {}) => ({
   resolveProviderSessionId: (sessionId) => sessionId || null,
   resolveResumeModel: async (_sessionId, requestedModel) => requestedModel || undefined,
   getProviderModels: async () => ({ OPTIONS: [], DEFAULT: '' }),
-  normalizeMessage: (raw, sessionId) => piNormalizeStub(raw, sessionId),
+  normalizeMessage: (raw, sessionId) => mapPiEventToMessages(raw, sessionId),
   isProviderInstalled: async () => true,
   ...overrides,
 });
@@ -360,7 +343,7 @@ test('processPiOutputLine forwards non-JSON lines as stream deltas', () => {
     setCapturedSessionId: () => {},
     setUsage: () => {},
     registerSession: () => {},
-    normalizeMessage: piNormalizeStub,
+    normalizeMessage: mapPiEventToMessages,
   });
 
   assert.equal(messages.length, 1);

--- a/server/modules/providers/list/pi/pi-runtime.provider.test.js
+++ b/server/modules/providers/list/pi/pi-runtime.provider.test.js
@@ -1,0 +1,440 @@
+import assert from 'node:assert/strict';
+import { chmod, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+
+import { AppError } from '@/shared/utils.js';
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+import {
+  abortPiSession,
+  buildPiArgs,
+  piRuntime,
+  processPiOutputLine,
+} from './pi-runtime.provider.js';
+
+// The runtime contract only cares that normalizeMessage maps one raw pi event
+// onto zero or more normalized messages; the real mapping is Task 6's
+// `mapPiEventToMessages`. This inline stub is the smallest mapping that lets
+// the runtime tests observe a live stream delta.
+const piNormalizeStub = (raw, sessionId) => {
+  if (
+    raw
+    && typeof raw === 'object'
+    && raw.type === 'message_update'
+    && raw.assistantMessageEvent?.type === 'text_delta'
+  ) {
+    return [{
+      kind: 'stream_delta',
+      content: raw.assistantMessageEvent.delta,
+      sessionId,
+      provider: 'pi',
+    }];
+  }
+  return [];
+};
+
+const makeRuntimeContext = (overrides = {}) => ({
+  resolveProviderSessionId: (sessionId) => sessionId || null,
+  resolveResumeModel: async (_sessionId, requestedModel) => requestedModel || undefined,
+  getProviderModels: async () => ({ OPTIONS: [], DEFAULT: '' }),
+  normalizeMessage: (raw, sessionId) => piNormalizeStub(raw, sessionId),
+  isProviderInstalled: async () => true,
+  ...overrides,
+});
+
+// Fake event stream copied from the recorded `pi -p --mode json` transcript in
+// docs/pi-notes.md (pi 0.85.1). Field shapes are the protocol facts that both
+// the runtime and Task 6's normalizer build on.
+const FAKE_SESSION_ID = '0198c0de-7a5b-7f3e-9a1c-3d2e4f5a6b7c';
+const FINAL_USAGE = {
+  input: 1474,
+  output: 18,
+  cacheRead: 128,
+  cacheWrite: 0,
+  totalTokens: 1620,
+  cost: { input: 0.001, output: 0.002, total: 0.003 },
+};
+const FAKE_EVENTS = [
+  {
+    type: 'session',
+    version: 3,
+    id: FAKE_SESSION_ID,
+    timestamp: '2026-09-12T13:52:05.003Z',
+    cwd: process.cwd(),
+  },
+  { type: 'agent_start' },
+  { type: 'turn_start' },
+  {
+    type: 'message_start',
+    message: { role: 'user', content: [{ type: 'text', text: 'Say hi' }] },
+  },
+  {
+    type: 'message_end',
+    message: { role: 'user', content: [{ type: 'text', text: 'Say hi' }] },
+  },
+  {
+    type: 'message_start',
+    message: {
+      role: 'assistant',
+      content: [{ type: 'text', text: '', stopReason: 'pending' }],
+    },
+  },
+  {
+    type: 'message_update',
+    usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, totalTokens: 0 },
+    assistantMessageEvent: { type: 'text_delta', contentIndex: 0, delta: 'Hello' },
+  },
+  {
+    type: 'message_update',
+    usage: FINAL_USAGE,
+    assistantMessageEvent: { type: 'text_delta', contentIndex: 0, delta: ' world' },
+  },
+  {
+    type: 'message_end',
+    message: {
+      role: 'assistant',
+      content: [{ type: 'text', text: 'Hello world' }],
+      stopReason: 'stop',
+      usage: FINAL_USAGE,
+    },
+  },
+  { type: 'turn_end' },
+  { type: 'agent_end', messages: [] },
+  { type: 'agent_settled' },
+];
+
+const findEnvKey = (name) =>
+  Object.keys(process.env).find((key) => key.toLowerCase() === name.toLowerCase()) || name;
+
+async function writeFakePi(binDir, { mode = 'replay' } = {}) {
+  const scriptPath = path.join(binDir, 'pi.js');
+  await writeFile(scriptPath, `
+const fs = require('node:fs');
+const capturePath = process.env.PI_ARGS_CAPTURE;
+const args = process.argv.slice(2);
+if (capturePath) {
+  fs.writeFileSync(capturePath, JSON.stringify(args));
+}
+
+// Resume runs keep the same session id, so the fake echoes the requested
+// --session value back in the header; new runs mint a fixed one.
+const sessionFlagIndex = args.indexOf('--session');
+const headerId = sessionFlagIndex >= 0 ? args[sessionFlagIndex + 1] : ${JSON.stringify(FAKE_SESSION_ID)};
+const header = JSON.stringify({
+  type: 'session',
+  version: 3,
+  id: headerId,
+  timestamp: '2026-09-12T13:52:05.003Z',
+  cwd: process.cwd(),
+});
+
+const mode = process.env.PI_EVENT_MODE || '${mode}';
+if (mode === 'hang') {
+  console.log(header);
+  // Long-running turn: no further output, process stays alive until killed.
+  setTimeout(() => {}, 30_000);
+} else if (mode === 'garbage') {
+  console.log('pi: warning: partially written line');
+} else if (mode === 'model-error') {
+  // pi exits 0 even when the model call failed; the error only shows up as
+  // stopReason/errorMessage on the assistant message (docs/pi-notes.md).
+  console.log(header);
+  console.log(JSON.stringify({ type: 'agent_start' }));
+  console.log(JSON.stringify({
+    type: 'message_start',
+    message: { role: 'assistant', content: [{ type: 'text', text: '', stopReason: 'pending' }] },
+  }));
+  console.log(JSON.stringify({
+    type: 'message_end',
+    message: { role: 'assistant', content: [{ type: 'text', text: '' }], stopReason: 'error', errorMessage: '403 {"error":"forbidden"}' },
+  }));
+  console.log(JSON.stringify({ type: 'agent_end', messages: [], willRetry: false }));
+  console.log(JSON.stringify({ type: 'agent_settled' }));
+} else {
+  const events = ${JSON.stringify(FAKE_EVENTS)}.map((event) => JSON.stringify(event));
+  console.log([header].concat(events.slice(1)).join('\\n'));
+}
+`, 'utf8');
+
+  if (process.platform === 'win32') {
+    const commandPath = path.join(binDir, 'pi.cmd');
+    await writeFile(commandPath, '@echo off\r\nnode "%~dp0pi.js" %*\r\n', 'utf8');
+    return;
+  }
+
+  const commandPath = path.join(binDir, 'pi');
+  await writeFile(commandPath, '#!/bin/sh\nnode "$(dirname "$0")/pi.js" "$@"\n', 'utf8');
+  await chmod(commandPath, 0o755);
+}
+
+function createWriter(messages) {
+  return {
+    userId: null,
+    sessionId: null,
+    setSessionIdCalls: 0,
+    send(message) {
+      messages.push(message);
+    },
+    setSessionId(sessionId) {
+      this.setSessionIdCalls += 1;
+      this.sessionId = sessionId;
+    },
+  };
+}
+
+async function withFakePiOnPath(mode, fn) {
+  const tempRoot = await mkdtemp(path.join(os.tmpdir(), 'pi-cli-'));
+  const pathKey = findEnvKey('PATH');
+  const pathExtKey = findEnvKey('PATHEXT');
+  const previousPath = process.env[pathKey];
+  const previousPathExt = process.env[pathExtKey];
+  const previousArgsCapture = process.env.PI_ARGS_CAPTURE;
+  const previousMode = process.env.PI_EVENT_MODE;
+
+  try {
+    if (mode !== 'missing') {
+      await writeFakePi(tempRoot, { mode });
+    }
+    // "missing" swaps PATH for an empty dir: prepending would still resolve a
+    // real `pi` installed further down PATH, and the ENOENT contract needs the
+    // lookup to actually fail.
+    process.env[pathKey] = mode === 'missing'
+      ? tempRoot
+      : `${tempRoot}${path.delimiter}${previousPath || ''}`;
+    process.env.PI_EVENT_MODE = mode;
+    if (process.platform === 'win32') {
+      process.env[pathExtKey] = previousPathExt?.toUpperCase().includes('.CMD')
+        ? previousPathExt
+        : `.COM;.EXE;.BAT;.CMD${previousPathExt ? `;${previousPathExt}` : ''}`;
+    }
+    return await fn(tempRoot);
+  } finally {
+    if (previousPath === undefined) {
+      delete process.env[pathKey];
+    } else {
+      process.env[pathKey] = previousPath;
+    }
+
+    if (previousPathExt === undefined) {
+      delete process.env[pathExtKey];
+    } else {
+      process.env[pathExtKey] = previousPathExt;
+    }
+
+    if (previousArgsCapture === undefined) {
+      delete process.env.PI_ARGS_CAPTURE;
+    } else {
+      process.env.PI_ARGS_CAPTURE = previousArgsCapture;
+    }
+
+    if (previousMode === undefined) {
+      delete process.env.PI_EVENT_MODE;
+    } else {
+      process.env.PI_EVENT_MODE = previousMode;
+    }
+
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+}
+
+test('buildPiArgs maps options onto the pi print/json invocation', () => {
+  assert.deepEqual(
+    buildPiArgs({ providerSessionId: 'abc', model: 'anthropic/claude-sonnet-4', prompt: 'hi' }),
+    ['-p', '--mode', 'json', '--session', 'abc', '--model', 'anthropic/claude-sonnet-4', 'hi'],
+  );
+  assert.deepEqual(buildPiArgs({ prompt: 'hi' }), ['-p', '--mode', 'json', 'hi']);
+  // Attachment-only runs send no positional prompt at all.
+  assert.deepEqual(buildPiArgs({}), ['-p', '--mode', 'json']);
+});
+
+test('spawnPi emits session_created, stream deltas and exactly one terminal complete', async () => {
+  const messages = [];
+  let argsCapturePath = '';
+  await withFakePiOnPath('replay', async (tempRoot) => {
+    argsCapturePath = path.join(tempRoot, 'pi-args.json');
+    process.env.PI_ARGS_CAPTURE = argsCapturePath;
+    const writer = createWriter(messages);
+    // pi has no permission system: permissionMode/effort must be ignored.
+    await piRuntime.run(
+      'Say hi',
+      { sessionId: 'app-1', cwd: tempRoot, permissionMode: 'bypassPermissions', effort: 'high' },
+      writer,
+      makeRuntimeContext({ resolveProviderSessionId: () => null }),
+    );
+
+    const kinds = messages.map((message) => message.kind);
+    const complete = messages.find((message) => message.kind === 'complete');
+
+    assert.equal(messages[0].kind, 'session_created');
+    assert.equal(messages[0].newSessionId, FAKE_SESSION_ID);
+    assert.equal(writer.setSessionIdCalls, 1);
+    assert.equal(writer.sessionId, FAKE_SESSION_ID);
+
+    const sessionCreatedIndex = kinds.indexOf('session_created');
+    const firstDeltaIndex = kinds.indexOf('stream_delta');
+    assert.ok(firstDeltaIndex > sessionCreatedIndex);
+    assert.deepEqual(
+      messages.filter((message) => message.kind === 'stream_delta').map((message) => message.content),
+      ['Hello', ' world'],
+    );
+
+    // Exactly one terminal complete, and it closes the run.
+    assert.equal(kinds.filter((kind) => kind === 'complete').length, 1);
+    assert.equal(messages.at(-1).kind, 'complete');
+    assert.equal(complete?.success, true);
+    assert.equal(complete?.aborted, false);
+    assert.equal(complete?.actualSessionId, FAKE_SESSION_ID);
+    assert.equal(messages.some((message) => message.kind === 'error'), false);
+
+    // Last recorded usage (from message_update) feeds the token budget before complete.
+    const tokenBudgetIndex = kinds.indexOf('status');
+    assert.ok(tokenBudgetIndex > -1 && tokenBudgetIndex < kinds.indexOf('complete'));
+    const tokenBudgetMessage = messages[tokenBudgetIndex];
+    assert.equal(tokenBudgetMessage.text, 'token_budget');
+    assert.equal(tokenBudgetMessage.tokenBudget.used, FINAL_USAGE.totalTokens);
+    assert.equal(tokenBudgetMessage.tokenBudget.inputTokens, FINAL_USAGE.input + FINAL_USAGE.cacheRead);
+    assert.equal(tokenBudgetMessage.tokenBudget.outputTokens, FINAL_USAGE.output);
+    assert.equal(tokenBudgetMessage.tokenBudget.cost, FINAL_USAGE.cost.total);
+
+    const launchedArgs = JSON.parse(await readFile(argsCapturePath, 'utf8'));
+    assert.deepEqual(launchedArgs.slice(0, 3), ['-p', '--mode', 'json']);
+    // pi has no --dir flag; the working directory is the spawn cwd option.
+    assert.equal(launchedArgs.includes('--dir'), false);
+    // pi has no permission/effort levers: those options map to no flag at all.
+    assert.equal(launchedArgs.includes('--auto'), false);
+    assert.equal(launchedArgs.includes('--agent'), false);
+    assert.equal(launchedArgs.includes('--variant'), false);
+    assert.equal(launchedArgs.at(-1), 'Say hi');
+  });
+});
+
+test('spawnPi resumes with --session and does not re-announce an existing session', async () => {
+  const messages = [];
+  await withFakePiOnPath('replay', async (tempRoot) => {
+    const argsCapturePath = path.join(tempRoot, 'pi-resume-args.json');
+    process.env.PI_ARGS_CAPTURE = argsCapturePath;
+    const writer = createWriter(messages);
+
+    await piRuntime.run(
+      'Continue',
+      { sessionId: 'app-1', cwd: tempRoot },
+      writer,
+      makeRuntimeContext({ resolveProviderSessionId: () => 'existing-session' }),
+    );
+
+    assert.equal(messages.some((message) => message.kind === 'session_created'), false);
+    assert.equal(writer.setSessionIdCalls, 0);
+    assert.equal(messages.filter((message) => message.kind === 'complete').length, 1);
+
+    const launchedArgs = JSON.parse(await readFile(argsCapturePath, 'utf8'));
+    const sessionIndex = launchedArgs.indexOf('--session');
+    assert.ok(sessionIndex > -1);
+    assert.equal(launchedArgs[sessionIndex + 1], 'existing-session');
+  });
+});
+
+test('spawnPi resolves successfully when the model errored but pi exited 0', async () => {
+  const messages = [];
+  await withFakePiOnPath('model-error', async (tempRoot) => {
+    const writer = createWriter(messages);
+    await piRuntime.run('Say hi', { sessionId: 'app-1', cwd: tempRoot }, writer, makeRuntimeContext());
+
+    // Exit code 0 is not success evidence for pi, but the runtime treats the
+    // process lifecycle only; error mapping belongs to normalizeMessage.
+    assert.equal(messages.filter((message) => message.kind === 'complete').length, 1);
+    assert.equal(messages.at(-1).kind, 'complete');
+    assert.equal(messages.at(-1).success, true);
+  });
+});
+
+test('processPiOutputLine forwards non-JSON lines as stream deltas', () => {
+  const messages = [];
+  const writer = createWriter(messages);
+  processPiOutputLine('pi: warning: partially written line', {
+    ws: writer,
+    sessionId: 'app-1',
+    getCapturedSessionId: () => null,
+    setCapturedSessionId: () => {},
+    setUsage: () => {},
+    registerSession: () => {},
+    normalizeMessage: piNormalizeStub,
+  });
+
+  assert.equal(messages.length, 1);
+  assert.equal(messages[0].kind, 'stream_delta');
+  assert.equal(messages[0].content, 'pi: warning: partially written line');
+  assert.equal(messages[0].sessionId, 'app-1');
+});
+
+test('spawnPi keeps stdout non-JSON lines streaming and still completes once', async () => {
+  const messages = [];
+  await withFakePiOnPath('garbage', async (tempRoot) => {
+    const writer = createWriter(messages);
+    await piRuntime.run('Say hi', { sessionId: 'app-1', cwd: tempRoot }, writer, makeRuntimeContext());
+
+    assert.deepEqual(
+      messages.filter((message) => message.kind === 'stream_delta').map((message) => message.content),
+      ['pi: warning: partially written line'],
+    );
+    assert.equal(messages.filter((message) => message.kind === 'complete').length, 1);
+  });
+});
+
+test('abortPiSession kills the run, suppresses the runtime complete and rejects once', async () => {
+  const messages = [];
+  await withFakePiOnPath('hang', async (tempRoot) => {
+    const writer = createWriter(messages);
+    const runPromise = piRuntime.run('Say hi', { sessionId: 'app-abort', cwd: tempRoot }, writer, makeRuntimeContext());
+    // The gateway rejects the run promise too; swallow it until assert.rejects.
+    let rejection = null;
+    runPromise.catch((error) => {
+      rejection = error;
+    });
+
+    // Poll until the child is registered in the process table, then abort.
+    let aborted = false;
+    for (let attempt = 0; attempt < 100 && !aborted; attempt += 1) {
+      aborted = abortPiSession('app-abort');
+      if (!aborted) {
+        await sleep(50);
+      }
+    }
+    assert.equal(aborted, true);
+    // A second abort finds nothing running.
+    assert.equal(abortPiSession('app-abort'), false);
+
+    await assert.rejects(runPromise, /terminated|exited with code/);
+    assert.ok(rejection instanceof Error);
+
+    // The gateway (`chatRunRegistry.completeRun`) owns the single aborted
+    // `complete` for cancelled runs; the runtime itself must stay silent here
+    // or clients would see the run finish twice.
+    assert.equal(messages.some((message) => message.kind === 'complete'), false);
+  });
+});
+
+test('spawnPi rejects PROVIDER_NOT_INSTALLED when the CLI is missing', async () => {
+  const messages = [];
+  await withFakePiOnPath('missing', async (tempRoot) => {
+    const writer = createWriter(messages);
+    await assert.rejects(
+      piRuntime.run('Say hi', { sessionId: 'app-1', cwd: tempRoot }, writer, makeRuntimeContext({
+        isProviderInstalled: async () => false,
+      })),
+      (error) => {
+        assert.ok(error instanceof AppError);
+        assert.equal(error.code, 'PROVIDER_NOT_INSTALLED');
+        assert.match(error.message, /Pi CLI is not installed/);
+        return true;
+      },
+    );
+
+    assert.equal(messages.filter((message) => message.kind === 'error').length, 1);
+    const completes = messages.filter((message) => message.kind === 'complete');
+    assert.equal(completes.length, 1);
+    assert.equal(completes[0].success, false);
+  });
+});

--- a/server/modules/providers/list/pi/pi-session-synchronizer.provider.ts
+++ b/server/modules/providers/list/pi/pi-session-synchronizer.provider.ts
@@ -1,0 +1,18 @@
+import type { IProviderSessionSynchronizer } from '@/shared/interfaces.js';
+
+/**
+ * Phase 1 synchronizer placeholder for Pi.
+ *
+ * Reporting zero processed sessions keeps the shared scan cursor advancing
+ * while Pi has no on-disk indexer yet; the JSONL scanner under
+ * `getPiSessionDir()` replaces both methods.
+ */
+export class PiSessionSynchronizer implements IProviderSessionSynchronizer {
+  async synchronize(): Promise<number> {
+    return 0;
+  }
+
+  async synchronizeFile(): Promise<string | null> {
+    return null;
+  }
+}

--- a/server/modules/providers/list/pi/pi-session-synchronizer.provider.ts
+++ b/server/modules/providers/list/pi/pi-session-synchronizer.provider.ts
@@ -1,18 +1,255 @@
+import fsSync from 'node:fs';
+import path from 'node:path';
+
+import { sessionsDb } from '@/modules/database/index.js';
 import type { IProviderSessionSynchronizer } from '@/shared/interfaces.js';
+import type { AnyRecord } from '@/shared/types.js';
+import {
+  getPiSessionDir,
+  normalizeProviderTimestamp,
+  normalizeSessionName,
+  readOptionalString,
+} from '@/shared/utils.js';
+
+import { normalizeTranscriptEntry, readPiTranscriptEntries } from './pi-sessions.provider.js';
+
+const PROVIDER = 'pi';
+const FALLBACK_TITLE = 'Untitled pi Session';
+
+type PiSessionHeader = {
+  providerSessionId: string;
+  projectPath: string;
+  createdAt: string;
+};
+
+type PiSessionTranscript = {
+  path: string;
+  /** File mtime, ISO-normalized: pi appends resumes, so this is last activity. */
+  updatedAt: string;
+};
 
 /**
- * Phase 1 synchronizer placeholder for Pi.
+ * Extracts the `session` header entry every pi transcript starts with.
  *
- * Reporting zero processed sessions keeps the shared scan cursor advancing
- * while Pi has no on-disk indexer yet; the JSONL scanner under
- * `getPiSessionDir()` replaces both methods.
+ * Verified layout (docs/pi-notes.md, pi 0.85.1): the first line carries the
+ * provider-native session id and the working directory the session ran in —
+ * the only two values the sidebar needs to place the session.
  */
-export class PiSessionSynchronizer implements IProviderSessionSynchronizer {
-  async synchronize(): Promise<number> {
-    return 0;
+const readPiSessionHeader = (entries: AnyRecord[]): PiSessionHeader | null => {
+  for (const entry of entries) {
+    if (readOptionalString(entry.type) !== 'session') {
+      continue;
+    }
+
+    const providerSessionId = readOptionalString(entry.id);
+    const projectPath = readOptionalString(entry.cwd);
+    if (!providerSessionId || !projectPath) {
+      return null;
+    }
+
+    return {
+      providerSessionId,
+      projectPath,
+      createdAt: normalizeProviderTimestamp(entry.timestamp),
+    };
   }
 
-  async synchronizeFile(): Promise<string | null> {
-    return null;
+  return null;
+};
+
+/**
+ * Derives a sidebar title from one parsed transcript.
+ *
+ * An explicit `session_info` name wins when pi records one (not present in the
+ * 0.85.1 samples, so treated as optional); otherwise the first user prompt is
+ * used, read through the same normalizer the history view renders so
+ * `<images_input>`/`<files_input>` scaffolding never leaks into the title.
+ */
+const readPiSessionTitle = (entries: AnyRecord[]): string | undefined => {
+  for (const entry of entries) {
+    if (readOptionalString(entry.type) !== 'session_info') {
+      continue;
+    }
+
+    const name = readOptionalString(entry.name);
+    if (name) {
+      return name;
+    }
+  }
+
+  for (const entry of entries) {
+    const userText = normalizeTranscriptEntry(entry, null)
+      .find((message) => message.kind === 'text' && message.role === 'user')
+      ?.content;
+    if (userText) {
+      return userText;
+    }
+  }
+
+  return undefined;
+};
+
+/**
+ * Session indexer for pi's JSONL transcripts under `~/.pi/agent/sessions`.
+ */
+export class PiSessionSynchronizer implements IProviderSessionSynchronizer {
+  private readonly provider = PROVIDER;
+
+  /**
+   * Recursively scans the pi session directory and upserts every transcript
+   * modified since the given cursor into DB.
+   */
+  async synchronize(since?: Date): Promise<number> {
+    const transcripts = this.listSessionTranscripts(since);
+
+    let processed = 0;
+    for (const transcript of transcripts) {
+      if (this.upsertSession(transcript)) {
+        processed += 1;
+      }
+    }
+
+    return processed;
+  }
+
+  /**
+   * Handles watcher changes for one pi session transcript.
+   */
+  async synchronizeFile(filePath: string): Promise<string | null> {
+    if (!this.isPiSessionTranscript(filePath)) {
+      return null;
+    }
+
+    const transcript = this.readTranscriptTimestamp(filePath);
+    if (!transcript) {
+      return null;
+    }
+
+    return this.upsertSession(transcript);
+  }
+
+  /**
+   * Lists `.jsonl` transcripts under the pi session directory, recursively.
+   *
+   * The `since` cursor filters on mtime: pi appends resumed turns to the same
+   * file, so an updated mtime is what makes an existing session re-index.
+   */
+  private listSessionTranscripts(since?: Date): PiSessionTranscript[] {
+    const transcripts: PiSessionTranscript[] = [];
+    const walk = (directory: string): void => {
+      let entries: fsSync.Dirent[];
+      try {
+        entries = fsSync.readdirSync(directory, { withFileTypes: true });
+      } catch {
+        // A missing pi data directory just means "no sessions yet".
+        return;
+      }
+
+      for (const entry of entries) {
+        const entryPath = path.join(directory, entry.name);
+        if (entry.isDirectory()) {
+          walk(entryPath);
+        } else if (entry.name.endsWith('.jsonl')) {
+          const transcript = this.readTranscriptTimestamp(entryPath);
+          if (!transcript) {
+            continue;
+          }
+          if (since && new Date(transcript.updatedAt).getTime() < since.getTime()) {
+            continue;
+          }
+          transcripts.push(transcript);
+        }
+      }
+    };
+
+    walk(getPiSessionDir());
+    // File names lead with a timestamp, so lexical order is chronological and
+    // sidebar upserts land oldest-first.
+    return transcripts.sort((a, b) => a.path.localeCompare(b.path));
+  }
+
+  /** Reads one transcript's mtime as its last-activity timestamp. */
+  private readTranscriptTimestamp(filePath: string): PiSessionTranscript | null {
+    try {
+      return {
+        path: filePath,
+        updatedAt: normalizeProviderTimestamp(fsSync.statSync(filePath).mtimeMs),
+      };
+    } catch {
+      // The file may have been removed between listing and reading.
+      return null;
+    }
+  }
+
+  /**
+   * Only transcripts inside the pi session directory are pi sessions.
+   *
+   * The watcher hands this synchronizer every `.jsonl` change under the pi
+   * root; anything else (opencode's sqlite store, stray files) is ignored.
+   */
+  private isPiSessionTranscript(filePath: string): boolean {
+    if (!filePath.endsWith('.jsonl')) {
+      return false;
+    }
+
+    const relative = path.relative(getPiSessionDir(), filePath);
+    return relative !== '' && !relative.startsWith('..') && !path.isAbsolute(relative);
+  }
+
+  /**
+   * Parses and upserts one pi transcript, returning the canonical session row
+   * id, or null when the file carries no usable session header.
+   */
+  private upsertSession(transcript: PiSessionTranscript): string | null {
+    let entries: AnyRecord[];
+    try {
+      entries = readPiTranscriptEntries(transcript.path);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      console.warn(`[PiProvider] Failed to read session transcript ${transcript.path}:`, message);
+      return null;
+    }
+
+    const header = readPiSessionHeader(entries);
+    if (!header) {
+      return null;
+    }
+
+    const pendingAppSession = sessionsDb.getSessionByProviderSessionId(header.providerSessionId)
+      ?? sessionsDb.getSessionById(header.providerSessionId)
+      ?? sessionsDb.findLatestPendingAppSession(this.provider, header.projectPath);
+    if (pendingAppSession && !pendingAppSession.provider_session_id) {
+      // Slow model responses can let the watcher index the transcript before
+      // the runtime reports its provider id back through the websocket
+      // mapping. Bind that id to the fresh app row first so the watcher does
+      // not create a temporary provider-id sidebar entry for the same session.
+      sessionsDb.assignProviderSessionId(pendingAppSession.session_id, header.providerSessionId);
+    }
+
+    // App-created sessions are keyed by an app id, so disk-discovered provider
+    // ids must be resolved through the provider-id mapping first.
+    const existingSession = sessionsDb.getSessionByProviderSessionId(header.providerSessionId)
+      ?? sessionsDb.getSessionById(header.providerSessionId);
+    const existingName = existingSession?.custom_name;
+
+    let nextName: string | undefined;
+    if (existingName && existingName !== FALLBACK_TITLE) {
+      nextName = existingName;
+    } else {
+      nextName = readPiSessionTitle(entries);
+    }
+
+    // pi keeps every session of a working directory in one shared tree, so
+    // jsonl_path must stay null to avoid deleting that folder when one app
+    // session is removed.
+    return sessionsDb.createSession(
+      header.providerSessionId,
+      this.provider,
+      header.projectPath,
+      normalizeSessionName(nextName, FALLBACK_TITLE),
+      header.createdAt,
+      transcript.updatedAt,
+      null,
+    );
   }
 }

--- a/server/modules/providers/list/pi/pi-sessions.provider.test.ts
+++ b/server/modules/providers/list/pi/pi-sessions.provider.test.ts
@@ -94,6 +94,9 @@ test('mapPiEventToMessages maps pi stream events onto normalized messages', () =
   );
   assert.deepEqual(kinds(toolResult), ['tool_result']);
   assert.equal(toolResult[0]?.toolId, 'c1');
+  // The transcript renderer reads the top-level `content` string; without it
+  // the client's formatToolResultContent crashes on `.trim()`.
+  assert.equal(toolResult[0]?.content, 'a\nb');
   assert.deepEqual(toolResult[0]?.toolResult, { content: 'a\nb', isError: false });
 
   // Streaming partial results only exist for live progress; the transcript
@@ -311,6 +314,9 @@ test('fetchHistory reads a pi session jsonl with attachments, tool calls and tok
 
     assert.equal(toolResult?.kind, 'tool_result');
     assert.equal(toolResult?.toolId, 'call_1');
+    // Top-level `content` mirrors claude's tool_result shape; the client
+    // transcript reads it directly and crashes on undefined without it.
+    assert.equal(toolResult?.content, 'a.txt\nb.txt');
     assert.deepEqual(toolResult?.toolResult, { content: 'a.txt\nb.txt', isError: false });
 
     assert.equal(finalText?.content, 'Two files found.');

--- a/server/modules/providers/list/pi/pi-sessions.provider.test.ts
+++ b/server/modules/providers/list/pi/pi-sessions.provider.test.ts
@@ -1,0 +1,360 @@
+import assert from 'node:assert/strict';
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+
+import type { NormalizedMessage } from '@/shared/types.js';
+
+import { mapPiEventToMessages, PiSessionsProvider } from './pi-sessions.provider.js';
+
+const kinds = (messages: NormalizedMessage[]) => messages.map((message) => message.kind);
+
+test('mapPiEventToMessages maps pi stream events onto normalized messages', () => {
+  const delta = mapPiEventToMessages(
+    { type: 'message_update', assistantMessageEvent: { type: 'text_delta', contentIndex: 0, delta: 'Hi' } },
+    's1',
+  );
+  assert.deepEqual(kinds(delta), ['stream_delta']);
+  assert.equal(delta[0]?.content, 'Hi');
+  assert.equal(delta[0]?.sessionId, 's1');
+  assert.equal(delta[0]?.provider, 'pi');
+
+  const thinking = mapPiEventToMessages(
+    { type: 'message_update', assistantMessageEvent: { type: 'thinking_delta', contentIndex: 0, delta: 'hmm' } },
+    's1',
+  );
+  assert.deepEqual(kinds(thinking), ['thinking']);
+  assert.equal(thinking[0]?.content, 'hmm');
+
+  // Marker events (text_end/thinking_end) repeat what the deltas already
+  // streamed as full content; emitting them would duplicate every turn.
+  for (const eventType of [
+    'text_start',
+    'text_end',
+    'thinking_start',
+    'thinking_end',
+    'toolcall_start',
+    'toolcall_delta',
+    'toolcall_end',
+  ]) {
+    assert.deepEqual(
+      mapPiEventToMessages(
+        { type: 'message_update', assistantMessageEvent: { type: eventType, contentIndex: 0, delta: 'x', content: 'x' } },
+        's1',
+      ),
+      [],
+      eventType,
+    );
+  }
+
+  const toolUse = mapPiEventToMessages(
+    { type: 'tool_execution_start', toolCallId: 'c1', toolName: 'bash', args: { command: 'ls' } },
+    's1',
+  );
+  assert.deepEqual(kinds(toolUse), ['tool_use']);
+  assert.equal(toolUse[0]?.toolName, 'bash');
+  assert.equal(toolUse[0]?.toolId, 'c1');
+  assert.deepEqual(toolUse[0]?.toolInput, { command: 'ls' });
+
+  const toolResult = mapPiEventToMessages(
+    {
+      type: 'tool_execution_end',
+      toolCallId: 'c1',
+      toolName: 'bash',
+      result: { content: [{ type: 'text', text: 'a\nb' }] },
+      isError: false,
+    },
+    's1',
+  );
+  assert.deepEqual(kinds(toolResult), ['tool_result']);
+  assert.equal(toolResult[0]?.toolId, 'c1');
+  assert.deepEqual(toolResult[0]?.toolResult, { content: 'a\nb', isError: false });
+
+  // Streaming partial results only exist for live progress; the transcript
+  // draws the tool card from start/end alone.
+  assert.deepEqual(
+    mapPiEventToMessages({ type: 'tool_execution_update', toolCallId: 'c1', partialResult: { content: [] } }, 's1'),
+    [],
+  );
+
+  assert.deepEqual(
+    kinds(mapPiEventToMessages({ type: 'message_end', message: { role: 'assistant', content: [] } }, 's1')),
+    ['stream_end'],
+  );
+  // User turns were already drawn client-side as the optimistic prompt.
+  assert.deepEqual(
+    mapPiEventToMessages({ type: 'message_end', message: { role: 'user', content: [{ type: 'text', text: 'q' }] } }, 's1'),
+    [],
+  );
+  assert.deepEqual(
+    mapPiEventToMessages({ type: 'message_start', message: { role: 'assistant', content: [] } }, 's1'),
+    [],
+  );
+});
+
+test('mapPiEventToMessages maps model errors to error rows and ignores lifecycle events', () => {
+  // pi exits 0 even when the model call failed (docs/pi-notes.md), so this
+  // mapping is the only channel a 403/500 has to the UI.
+  const modelError = mapPiEventToMessages(
+    {
+      type: 'message_end',
+      message: {
+        role: 'assistant',
+        content: [{ type: 'text', text: '' }],
+        stopReason: 'error',
+        errorMessage: '403 {"error":"forbidden"}',
+      },
+    },
+    's1',
+  );
+  assert.deepEqual(kinds(modelError), ['error']);
+  assert.equal(modelError[0]?.content, '403 {"error":"forbidden"}');
+  assert.equal(modelError[0]?.isError, true);
+
+  // turn_end repeats the same failure; message_end stays the single outlet so
+  // the error is not emitted twice per run.
+  assert.deepEqual(
+    mapPiEventToMessages(
+      { type: 'turn_end', message: { role: 'assistant', content: [], stopReason: 'error', errorMessage: '403' } },
+      's1',
+    ),
+    [],
+  );
+
+  assert.deepEqual(kinds(mapPiEventToMessages({ type: 'extension_error', error: 'boom' }, 's1')), ['error']);
+
+  for (const eventType of [
+    'session',
+    'agent_start',
+    'agent_end',
+    'agent_settled',
+    'turn_start',
+    'compaction_start',
+    'compaction_end',
+    'auto_retry_start',
+    'queue_update',
+  ]) {
+    assert.deepEqual(mapPiEventToMessages({ type: eventType }, 's1'), [], eventType);
+  }
+
+  assert.deepEqual(mapPiEventToMessages('not-an-object', 's1'), []);
+  assert.deepEqual(mapPiEventToMessages(null, 's1'), []);
+});
+
+const PI_SESSION_ID = 'f47ac10b-9d3e-4c7a-8b21-5e6f7a8b9c0d';
+// pi encodes the cwd into the folder name; the reader must not depend on that
+// scheme, so the fixture uses an opaque directory name.
+const PI_SESSION_FILE = `2026-09-12T13-52-05-003Z_${PI_SESSION_ID}.jsonl`;
+
+const historyLine = (entry: Record<string, unknown>) => JSON.stringify(entry);
+
+const HISTORY_LINES = [
+  historyLine({
+    type: 'session',
+    version: 3,
+    id: PI_SESSION_ID,
+    timestamp: '2026-09-12T13:52:05.003Z',
+    cwd: '/tmp/fake-project',
+  }),
+  // pi also records model/thinking-level switches in the same file.
+  historyLine({ type: 'model_change', model: 'glm-5.3' }),
+  historyLine({ type: 'thinking_level_change', level: 'high' }),
+  historyLine({
+    type: 'message',
+    id: 'm-user',
+    parentId: null,
+    timestamp: '2026-09-12T13:52:06.000Z',
+    message: {
+      role: 'user',
+      content: [
+        {
+          type: 'text',
+          text: 'List the files\n\n<images_input>\n1. /tmp/shot.png\n</images_input>\n\n<files_input>\n1. /tmp/notes.md\n</files_input>',
+        },
+      ],
+      api: 'anthropic-messages',
+      provider: 'anthropic',
+      model: 'glm-5.3',
+      stopReason: 'stop',
+      usage: { input: 10, output: 0, cacheRead: 0, cacheWrite: 0, totalTokens: 10 },
+    },
+  }),
+  historyLine({
+    type: 'message',
+    id: 'm-asst-1',
+    parentId: 'm-user',
+    timestamp: '2026-09-12T13:52:07.000Z',
+    message: {
+      role: 'assistant',
+      content: [
+        { type: 'thinking', thinking: 'Peek at the directory first.', thinkingSignature: 'sig' },
+        { type: 'text', text: 'Running ls.' },
+        { type: 'toolCall', id: 'call_1', name: 'bash', arguments: { command: 'ls' } },
+      ],
+      api: 'anthropic-messages',
+      provider: 'anthropic',
+      model: 'glm-5.3',
+      stopReason: 'toolUse',
+      usage: { input: 100, output: 20, cacheRead: 10, cacheWrite: 5, totalTokens: 135 },
+    },
+  }),
+  historyLine({
+    type: 'message',
+    id: 'm-tool-1',
+    parentId: 'm-asst-1',
+    timestamp: '2026-09-12T13:52:08.000Z',
+    message: {
+      role: 'toolResult',
+      toolCallId: 'call_1',
+      toolName: 'bash',
+      content: [{ type: 'text', text: 'a.txt\nb.txt' }],
+      isError: false,
+      usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, totalTokens: 0 },
+    },
+  }),
+  historyLine({
+    type: 'message',
+    id: 'm-asst-2',
+    parentId: 'm-tool-1',
+    timestamp: '2026-09-12T13:52:09.000Z',
+    message: {
+      role: 'assistant',
+      content: [{ type: 'text', text: 'Two files found.' }],
+      api: 'anthropic-messages',
+      provider: 'anthropic',
+      model: 'glm-5.3',
+      stopReason: 'stop',
+      usage: { input: 150, output: 30, cacheRead: 20, cacheWrite: 0, totalTokens: 200 },
+    },
+  }),
+];
+
+const patchHomeDir = (nextHomeDir: string) => {
+  const original = os.homedir;
+  (os as any).homedir = () => nextHomeDir;
+  return () => {
+    (os as any).homedir = original;
+  };
+};
+
+async function writePiSessionFixture(homeDir: string, lines: string[]): Promise<void> {
+  const sessionDir = path.join(homeDir, '.pi', 'agent', 'sessions', '--tmp-fake-project');
+  await mkdir(sessionDir, { recursive: true });
+  await writeFile(path.join(sessionDir, PI_SESSION_FILE), `${lines.join('\n')}\n`, 'utf8');
+}
+
+async function withIsolatedPiHome(run: (homeDir: string) => Promise<void>): Promise<void> {
+  const tempRoot = await mkdtemp(path.join(os.tmpdir(), 'pi-sessions-'));
+  const restoreHomeDir = patchHomeDir(tempRoot);
+  try {
+    await run(tempRoot);
+  } finally {
+    restoreHomeDir();
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+}
+
+test('fetchHistory reads a pi session jsonl with attachments, tool calls and token usage', async () => {
+  await withIsolatedPiHome(async (homeDir) => {
+    await writePiSessionFixture(homeDir, HISTORY_LINES);
+    const provider = new PiSessionsProvider();
+    // The reader addresses the transcript by the provider-native id recorded on
+    // the session row, never by the app-facing id it was called with.
+    const history = await provider.fetchHistory('app-row', { providerSessionId: PI_SESSION_ID });
+
+    assert.equal(history.total, 6);
+    const [user, thinking, assistantText, toolUse, toolResult, finalText] = history.messages;
+
+    assert.equal(user?.kind, 'text');
+    assert.equal(user?.role, 'user');
+    assert.equal(user?.content, 'List the files');
+    assert.deepEqual(user?.images, [{ path: '/tmp/shot.png' }]);
+    assert.deepEqual(user?.files, [{ path: '/tmp/notes.md' }]);
+
+    assert.equal(thinking?.kind, 'thinking');
+    assert.equal(thinking?.content, 'Peek at the directory first.');
+
+    assert.equal(assistantText?.kind, 'text');
+    assert.equal(assistantText?.role, 'assistant');
+    assert.equal(assistantText?.content, 'Running ls.');
+
+    assert.equal(toolUse?.kind, 'tool_use');
+    assert.equal(toolUse?.toolName, 'bash');
+    assert.equal(toolUse?.toolId, 'call_1');
+    assert.deepEqual(toolUse?.toolInput, { command: 'ls' });
+
+    assert.equal(toolResult?.kind, 'tool_result');
+    assert.equal(toolResult?.toolId, 'call_1');
+    assert.deepEqual(toolResult?.toolResult, { content: 'a.txt\nb.txt', isError: false });
+
+    assert.equal(finalText?.content, 'Two files found.');
+
+    // The last assistant usage is the run's final accounting.
+    assert.deepEqual(history.tokenUsage, {
+      used: 200,
+      inputTokens: 170,
+      outputTokens: 30,
+      breakdown: { input: 170, output: 30 },
+      totalTokens: 200,
+    });
+  });
+});
+
+test('fetchHistory pages from the tail like every other provider', async () => {
+  await withIsolatedPiHome(async (homeDir) => {
+    await writePiSessionFixture(homeDir, HISTORY_LINES);
+    const provider = new PiSessionsProvider();
+
+    const page = await provider.fetchHistory('app-row', { providerSessionId: PI_SESSION_ID, limit: 2 });
+    assert.equal(page.total, 6);
+    assert.equal(page.messages.length, 2);
+    assert.deepEqual(kinds(page.messages), ['tool_result', 'text']);
+    assert.equal(page.hasMore, true);
+
+    const older = await provider.fetchHistory('app-row', { providerSessionId: PI_SESSION_ID, limit: 2, offset: 4 });
+    assert.deepEqual(older.messages.map((message) => message.content), ['List the files', 'Peek at the directory first.']);
+    assert.equal(older.hasMore, false);
+
+    // Partial ids match the transcript file name, so callers may pass the
+    // short form a user copied out of a title.
+    const byFragment = await provider.fetchHistory('f47ac10b');
+    assert.equal(byFragment.total, 6);
+  });
+});
+
+test('fetchHistory surfaces pi model errors recorded in the transcript', async () => {
+  await withIsolatedPiHome(async (homeDir) => {
+    await writePiSessionFixture(homeDir, [
+      historyLine({ type: 'session', version: 3, id: PI_SESSION_ID, timestamp: '2026-09-12T13:52:05.003Z' }),
+      historyLine({
+        type: 'message',
+        id: 'm-err',
+        parentId: null,
+        timestamp: '2026-09-12T13:52:06.000Z',
+        message: {
+          role: 'assistant',
+          content: [{ type: 'text', text: '' }],
+          stopReason: 'error',
+          errorMessage: '403 {"error":"forbidden"}',
+          usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, totalTokens: 0 },
+        },
+      }),
+    ]);
+    const provider = new PiSessionsProvider();
+    const history = await provider.fetchHistory(PI_SESSION_ID);
+
+    const errorRow = history.messages.find((message) => message.kind === 'error');
+    assert.equal(errorRow?.content, '403 {"error":"forbidden"}');
+  });
+});
+
+test('fetchHistory returns an empty page when no transcript matches', async () => {
+  await withIsolatedPiHome(async (homeDir) => {
+    await writePiSessionFixture(homeDir, HISTORY_LINES);
+    const provider = new PiSessionsProvider();
+    const history = await provider.fetchHistory('missing-session');
+
+    assert.deepEqual(history, { messages: [], total: 0, hasMore: false, offset: 0, limit: null });
+  });
+});

--- a/server/modules/providers/list/pi/pi-sessions.provider.test.ts
+++ b/server/modules/providers/list/pi/pi-sessions.provider.test.ts
@@ -20,20 +20,45 @@ test('mapPiEventToMessages maps pi stream events onto normalized messages', () =
   assert.equal(delta[0]?.sessionId, 's1');
   assert.equal(delta[0]?.provider, 'pi');
 
-  const thinking = mapPiEventToMessages(
-    { type: 'message_update', assistantMessageEvent: { type: 'thinking_delta', contentIndex: 0, delta: 'hmm' } },
+  // `thinking_delta` emits nothing: the frontend appends every non-
+  // stream_delta message verbatim, so forwarding per-token deltas would
+  // render one thinking fragment per token.
+  assert.deepEqual(
+    mapPiEventToMessages(
+      { type: 'message_update', assistantMessageEvent: { type: 'thinking_delta', contentIndex: 0, delta: 'hmm' } },
+      's1',
+    ),
+    [],
+  );
+
+  // `thinking_end` carries the full block content (docs/pi-notes.md) and is
+  // the single thinking outlet: one message per reasoning block, verbatim
+  // (no trim), so leading/trailing whitespace survives.
+  const thinkingEnd = mapPiEventToMessages(
+    { type: 'message_update', assistantMessageEvent: { type: 'thinking_end', contentIndex: 0, content: '  full reasoning\n' } },
     's1',
   );
-  assert.deepEqual(kinds(thinking), ['thinking']);
-  assert.equal(thinking[0]?.content, 'hmm');
+  assert.deepEqual(kinds(thinkingEnd), ['thinking']);
+  assert.equal(thinkingEnd[0]?.content, '  full reasoning\n');
+  assert.equal(thinkingEnd[0]?.sessionId, 's1');
+  assert.equal(thinkingEnd[0]?.provider, 'pi');
 
-  // Marker events (text_end/thinking_end) repeat what the deltas already
-  // streamed as full content; emitting them would duplicate every turn.
+  // An empty thinking block emits nothing.
+  assert.deepEqual(
+    mapPiEventToMessages(
+      { type: 'message_update', assistantMessageEvent: { type: 'thinking_end', contentIndex: 0, content: '' } },
+      's1',
+    ),
+    [],
+  );
+
+  // Remaining marker events stay silent: `text_end` would duplicate what the
+  // stream_delta channel already drew, `thinking_start` starts nothing that
+  // `thinking_end` does not carry itself.
   for (const eventType of [
     'text_start',
     'text_end',
     'thinking_start',
-    'thinking_end',
     'toolcall_start',
     'toolcall_delta',
     'toolcall_end',

--- a/server/modules/providers/list/pi/pi-sessions.provider.ts
+++ b/server/modules/providers/list/pi/pi-sessions.provider.ts
@@ -237,8 +237,13 @@ const findPiSessionTranscript = (sessionId: string): string | null => {
   return matches.sort().at(-1) ?? null;
 };
 
-/** Reads a pi JSONL transcript into parsed entries, skipping malformed lines. */
-const readPiTranscriptEntries = (transcriptPath: string): AnyRecord[] => {
+/**
+ * Reads a pi JSONL transcript into parsed entries, skipping malformed lines.
+ *
+ * Exported so the session synchronizer reuses the exact reader (torn last
+ * line tolerance included) when indexing the same transcripts into the DB.
+ */
+export const readPiTranscriptEntries = (transcriptPath: string): AnyRecord[] => {
   const entries: AnyRecord[] = [];
   const lines = fsSync.readFileSync(transcriptPath, 'utf8').split(/\r?\n/);
 
@@ -271,8 +276,11 @@ const readPiTranscriptEntries = (transcriptPath: string): AnyRecord[] => {
  * - `assistant`  → content blocks expand in order: text → `text`,
  *                  thinking → `thinking`, toolCall → `tool_use`
  * - `toolResult` → standalone `tool_result` keyed by its toolCallId
+ *
+ * Exported so the session synchronizer titles sessions from the same user-text
+ * extraction (attachment tags stripped) that history rendering uses.
  */
-const normalizeTranscriptEntry = (entry: AnyRecord, sessionId: string | null): NormalizedMessage[] => {
+export const normalizeTranscriptEntry = (entry: AnyRecord, sessionId: string | null): NormalizedMessage[] => {
   if (readOptionalString(entry.type) !== 'message') {
     return [];
   }

--- a/server/modules/providers/list/pi/pi-sessions.provider.ts
+++ b/server/modules/providers/list/pi/pi-sessions.provider.ts
@@ -1,28 +1,470 @@
+import fsSync from 'node:fs';
+import path from 'node:path';
+
+import { parseFilesInputTag, parseImagesInputTag } from '@/shared/image-attachments.js';
 import type { IProviderSessions } from '@/shared/interfaces.js';
-import type { FetchHistoryOptions, FetchHistoryResult, NormalizedMessage } from '@/shared/types.js';
+import type { AnyRecord, FetchHistoryOptions, FetchHistoryResult, NormalizedMessage } from '@/shared/types.js';
+import {
+  createNormalizedMessage,
+  generateMessageId,
+  getPiSessionDir,
+  normalizeProviderTimestamp,
+  readObjectRecord,
+  readOptionalString,
+  sliceTailPage,
+} from '@/shared/utils.js';
+
+const PROVIDER = 'pi';
 
 /**
- * Phase 1 sessions placeholder for Pi.
+ * Reads one string field verbatim when non-empty.
  *
- * Live `pi --mode json` events and JSONL transcripts are normalized by the
- * sessions facet; until then the adapter reports "no messages" so history and
- * realtime consumers degrade to an empty transcript instead of failing.
+ * Unlike `readOptionalString` this never trims: streaming deltas and tool
+ * output carry significant leading/trailing whitespace (" world", "ls\n"),
+ * which a trimmed read would silently corrupt.
  */
-export class PiSessionsProvider implements IProviderSessions {
-  normalizeMessage(): NormalizedMessage[] {
+const readVerbatimString = (value: unknown): string | undefined => {
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
+};
+
+/**
+ * Joins one tool result's content blocks into the display string every other
+ * provider carries on `toolResult.content`. pi sends `[{type:'text',text}]`
+ * blocks (probe/sample4.jsonl) but tolerates plain strings.
+ */
+const joinBlockText = (value: unknown): string => {
+  if (typeof value === 'string') {
+    return value;
+  }
+
+  if (!Array.isArray(value)) {
+    return '';
+  }
+
+  return value
+    .map((block) => readVerbatimString(readObjectRecord(block)?.text) ?? '')
+    .filter(Boolean)
+    .join('\n');
+};
+
+/**
+ * Maps pi's cumulative usage counters onto the token-usage shape opencode
+ * history returns (`used`/`inputTokens`/`outputTokens`/`breakdown`). Cache
+ * reads count as input, matching the pi runtime's token budget. pi's own
+ * `totalTokens` is kept alongside so cost-heavy consumers see the raw figure.
+ */
+const buildPiTokenUsage = (usage: AnyRecord): AnyRecord | undefined => {
+  const inputTokens = Number(usage.input ?? 0) + Number(usage.cacheRead ?? 0);
+  const outputTokens = Number(usage.output ?? 0);
+  const totalTokens = Number(usage.totalTokens ?? 0);
+  const used = totalTokens || inputTokens + outputTokens;
+  if (used <= 0) {
+    return undefined;
+  }
+
+  return {
+    used,
+    inputTokens,
+    outputTokens,
+    breakdown: {
+      input: inputTokens,
+      output: outputTokens,
+    },
+    totalTokens,
+  };
+};
+
+/**
+ * Maps one live `pi -p --mode json` event onto zero or more normalized
+ * messages. This is the real body behind the runtime's
+ * `context.normalizeMessage` callback (pi-runtime.provider.js).
+ *
+ * Event → message mapping (verified against probe/*.jsonl, pi 0.85.1):
+ * - `message_update` + `text_delta`     → `stream_delta` (content = delta)
+ * - `message_update` + `thinking_delta` → `thinking` (content = delta)
+ * - `message_update` + `*_start`/`*_end` → [] (they restate what the deltas
+ *   already streamed; emitting them would duplicate the block)
+ * - `message_update` + `toolcall_*`     → [] (tool activity is carried by the
+ *   top-level `tool_execution_*` events instead)
+ * - `tool_execution_start`              → `tool_use` (toolName/toolInput/toolId)
+ * - `tool_execution_end`                → `tool_result` (toolId + toolResult)
+ *   Deliberately NOT folded onto the `tool_use`: pi emits start and end as
+ *   separate events, so a standalone `tool_result` keyed by `toolId` is what
+ *   the transcript renderer already pairs with its `tool_use` row.
+ * - `tool_execution_update`             → [] (partial results duplicate the final one)
+ * - `message_end` (role assistant)      → `stream_end`
+ * - `message_end` carrying `stopReason: 'error'` plus `errorMessage`
+ *                                       → `error` — pi exits 0 even when the
+ *   model call failed, so this is the runtime's ONLY error signal. pi echoes
+ *   the same failed turn on `message_start`/`turn_end`; `message_end` stays
+ *   the single outlet so one failed turn surfaces exactly one error row.
+ * - `extension_error`                   → `error` (content = the error field)
+ * - `message_start`/user echoes/`turn_*`/`agent_*`/`session`/`model_change`/
+ *   `thinking_level_change`/`agent_settled` → []
+ *
+ * Exported so the runtime tests drive the exact mapping the live stream uses.
+ */
+export function mapPiEventToMessages(rawEvent: unknown, sessionId: string | null): NormalizedMessage[] {
+  const event = readObjectRecord(rawEvent);
+  if (!event) {
     return [];
   }
 
-  async fetchHistory(
-    _sessionId: string,
-    _options?: FetchHistoryOptions,
-  ): Promise<FetchHistoryResult> {
-    return {
-      messages: [],
-      total: 0,
-      hasMore: false,
-      offset: 0,
-      limit: null,
+  const type = readOptionalString(event.type);
+  const message = readObjectRecord(event.message);
+  const timestamp = normalizeProviderTimestamp(event.timestamp ?? message?.timestamp);
+  const build = (fields: { kind: NormalizedMessage['kind'] } & Record<string, unknown>): NormalizedMessage => createNormalizedMessage({
+    ...fields,
+    sessionId,
+    timestamp,
+    provider: PROVIDER,
+  });
+
+  if (type === 'message_update') {
+    const update = readObjectRecord(event.assistantMessageEvent);
+    const updateType = readOptionalString(update?.type);
+    const content = readVerbatimString(update?.delta);
+
+    if (updateType === 'text_delta' && content) {
+      return [build({ kind: 'stream_delta', content })];
+    }
+    if (updateType === 'thinking_delta' && content) {
+      return [build({ kind: 'thinking', content })];
+    }
+    return [];
+  }
+
+  if (type === 'tool_execution_start') {
+    return [build({
+      kind: 'tool_use',
+      toolName: readOptionalString(event.toolName) ?? 'Tool',
+      toolInput: event.args ?? {},
+      toolId: readOptionalString(event.toolCallId) ?? generateMessageId('tool'),
+    })];
+  }
+
+  if (type === 'tool_execution_end') {
+    const toolResult: NonNullable<NormalizedMessage['toolResult']> = {
+      content: joinBlockText(readObjectRecord(event.result)?.content ?? event.result),
     };
+    // pi reports `isError` on the end event (probe/sample4.jsonl); treat it as
+    // optional so an absent field stays undefined rather than a false claim.
+    if (event.isError !== undefined) {
+      toolResult.isError = event.isError === true;
+    }
+
+    return [build({
+      kind: 'tool_result',
+      toolId: readOptionalString(event.toolCallId),
+      toolName: readOptionalString(event.toolName),
+      toolResult,
+    })];
+  }
+
+  if (type === 'message_start' || type === 'message_end' || type === 'turn_end') {
+    // Error mapping must win over the stream_end mapping: the assistant
+    // message_end of a failed turn carries the error instead of content. The
+    // message_start/turn_end echoes of the same failure stay silent so one
+    // failed turn surfaces exactly one error row.
+    if (type === 'message_end' && readOptionalString(message?.stopReason) === 'error') {
+      const errorContent = readOptionalString(message?.errorMessage);
+      if (errorContent) {
+        return [build({ kind: 'error', content: errorContent, isError: true })];
+      }
+    }
+
+    if (type === 'message_end' && readOptionalString(message?.role) === 'assistant') {
+      return [build({ kind: 'stream_end' })];
+    }
+
+    // User/toolResult message echoes and turn bookkeeping emit nothing.
+    return [];
+  }
+
+  if (type === 'extension_error') {
+    return [build({
+      kind: 'error',
+      content: readOptionalString(event.error) ?? readOptionalString(event.errorMessage) ?? 'Unknown pi error',
+      isError: true,
+    })];
+  }
+
+  // session/agent_*/turn_start/model_change/thinking_level_change/agent_settled
+  return [];
+}
+
+/**
+ * Locates one pi transcript by provider-native session id.
+ *
+ * pi writes `~/.pi/agent/sessions/<encoded-cwd>/<ISO timestamp>_<uuid>.jsonl`
+ * and keeps every session of one working directory flat in that folder, so a
+ * recursive `*<id>*.jsonl` match covers both full uuids and the partial ids
+ * `pi --session` accepts. Names start with a timestamp, so lexical order is
+ * chronological and the last match is the newest.
+ */
+const findPiSessionTranscript = (sessionId: string): string | null => {
+  const normalizedId = sessionId.trim();
+  if (
+    !normalizedId
+    || normalizedId.includes('..')
+    || normalizedId.includes('/')
+    || normalizedId.includes('\\')
+  ) {
+    return null;
+  }
+
+  const matches: string[] = [];
+  const walk = (directory: string): void => {
+    let entries: fsSync.Dirent[];
+    try {
+      entries = fsSync.readdirSync(directory, { withFileTypes: true });
+    } catch {
+      // A missing pi data directory just means "no sessions yet".
+      return;
+    }
+
+    for (const entry of entries) {
+      const entryPath = path.join(directory, entry.name);
+      if (entry.isDirectory()) {
+        walk(entryPath);
+      } else if (entry.name.endsWith('.jsonl') && entry.name.includes(normalizedId)) {
+        matches.push(entryPath);
+      }
+    }
+  };
+
+  walk(getPiSessionDir());
+  return matches.sort().at(-1) ?? null;
+};
+
+/** Reads a pi JSONL transcript into parsed entries, skipping malformed lines. */
+const readPiTranscriptEntries = (transcriptPath: string): AnyRecord[] => {
+  const entries: AnyRecord[] = [];
+  const lines = fsSync.readFileSync(transcriptPath, 'utf8').split(/\r?\n/);
+
+  for (const line of lines) {
+    if (!line.trim()) {
+      continue;
+    }
+
+    try {
+      const entry = readObjectRecord(JSON.parse(line));
+      if (entry) {
+        entries.push(entry);
+      }
+    } catch {
+      // pi may leave a torn last line while appending; skip it.
+    }
+  }
+
+  return entries;
+};
+
+/**
+ * Normalizes one parsed transcript entry into history messages.
+ *
+ * Only `type: 'message'` entries expand — headers (`session`), model and
+ * thinking-level changes, and labels are metadata, not conversation. Within a
+ * message entry the role decides the shape:
+ * - `user`       → one `text` message, with `<images_input>`/`<files_input>`
+ *                  blocks stripped back into images/files fields
+ * - `assistant`  → content blocks expand in order: text → `text`,
+ *                  thinking → `thinking`, toolCall → `tool_use`
+ * - `toolResult` → standalone `tool_result` keyed by its toolCallId
+ */
+const normalizeTranscriptEntry = (entry: AnyRecord, sessionId: string | null): NormalizedMessage[] => {
+  if (readOptionalString(entry.type) !== 'message') {
+    return [];
+  }
+
+  const message = readObjectRecord(entry.message);
+  const role = readOptionalString(message?.role);
+  const timestamp = normalizeProviderTimestamp(entry.timestamp ?? message?.timestamp);
+  const baseId = readOptionalString(entry.id) ?? generateMessageId('pi');
+  const blocks = Array.isArray(message?.content) ? message.content : [];
+
+  const normalized: NormalizedMessage[] = [];
+
+  if (role === 'user' || role === 'assistant') {
+    const messageRole = role === 'user' ? 'user' : 'assistant';
+
+    // A failed turn is persisted with `stopReason: 'error'` + `errorMessage`
+    // on the assistant entry (pi exits 0 regardless); surface it as an error
+    // row before whatever partial content the entry carries.
+    if (messageRole === 'assistant' && readOptionalString(message?.stopReason) === 'error') {
+      const errorContent = readOptionalString(message?.errorMessage);
+      if (errorContent) {
+        normalized.push(createNormalizedMessage({
+          id: `${baseId}_error`,
+          sessionId,
+          timestamp,
+          provider: PROVIDER,
+          kind: 'error',
+          content: errorContent,
+          isError: true,
+        }));
+      }
+    }
+
+    blocks.forEach((block, index) => {
+      const record = readObjectRecord(block);
+      const blockType = readOptionalString(record?.type);
+      const blockId = `${baseId}_${index}`;
+
+      if (blockType === 'text') {
+        const rawText = typeof record?.text === 'string' ? record.text : '';
+        if (messageRole === 'assistant') {
+          if (rawText.trim()) {
+            normalized.push(createNormalizedMessage({
+              id: blockId,
+              sessionId,
+              timestamp,
+              provider: PROVIDER,
+              kind: 'text',
+              role: messageRole,
+              content: rawText,
+            }));
+          }
+          return;
+        }
+
+        // User prompts sent with attachments carry <images_input>/
+        // <files_input> blocks appended by the chat composer; strip them for
+        // display and surface the paths as images/files.
+        const parsedImages = parseImagesInputTag(rawText);
+        const parsedFiles = parseFilesInputTag(parsedImages.text);
+        if (
+          parsedFiles.text.trim()
+          || parsedImages.attachments.length > 0
+          || parsedFiles.attachments.length > 0
+        ) {
+          normalized.push(createNormalizedMessage({
+            id: blockId,
+            sessionId,
+            timestamp,
+            provider: PROVIDER,
+            kind: 'text',
+            role: messageRole,
+            content: parsedFiles.text,
+            images: parsedImages.attachments.length > 0 ? parsedImages.attachments : undefined,
+            files: parsedFiles.attachments.length > 0 ? parsedFiles.attachments : undefined,
+          }));
+        }
+        return;
+      }
+
+      if (blockType === 'thinking') {
+        const content = typeof record?.thinking === 'string' ? record.thinking : '';
+        if (content.trim()) {
+          normalized.push(createNormalizedMessage({
+            id: blockId,
+            sessionId,
+            timestamp,
+            provider: PROVIDER,
+            kind: 'thinking',
+            content,
+          }));
+        }
+        return;
+      }
+
+      if (blockType === 'toolCall') {
+        normalized.push(createNormalizedMessage({
+          id: blockId,
+          sessionId,
+          timestamp,
+          provider: PROVIDER,
+          kind: 'tool_use',
+          toolName: readOptionalString(record?.name) ?? 'Tool',
+          toolInput: record?.arguments ?? {},
+          toolId: readOptionalString(record?.id) ?? blockId,
+        }));
+      }
+    });
+
+    return normalized;
+  }
+
+  if (role === 'toolResult') {
+    const toolResult: NonNullable<NormalizedMessage['toolResult']> = {
+      content: joinBlockText(message?.content),
+    };
+    if (message?.isError !== undefined) {
+      toolResult.isError = message.isError === true;
+    }
+
+    normalized.push(createNormalizedMessage({
+      id: baseId,
+      sessionId,
+      timestamp,
+      provider: PROVIDER,
+      kind: 'tool_result',
+      toolName: readOptionalString(message?.toolName),
+      toolId: readOptionalString(message?.toolCallId) ?? baseId,
+      toolResult,
+    }));
+  }
+
+  return normalized;
+};
+
+export class PiSessionsProvider implements IProviderSessions {
+  /**
+   * Normalizes live `pi -p --mode json` events into frontend messages.
+   */
+  normalizeMessage(rawMessage: unknown, sessionId: string | null): NormalizedMessage[] {
+    return mapPiEventToMessages(rawMessage, sessionId);
+  }
+
+  /**
+   * Loads pi history from the session's JSONL transcript under
+   * `~/.pi/agent/sessions`.
+   */
+  async fetchHistory(
+    sessionId: string,
+    options: FetchHistoryOptions = {},
+  ): Promise<FetchHistoryResult> {
+    const { limit = null, offset = 0 } = options;
+    // pi keys transcript file names by its provider-native session id, not
+    // the app-facing id this method is addressed with.
+    const providerSessionId = options.providerSessionId ?? sessionId;
+
+    try {
+      const transcriptPath = findPiSessionTranscript(providerSessionId);
+      if (!transcriptPath) {
+        return { messages: [], total: 0, hasMore: false, offset: 0, limit: null };
+      }
+
+      const entries = readPiTranscriptEntries(transcriptPath);
+      const normalized = entries.flatMap((entry) => normalizeTranscriptEntry(entry, sessionId));
+
+      // pi's per-event usage is cumulative, so the last assistant entry that
+      // carries one is the run's final accounting.
+      let tokenUsage: AnyRecord | undefined;
+      for (const entry of entries) {
+        const usage = readObjectRecord(readObjectRecord(entry.message)?.usage);
+        if (usage && readOptionalString(readObjectRecord(entry.message)?.role) === 'assistant') {
+          tokenUsage = buildPiTokenUsage(usage) ?? tokenUsage;
+        }
+      }
+
+      const normalizedOffset = Math.max(0, offset);
+      const normalizedLimit = limit === null ? null : Math.max(0, limit);
+      const total = normalized.length;
+      const { page, hasMore } = sliceTailPage(normalized, normalizedLimit, normalizedOffset);
+
+      return {
+        messages: page,
+        total,
+        hasMore,
+        offset: normalizedOffset,
+        limit: normalizedLimit,
+        tokenUsage,
+      };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      console.warn(`[PiProvider] Failed to load session ${sessionId}:`, message);
+      return { messages: [], total: 0, hasMore: false, offset: 0, limit: null };
+    }
   }
 }

--- a/server/modules/providers/list/pi/pi-sessions.provider.ts
+++ b/server/modules/providers/list/pi/pi-sessions.provider.ts
@@ -97,7 +97,7 @@ const buildPiTokenUsage = (usage: AnyRecord): AnyRecord | undefined => {
  * - `message_update` + `toolcall_*`     → [] (tool activity is carried by the
  *   top-level `tool_execution_*` events instead)
  * - `tool_execution_start`              → `tool_use` (toolName/toolInput/toolId)
- * - `tool_execution_end`                → `tool_result` (toolId + toolResult)
+ * - `tool_execution_end`                → `tool_result` (toolId + content + toolResult)
  *   Deliberately NOT folded onto the `tool_use`: pi emits start and end as
  *   separate events, so a standalone `tool_result` keyed by `toolId` is what
  *   the transcript renderer already pairs with its `tool_use` row.
@@ -173,8 +173,9 @@ export function mapPiEventToMessages(rawEvent: unknown, sessionId: string | null
   }
 
   if (type === 'tool_execution_end') {
+    const resultText = joinBlockText(readObjectRecord(event.result)?.content ?? event.result);
     const toolResult: NonNullable<NormalizedMessage['toolResult']> = {
-      content: joinBlockText(readObjectRecord(event.result)?.content ?? event.result),
+      content: resultText,
     };
     // pi reports `isError` on the end event (probe/sample4.jsonl); treat it as
     // optional so an absent field stays undefined rather than a false claim.
@@ -186,6 +187,10 @@ export function mapPiEventToMessages(rawEvent: unknown, sessionId: string | null
       kind: 'tool_result',
       toolId: readOptionalString(event.toolCallId),
       toolName: readOptionalString(event.toolName),
+      // The transcript renderer reads the top-level `content` string
+      // (claude tool_result convention); `toolResult` stays for consumers of
+      // the structured payload.
+      content: resultText,
       toolResult,
     })];
   }
@@ -304,7 +309,8 @@ export const readPiTranscriptEntries = (transcriptPath: string): AnyRecord[] => 
  *                  blocks stripped back into images/files fields
  * - `assistant`  → content blocks expand in order: text → `text`,
  *                  thinking → `thinking`, toolCall → `tool_use`
- * - `toolResult` → standalone `tool_result` keyed by its toolCallId
+ * - `toolResult` → standalone `tool_result` keyed by its toolCallId, carrying
+ *                  the block text as the top-level `content` string
  *
  * Exported so the session synchronizer titles sessions from the same user-text
  * extraction (attachment tags stripped) that history rendering uses.
@@ -423,8 +429,9 @@ export const normalizeTranscriptEntry = (entry: AnyRecord, sessionId: string | n
   }
 
   if (role === 'toolResult') {
+    const resultText = joinBlockText(message?.content);
     const toolResult: NonNullable<NormalizedMessage['toolResult']> = {
-      content: joinBlockText(message?.content),
+      content: resultText,
     };
     if (message?.isError !== undefined) {
       toolResult.isError = message.isError === true;
@@ -438,6 +445,10 @@ export const normalizeTranscriptEntry = (entry: AnyRecord, sessionId: string | n
       kind: 'tool_result',
       toolName: readOptionalString(message?.toolName),
       toolId: readOptionalString(message?.toolCallId) ?? baseId,
+      // The transcript renderer reads the top-level `content` string
+      // (claude tool_result convention); `toolResult` stays for consumers of
+      // the structured payload.
+      content: resultText,
       toolResult,
     }));
   }

--- a/server/modules/providers/list/pi/pi-sessions.provider.ts
+++ b/server/modules/providers/list/pi/pi-sessions.provider.ts
@@ -81,9 +81,19 @@ const buildPiTokenUsage = (usage: AnyRecord): AnyRecord | undefined => {
  *
  * Event → message mapping (verified against probe/*.jsonl, pi 0.85.1):
  * - `message_update` + `text_delta`     → `stream_delta` (content = delta)
- * - `message_update` + `thinking_delta` → `thinking` (content = delta)
- * - `message_update` + `*_start`/`*_end` → [] (they restate what the deltas
- *   already streamed; emitting them would duplicate the block)
+ * - `message_update` + `thinking_end`   → `thinking` (content = the event's
+ *   full content, verbatim) — exactly one message per reasoning block. The
+ *   aggregation lives server-side because the frontend has no thinking
+ *   aggregation channel: only `stream_delta` is throttled into a single
+ *   bubble while every other kind is appended one row per message, so
+ *   forwarding each `thinking_delta` would flood the transcript with one
+ *   fragment per token. pi makes this cheap: `thinking_end` carries the
+ *   block's full content (docs/pi-notes.md).
+ * - `message_update` + `thinking_start`/`thinking_delta` → [] (dropped; the
+ *   `thinking_end` full content replaces them)
+ * - `message_update` + other `*_start`/`*_end` (incl. `text_end`, whose full
+ *   content would duplicate what the stream_delta channel already drew) and
+ *   `toolcall_*` → []
  * - `message_update` + `toolcall_*`     → [] (tool activity is carried by the
  *   top-level `tool_execution_*` events instead)
  * - `tool_execution_start`              → `tool_use` (toolName/toolInput/toolId)
@@ -123,14 +133,33 @@ export function mapPiEventToMessages(rawEvent: unknown, sessionId: string | null
   if (type === 'message_update') {
     const update = readObjectRecord(event.assistantMessageEvent);
     const updateType = readOptionalString(update?.type);
-    const content = readVerbatimString(update?.delta);
 
-    if (updateType === 'text_delta' && content) {
-      return [build({ kind: 'stream_delta', content })];
+    if (updateType === 'text_delta') {
+      const delta = readVerbatimString(update?.delta);
+      if (delta) {
+        return [build({ kind: 'stream_delta', content: delta })];
+      }
+      return [];
     }
-    if (updateType === 'thinking_delta' && content) {
-      return [build({ kind: 'thinking', content })];
+
+    // Thinking aggregates into ONE message per reasoning block, emitted from
+    // `thinking_end`. The aggregation must happen server-side: the frontend
+    // only folds `stream_delta` into a single throttled bubble
+    // (useChatRealtimeHandlers) and appends every other kind verbatim via
+    // sessionStore.appendRealtime, so streaming `thinking_delta` events would
+    // render one thinking fragment per token. pi's `thinking_end` already
+    // carries the full block content (docs/pi-notes.md), so start/delta are
+    // simply dropped. Content is read verbatim — no trim.
+    if (updateType === 'thinking_end') {
+      const content = readVerbatimString(update?.content);
+      if (content) {
+        return [build({ kind: 'thinking', content })];
+      }
+      return [];
     }
+
+    // `*_start` markers, `text_end` (its full content would duplicate what the
+    // stream_delta channel already drew) and `toolcall_*` emit nothing.
     return [];
   }
 

--- a/server/modules/providers/list/pi/pi-sessions.provider.ts
+++ b/server/modules/providers/list/pi/pi-sessions.provider.ts
@@ -1,0 +1,28 @@
+import type { IProviderSessions } from '@/shared/interfaces.js';
+import type { FetchHistoryOptions, FetchHistoryResult, NormalizedMessage } from '@/shared/types.js';
+
+/**
+ * Phase 1 sessions placeholder for Pi.
+ *
+ * Live `pi --mode json` events and JSONL transcripts are normalized by the
+ * sessions facet; until then the adapter reports "no messages" so history and
+ * realtime consumers degrade to an empty transcript instead of failing.
+ */
+export class PiSessionsProvider implements IProviderSessions {
+  normalizeMessage(): NormalizedMessage[] {
+    return [];
+  }
+
+  async fetchHistory(
+    _sessionId: string,
+    _options?: FetchHistoryOptions,
+  ): Promise<FetchHistoryResult> {
+    return {
+      messages: [],
+      total: 0,
+      hasMore: false,
+      offset: 0,
+      limit: null,
+    };
+  }
+}

--- a/server/modules/providers/list/pi/pi-skills.provider.ts
+++ b/server/modules/providers/list/pi/pi-skills.provider.ts
@@ -1,28 +1,86 @@
+import { access, readFile, stat } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 
 import { SkillsProvider } from '@/modules/providers/shared/skills/skills.provider.js';
 import type { ProviderSkillSource } from '@/shared/types.js';
+import {
+  addUniqueProviderSkillSource,
+  readObjectRecord,
+  readStringArray,
+} from '@/shared/utils.js';
+
+const directoryExists = async (dirPath: string): Promise<boolean> => {
+  try {
+    return (await stat(dirPath)).isDirectory();
+  } catch {
+    return false;
+  }
+};
 
 /**
- * Skills adapter for Pi.
+ * Reads the extra skill folders pi's `settings.json` points at.
  *
- * Phase 1 only exposes Pi's user-level skill folder for reading; the managed
- * global write source stays unset, so the inherited addSkills/removeSkill keep
- * rejecting writes until the skills facet lands.
+ * pi's user-level `~/.pi/agent/settings.json` accepts a `skills` array of
+ * additional directories. Entries are filtered to folders that still exist so a
+ * stale path cannot add an empty source; a missing or malformed settings file
+ * simply contributes nothing.
+ */
+const readPiSettingsSkillDirectories = async (): Promise<string[]> => {
+  try {
+    const settingsPath = path.join(os.homedir(), '.pi', 'agent', 'settings.json');
+    await access(settingsPath);
+    const settings = readObjectRecord(JSON.parse(await readFile(settingsPath, 'utf8')));
+    return (readStringArray(settings?.skills) ?? []).filter(
+      (entry) => entry.trim().length > 0,
+    );
+  } catch {
+    return [];
+  }
+};
+
+/**
+ * Skills adapter for pi.
+ *
+ * pi discovers skills in its own user folder, in every folder configured under
+ * `skills` in its settings.json, and in the workspace's `.pi/skills` folder. The
+ * shared base scans each root for `SKILL.md`; the managed global write source
+ * stays unset, so the inherited addSkills/removeSkill keep rejecting writes
+ * until pi exposes a writable skill home.
  */
 export class PiSkillsProvider extends SkillsProvider {
   constructor() {
     super('pi');
   }
 
-  protected async getSkillSources(_workspacePath: string): Promise<ProviderSkillSource[]> {
-    return [
-      {
+  protected async getSkillSources(workspacePath: string): Promise<ProviderSkillSource[]> {
+    const sources: ProviderSkillSource[] = [];
+    const seenRootDirs = new Set<string>();
+
+    addUniqueProviderSkillSource(sources, seenRootDirs, {
+      scope: 'user',
+      rootDir: path.join(os.homedir(), '.pi', 'agent', 'skills'),
+      commandPrefix: '/',
+    });
+
+    for (const configuredDir of await readPiSettingsSkillDirectories()) {
+      if (!(await directoryExists(configuredDir))) {
+        continue;
+      }
+
+      addUniqueProviderSkillSource(sources, seenRootDirs, {
         scope: 'user',
-        rootDir: path.join(os.homedir(), '.pi', 'agent', 'skills'),
+        rootDir: configuredDir,
         commandPrefix: '/',
-      },
-    ];
+      });
+    }
+
+    addUniqueProviderSkillSource(sources, seenRootDirs, {
+      scope: 'project',
+      rootDir: path.join(path.resolve(workspacePath), '.pi', 'skills'),
+      commandPrefix: '/',
+    });
+
+    return sources;
   }
 }

--- a/server/modules/providers/list/pi/pi-skills.provider.ts
+++ b/server/modules/providers/list/pi/pi-skills.provider.ts
@@ -1,0 +1,28 @@
+import os from 'node:os';
+import path from 'node:path';
+
+import { SkillsProvider } from '@/modules/providers/shared/skills/skills.provider.js';
+import type { ProviderSkillSource } from '@/shared/types.js';
+
+/**
+ * Skills adapter for Pi.
+ *
+ * Phase 1 only exposes Pi's user-level skill folder for reading; the managed
+ * global write source stays unset, so the inherited addSkills/removeSkill keep
+ * rejecting writes until the skills facet lands.
+ */
+export class PiSkillsProvider extends SkillsProvider {
+  constructor() {
+    super('pi');
+  }
+
+  protected async getSkillSources(_workspacePath: string): Promise<ProviderSkillSource[]> {
+    return [
+      {
+        scope: 'user',
+        rootDir: path.join(os.homedir(), '.pi', 'agent', 'skills'),
+        commandPrefix: '/',
+      },
+    ];
+  }
+}

--- a/server/modules/providers/list/pi/pi.provider.ts
+++ b/server/modules/providers/list/pi/pi.provider.ts
@@ -26,7 +26,7 @@ import type {
 export class PiProvider extends AbstractProvider {
   readonly runtime: IProviderRuntime = piRuntime;
   readonly models: IProviderModels = new PiProviderModels();
-  readonly mcp = new PiMcpProvider();
+  readonly mcp: IProviderMcp = new PiMcpProvider();
   readonly auth: IProviderAuth = new PiProviderAuth();
   readonly skills: IProviderSkills = new PiSkillsProvider();
   readonly sessions: IProviderSessions = new PiSessionsProvider();

--- a/server/modules/providers/list/pi/pi.provider.ts
+++ b/server/modules/providers/list/pi/pi.provider.ts
@@ -19,9 +19,9 @@ import type {
 /**
  * Registration for the `pi` provider.
  *
- * All seven facets are instantiable today; the session and MCP adapters are
- * deliberately inert placeholders that the sessions and MCP tasks replace
- * with real config implementations.
+ * All seven facets are implemented. pi itself has no fork or MCP support, so
+ * those facets expose no capability beyond what pi's CLI offers: MCP is a
+ * NOT_SUPPORTED stub and session forking stays disabled.
  */
 export class PiProvider extends AbstractProvider {
   readonly runtime: IProviderRuntime = piRuntime;

--- a/server/modules/providers/list/pi/pi.provider.ts
+++ b/server/modules/providers/list/pi/pi.provider.ts
@@ -1,6 +1,7 @@
 import { PiProviderAuth } from '@/modules/providers/list/pi/pi-auth.provider.js';
 import { PiMcpProvider } from '@/modules/providers/list/pi/pi-mcp.provider.js';
 import { PiProviderModels } from '@/modules/providers/list/pi/pi-models.provider.js';
+import { piRuntime } from '@/modules/providers/list/pi/pi-runtime.provider.js';
 import { PiSessionSynchronizer } from '@/modules/providers/list/pi/pi-session-synchronizer.provider.js';
 import { PiSessionsProvider } from '@/modules/providers/list/pi/pi-sessions.provider.js';
 import { PiSkillsProvider } from '@/modules/providers/list/pi/pi-skills.provider.js';
@@ -14,31 +15,13 @@ import type {
   IProviderSkills,
   IProviderSessions,
 } from '@/shared/interfaces.js';
-import { AppError } from '@/shared/utils.js';
-
-/**
- * Phase 1 runtime placeholder for Pi.
- *
- * The real adapter spawns `pi -p --mode json` and streams its JSON events onto
- * the normalized writer. Until it lands, every run fails with a typed
- * `NOT_SUPPORTED` error instead of a raw crash, and abort reports "nothing was
- * running" so an in-flight cancel stays a no-op rather than an exception.
- */
-const piRuntime: IProviderRuntime = {
-  async run(): Promise<unknown> {
-    throw new AppError('Pi runtime is not implemented yet.', {
-      code: 'NOT_SUPPORTED',
-    });
-  },
-  abort: () => false,
-};
 
 /**
  * Registration for the `pi` provider.
  *
- * All seven facets are instantiable today; the runtime, session, and MCP
- * adapters are deliberately inert placeholders that the runtime, sessions, and
- * MCP tasks replace with real spawn/parse/config implementations.
+ * All seven facets are instantiable today; the session and MCP adapters are
+ * deliberately inert placeholders that the sessions and MCP tasks replace
+ * with real config implementations.
  */
 export class PiProvider extends AbstractProvider {
   readonly runtime: IProviderRuntime = piRuntime;

--- a/server/modules/providers/list/pi/pi.provider.ts
+++ b/server/modules/providers/list/pi/pi.provider.ts
@@ -1,3 +1,9 @@
+import { PiProviderAuth } from '@/modules/providers/list/pi/pi-auth.provider.js';
+import { PiMcpProvider } from '@/modules/providers/list/pi/pi-mcp.provider.js';
+import { PiProviderModels } from '@/modules/providers/list/pi/pi-models.provider.js';
+import { PiSessionSynchronizer } from '@/modules/providers/list/pi/pi-session-synchronizer.provider.js';
+import { PiSessionsProvider } from '@/modules/providers/list/pi/pi-sessions.provider.js';
+import { PiSkillsProvider } from '@/modules/providers/list/pi/pi-skills.provider.js';
 import { AbstractProvider } from '@/modules/providers/shared/base/abstract.provider.js';
 import type {
   IProviderAuth,
@@ -8,58 +14,40 @@ import type {
   IProviderSkills,
   IProviderSessions,
 } from '@/shared/interfaces.js';
+import { AppError } from '@/shared/utils.js';
 
 /**
- * Placeholder that fails loudly until the real adapter lands.
- */
-function notImplemented(): never {
-  throw new Error('not implemented');
-}
-
-/**
- * Registration stub for the `pi` provider.
+ * Phase 1 runtime placeholder for Pi.
  *
- * Only the registry identity is real today: the synchronizer reports zero
- * sessions so the shared scan cursor is not poisoned, and every other facet
- * throws until the runtime/model/MCP/auth/skill/session adapters replace them.
+ * The real adapter spawns `pi -p --mode json` and streams its JSON events onto
+ * the normalized writer. Until it lands, every run fails with a typed
+ * `NOT_SUPPORTED` error instead of a raw crash, and abort reports "nothing was
+ * running" so an in-flight cancel stays a no-op rather than an exception.
+ */
+const piRuntime: IProviderRuntime = {
+  async run(): Promise<unknown> {
+    throw new AppError('Pi runtime is not implemented yet.', {
+      code: 'NOT_SUPPORTED',
+    });
+  },
+  abort: () => false,
+};
+
+/**
+ * Registration for the `pi` provider.
+ *
+ * All seven facets are instantiable today; the runtime, session, and MCP
+ * adapters are deliberately inert placeholders that the runtime, sessions, and
+ * MCP tasks replace with real spawn/parse/config implementations.
  */
 export class PiProvider extends AbstractProvider {
-  readonly runtime: IProviderRuntime = {
-    run: () => notImplemented(),
-    abort: () => notImplemented(),
-  };
-
-  readonly models: IProviderModels = {
-    getSupportedModels: () => notImplemented(),
-    getCurrentActiveModel: () => notImplemented(),
-  };
-
-  readonly mcp: IProviderMcp = {
-    listServers: () => notImplemented(),
-    listServersForScope: () => notImplemented(),
-    upsertServer: () => notImplemented(),
-    removeServer: () => notImplemented(),
-  };
-
-  readonly auth: IProviderAuth = {
-    getStatus: () => notImplemented(),
-  };
-
-  readonly skills: IProviderSkills = {
-    listSkills: () => notImplemented(),
-    addSkills: () => notImplemented(),
-    removeSkill: () => notImplemented(),
-  };
-
-  readonly sessions: IProviderSessions = {
-    normalizeMessage: () => notImplemented(),
-    fetchHistory: () => notImplemented(),
-  };
-
-  readonly sessionSynchronizer: IProviderSessionSynchronizer = {
-    synchronize: async () => 0,
-    synchronizeFile: async () => null,
-  };
+  readonly runtime: IProviderRuntime = piRuntime;
+  readonly models: IProviderModels = new PiProviderModels();
+  readonly mcp = new PiMcpProvider();
+  readonly auth: IProviderAuth = new PiProviderAuth();
+  readonly skills: IProviderSkills = new PiSkillsProvider();
+  readonly sessions: IProviderSessions = new PiSessionsProvider();
+  readonly sessionSynchronizer: IProviderSessionSynchronizer = new PiSessionSynchronizer();
 
   constructor() {
     super('pi');

--- a/server/modules/providers/list/pi/pi.provider.ts
+++ b/server/modules/providers/list/pi/pi.provider.ts
@@ -1,0 +1,67 @@
+import { AbstractProvider } from '@/modules/providers/shared/base/abstract.provider.js';
+import type {
+  IProviderAuth,
+  IProviderMcp,
+  IProviderModels,
+  IProviderRuntime,
+  IProviderSessionSynchronizer,
+  IProviderSkills,
+  IProviderSessions,
+} from '@/shared/interfaces.js';
+
+/**
+ * Placeholder that fails loudly until the real adapter lands.
+ */
+function notImplemented(): never {
+  throw new Error('not implemented');
+}
+
+/**
+ * Registration stub for the `pi` provider.
+ *
+ * Only the registry identity is real today: the synchronizer reports zero
+ * sessions so the shared scan cursor is not poisoned, and every other facet
+ * throws until the runtime/model/MCP/auth/skill/session adapters replace them.
+ */
+export class PiProvider extends AbstractProvider {
+  readonly runtime: IProviderRuntime = {
+    run: () => notImplemented(),
+    abort: () => notImplemented(),
+  };
+
+  readonly models: IProviderModels = {
+    getSupportedModels: () => notImplemented(),
+    getCurrentActiveModel: () => notImplemented(),
+  };
+
+  readonly mcp: IProviderMcp = {
+    listServers: () => notImplemented(),
+    listServersForScope: () => notImplemented(),
+    upsertServer: () => notImplemented(),
+    removeServer: () => notImplemented(),
+  };
+
+  readonly auth: IProviderAuth = {
+    getStatus: () => notImplemented(),
+  };
+
+  readonly skills: IProviderSkills = {
+    listSkills: () => notImplemented(),
+    addSkills: () => notImplemented(),
+    removeSkill: () => notImplemented(),
+  };
+
+  readonly sessions: IProviderSessions = {
+    normalizeMessage: () => notImplemented(),
+    fetchHistory: () => notImplemented(),
+  };
+
+  readonly sessionSynchronizer: IProviderSessionSynchronizer = {
+    synchronize: async () => 0,
+    synchronizeFile: async () => null,
+  };
+
+  constructor() {
+    super('pi');
+  }
+}

--- a/server/modules/providers/provider.registry.ts
+++ b/server/modules/providers/provider.registry.ts
@@ -2,6 +2,7 @@ import { ClaudeProvider } from '@/modules/providers/list/claude/claude.provider.
 import { CodexProvider } from '@/modules/providers/list/codex/codex.provider.js';
 import { CursorProvider } from '@/modules/providers/list/cursor/cursor.provider.js';
 import { OpenCodeProvider } from '@/modules/providers/list/opencode/opencode.provider.js';
+import { PiProvider } from '@/modules/providers/list/pi/pi.provider.js';
 import type { IProvider } from '@/shared/interfaces.js';
 import type { LLMProvider } from '@/shared/types.js';
 import { AppError } from '@/shared/utils.js';
@@ -11,6 +12,7 @@ const providers: Record<LLMProvider, IProvider> = {
   codex: new CodexProvider(),
   cursor: new CursorProvider(),
   opencode: new OpenCodeProvider(),
+  pi: new PiProvider(),
 };
 
 /**

--- a/server/modules/providers/provider.routes.ts
+++ b/server/modules/providers/provider.routes.ts
@@ -287,6 +287,7 @@ const parseProvider = (value: unknown): LLMProvider => {
     || normalized === 'codex'
     || normalized === 'cursor'
     || normalized === 'opencode'
+    || normalized === 'pi'
   ) {
     return normalized;
   }

--- a/server/modules/providers/services/provider-capabilities.service.ts
+++ b/server/modules/providers/services/provider-capabilities.service.ts
@@ -104,6 +104,22 @@ const PROVIDER_CAPABILITIES: Record<LLMProvider, ProviderCapabilities> = {
     supportsMessageEditing: false,
     supportsSessionForking: false,
   },
+  pi: {
+    provider: 'pi',
+    // Placeholder until the pi adapters land: the runtime accepts no
+    // permission modes yet, and only image attachments plus abort (SIGTERM)
+    // are known wire capabilities.
+    permissionModes: ['default'],
+    defaultPermissionMode: 'default',
+    supportsImages: true,
+    supportsFiles: false,
+    supportsAbort: true,
+    supportsPermissionRequests: false,
+    supportsTokenUsage: false,
+    supportsEffort: false,
+    supportsMessageEditing: false,
+    supportsSessionForking: false,
+  },
 };
 
 /**

--- a/server/modules/providers/services/provider-capabilities.service.ts
+++ b/server/modules/providers/services/provider-capabilities.service.ts
@@ -106,9 +106,8 @@ const PROVIDER_CAPABILITIES: Record<LLMProvider, ProviderCapabilities> = {
   },
   pi: {
     provider: 'pi',
-    // Placeholder until the pi adapters land: the runtime accepts no
-    // permission modes yet, and only image attachments plus abort (SIGTERM)
-    // are known wire capabilities.
+    // pi has no permission system, fork, or MCP support, so only the default
+    // mode is offered; image attachments and abort (SIGTERM) are supported.
     permissionModes: ['default'],
     defaultPermissionMode: 'default',
     supportsImages: true,

--- a/server/modules/providers/services/provider-token-usage.service.ts
+++ b/server/modules/providers/services/provider-token-usage.service.ts
@@ -393,8 +393,9 @@ export function createProviderTokenUsageService(
         };
       }
 
-      // Pi reports usage through its runtime event stream (Phase 1); it has no
-      // on-disk artifact to read back, so the endpoint answers with an explicit
+      // Pi already carries cumulative usage in its live runtime events, and
+      // reading historical usage back is the sessions API's job (it parses the
+      // JSONL transcripts), so this endpoint answers with an explicit
       // unsupported result the same way Cursor does.
       if (session.provider === 'pi') {
         return {

--- a/server/modules/providers/services/provider-token-usage.service.ts
+++ b/server/modules/providers/services/provider-token-usage.service.ts
@@ -393,6 +393,17 @@ export function createProviderTokenUsageService(
         };
       }
 
+      // Pi reports usage through its runtime event stream (Phase 1); it has no
+      // on-disk artifact to read back, so the endpoint answers with zeros.
+      if (session.provider === 'pi') {
+        return {
+          used: 0,
+          inputTokens: 0,
+          outputTokens: 0,
+          breakdown: { input: 0, output: 0 },
+        };
+      }
+
       if (session.provider === 'opencode') {
         const databasePath = dependencies.getOpenCodeDatabasePath();
         if (!dependencies.fileExists(databasePath)) {

--- a/server/modules/providers/services/provider-token-usage.service.ts
+++ b/server/modules/providers/services/provider-token-usage.service.ts
@@ -394,13 +394,17 @@ export function createProviderTokenUsageService(
       }
 
       // Pi reports usage through its runtime event stream (Phase 1); it has no
-      // on-disk artifact to read back, so the endpoint answers with zeros.
+      // on-disk artifact to read back, so the endpoint answers with an explicit
+      // unsupported result the same way Cursor does.
       if (session.provider === 'pi') {
         return {
           used: 0,
+          total: 0,
           inputTokens: 0,
           outputTokens: 0,
           breakdown: { input: 0, output: 0 },
+          unsupported: true,
+          message: 'Token usage tracking not available for Pi sessions',
         };
       }
 

--- a/server/modules/providers/services/session-synchronizer.service.ts
+++ b/server/modules/providers/services/session-synchronizer.service.ts
@@ -84,6 +84,7 @@ async function runSessionSynchronization(): Promise<SessionSynchronizeResult> {
     codex: 0,
     cursor: 0,
     opencode: 0,
+    pi: 0,
   };
   const failures: string[] = [];
 

--- a/server/modules/providers/services/sessions-watcher.service.ts
+++ b/server/modules/providers/services/sessions-watcher.service.ts
@@ -6,6 +6,7 @@ import chokidar, { type FSWatcher } from 'chokidar';
 
 import { sessionSynchronizerService } from '@/modules/providers/services/session-synchronizer.service.js';
 import { broadcastSessionUpsertedBatch } from '@/modules/websocket/index.js';
+import { getPiSessionDir } from '@/shared/utils.js';
 import type { LLMProvider } from '@/shared/types.js';
 
 type WatcherEventType = 'add' | 'change';
@@ -29,7 +30,7 @@ const PROVIDER_WATCH_PATHS: Array<{ provider: LLMProvider; rootPath: string }> =
   },
   {
     provider: 'pi',
-    rootPath: path.join(os.homedir(), '.pi', 'agent', 'sessions'),
+    rootPath: getPiSessionDir(),
   },
 ];
 

--- a/server/modules/providers/services/sessions-watcher.service.ts
+++ b/server/modules/providers/services/sessions-watcher.service.ts
@@ -27,6 +27,10 @@ const PROVIDER_WATCH_PATHS: Array<{ provider: LLMProvider; rootPath: string }> =
     provider: 'opencode',
     rootPath: path.join(os.homedir(), '.local', 'share', 'opencode'),
   },
+  {
+    provider: 'pi',
+    rootPath: path.join(os.homedir(), '.pi', 'agent', 'sessions'),
+  },
 ];
 
 const WATCHER_IGNORED_PATTERNS = [

--- a/server/modules/providers/tests/mcp.test.ts
+++ b/server/modules/providers/tests/mcp.test.ts
@@ -313,8 +313,10 @@ test('providerMcpService global adder writes to all providers and rejects unsupp
       workspacePath,
     });
 
-    assert.equal(globalResult.length, 4);
-    assert.ok(globalResult.every((entry) => entry.created === true));
+    // `pi` is registered but does not support MCP yet, so only the four MCP
+    // providers report a successful write while `pi` reports created === false.
+    assert.equal(globalResult.length, 5);
+    assert.ok(globalResult.every((entry) => entry.created === (entry.provider !== 'pi')));
 
     const claudeProject = await readJson(path.join(workspacePath, '.mcp.json'));
     assert.ok((claudeProject.mcpServers as Record<string, unknown>)['global-http']);

--- a/server/modules/providers/tests/pi-e2e.provider.test.js
+++ b/server/modules/providers/tests/pi-e2e.provider.test.js
@@ -1,0 +1,472 @@
+import assert from 'node:assert/strict';
+import { randomUUID } from 'node:crypto';
+import { mkdir, mkdtemp, readdir, rmdir, rm } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import test, { after } from 'node:test';
+
+import {
+  closeConnection,
+  initializeDatabase,
+  sessionsDb,
+} from '@/modules/database/index.js';
+import {
+  providerModelsService,
+  providerRuntimeService,
+  sessionsService,
+} from '@/modules/providers/index.js';
+import { chatRunRegistry, connectedClients } from '@/modules/websocket/index.js';
+import { getPiSessionDir } from '@/shared/utils.js';
+
+/**
+ * Opt-in end-to-end coverage: a real `pi` CLI on PATH talking to a real model
+ * through the exact production stack (provider runtime service → gateway run
+ * registry → gateway writer → isolated app database).
+ *
+ * Skipped unless the caller opts in, because every turn costs real tokens:
+ *
+ *   PI_E2E=1 PI_E2E_MODEL=glm-5.3 npm test -- pi-e2e
+ *
+ * The model id and the credentials both come from the environment (plus the
+ * user's own `~/.pi/agent/models.json`); nothing is hardcoded here.
+ */
+const enabled = process.env.PI_E2E === '1';
+const model = process.env.PI_E2E_MODEL;
+const skipReason = !enabled
+  ? 'opt-in: set PI_E2E=1 to run against a real pi CLI'
+  : !model
+    ? 'opt-in: set PI_E2E_MODEL=<provider/model> to choose the real model'
+    : false;
+
+// Real model turns take seconds to tens of seconds; a hung child must not
+// wedge the suite forever either.
+const TEST_TIMEOUT_MS = 5 * 60 * 1000;
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+// ---------------------------------------------------------------------------
+// Isolated database + production gateway stand-ins
+// ---------------------------------------------------------------------------
+
+let databaseReady = false;
+let databaseDir = null;
+
+/**
+ * Points the app database at a throwaway file so the e2e never touches the
+ * developer's real sessions (same isolation the websocket tests use).
+ */
+async function ensureIsolatedDatabase() {
+  if (databaseReady) {
+    return;
+  }
+
+  databaseDir = await mkdtemp(path.join(os.tmpdir(), 'pi-e2e-db-'));
+  process.env.DATABASE_PATH = path.join(databaseDir, 'auth.db');
+  closeConnection();
+  await initializeDatabase();
+  databaseReady = true;
+}
+
+after(() => {
+  connectedClients.clear();
+  chatRunRegistry.clearAll();
+  if (databaseReady) {
+    closeConnection();
+    databaseReady = false;
+  }
+  if (databaseDir) {
+    void rm(databaseDir, { recursive: true, force: true });
+    databaseDir = null;
+  }
+});
+
+/**
+ * Minimal stand-in for a websocket connection: collects the exact JSON frames
+ * a browser would receive, so assertions run against the client-visible
+ * protocol (app session ids, seq numbers) rather than runtime internals.
+ */
+class FakeConnection {
+  readyState = 1; // WS_OPEN_STATE
+
+  frames = [];
+
+  send(data) {
+    this.frames.push(JSON.parse(data));
+  }
+}
+
+/**
+ * Drives one turn exactly the way `dispatchRun` (chat-websocket.service.ts)
+ * does: reserve the run in the registry, record the model selection, dispatch
+ * through the production runtime service, and apply the same safety-net
+ * complete. Returns what the client would have seen.
+ */
+async function runProductionTurn({ appSessionId, prompt, cwd, model: turnModel }) {
+  const session = sessionsDb.getSessionById(appSessionId);
+  assert.ok(session, 'the app session row must exist before a turn runs');
+
+  const connection = new FakeConnection();
+  const run = chatRunRegistry.startRun({
+    appSessionId,
+    provider: session.provider,
+    providerSessionId: session.provider_session_id,
+    connection,
+    userId: null,
+  });
+  assert.ok(run, 'the session must not already have a run in progress');
+
+  // dispatchRun records the picked model on the row before dispatching, which
+  // is what makes the resume turn resolve its model from the database.
+  if (turnModel) {
+    providerModelsService.setSessionModel(session.provider, appSessionId, turnModel);
+  }
+
+  let failure = null;
+  try {
+    await providerRuntimeService.run(
+      session.provider,
+      prompt,
+      {
+        sessionId: appSessionId,
+        cwd,
+        projectPath: cwd,
+        model: turnModel,
+      },
+      run.writer,
+    );
+  } catch (error) {
+    // dispatchRun swallows runtime rejections the same way and relies on the
+    // terminal complete (its own or the abort handler's) to unstick the UI.
+    failure = error instanceof Error ? error.message : String(error);
+  } finally {
+    chatRunRegistry.completeRunIfCurrent(run, { exitCode: 1 });
+  }
+
+  const recorded = chatRunRegistry.getRun(appSessionId);
+  return {
+    connection,
+    failure,
+    events: recorded ? [...recorded.events] : [],
+    stillProcessing: chatRunRegistry.isProcessing(appSessionId),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// pi session file helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Locates the transcript pi wrote for one provider session id.
+ *
+ * pi stores every session of a working directory flat inside
+ * `~/.pi/agent/sessions/<encoded cwd>/`, so the encoded directory is asserted
+ * indirectly: it must sit directly under the sessions root and carry a
+ * mangled form of the temp cwd (the test's mkdtemp leaf name survives any
+ * dash encoding pi applies).
+ */
+async function findPiTranscript(providerSessionId, cwdLeafName) {
+  const root = getPiSessionDir();
+  let rootEntries = [];
+  try {
+    rootEntries = await readdir(root, { withFileTypes: true });
+  } catch {
+    return null;
+  }
+
+  for (const entry of rootEntries) {
+    if (!entry.isDirectory() || !entry.name.includes(cwdLeafName)) {
+      continue;
+    }
+
+    const encodedDir = path.join(root, entry.name);
+    const files = await readdir(encodedDir);
+    const transcript = files.find(
+      (name) => name.endsWith('.jsonl') && name.includes(providerSessionId),
+    );
+    if (transcript) {
+      return { transcriptPath: path.join(encodedDir, transcript), encodedDir };
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Removes the transcript and its (now likely empty) encoded cwd directory so
+ * e2e runs do not accumulate test sessions in the developer's real pi data
+ * directory. Non-recursive on purpose: a directory that still holds anything
+ * else is left alone.
+ */
+async function cleanupPiTranscript(encodedDir, transcriptPath) {
+  await rm(transcriptPath, { force: true });
+  try {
+    await rmdir(encodedDir);
+  } catch {
+    // Still has content (or is gone) — leave it be.
+  }
+}
+
+/**
+ * Best-effort teardown for one scenario: resolves the session's provider id
+ * through the same row the gateway wrote and deletes the transcript pi left
+ * behind (an aborted run still writes its header).
+ */
+async function cleanupSessionArtifacts(appSessionId, cwdLeafName) {
+  const providerSessionId = sessionsDb.getSessionById(appSessionId)?.provider_session_id;
+  if (!providerSessionId) {
+    return;
+  }
+
+  const transcript = await findPiTranscript(providerSessionId, cwdLeafName);
+  if (transcript) {
+    await cleanupPiTranscript(transcript.encodedDir, transcript.transcriptPath);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// The e2e scenarios
+// ---------------------------------------------------------------------------
+
+test(
+  'pi e2e: run → stream → complete → session file → resume → history',
+  { skip: skipReason, timeout: TEST_TIMEOUT_MS },
+  async () => {
+    await ensureIsolatedDatabase();
+    const workDir = await mkdtemp(path.join(os.tmpdir(), 'pi-e2e-run-'));
+    const cwdLeafName = path.basename(workDir);
+    const appSessionId = `pi-e2e-${randomUUID()}`;
+    sessionsDb.createAppSession(appSessionId, 'pi', workDir);
+
+    let transcript = null;
+    try {
+      // --- turn 1: fresh session, streamed reply, terminal complete -------
+      const first = await runProductionTurn({
+        appSessionId,
+        prompt: 'Reply with exactly: e2e-hello',
+        cwd: workDir,
+        model,
+      });
+
+      // The gateway swallows `session_created` and maps the provider-native id
+      // onto the app row instead; the client-visible frames carry the app id.
+      const mappedProviderId = sessionsDb.getSessionById(appSessionId).provider_session_id;
+      assert.ok(mappedProviderId, 'the gateway must persist the provider session mapping');
+      assert.notEqual(mappedProviderId, appSessionId);
+
+      const streamedText = first.connection.frames
+        .filter((frame) => frame.kind === 'stream_delta')
+        .map((frame) => frame.content)
+        .join('');
+      assert.match(streamedText, /e2e-hello/);
+      assert.ok(
+        first.connection.frames.every((frame) => frame.sessionId === appSessionId),
+        'every client frame must be remapped to the app session id',
+      );
+
+      const completes = first.connection.frames.filter((frame) => frame.kind === 'complete');
+      assert.equal(completes.length, 1, 'exactly one terminal complete per run');
+      assert.equal(completes[0].aborted, false);
+      assert.equal(completes[0].success, true);
+      assert.equal(completes[0].provider, 'pi');
+      assert.equal(first.failure, null);
+      assert.equal(first.stillProcessing, false);
+
+      const tokenBudget = first.connection.frames.find(
+        (frame) => frame.kind === 'status' && frame.text === 'token_budget',
+      );
+      assert.ok(tokenBudget, 'the run must report a token budget from pi usage');
+      assert.ok(tokenBudget.tokenBudget.used > 0);
+
+      // --- session transcript: one jsonl under the cwd-encoded directory ---
+      transcript = await findPiTranscript(mappedProviderId, cwdLeafName);
+      assert.ok(transcript, 'pi must persist the session under ~/.pi/agent/sessions');
+      assert.equal(
+        path.dirname(transcript.encodedDir),
+        getPiSessionDir(),
+        'pi keeps all sessions of one cwd flat in a single directory',
+      );
+      const siblings = await readdir(transcript.encodedDir);
+      assert.equal(
+        siblings.filter((name) => name.endsWith('.jsonl')).length,
+        1,
+        'a fresh pi session writes exactly one transcript for its cwd',
+      );
+
+      // --- turn 2: resume through the same app session id ------------------
+      const second = await runProductionTurn({
+        appSessionId,
+        prompt: 'What exact phrase did I ask you to reply with in this session? Quote it.',
+        cwd: workDir,
+        model,
+      });
+
+      const resumedText = second.connection.frames
+        .filter((frame) => frame.kind === 'stream_delta')
+        .map((frame) => frame.content)
+        .join('');
+      assert.match(resumedText, /e2e-hello/);
+      assert.equal(second.connection.frames.filter((frame) => frame.kind === 'complete').length, 1);
+      assert.equal(second.failure, null);
+      // Resume reuses the provider transcript instead of starting a new one.
+      assert.equal(
+        sessionsDb.getSessionById(appSessionId).provider_session_id,
+        mappedProviderId,
+        'resume keeps the provider-native session id',
+      );
+      const resumedSiblings = await readdir(transcript.encodedDir);
+      assert.equal(
+        resumedSiblings.filter((name) => name.endsWith('.jsonl')).length,
+        1,
+        'resumed turns append to the same session file',
+      );
+
+      // --- history: the production REST read path over the JSONL ----------
+      const history = await sessionsService.fetchHistory(appSessionId, {});
+      const historyText = history.messages
+        .filter((message) => message.kind === 'text')
+        .map((message) => message.content)
+        .join('\n');
+      assert.match(historyText, /e2e-hello/);
+      assert.ok(
+        history.messages.some((message) => message.kind === 'text' && message.role === 'user'),
+        'history must contain the user prompt',
+      );
+      assert.ok(history.tokenUsage && history.tokenUsage.used > 0);
+    } finally {
+      await cleanupSessionArtifacts(appSessionId, cwdLeafName);
+      await rm(workDir, { recursive: true, force: true });
+      chatRunRegistry.clearAll();
+    }
+  },
+);
+
+test(
+  'pi e2e: a tool turn pairs every tool_use with its tool_result',
+  { skip: skipReason, timeout: TEST_TIMEOUT_MS },
+  async () => {
+    await ensureIsolatedDatabase();
+    const workDir = await mkdtemp(path.join(os.tmpdir(), 'pi-e2e-tool-'));
+    const appSessionId = `pi-e2e-${randomUUID()}`;
+    sessionsDb.createAppSession(appSessionId, 'pi', workDir);
+
+    try {
+      await mkdir(path.join(workDir, 'pi-e2e-marker-dir'), { recursive: true });
+
+      const turn = await runProductionTurn({
+        appSessionId,
+        prompt:
+          'Use the bash tool to run exactly this one command, then answer with the command output: ls -a',
+        cwd: workDir,
+        model,
+      });
+
+      const toolUses = turn.connection.frames.filter((frame) => frame.kind === 'tool_use');
+      const toolResults = turn.connection.frames.filter((frame) => frame.kind === 'tool_result');
+      assert.ok(toolUses.length > 0, 'the run must report tool activity from pi');
+      assert.ok(toolResults.length > 0, 'the run must report tool results from pi');
+
+      // Every tool call pi starts must be closed by a result keyed by the same id.
+      for (const toolUse of toolUses) {
+        const paired = toolResults.filter((frame) => frame.toolId === toolUse.toolId);
+        assert.equal(paired.length, 1, `tool_use ${toolUse.toolId} must pair with one tool_result`);
+        assert.equal(paired[0].toolName, toolUse.toolName);
+      }
+
+      const bashResult = toolUses.some((frame) => frame.toolName === 'bash')
+        ? toolResults.find((frame) => frame.toolName === 'bash')
+        : toolResults[0];
+      assert.ok(bashResult, 'the bash tool result must reach the client');
+      assert.equal(bashResult.toolResult.isError, false);
+      assert.match(bashResult.toolResult.content, /pi-e2e-marker-dir/);
+
+      // Calibration observation (docs/pi-notes.md): pi finalizes one assistant
+      // message per tool round, so a tool turn streams more than one
+      // stream_end. Logged for the e2e calibration notes, not asserted.
+      const streamEnds = turn.connection.frames.filter((frame) => frame.kind === 'stream_end');
+      console.log(`[pi-e2e] tool turn stream_end count: ${streamEnds.length}`);
+
+      assert.equal(turn.connection.frames.filter((frame) => frame.kind === 'complete').length, 1);
+      assert.equal(turn.failure, null);
+
+      // The persisted history carries the same pairing back after the run.
+      const history = await sessionsService.fetchHistory(appSessionId, {});
+      const historyToolUses = history.messages.filter((message) => message.kind === 'tool_use');
+      const historyToolResults = history.messages.filter((message) => message.kind === 'tool_result');
+      assert.ok(historyToolUses.length > 0, 'history must contain the tool call');
+      assert.ok(historyToolResults.length > 0, 'history must contain the tool result');
+      for (const toolUse of historyToolUses) {
+        assert.ok(
+          historyToolResults.some((frame) => frame.toolId === toolUse.toolId),
+          'history tool_result must be keyed by the same tool id',
+        );
+      }
+    } finally {
+      await cleanupSessionArtifacts(appSessionId, path.basename(workDir));
+      await rm(workDir, { recursive: true, force: true });
+      chatRunRegistry.clearAll();
+    }
+  },
+);
+
+test(
+  'pi e2e: aborting a long run SIGTERMs pi and the client sees one aborted complete',
+  { skip: skipReason, timeout: TEST_TIMEOUT_MS },
+  async () => {
+    await ensureIsolatedDatabase();
+    const workDir = await mkdtemp(path.join(os.tmpdir(), 'pi-e2e-abort-'));
+    const appSessionId = `pi-e2e-${randomUUID()}`;
+    sessionsDb.createAppSession(appSessionId, 'pi', workDir);
+
+    try {
+      const connection = new FakeConnection();
+      const run = chatRunRegistry.startRun({
+        appSessionId,
+        provider: 'pi',
+        providerSessionId: sessionsDb.getSessionById(appSessionId).provider_session_id,
+        connection,
+        userId: null,
+      });
+      assert.ok(run);
+
+      let failure = null;
+      const runPromise = providerRuntimeService.run(
+        'pi',
+        'Count slowly from 1 to 100, one number per line.',
+        { sessionId: appSessionId, cwd: workDir, projectPath: workDir, model },
+        run.writer,
+      ).catch((error) => {
+        failure = error instanceof Error ? error.message : String(error);
+      });
+
+      // Poll like a user hammering Stop: the process row appears as soon as pi
+      // is spawned, then give the turn a second so there is something to cut.
+      let aborted = false;
+      for (let attempt = 0; attempt < 100 && !aborted; attempt += 1) {
+        aborted = await providerRuntimeService.abort('pi', appSessionId);
+        if (!aborted) {
+          await sleep(100);
+        }
+      }
+      assert.equal(aborted, true, 'the running pi process must be abortable by app session id');
+      await sleep(1000);
+      assert.equal(await providerRuntimeService.abort('pi', appSessionId), false);
+
+      // handleChatAbort's exact sequence: the gateway emits the terminal
+      // complete on the run's behalf because aborted runtimes stay silent.
+      chatRunRegistry.completeRun(appSessionId, { exitCode: 0, aborted: true });
+
+      await runPromise;
+      assert.match(failure || '', /terminated|exited with code/);
+
+      const completes = connection.frames.filter((frame) => frame.kind === 'complete');
+      assert.equal(completes.length, 1, 'exactly one complete reaches the client');
+      assert.equal(completes[0].aborted, true);
+      assert.equal(completes[0].provider, 'pi');
+      assert.equal(chatRunRegistry.isProcessing(appSessionId), false, 'the session must not stay stuck');
+    } finally {
+      await cleanupSessionArtifacts(appSessionId, path.basename(workDir));
+      await rm(workDir, { recursive: true, force: true });
+      chatRunRegistry.clearAll();
+    }
+  },
+);

--- a/server/modules/providers/tests/pi-facets.test.ts
+++ b/server/modules/providers/tests/pi-facets.test.ts
@@ -1,0 +1,344 @@
+import assert from 'node:assert/strict';
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+
+import { PiProviderAuth } from '@/modules/providers/list/pi/pi-auth.provider.js';
+import { PiMcpProvider } from '@/modules/providers/list/pi/pi-mcp.provider.js';
+import {
+  PI_PREDEFINED_MODELS,
+  PiProviderModels,
+} from '@/modules/providers/list/pi/pi-models.provider.js';
+import { PiSkillsProvider } from '@/modules/providers/list/pi/pi-skills.provider.js';
+import { createProviderTokenUsageService } from '@/modules/providers/services/provider-token-usage.service.js';
+import { AppError } from '@/shared/utils.js';
+
+// ---------------------------------------------------------------------------
+// Shared isolation helpers
+// ---------------------------------------------------------------------------
+
+const patchHomeDir = (nextHomeDir: string) => {
+  const original = os.homedir;
+  (os as any).homedir = () => nextHomeDir;
+  return () => {
+    (os as any).homedir = original;
+  };
+};
+
+/**
+ * Environment variables pi accepts as credentials. The list mirrors the auth
+ * adapter's own probe set so "no credentials" tests stay honest even when the
+ * developer machine running the suite has a real key exported.
+ */
+const PI_ENV_CREDENTIAL_KEYS = [
+  'ANTHROPIC_API_KEY',
+  'ANTHROPIC_AUTH_TOKEN',
+  'OPENAI_API_KEY',
+  'GOOGLE_GENERATIVE_AI_API_KEY',
+  'ZAI_CODING_CN_API_KEY',
+];
+
+const withEnvironmentCredentials = async (
+  values: Record<string, string>,
+  run: () => Promise<void>,
+): Promise<void> => {
+  const savedEntries = PI_ENV_CREDENTIAL_KEYS.map(
+    (key) => [key, process.env[key]] as const,
+  );
+  try {
+    for (const key of PI_ENV_CREDENTIAL_KEYS) {
+      delete process.env[key];
+    }
+    for (const [key, value] of Object.entries(values)) {
+      process.env[key] = value;
+    }
+    await run();
+  } finally {
+    for (const [key, value] of savedEntries) {
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+  }
+};
+
+const withPath = async (nextPath: string, run: () => Promise<void>): Promise<void> => {
+  const originalPath = process.env.PATH;
+  process.env.PATH = nextPath;
+  try {
+    await run();
+  } finally {
+    process.env.PATH = originalPath;
+  }
+};
+
+/** Writes a `pi` stub that exits 0 for `--version`, then hands back its dir. */
+const writeFakePiCli = async (binDir: string): Promise<string> => {
+  await mkdir(binDir, { recursive: true });
+  // A shebang script resolves through the kernel on macOS/Linux; the CI and
+  // developer suites for this repo never run the server tests on Windows.
+  await writeFile(path.join(binDir, 'pi'), '#!/bin/sh\nexit 0\n', { mode: 0o755 });
+  return binDir;
+};
+
+const withIsolatedPiHome = async (run: (homeDir: string) => Promise<void>): Promise<void> => {
+  const tempRoot = await mkdtemp(path.join(os.tmpdir(), 'pi-facets-'));
+  const restoreHomeDir = patchHomeDir(tempRoot);
+  try {
+    await run(tempRoot);
+  } finally {
+    restoreHomeDir();
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+};
+
+const writeSkill = async (skillDir: string, name: string, description: string): Promise<void> => {
+  await mkdir(skillDir, { recursive: true });
+  await writeFile(
+    path.join(skillDir, 'SKILL.md'),
+    `---\nname: ${name}\ndescription: ${description}\n---\n\nBody for ${name}.\n`,
+    'utf8',
+  );
+};
+
+// ---------------------------------------------------------------------------
+// auth
+// ---------------------------------------------------------------------------
+
+test('auth reports an installed pi with no credentials as merely unauthenticated', async () => {
+  await withIsolatedPiHome(async (homeDir) => {
+    const binDir = await writeFakePiCli(path.join(homeDir, 'bin'));
+    await withPath(binDir, async () => {
+      await withEnvironmentCredentials({}, async () => {
+        const status = await new PiProviderAuth().getStatus();
+
+        assert.equal(status.provider, 'pi');
+        assert.equal(status.installed, true);
+        assert.equal(status.authenticated, false);
+        assert.equal(status.method, null);
+        // pi has no account identity, so there is no email to report.
+        assert.equal(status.email, null);
+        // An unauthenticated pi is a neutral state, not an error the UI should
+        // render as a failure.
+        assert.equal(status.error, undefined);
+      });
+    });
+  });
+});
+
+test('auth reports pi as not installed when the CLI is missing from PATH', async () => {
+  await withIsolatedPiHome(async (homeDir) => {
+    const emptyDir = path.join(homeDir, 'empty-bin');
+    await mkdir(emptyDir, { recursive: true });
+    await withPath(emptyDir, async () => {
+      await withEnvironmentCredentials({}, async () => {
+        const status = await new PiProviderAuth().getStatus();
+
+        assert.equal(status.installed, false);
+        assert.equal(status.authenticated, false);
+      });
+    });
+  });
+});
+
+test('auth accepts provider API keys exported into the environment', async () => {
+  await withIsolatedPiHome(async (homeDir) => {
+    const binDir = await writeFakePiCli(path.join(homeDir, 'bin'));
+    await withPath(binDir, async () => {
+      await withEnvironmentCredentials({ ANTHROPIC_API_KEY: 'test-key-placeholder' }, async () => {
+        const status = await new PiProviderAuth().getStatus();
+
+        assert.equal(status.authenticated, true);
+        assert.equal(status.method, 'env');
+        assert.equal(status.email, null);
+      });
+    });
+  });
+});
+
+test('auth prefers the pi auth store over environment keys', async () => {
+  await withIsolatedPiHome(async (homeDir) => {
+    const binDir = await writeFakePiCli(path.join(homeDir, 'bin'));
+    const agentDir = path.join(homeDir, '.pi', 'agent');
+    await mkdir(agentDir, { recursive: true });
+    await writeFile(path.join(agentDir, 'auth.json'), '{}\n', 'utf8');
+    await withPath(binDir, async () => {
+      await withEnvironmentCredentials({ OPENAI_API_KEY: 'test-key-placeholder' }, async () => {
+        const status = await new PiProviderAuth().getStatus();
+
+        assert.equal(status.authenticated, true);
+        assert.equal(status.method, 'oauth');
+      });
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// models
+// ---------------------------------------------------------------------------
+
+test('the pi catalog keeps the frontend default and declares effort for every model', () => {
+  assert.equal(PI_PREDEFINED_MODELS.DEFAULT, 'anthropic/claude-sonnet-4');
+
+  const values = PI_PREDEFINED_MODELS.OPTIONS.map((option) => option.value);
+  assert.ok(values.length > 0);
+  assert.ok(values.includes(PI_PREDEFINED_MODELS.DEFAULT));
+
+  for (const option of PI_PREDEFINED_MODELS.OPTIONS) {
+    assert.ok(option.label.trim().length > 0, `${option.value} needs a label`);
+    assert.ok(
+      Array.isArray(option.effort?.values),
+      `${option.value} must declare an effort list (empty until pi exposes one)`,
+    );
+  }
+
+  for (const providerPrefix of ['anthropic/', 'zai-coding-cn/', 'openai/']) {
+    assert.ok(
+      values.some((value) => value.startsWith(providerPrefix)),
+      `catalog is missing a ${providerPrefix}* model`,
+    );
+  }
+});
+
+test('the pi models facet serves the curated catalog and its default', async () => {
+  const models = new PiProviderModels();
+
+  assert.deepEqual(await models.getSupportedModels(), PI_PREDEFINED_MODELS);
+  assert.deepEqual(await models.getCurrentActiveModel(), {
+    model: PI_PREDEFINED_MODELS.DEFAULT,
+  });
+  // Phase 1 has no runtime model state to read back, so a session id resolves
+  // to the same curated default.
+  assert.deepEqual(await models.getCurrentActiveModel('session-1'), {
+    model: PI_PREDEFINED_MODELS.DEFAULT,
+  });
+});
+
+// ---------------------------------------------------------------------------
+// skills
+// ---------------------------------------------------------------------------
+
+test('listSkills reads pi user skills, settings.json sources and workspace skills', async () => {
+  await withIsolatedPiHome(async (homeDir) => {
+    const configuredDir = path.join(homeDir, 'configured-skills');
+    await writeSkill(path.join(configuredDir, 'deploy-notes'), 'deploy-notes', 'Deploy checklist.');
+    await writeSkill(
+      path.join(homeDir, '.pi', 'agent', 'skills', 'release-check'),
+      'release-check',
+      'Release checklist.',
+    );
+
+    const workspacePath = path.join(homeDir, 'workspace');
+    await writeSkill(
+      path.join(workspacePath, '.pi', 'skills', 'repo-lint'),
+      'repo-lint',
+      'Repository lint.',
+    );
+
+    const agentDir = path.join(homeDir, '.pi', 'agent');
+    await mkdir(agentDir, { recursive: true });
+    await writeFile(
+      path.join(agentDir, 'settings.json'),
+      `${JSON.stringify({ skills: [configuredDir] })}\n`,
+      'utf8',
+    );
+
+    const skills = await new PiSkillsProvider().listSkills({ workspacePath });
+    const byName = new Map(skills.map((skill) => [skill.name, skill]));
+
+    assert.deepEqual([...byName.keys()].sort(), ['deploy-notes', 'release-check', 'repo-lint']);
+    assert.equal(byName.get('deploy-notes')?.command, '/deploy-notes');
+    assert.equal(byName.get('deploy-notes')?.scope, 'user');
+    assert.equal(byName.get('deploy-notes')?.provider, 'pi');
+    assert.equal(byName.get('deploy-notes')?.description, 'Deploy checklist.');
+    assert.equal(byName.get('release-check')?.scope, 'user');
+    assert.equal(byName.get('repo-lint')?.scope, 'project');
+    assert.equal(byName.get('repo-lint')?.command, '/repo-lint');
+  });
+});
+
+test('listSkills skips settings.json skill directories that no longer exist', async () => {
+  await withIsolatedPiHome(async (homeDir) => {
+    const configuredDir = path.join(homeDir, 'configured-skills');
+    await writeSkill(path.join(configuredDir, 'deploy-notes'), 'deploy-notes', 'Deploy checklist.');
+
+    const agentDir = path.join(homeDir, '.pi', 'agent');
+    await mkdir(agentDir, { recursive: true });
+    await writeFile(
+      path.join(agentDir, 'settings.json'),
+      `${JSON.stringify({ skills: [configuredDir, path.join(homeDir, 'gone-skills')] })}\n`,
+      'utf8',
+    );
+
+    const skills = await new PiSkillsProvider().listSkills({
+      workspacePath: path.join(homeDir, 'workspace'),
+    });
+
+    assert.deepEqual(skills.map((skill) => skill.name), ['deploy-notes']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// mcp
+// ---------------------------------------------------------------------------
+
+test('pi reports no MCP servers in any scope', async () => {
+  const servers = await new PiMcpProvider().listServers({
+    workspacePath: path.join(os.tmpdir(), 'pi-facets-mcp'),
+  });
+
+  assert.deepEqual(servers, { user: [], local: [], project: [] });
+});
+
+test('pi rejects MCP server writes as unsupported', async () => {
+  const mcp = new PiMcpProvider();
+
+  await assert.rejects(
+    () => mcp.upsertServer({
+      name: 'docs',
+      transport: 'stdio',
+      command: 'npx',
+      args: ['-y', 'docs-server'],
+      scope: 'project',
+      workspacePath: path.join(os.tmpdir(), 'pi-facets-mcp'),
+    }),
+    (error: unknown) => (
+      error instanceof AppError
+      && error.code === 'NOT_SUPPORTED'
+      && /Pi does not support MCP/.test(error.message)
+    ),
+  );
+});
+
+// ---------------------------------------------------------------------------
+// token usage
+// ---------------------------------------------------------------------------
+
+test('pi token usage returns an explicit unsupported result', async () => {
+  const service = createProviderTokenUsageService({
+    getSessionById: () => ({
+      session_id: 'app-session',
+      provider: 'pi',
+      provider_session_id: 'provider-session',
+      project_path: null,
+      jsonl_path: null,
+      custom_name: null,
+      model: null,
+      effort: null,
+      forked_from_session_id: null,
+      isArchived: 0,
+      created_at: '2026-01-01T00:00:00.000Z',
+      updated_at: '2026-01-01T00:00:00.000Z',
+    }),
+  });
+
+  const result = await service.getSessionTokenUsage('app-session');
+
+  assert.equal(result.unsupported, true);
+  assert.equal(result.used, 0);
+  assert.equal(result.total, 0);
+  assert.deepEqual(result.breakdown, { input: 0, output: 0 });
+});

--- a/server/modules/providers/tests/pi-facets.test.ts
+++ b/server/modules/providers/tests/pi-facets.test.ts
@@ -28,14 +28,15 @@ const patchHomeDir = (nextHomeDir: string) => {
 
 /**
  * Environment variables pi accepts as credentials. The list mirrors the auth
- * adapter's own probe set so "no credentials" tests stay honest even when the
- * developer machine running the suite has a real key exported.
+ * adapter's own probe set (pi's env-api-keys mapping) so "no credentials"
+ * tests stay honest even when the developer machine running the suite has a
+ * real key exported.
  */
 const PI_ENV_CREDENTIAL_KEYS = [
   'ANTHROPIC_API_KEY',
   'ANTHROPIC_AUTH_TOKEN',
   'OPENAI_API_KEY',
-  'GOOGLE_GENERATIVE_AI_API_KEY',
+  'GEMINI_API_KEY',
   'ZAI_CODING_CN_API_KEY',
 ];
 

--- a/server/modules/providers/tests/pi-registry.test.ts
+++ b/server/modules/providers/tests/pi-registry.test.ts
@@ -1,5 +1,6 @@
-import test from 'node:test';
 import assert from 'node:assert/strict';
+import test from 'node:test';
+
 import { providerRegistry } from '@/modules/providers/provider.registry.js';
 
 test('pi is a registered provider', () => {

--- a/server/modules/providers/tests/pi-registry.test.ts
+++ b/server/modules/providers/tests/pi-registry.test.ts
@@ -1,0 +1,13 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { providerRegistry } from '@/modules/providers/provider.registry.js';
+
+test('pi is a registered provider', () => {
+  const provider = providerRegistry.resolveProvider('pi');
+  assert.equal(provider.id, 'pi');
+  assert.equal(providerRegistry.listProviders().length, 5);
+});
+
+test('resolveProvider throws for unknown provider', () => {
+  assert.throws(() => providerRegistry.resolveProvider('nope'), /Unsupported provider/);
+});

--- a/server/modules/providers/tests/pi-session-synchronizer.test.ts
+++ b/server/modules/providers/tests/pi-session-synchronizer.test.ts
@@ -1,0 +1,228 @@
+import assert from 'node:assert/strict';
+import { mkdir, mkdtemp, rm, utimes, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+
+import { closeConnection, initializeDatabase, sessionsDb } from '@/modules/database/index.js';
+import { PiSessionSynchronizer } from '@/modules/providers/list/pi/pi-session-synchronizer.provider.js';
+
+const patchHomeDir = (nextHomeDir: string) => {
+  const original = os.homedir;
+  (os as any).homedir = () => nextHomeDir;
+  return () => {
+    (os as any).homedir = original;
+  };
+};
+
+async function withIsolatedDatabase(runTest: () => void | Promise<void>): Promise<void> {
+  const previousDatabasePath = process.env.DATABASE_PATH;
+  const tempDirectory = await mkdtemp(path.join(os.tmpdir(), 'pi-synchronizer-db-'));
+  const databasePath = path.join(tempDirectory, 'auth.db');
+
+  closeConnection();
+  process.env.DATABASE_PATH = databasePath;
+  await initializeDatabase();
+
+  try {
+    await runTest();
+  } finally {
+    closeConnection();
+    if (previousDatabasePath === undefined) {
+      delete process.env.DATABASE_PATH;
+    } else {
+      process.env.DATABASE_PATH = previousDatabasePath;
+    }
+    await rm(tempDirectory, { recursive: true, force: true });
+  }
+}
+
+const SESSION_ONE_ID = '01a095e3-bb8a-72a9-83a6-66b7c73b176d';
+const SESSION_TWO_ID = '02b106f4-cc9b-83ba-94b7-77c8d84c287e';
+const SESSION_THREE_ID = '03c217a5-ddac-94cb-a5c8-88d9e95d398f';
+
+const sessionHeaderLine = (sessionId: string, timestamp: string, cwd: string) =>
+  JSON.stringify({ type: 'session', version: 3, id: sessionId, timestamp, cwd });
+
+const userMessageLine = (text: string) =>
+  JSON.stringify({
+    type: 'message',
+    id: 'm-user',
+    parentId: null,
+    timestamp: '2026-09-12T13:52:06.000Z',
+    message: {
+      role: 'user',
+      content: [{ type: 'text', text }],
+      api: 'anthropic-messages',
+      provider: 'anthropic',
+      model: 'glm-5.3',
+      stopReason: 'stop',
+      usage: { input: 10, output: 0, cacheRead: 0, cacheWrite: 0, totalTokens: 10 },
+    },
+  });
+
+/**
+ * Writes one pi transcript the way pi 0.85.1 lays sessions out on disk:
+ * `~/.pi/agent/sessions/<encoded-cwd>/<ISO timestamp>_<session uuid>.jsonl`.
+ */
+async function writePiSession(
+  homeDir: string,
+  options: {
+    encodedCwd: string;
+    fileName: string;
+    lines: string[];
+    mtime?: Date;
+  },
+): Promise<string> {
+  const sessionDirectory = path.join(homeDir, '.pi', 'agent', 'sessions', options.encodedCwd);
+  await mkdir(sessionDirectory, { recursive: true });
+  const filePath = path.join(sessionDirectory, options.fileName);
+  await writeFile(filePath, `${options.lines.join('\n')}\n`, 'utf8');
+  if (options.mtime) {
+    await utimes(filePath, options.mtime, options.mtime);
+  }
+  return filePath;
+}
+
+async function withIsolatedPiHome(run: (homeDir: string) => Promise<void>): Promise<void> {
+  const tempRoot = await mkdtemp(path.join(os.tmpdir(), 'pi-synchronizer-home-'));
+  const restoreHomeDir = patchHomeDir(tempRoot);
+  try {
+    await run(tempRoot);
+  } finally {
+    restoreHomeDir();
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+}
+
+test('synchronize upserts pi sessions into the sidebar db', async () => {
+  await withIsolatedPiHome(async (homeDir) => {
+    const projectOne = path.join(homeDir, 'workspaces', 'checkout');
+    const projectTwo = path.join(homeDir, 'workspaces', 'docs');
+
+    // Long enough that the 120-char session name bound kicks in.
+    const longPrompt = `Fix the login redirect loop${' and keep the retry budget intact'.repeat(4)}`;
+    await writePiSession(homeDir, {
+      encodedCwd: '--x--',
+      fileName: `2026-09-12T13-52-05-003Z_${SESSION_ONE_ID}.jsonl`,
+      lines: [
+        sessionHeaderLine(SESSION_ONE_ID, '2026-09-12T13:52:05.003Z', projectOne),
+        userMessageLine(longPrompt),
+      ],
+    });
+    // A header-only transcript: the session still gets indexed, untitled.
+    await writePiSession(homeDir, {
+      encodedCwd: '--y--',
+      fileName: `2026-09-12T14-00-00-000Z_${SESSION_TWO_ID}.jsonl`,
+      lines: [sessionHeaderLine(SESSION_TWO_ID, '2026-09-12T14:00:00.000Z', projectTwo)],
+    });
+
+    await withIsolatedDatabase(async () => {
+      const processed = await new PiSessionSynchronizer().synchronize(new Date(0));
+      assert.equal(processed, 2);
+
+      const first = sessionsDb.getSessionByProviderSessionId(SESSION_ONE_ID);
+      assert.equal(first?.provider, 'pi');
+      assert.equal(first?.project_path, projectOne);
+      // The name comes from the first user message, truncated to the standard bound.
+      assert.equal(first?.custom_name?.length, 120);
+      assert.ok(first?.custom_name?.startsWith('Fix the login redirect loop'));
+      // pi keeps every transcript in one shared tree, so the row must never
+      // claim a deletable jsonl path (same reasoning as opencode).
+      assert.equal(first?.jsonl_path, null);
+      assert.equal(first?.created_at, '2026-09-12T13:52:05.003Z');
+
+      const second = sessionsDb.getSessionByProviderSessionId(SESSION_TWO_ID);
+      assert.equal(second?.provider, 'pi');
+      assert.equal(second?.project_path, projectTwo);
+      assert.equal(second?.custom_name, 'Untitled pi Session');
+    });
+  });
+});
+
+test('synchronizeFile only handles pi session jsonl files', async () => {
+  await withIsolatedPiHome(async (homeDir) => {
+    const projectPath = path.join(homeDir, 'workspaces', 'changelog');
+    const transcriptPath = await writePiSession(homeDir, {
+      encodedCwd: '--z--',
+      fileName: `2026-09-12T15-00-00-000Z_${SESSION_THREE_ID}.jsonl`,
+      lines: [
+        sessionHeaderLine(SESSION_THREE_ID, '2026-09-12T15:00:00.000Z', projectPath),
+        userMessageLine('Summarize the changelog'),
+      ],
+    });
+
+    await withIsolatedDatabase(async () => {
+      const synchronizer = new PiSessionSynchronizer();
+
+      // Foreign artifacts (opencode's sqlite store, stray jsonl elsewhere)
+      // must not be touched.
+      assert.equal(await synchronizer.synchronizeFile('/tmp/opencode.db'), null);
+      assert.equal(await synchronizer.synchronizeFile(path.join(homeDir, 'notes.jsonl')), null);
+
+      const sessionId = await synchronizer.synchronizeFile(transcriptPath);
+      assert.equal(sessionId, SESSION_THREE_ID);
+
+      const indexed = sessionsDb.getSessionByProviderSessionId(SESSION_THREE_ID);
+      assert.equal(indexed?.provider, 'pi');
+      assert.equal(indexed?.project_path, projectPath);
+      assert.equal(indexed?.custom_name, 'Summarize the changelog');
+    });
+  });
+});
+
+test('synchronize(since) skips files whose mtime is older than the cursor', async () => {
+  await withIsolatedPiHome(async (homeDir) => {
+    const projectPath = path.join(homeDir, 'workspaces', 'old-and-new');
+    await writePiSession(homeDir, {
+      encodedCwd: '--old--',
+      fileName: `2026-09-12T09-00-00-000Z_${SESSION_ONE_ID}.jsonl`,
+      lines: [sessionHeaderLine(SESSION_ONE_ID, '2026-09-12T09:00:00.000Z', projectPath)],
+      mtime: new Date(Date.now() - 3_600_000),
+    });
+    await writePiSession(homeDir, {
+      encodedCwd: '--new--',
+      fileName: `2026-09-12T16-00-00-000Z_${SESSION_TWO_ID}.jsonl`,
+      lines: [sessionHeaderLine(SESSION_TWO_ID, '2026-09-12T16:00:00.000Z', projectPath)],
+    });
+
+    await withIsolatedDatabase(async () => {
+      const processed = await new PiSessionSynchronizer().synchronize(
+        new Date(Date.now() - 1_800_000),
+      );
+      assert.equal(processed, 1);
+      assert.equal(sessionsDb.getSessionByProviderSessionId(SESSION_TWO_ID)?.provider, 'pi');
+      assert.equal(sessionsDb.getSessionByProviderSessionId(SESSION_ONE_ID), null);
+
+      // A full scan (no cursor) still picks the older file up.
+      assert.equal(await new PiSessionSynchronizer().synchronize(), 2);
+      assert.ok(sessionsDb.getSessionByProviderSessionId(SESSION_ONE_ID));
+    });
+  });
+});
+
+test('synchronizeFile adopts the pending app session instead of creating a duplicate', async () => {
+  await withIsolatedPiHome(async (homeDir) => {
+    const projectPath = path.join(homeDir, 'workspaces', 'race');
+    const transcriptPath = await writePiSession(homeDir, {
+      encodedCwd: '--race--',
+      fileName: `2026-09-12T17-00-00-000Z_${SESSION_ONE_ID}.jsonl`,
+      lines: [
+        sessionHeaderLine(SESSION_ONE_ID, '2026-09-12T17:00:00.000Z', projectPath),
+        userMessageLine('Why is the build red?'),
+      ],
+    });
+
+    await withIsolatedDatabase(async () => {
+      sessionsDb.createAppSession('app-session-1', 'pi', projectPath, 'Why is the build red?');
+
+      const sessionId = await new PiSessionSynchronizer().synchronizeFile(transcriptPath);
+
+      assert.equal(sessionId, 'app-session-1');
+      assert.equal(sessionsDb.getAllSessions().length, 1);
+      const adopted = sessionsDb.getSessionById('app-session-1');
+      assert.equal(adopted?.provider_session_id, SESSION_ONE_ID);
+      assert.equal(adopted?.custom_name, 'Why is the build red?');
+    });
+  });
+});

--- a/server/modules/providers/tests/provider-runtime.service.test.ts
+++ b/server/modules/providers/tests/provider-runtime.service.test.ts
@@ -76,6 +76,7 @@ test('providerRegistry owns one runtime for every registered provider', () => {
     'codex',
     'cursor',
     'opencode',
+    'pi',
   ]);
   assert.equal(providers.every((provider) => typeof provider.runtime.run === 'function'), true);
   assert.equal(providers.every((provider) => typeof provider.runtime.abort === 'function'), true);

--- a/server/modules/websocket/services/shell-websocket.service.ts
+++ b/server/modules/websocket/services/shell-websocket.service.ts
@@ -217,6 +217,13 @@ function buildShellCommand(
     return initialCommand || 'opencode';
   }
 
+  if (provider === 'pi') {
+    if (resumeSessionId) {
+      return `pi --session "${resumeSessionId}"`;
+    }
+    return initialCommand || 'pi';
+  }
+
   // Launching with the flag is what unlocks "bypass permissions" in the CLI's
   // shift+tab permission-mode cycle; it cannot be enabled from inside a
   // session started without it.
@@ -543,7 +550,9 @@ export function handleShellConnection(
                 ? 'Codex'
                 : provider === 'opencode'
                     ? 'OpenCode'
-                  : 'Claude';
+                  : provider === 'pi'
+                      ? 'Pi'
+                    : 'Claude';
           welcomeMsg = hasSession && resumeSessionId
             ? `\x1b[36mResuming ${providerName} session ${resumeSessionId} in: ${projectPath}\x1b[0m\r\n`
             : `\x1b[36mStarting new ${providerName} session in: ${projectPath}\x1b[0m\r\n`;

--- a/server/shared/types.ts
+++ b/server/shared/types.ts
@@ -66,7 +66,7 @@ export type AuthenticatedWebSocketRequest = IncomingMessage & {
  * Use this as the source of truth whenever a function or payload needs to identify
  * a specific LLM integration.
  */
-export type LLMProvider = 'claude' | 'codex' | 'cursor' | 'opencode';
+export type LLMProvider = 'claude' | 'codex' | 'cursor' | 'opencode' | 'pi';
 
 /**
  * One selectable model row in a provider model catalog.

--- a/server/shared/utils.ts
+++ b/server/shared/utils.ts
@@ -932,6 +932,20 @@ export function unwrapJsonStringLiteral(value: string): string {
 }
 
 // ---------------------------
+//----------------- PI SESSION STORAGE UTILITIES ------------
+/**
+ * Resolves the Pi session directory.
+ *
+ * Pi writes one JSONL transcript per session under `~/.pi/agent/sessions`
+ * (grouped per project directory). Watchers and synchronizers should treat this
+ * path as read-only input and never store it as the deletable transcript path
+ * of an individual app session row.
+ */
+export function getPiSessionDir(): string {
+  return path.join(os.homedir(), '.pi', 'agent', 'sessions');
+}
+
+// ---------------------------
 //----------------- SAFE DIRECTORY NAME UTILITIES ------------
 /**
  * Validates that a user or provider supplied identifier can safely be treated

--- a/src/modules/chat/ChatInterface.tsx
+++ b/src/modules/chat/ChatInterface.tsx
@@ -397,7 +397,9 @@ function ChatInterface({
         ? t('messageTypes.codex')
         : provider === 'opencode'
             ? t('messageTypes.opencode', { defaultValue: 'OpenCode' })
-          : t('messageTypes.claude');
+          : provider === 'pi'
+              ? t('messageTypes.pi', { defaultValue: 'Pi' })
+            : t('messageTypes.claude');
 
   if (!selectedProject) {
     return (

--- a/src/modules/chat/export/buildTranscriptMarkdown.ts
+++ b/src/modules/chat/export/buildTranscriptMarkdown.ts
@@ -15,6 +15,7 @@ const PROVIDER_LABELS: Record<string, string> = {
   codex: 'Codex',
   cursor: 'Cursor',
   opencode: 'OpenCode',
+  pi: 'Pi',
 };
 
 /** Fenced blocks need a longer fence than anything they contain. */

--- a/src/modules/chat/hooks/useChatMessages.ts
+++ b/src/modules/chat/hooks/useChatMessages.ts
@@ -7,7 +7,9 @@ import type { ChatMessage,NormalizedMessage,SubagentActivity } from '@/shared/ty
 import { formatUsageLimitText } from '@/modules/chat/utils/chatFormatting';
 
 function formatToolResultContent(content: unknown): string {
-  const text = typeof content === 'string' ? content : JSON.stringify(content);
+  // JSON.stringify(undefined) returns undefined (not a string), so a
+  // tool_result row without a content payload would crash the `.trim()` below.
+  const text = typeof content === 'string' ? content : (JSON.stringify(content) ?? '');
   const toolUseErrorMatch = /^<tool_use_error>([\s\S]*)<\/tool_use_error>$/.exec(text.trim());
   return toolUseErrorMatch ? toolUseErrorMatch[1] : text;
 }

--- a/src/modules/chat/hooks/useChatProviderState.ts
+++ b/src/modules/chat/hooks/useChatProviderState.ts
@@ -36,7 +36,7 @@ const FALLBACK_DEFAULT_MODEL: Record<LLMProvider, string> = {
   pi: 'anthropic/claude-sonnet-4',
 };
 
-const PROVIDERS: LLMProvider[] = ['claude', 'cursor', 'codex', 'opencode'];
+const PROVIDERS: LLMProvider[] = ['claude', 'cursor', 'codex', 'opencode', 'pi'];
 
 /** localStorage key holding the user's default model for one provider. */
 const providerModelStorageKey = (provider: LLMProvider): string => `${provider}-model`;

--- a/src/modules/chat/hooks/useChatProviderState.ts
+++ b/src/modules/chat/hooks/useChatProviderState.ts
@@ -33,6 +33,7 @@ const FALLBACK_DEFAULT_MODEL: Record<LLMProvider, string> = {
   cursor: 'gpt-5.3-codex',
   codex: 'gpt-5.4',
   opencode: 'anthropic/claude-sonnet-4-5',
+  pi: 'anthropic/claude-sonnet-4',
 };
 
 const PROVIDERS: LLMProvider[] = ['claude', 'cursor', 'codex', 'opencode'];
@@ -51,6 +52,7 @@ const FALLBACK_PERMISSION_MODES: Record<LLMProvider, PermissionMode[]> = {
   cursor: ['default', 'acceptEdits', 'bypassPermissions', 'plan'],
   codex: ['default', 'acceptEdits', 'bypassPermissions'],
   opencode: ['default', 'acceptEdits', 'bypassPermissions', 'plan'],
+  pi: ['default'],
 };
 
 type ProviderCapabilities = {

--- a/src/modules/chat/hooks/useSessionStore.ts
+++ b/src/modules/chat/hooks/useSessionStore.ts
@@ -120,9 +120,10 @@ async function requestSessionHistoryPage(
 }
 
 /**
- * Compute merged messages: server + realtime, deduped by id and adjacent
- * assistant echo (same trimmed text), so finalized stream rows do not stack
- * on top of the persisted copy before realtime is cleared.
+ * Compute merged messages: server + realtime, deduped by id and by
+ * same-turn assistant echo (same kind, same trimmed text — adjacency not
+ * required), so finalized stream rows do not stack on top of the persisted
+ * copy before realtime is cleared.
  */
 function readMessageTime(m: NormalizedMessage): number | null {
   const time = Date.parse(m.timestamp);
@@ -263,46 +264,87 @@ function isAssistantEchoedInSameTurnOnServer(
 }
 
 /**
+ * The rows this dedupe compares, keyed by (kind, trimmed content).
+ *
+ * Thinking rows carry no role on either side, so only text keeps the
+ * assistant gate. Empty content never dedupes.
+ */
+function assistantEchoScopeKey(message: NormalizedMessage): string | null {
+  const content = (message.content || '').trim();
+  if (content.length === 0) {
+    return null;
+  }
+  if (message.kind === 'thinking') {
+    return `thinking\n${content}`;
+  }
+  if (message.kind === 'text' && message.role === 'assistant') {
+    return `text\n${content}`;
+  }
+  return null;
+}
+
+/**
+ * Collapse duplicated assistant rows in the merged view.
+ *
  * After `finalizeStreaming`, the client holds a synthetic assistant `text` row
- * while the sessions API soon returns the same reply with a different id.
- * Those sit back-to-back in merged order and look like duplicate bubbles until
- * A persisted-tail refresh reconciles realtime. Collapse same-text assistant rows and
- * stream_placeholder → text when content matches. Thinking rows are matched the
- * same way: live event-stream rows and persisted transcript rows never share a
- * message id, so identical adjacent reasoning blocks are one block seen twice.
+ * while the sessions API soon returns the same reply with a different id, and
+ * live event-stream rows never share a message id with their persisted twins
+ * either — text and thinking alike are matched by content echo. The refresh
+ * that pulls the persisted copy back normally prunes the live one
+ * (`pruneRealtimeSupersededByServer`), but that prune locates the owning turn
+ * by walking chronology, and live rows (stamped when the client received them)
+ * and persisted rows (stamped when the provider wrote them) can interleave
+ * enough to mislocate the turn. When it misses, both copies survive into the
+ * merged view — and they are not adjacent: the timestamp sort weaves each copy
+ * in between the other side's sibling rows (server text, live thinking, live
+ * text, server thinking). Adjacency therefore cannot be relied on, so the
+ * comparison is scoped by turn instead of by position: within one user turn, a
+ * row whose (kind, trimmed content) was already emitted is dropped, however
+ * far after its twin it sorts. Rows are only ever removed, never reordered.
+ *
+ * A `stream_delta` row directly followed by its identical finalized text is
+ * still upgraded to the text row, as before.
+ *
+ * Accepted false-merge: a model that genuinely emits the exact same block
+ * twice inside one turn loses the second copy — the same trade the adjacent
+ * merge this replaces already made, over a wider window. Identical replies in
+ * different turns are unaffected: a user prompt or a tool call starts a new
+ * scope.
  */
 function dedupeAdjacentAssistantEchoes(merged: NormalizedMessage[]): NormalizedMessage[] {
   const out: NormalizedMessage[] = [];
+  // (kind, trimmed content) pairs already emitted within the current turn.
+  let seenInTurn = new Set<string>();
+
   for (const m of merged) {
-    const prev = out[out.length - 1];
-    if (prev) {
-      if (prev.kind === 'stream_delta' && m.kind === 'text' && m.role === 'assistant') {
-        const ps = (prev.content || '').trim();
-        const ms = (m.content || '').trim();
-        if (ps.length > 0 && ps === ms) {
-          out[out.length - 1] = m;
-          continue;
-        }
-      }
-      if (
-        prev.kind === 'text'
-        && m.kind === 'text'
-        && prev.role === 'assistant'
-        && m.role === 'assistant'
-      ) {
-        const ms = (m.content || '').trim();
-        if (ms.length > 0 && ms === (prev.content || '').trim()) {
-          continue;
-        }
-      }
-      if (prev.kind === 'thinking' && m.kind === 'thinking') {
-        const ms = (m.content || '').trim();
-        if (ms.length > 0 && ms === (prev.content || '').trim()) {
-          continue;
-        }
-      }
+    if ((m.kind === 'text' && m.role === 'user') || m.kind === 'tool_use') {
+      seenInTurn = new Set<string>();
+      out.push(m);
+      continue;
     }
-    out.push(m);
+
+    const echoKey = assistantEchoScopeKey(m);
+    if (echoKey !== null && seenInTurn.has(echoKey)) {
+      continue;
+    }
+
+    const prev = out[out.length - 1];
+    if (
+      prev
+      && prev.kind === 'stream_delta'
+      && m.kind === 'text'
+      && m.role === 'assistant'
+      && (prev.content || '').trim().length > 0
+      && (prev.content || '').trim() === (m.content || '').trim()
+    ) {
+      out[out.length - 1] = m;
+    } else {
+      out.push(m);
+    }
+
+    if (echoKey !== null) {
+      seenInTurn.add(echoKey);
+    }
   }
   return out;
 }

--- a/src/modules/chat/hooks/useSessionStore.ts
+++ b/src/modules/chat/hooks/useSessionStore.ts
@@ -225,10 +225,22 @@ function findServerTurnRangeByOrdinal(
   return { start, end };
 }
 
-function isAssistantTextEchoedInSameTurnOnServer(
+type AssistantEchoKind = 'text' | 'thinking';
+
+/**
+ * Whether a live row's content already exists in the persisted transcript as a
+ * row of the same kind inside the same user turn.
+ *
+ * Live event-stream rows and persisted transcript rows derive their message ids
+ * from different sources, so `serverIds.has(id)` never matches them — text and
+ * thinking alike are matched by content echo instead. Thinking rows carry no
+ * role on either side, so only text keeps the assistant gate.
+ */
+function isAssistantEchoedInSameTurnOnServer(
   message: NormalizedMessage,
   serverMessages: NormalizedMessage[],
   realtimeMessages: NormalizedMessage[],
+  kind: AssistantEchoKind = 'text',
 ): boolean {
   const assistantText = (message.content || '').trim();
   if (!assistantText) {
@@ -244,8 +256,8 @@ function isAssistantTextEchoedInSameTurnOnServer(
   return serverMessages
     .slice(turnRange.start + 1, turnRange.end)
     .some((serverMessage) =>
-      serverMessage.kind === 'text'
-      && serverMessage.role === 'assistant'
+      serverMessage.kind === kind
+      && (kind !== 'text' || serverMessage.role === 'assistant')
       && (serverMessage.content || '').trim() === assistantText,
     );
 }
@@ -255,7 +267,9 @@ function isAssistantTextEchoedInSameTurnOnServer(
  * while the sessions API soon returns the same reply with a different id.
  * Those sit back-to-back in merged order and look like duplicate bubbles until
  * A persisted-tail refresh reconciles realtime. Collapse same-text assistant rows and
- * stream_placeholder → text when content matches.
+ * stream_placeholder → text when content matches. Thinking rows are matched the
+ * same way: live event-stream rows and persisted transcript rows never share a
+ * message id, so identical adjacent reasoning blocks are one block seen twice.
  */
 function dedupeAdjacentAssistantEchoes(merged: NormalizedMessage[]): NormalizedMessage[] {
   const out: NormalizedMessage[] = [];
@@ -276,6 +290,12 @@ function dedupeAdjacentAssistantEchoes(merged: NormalizedMessage[]): NormalizedM
         && prev.role === 'assistant'
         && m.role === 'assistant'
       ) {
+        const ms = (m.content || '').trim();
+        if (ms.length > 0 && ms === (prev.content || '').trim()) {
+          continue;
+        }
+      }
+      if (prev.kind === 'thinking' && m.kind === 'thinking') {
         const ms = (m.content || '').trim();
         if (ms.length > 0 && ms === (prev.content || '').trim()) {
           continue;
@@ -310,14 +330,24 @@ function pruneRealtimeSupersededByServer(
     }
 
     if (message.kind === 'stream_delta' || message.id === `__streaming_${message.sessionId}`) {
-      if (isAssistantTextEchoedInSameTurnOnServer(message, serverMessages, realtimeMessages)) {
+      if (isAssistantEchoedInSameTurnOnServer(message, serverMessages, realtimeMessages)) {
         return false;
       }
       return true;
     }
 
     if (message.kind === 'text' && message.role === 'assistant') {
-      if (isAssistantTextEchoedInSameTurnOnServer(message, serverMessages, realtimeMessages)) {
+      if (isAssistantEchoedInSameTurnOnServer(message, serverMessages, realtimeMessages)) {
+        return false;
+      }
+      return true;
+    }
+
+    // Live event-stream rows and persisted transcript rows never share a
+    // message id, so thinking is matched by content echo too (same as text);
+    // without this a persisted-tail refresh left every reasoning block doubled.
+    if (message.kind === 'thinking') {
+      if (isAssistantEchoedInSameTurnOnServer(message, serverMessages, realtimeMessages, 'thinking')) {
         return false;
       }
       return true;

--- a/src/modules/chat/modals/CommandResultModal.tsx
+++ b/src/modules/chat/modals/CommandResultModal.tsx
@@ -57,6 +57,7 @@ const PROVIDER_LABELS: Record<string, string> = {
   cursor: 'Cursor',
   codex: 'Codex',
   opencode: 'OpenCode',
+  pi: 'Pi',
 };
 
 const FALLBACK_COMMANDS: CommandEntry[] = [

--- a/src/modules/chat/modals/ModelLibraryPanel.tsx
+++ b/src/modules/chat/modals/ModelLibraryPanel.tsx
@@ -24,6 +24,7 @@ const PROVIDERS: Array<{ id: LLMProvider; label: string }> = [
   { id: 'codex', label: 'Codex' },
   { id: 'cursor', label: 'Cursor' },
   { id: 'opencode', label: 'OpenCode' },
+  { id: 'pi', label: 'Pi' },
 ];
 
 type ModelLibraryPanelProps = {

--- a/src/modules/chat/tests/sessionStoreThinkingEcho.test.tsx
+++ b/src/modules/chat/tests/sessionStoreThinkingEcho.test.tsx
@@ -1,0 +1,166 @@
+import assert from 'node:assert/strict';
+
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, it, vi } from 'vitest';
+
+import type { NormalizedMessage } from '@/shared/types';
+
+/**
+ * Live event-stream rows and persisted transcript rows derive their message
+ * ids from different sources, so `serverIds.has(id)` never matches them. Text
+ * and thinking alike are therefore matched by content echo — otherwise every
+ * reasoning block renders twice once the persisted-tail refresh reconciles
+ * realtime.
+ */
+
+const sessionMessages = vi.fn();
+
+vi.mock('@/shared/api', () => ({
+  api: {
+    providers: {
+      sessionMessages: (...args: unknown[]) => sessionMessages(...args),
+    },
+  },
+}));
+
+const text = (id: string, role: 'user' | 'assistant', content: string, timestamp: string): NormalizedMessage => ({
+  id,
+  kind: 'text',
+  role,
+  provider: 'pi',
+  sessionId: 'session-1',
+  content,
+  timestamp,
+} as NormalizedMessage);
+
+// Persisted and live thinking rows carry no role — matching is by content only.
+const thinking = (id: string, content: string, timestamp: string): NormalizedMessage => ({
+  id,
+  kind: 'thinking',
+  provider: 'pi',
+  sessionId: 'session-1',
+  content,
+  timestamp,
+} as NormalizedMessage);
+
+const user = () => text('u1', 'user', 'first prompt', '2026-01-01T00:00:01.000Z');
+const answer = () => text('a1', 'assistant', 'first answer', '2026-01-01T00:00:03.000Z');
+const persistedThinking = () => thinking('p1', 'Let me reason about it.', '2026-01-01T00:00:02.000Z');
+
+const page = (messages: NormalizedMessage[]) => sessionMessages.mockResolvedValue({
+  ok: true,
+  json: async () => ({ data: { messages, total: messages.length, hasMore: false } }),
+});
+
+beforeEach(() => {
+  sessionMessages.mockReset();
+});
+
+afterEach(() => {
+  vi.resetModules();
+});
+
+async function loadedStore() {
+  const { useSessionStore } = await import('@/modules/chat/hooks/useSessionStore');
+  return renderHook(() => useSessionStore());
+}
+
+describe('thinking echoes between live stream and persisted history', () => {
+  it('drops a live thinking row once the persisted transcript holds the same block', async () => {
+    page([user(), answer()]);
+    const { result } = await loadedStore();
+    await act(async () => {
+      await result.current.fetchFromServer('session-1', { limit: 20, offset: 0 });
+    });
+
+    act(() => {
+      result.current.appendRealtime(
+        'session-1',
+        thinking('live-t1', 'Let me reason about it.', '2026-01-01T00:00:04.000Z'),
+      );
+    });
+    assert.equal(result.current.getMessages('session-1').length, 3);
+
+    // The run finished and the JSONL now holds the block under its own id.
+    page([user(), persistedThinking(), answer()]);
+    await act(async () => {
+      await result.current.refreshLatestFromServer('session-1');
+    });
+
+    assert.deepEqual(
+      result.current.getMessages('session-1').map((message) => message.id),
+      ['u1', 'p1', 'a1'],
+    );
+  });
+
+  it('keeps a live thinking row the persisted turn does not repeat', async () => {
+    page([user(), answer()]);
+    const { result } = await loadedStore();
+    await act(async () => {
+      await result.current.fetchFromServer('session-1', { limit: 20, offset: 0 });
+    });
+
+    act(() => {
+      result.current.appendRealtime(
+        'session-1',
+        thinking('live-t2', 'A different line of reasoning.', '2026-01-01T00:00:04.000Z'),
+      );
+    });
+
+    page([user(), persistedThinking(), answer()]);
+    await act(async () => {
+      await result.current.refreshLatestFromServer('session-1');
+    });
+
+    assert.deepEqual(
+      result.current.getMessages('session-1').map((message) => message.id),
+      ['u1', 'p1', 'a1', 'live-t2'],
+    );
+  });
+
+  it('collapses adjacent persisted and live thinking rows with identical content', async () => {
+    page([user(), persistedThinking(), answer()]);
+    const { result } = await loadedStore();
+    await act(async () => {
+      await result.current.fetchFromServer('session-1', { limit: 20, offset: 0 });
+    });
+
+    // Same block seen twice back-to-back in merged order, before any refresh
+    // can reconcile realtime: only the content ties them together.
+    act(() => {
+      result.current.appendRealtime(
+        'session-1',
+        thinking('live-t1', 'Let me reason about it.', '2026-01-01T00:00:02.000Z'),
+      );
+    });
+
+    assert.deepEqual(
+      result.current.getMessages('session-1').map((message) => message.id),
+      ['u1', 'p1', 'a1'],
+    );
+  });
+
+  it('still drops a live assistant text row the persisted turn already holds', async () => {
+    page([user(), answer()]);
+    const { result } = await loadedStore();
+    await act(async () => {
+      await result.current.fetchFromServer('session-1', { limit: 20, offset: 0 });
+    });
+
+    act(() => {
+      result.current.appendRealtime(
+        'session-1',
+        text('live-a1', 'assistant', 'first answer', '2026-01-01T00:00:04.000Z'),
+      );
+    });
+
+    await act(async () => {
+      await result.current.refreshLatestFromServer('session-1');
+    });
+
+    assert.deepEqual(
+      result.current.getMessages('session-1').map((message) => message.id),
+      ['u1', 'a1'],
+    );
+  });
+});

--- a/src/modules/chat/tests/sessionStoreThinkingEcho.test.tsx
+++ b/src/modules/chat/tests/sessionStoreThinkingEcho.test.tsx
@@ -11,6 +11,13 @@ import type { NormalizedMessage } from '@/shared/types';
  * and thinking alike are therefore matched by content echo — otherwise every
  * reasoning block renders twice once the persisted-tail refresh reconciles
  * realtime.
+ *
+ * The turn locating behind that prune keys off chronology, and live rows
+ * (stamped when the client received them) and persisted rows (stamped when the
+ * provider wrote them) can interleave enough to mislocate the turn. When the
+ * prune misses, the duplicate copies still reach the merged view — woven
+ * between each other's sibling rows rather than adjacent — so the merged-view
+ * dedupe drops same-turn same-kind duplicates by turn scope, not by position.
  */
 
 const sessionMessages = vi.fn();
@@ -161,6 +168,60 @@ describe('thinking echoes between live stream and persisted history', () => {
     assert.deepEqual(
       result.current.getMessages('session-1').map((message) => message.id),
       ['u1', 'a1'],
+    );
+  });
+
+  it('drops interleaved server/live echoes that never sort next to their twin', async () => {
+    // The completion flash: live rows are stamped when the client received
+    // them and persisted rows when the provider wrote them, so the timestamp
+    // sort weaves each copy between the other side's sibling rows —
+    // server text, live thinking, live text, server thinking — and no
+    // duplicate pair is adjacent.
+    page([
+      user(),
+      text('a1', 'assistant', 'first answer', '2026-01-01T00:00:03.000Z'),
+      thinking('p1', 'Let me reason about it.', '2026-01-01T00:00:04.500Z'),
+    ]);
+    const { result } = await loadedStore();
+    await act(async () => {
+      await result.current.fetchFromServer('session-1', { limit: 20, offset: 0 });
+    });
+
+    act(() => {
+      result.current.appendRealtime(
+        'session-1',
+        thinking('live-t1', 'Let me reason about it.', '2026-01-01T00:00:03.500Z'),
+      );
+      result.current.appendRealtime(
+        'session-1',
+        text('live-a1', 'assistant', 'first answer', '2026-01-01T00:00:04.000Z'),
+      );
+    });
+
+    const merged = result.current.getMessages('session-1');
+    assert.deepEqual(merged.map((message) => message.id), ['u1', 'a1', 'live-t1']);
+    const echoedContents = merged
+      .map((message) => `${message.kind}:${(message.content || '').trim()}`);
+    assert.equal(new Set(echoedContents).size, echoedContents.length);
+  });
+
+  it('keeps identical replies that belong to different turns', async () => {
+    page([
+      user(),
+      text('a1', 'assistant', 'same reply', '2026-01-01T00:00:03.000Z'),
+      text('u2', 'user', 'second prompt', '2026-01-01T00:00:05.000Z'),
+      text('a2', 'assistant', 'same reply', '2026-01-01T00:00:07.000Z'),
+    ]);
+    const { result } = await loadedStore();
+    await act(async () => {
+      await result.current.fetchFromServer('session-1', { limit: 20, offset: 0 });
+    });
+
+    // A user prompt starts a new echo scope: two turns answering with the
+    // exact same words are two genuine replies, not a server/live double.
+    assert.deepEqual(
+      result.current.getMessages('session-1').map((message) => message.id),
+      ['u1', 'a1', 'u2', 'a2'],
     );
   });
 });

--- a/src/modules/chat/transcript/MessageComponent.tsx
+++ b/src/modules/chat/transcript/MessageComponent.tsx
@@ -198,7 +198,9 @@ const MessageComponent = memo(({ message, prevMessage, createDiff, onFileOpen, s
                           ? t('messageTypes.codex')
                           : provider === 'opencode'
                               ? t('messageTypes.opencode', { defaultValue: 'OpenCode' })
-                              : t('messageTypes.claude'))}
+                              : provider === 'pi'
+                                  ? t('messageTypes.pi', { defaultValue: 'Pi' })
+                                : t('messageTypes.claude'))}
               </div>
             </div>
           )}

--- a/src/modules/chat/transcript/ProviderSelectionEmptyState.tsx
+++ b/src/modules/chat/transcript/ProviderSelectionEmptyState.tsx
@@ -310,6 +310,10 @@ export default function ProviderSelectionEmptyState({
                   model: providerModels.opencode,
                   defaultValue: "Ready with OpenCode {{model}}",
                 }),
+                pi: t("providerSelection.readyPrompt.pi", {
+                  model: providerModels.pi,
+                  defaultValue: "Ready with Pi {{model}}",
+                }),
               }[provider]
             }
           </p>

--- a/src/modules/chat/transcript/ProviderSelectionEmptyState.tsx
+++ b/src/modules/chat/transcript/ProviderSelectionEmptyState.tsx
@@ -31,6 +31,7 @@ const PROVIDER_META: { id: LLMProvider; name: string }[] = [
   { id: "codex", name: "OpenAI" },
   { id: "cursor", name: "Cursor" },
   { id: "opencode", name: "OpenCode" },
+  { id: "pi", name: "Pi" },
 ];
 
 const MOD_KEY =
@@ -78,6 +79,7 @@ function getProviderDisplayName(p: LLMProvider) {
   if (p === "cursor") return "Cursor";
   if (p === "codex") return "Codex";
   if (p === "opencode") return "OpenCode";
+  if (p === "pi") return "Pi";
   return "Claude";
 }
 

--- a/src/modules/i18n/locales/en/chat.json
+++ b/src/modules/i18n/locales/en/chat.json
@@ -18,7 +18,8 @@
     "claude": "Claude",
     "cursor": "Cursor",
     "codex": "Codex",
-    "opencode": "OpenCode"
+    "opencode": "OpenCode",
+    "pi": "Pi"
   },
   "tools": {
     "settings": "Tool Settings",
@@ -166,6 +167,7 @@
       "cursor": "Ready to use Cursor with {{model}}. Start typing your message below.",
       "codex": "Ready to use Codex with {{model}}. Start typing your message below.",
       "opencode": "Ready to use OpenCode with {{model}}. Start typing your message below.",
+      "pi": "Ready to use Pi with {{model}}. Start typing your message below.",
       "default": "Select a provider above to begin"
     },
     "pressToSearch": "Press <kbd>{{shortcut}}</kbd> to search sessions, files, and commits",

--- a/src/modules/i18n/locales/en/common.json
+++ b/src/modules/i18n/locales/en/common.json
@@ -347,6 +347,7 @@
     "unknownProvider": "Unknown",
     "browseFolders": "Browse folders",
     "closeLoginModal": "Close login modal",
+    "piSetupHint": "Pi has no login command: credentials come from environment variables or ~/.pi/agent/models.json. The pi CLI below is for setup and verification.",
     "pluginLoadFailed": "Plugin failed to load: {{error}}"
   },
   "cancel": "Cancel"

--- a/src/modules/i18n/locales/en/settings.json
+++ b/src/modules/i18n/locales/en/settings.json
@@ -368,6 +368,24 @@
       },
       "opencode": {
         "description": "OpenCode CLI assistant"
+      },
+      "pi": {
+        "description": "Pi coding agent CLI"
+      }
+    },
+    "pi": {
+      "setup": {
+        "title": "Set up Pi",
+        "installTitle": "Install Pi",
+        "description": "Pi has no login command: model credentials come from environment variables or its own models.json. Opening the pi CLI lets you finish the setup and verify it.",
+        "button": "Open pi CLI",
+        "installCommand": "npm install -g @earendil-works/pi-coding-agent",
+        "modelsHint": "Configure model providers in ~/.pi/agent/models.json or through environment variables such as $ANTHROPIC_API_KEY."
+      },
+      "authMethod": {
+        "label": "Credential source",
+        "env": "Environment variable",
+        "oauth": "pi auth store"
       }
     },
     "connectionStatus": "Connection Status",
@@ -600,6 +618,7 @@
   },
   "skillsPage": {
     "description": "Manage {{provider}} skills from local files, complete folders, and project-aware locations.",
+ "readOnlyDescription": "Showing the skills {{provider}} discovers on disk. To add a skill, place a SKILL.md folder in one of {{provider}}'s skill directories, then refresh.",
     "searchPlaceholder": "Search skills...",
     "searchAriaLabel": "Search skills",
     "clearSearch": "Clear skill search",
@@ -617,6 +636,7 @@
     "loading": "Loading {{provider}} skills…",
     "emptyTitle": "No skills discovered yet",
     "emptyDescription": "Add a global skill above or create project-specific skill folders in your workspace.",
+ "emptyReadOnlyDescription": "No skills discovered yet. Add a SKILL.md folder to a directory {{provider}} scans, for example:",
     "noMatchTitle": "No matching skills",
     "noMatchDescription": "Try a different command, name, scope, project, or source path.",
     "count_one": "{{count}} skill",

--- a/src/modules/i18n/locales/en/settings.json
+++ b/src/modules/i18n/locales/en/settings.json
@@ -618,7 +618,7 @@
   },
   "skillsPage": {
     "description": "Manage {{provider}} skills from local files, complete folders, and project-aware locations.",
- "readOnlyDescription": "Showing the skills {{provider}} discovers on disk. To add a skill, place a SKILL.md folder in one of {{provider}}'s skill directories, then refresh.",
+    "readOnlyDescription": "Showing the skills {{provider}} discovers on disk. To add a skill, place a SKILL.md folder in one of {{provider}}'s skill directories, then refresh.",
     "searchPlaceholder": "Search skills...",
     "searchAriaLabel": "Search skills",
     "clearSearch": "Clear skill search",
@@ -636,7 +636,7 @@
     "loading": "Loading {{provider}} skills…",
     "emptyTitle": "No skills discovered yet",
     "emptyDescription": "Add a global skill above or create project-specific skill folders in your workspace.",
- "emptyReadOnlyDescription": "No skills discovered yet. Add a SKILL.md folder to a directory {{provider}} scans, for example:",
+    "emptyReadOnlyDescription": "No skills discovered yet. Add a SKILL.md folder to a directory {{provider}} scans, for example:",
     "noMatchTitle": "No matching skills",
     "noMatchDescription": "Try a different command, name, scope, project, or source path.",
     "count_one": "{{count}} skill",

--- a/src/modules/mcp/McpServers.tsx
+++ b/src/modules/mcp/McpServers.tsx
@@ -21,6 +21,7 @@ const MCP_PROVIDER_BUTTON_CLASSES: Record<McpProvider, string> = {
   cursor: 'bg-primary text-primary-foreground hover:bg-primary/90',
   codex: 'bg-primary text-primary-foreground hover:bg-primary/90',
   opencode: 'bg-primary text-primary-foreground hover:bg-primary/90',
+  pi: 'bg-primary text-primary-foreground hover:bg-primary/90',
 };
 
 const getTransportIcon = (transport: string | undefined) => {

--- a/src/modules/onboarding/AgentConnectionsStep.tsx
+++ b/src/modules/onboarding/AgentConnectionsStep.tsx
@@ -37,6 +37,13 @@ const providerCards = [
     iconContainerClassName: 'bg-zinc-100 dark:bg-zinc-800',
     loginButtonClassName: 'bg-zinc-800 hover:bg-zinc-900 dark:bg-zinc-700 dark:hover:bg-zinc-600',
   },
+  {
+    provider: 'pi' as const,
+    title: 'Pi',
+    connectedClassName: 'bg-zinc-100 dark:bg-zinc-800/50 border-zinc-300 dark:border-zinc-600',
+    iconContainerClassName: 'bg-zinc-100 dark:bg-zinc-800',
+    loginButtonClassName: 'bg-zinc-800 hover:bg-zinc-900 dark:bg-zinc-700 dark:hover:bg-zinc-600',
+  },
 ];
 
 /** Rendered by Onboarding as its second step, listing every CLI provider the user can log into. */

--- a/src/modules/provider-auth/ProviderLoginModal.tsx
+++ b/src/modules/provider-auth/ProviderLoginModal.tsx
@@ -59,6 +59,12 @@ const getProviderCommand = ({
     return 'opencode auth login';
   }
 
+  // Pi ships no login subcommand — credentials come from its own models.json
+  // or environment variables — so open its TUI and let the user configure it.
+  if (provider === 'pi') {
+    return 'pi';
+  }
+
   return 'claude --dangerously-skip-permissions /login';
 };
 
@@ -67,6 +73,7 @@ const getProviderTitle = (provider: LLMProvider) => {
   if (provider === 'cursor') return 'Cursor CLI Login';
   if (provider === 'codex') return 'Codex CLI Login';
   if (provider === 'opencode') return 'OpenCode CLI Login';
+  if (provider === 'pi') return 'Pi CLI Login';
   return 'Claude CLI Login';
 };
 

--- a/src/modules/provider-auth/ProviderLoginModal.tsx
+++ b/src/modules/provider-auth/ProviderLoginModal.tsx
@@ -73,7 +73,7 @@ const getProviderTitle = (provider: LLMProvider) => {
   if (provider === 'cursor') return 'Cursor CLI Login';
   if (provider === 'codex') return 'Codex CLI Login';
   if (provider === 'opencode') return 'OpenCode CLI Login';
-  if (provider === 'pi') return 'Pi CLI Login';
+  if (provider === 'pi') return 'Pi CLI Setup';
   return 'Claude CLI Login';
 };
 
@@ -94,6 +94,16 @@ export default function ProviderLoginModal({
   const command = getProviderCommand({ provider, customCommand, isAuthenticated });
   const title = getProviderTitle(provider);
 
+  // Only Pi needs guidance here: its "login" is really a setup step, so the
+  // shell below would otherwise look like it should be asking for credentials.
+  const hint =
+    provider === 'pi'
+      ? t('common:misc.piSetupHint', {
+          defaultValue:
+            'Pi has no login command: credentials come from environment variables or ~/.pi/agent/models.json. The pi CLI below is for setup and verification.',
+        })
+      : null;
+
   const handleComplete = (exitCode: number) => {
     onComplete?.(exitCode);
     // Keep the modal open so users can read terminal output before closing.
@@ -102,8 +112,11 @@ export default function ProviderLoginModal({
   return (
     <div className="fixed inset-0 z-[9999] flex items-center justify-center bg-black bg-opacity-50 max-md:items-stretch max-md:justify-stretch">
       <div className="flex h-3/4 w-full max-w-4xl flex-col rounded-lg bg-white shadow-xl dark:bg-gray-800 max-md:m-0 max-md:h-full max-md:max-w-none max-md:rounded-none md:m-4 md:h-3/4 md:max-w-4xl md:rounded-lg">
-        <div className="flex items-center justify-between border-b border-gray-200 p-4 dark:border-gray-700">
-          <h3 className="text-lg font-semibold text-gray-900 dark:text-white">{title}</h3>
+        <div className="flex items-start justify-between gap-4 border-b border-gray-200 p-4 dark:border-gray-700">
+          <div className="min-w-0">
+            <h3 className="text-lg font-semibold text-gray-900 dark:text-white">{title}</h3>
+            {hint && <p className="mt-1 text-xs text-muted-foreground">{hint}</p>}
+          </div>
           <button
             onClick={onClose}
             className="text-gray-400 transition-colors hover:text-gray-600 dark:hover:text-gray-300"

--- a/src/modules/provider-auth/hooks/useProviderAuthStatus.ts
+++ b/src/modules/provider-auth/hooks/useProviderAuthStatus.ts
@@ -3,7 +3,7 @@ import { useCallback, useState } from 'react';
 import { api } from '@/shared/api';
 import type { LLMProvider, ProviderAuthStatus, ProviderAuthStatusMap } from '@/shared/types';
 
-const CLI_PROVIDERS: LLMProvider[] = ['claude', 'cursor', 'codex', 'opencode'];
+const CLI_PROVIDERS: LLMProvider[] = ['claude', 'cursor', 'codex', 'opencode', 'pi'];
 
 const createInitialProviderAuthStatusMap = (loading = true): ProviderAuthStatusMap => ({
   claude: { authenticated: false, email: null, method: null, error: null, loading },

--- a/src/modules/provider-auth/hooks/useProviderAuthStatus.ts
+++ b/src/modules/provider-auth/hooks/useProviderAuthStatus.ts
@@ -14,6 +14,7 @@ const createInitialProviderAuthStatusMap = (loading = true): ProviderAuthStatusM
 });
 
 type ProviderAuthStatusPayload = {
+  installed?: boolean;
   authenticated?: boolean;
   email?: string | null;
   method?: string | null;
@@ -36,6 +37,7 @@ const toProviderAuthStatus = (
   payload: ProviderAuthStatusPayload,
   fallbackError: string | null = null,
 ): ProviderAuthStatus => ({
+  installed: payload.installed,
   authenticated: Boolean(payload.authenticated),
   email: payload.email ?? null,
   method: payload.method ?? null,

--- a/src/modules/provider-auth/hooks/useProviderAuthStatus.ts
+++ b/src/modules/provider-auth/hooks/useProviderAuthStatus.ts
@@ -10,6 +10,7 @@ const createInitialProviderAuthStatusMap = (loading = true): ProviderAuthStatusM
   cursor: { authenticated: false, email: null, method: null, error: null, loading },
   codex: { authenticated: false, email: null, method: null, error: null, loading },
   opencode: { authenticated: false, email: null, method: null, error: null, loading },
+  pi: { authenticated: false, email: null, method: null, error: null, loading },
 });
 
 type ProviderAuthStatusPayload = {

--- a/src/modules/settings/tabs/agents-settings/AgentsSettingsTab.tsx
+++ b/src/modules/settings/tabs/agents-settings/AgentsSettingsTab.tsx
@@ -34,13 +34,17 @@ export default function AgentsSettingsTab({
   const [selectedAgent, setSelectedAgent] = useState<AgentProvider>('claude');
   const [selectedCategory, setSelectedCategory] = useState<AgentCategory>('account');
   const visibleCategories = useMemo<AgentCategory[]>(() => (
+    // OpenCode hides its own skills folder from this tab; Pi has neither
+    // permissions nor MCP support, so it only offers account and skills.
     selectedAgent === 'opencode'
       ? ['account', 'permissions', 'mcp']
-      : ['account', 'permissions', 'mcp', 'skills']
+      : selectedAgent === 'pi'
+        ? ['account', 'skills']
+        : ['account', 'permissions', 'mcp', 'skills']
   ), [selectedAgent]);
 
   const visibleAgents = useMemo<AgentProvider[]>(() => {
-    return ['claude', 'cursor', 'codex', 'opencode'];
+    return ['claude', 'cursor', 'codex', 'opencode', 'pi'];
   }, []);
 
   const agentContextById = useMemo<AgentContextByProvider>(() => ({

--- a/src/modules/settings/tabs/agents-settings/AgentsSettingsTab.tsx
+++ b/src/modules/settings/tabs/agents-settings/AgentsSettingsTab.tsx
@@ -60,12 +60,17 @@ export default function AgentsSettingsTab({
       authStatus: providerAuthStatus.opencode,
       onLogin: () => onProviderLogin('opencode'),
     },
+    pi: {
+      authStatus: providerAuthStatus.pi,
+      onLogin: () => onProviderLogin('pi'),
+    },
   }), [
     onProviderLogin,
     providerAuthStatus.claude,
     providerAuthStatus.codex,
     providerAuthStatus.cursor,
     providerAuthStatus.opencode,
+    providerAuthStatus.pi,
   ]);
 
   useEffect(() => {

--- a/src/modules/settings/tabs/agents-settings/sections/AgentSelectorSection.tsx
+++ b/src/modules/settings/tabs/agents-settings/sections/AgentSelectorSection.tsx
@@ -13,6 +13,7 @@ const AGENT_NAMES: Record<AgentProvider, string> = {
   cursor: 'Cursor',
   codex: 'Codex',
   opencode: 'OpenCode',
+  pi: 'Pi',
 };
 
 /** Rendered by AgentsSettingsTab to pick which agent provider the tab is configuring. */

--- a/src/modules/settings/tabs/agents-settings/sections/AgentSelectorSection.tsx
+++ b/src/modules/settings/tabs/agents-settings/sections/AgentSelectorSection.tsx
@@ -30,7 +30,8 @@ export default function AgentSelectorSection({
           const dotColor =
             agent === 'claude' ? 'bg-blue-500' :
             agent === 'cursor' ? 'bg-purple-500' :
-            agent === 'opencode' ? 'bg-zinc-500' : 'bg-foreground/60';
+            agent === 'opencode' ? 'bg-zinc-500' :
+            agent === 'pi' ? 'bg-gray-500' : 'bg-foreground/60';
 
           return (
             <Pill

--- a/src/modules/settings/tabs/agents-settings/sections/content/AccountContent.tsx
+++ b/src/modules/settings/tabs/agents-settings/sections/content/AccountContent.tsx
@@ -54,6 +54,14 @@ const agentConfig: Record<AgentProvider, AgentVisualConfig> = {
     subtextClass: 'text-zinc-700 dark:text-zinc-300',
     buttonClass: 'bg-zinc-900 hover:bg-zinc-800 active:bg-zinc-950 dark:bg-zinc-700 dark:hover:bg-zinc-600',
   },
+  pi: {
+    name: 'Pi',
+    bgClass: 'bg-muted/50',
+    borderClass: 'border-gray-300 dark:border-gray-600',
+    textClass: 'text-gray-900 dark:text-gray-100',
+    subtextClass: 'text-gray-700 dark:text-gray-300',
+    buttonClass: 'bg-gray-800 hover:bg-gray-900 active:bg-gray-950 dark:bg-gray-700 dark:hover:bg-gray-600 dark:active:bg-gray-500',
+  },
 };
 
 /** Rendered by AgentCategoryContentSection for the "account" category to show sign-in state for one provider. */

--- a/src/modules/settings/tabs/agents-settings/sections/content/AccountContent.tsx
+++ b/src/modules/settings/tabs/agents-settings/sections/content/AccountContent.tsx
@@ -1,4 +1,4 @@
-import { LogIn } from 'lucide-react';
+import { LogIn, Terminal } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 
 import { Badge, Button, LLMProviderLogo } from '@/shared/ui';
@@ -56,6 +56,7 @@ const agentConfig: Record<AgentProvider, AgentVisualConfig> = {
   },
   pi: {
     name: 'Pi',
+    description: 'Pi coding agent CLI',
     bgClass: 'bg-muted/50',
     borderClass: 'border-gray-300 dark:border-gray-600',
     textClass: 'text-gray-900 dark:text-gray-100',
@@ -119,29 +120,86 @@ export default function AccountContent({ agent, authStatus, onLogin }: AccountCo
             </div>
           </div>
 
-          {authStatus.method !== 'api_key' && (
-            <div className="border-t border-border/50 pt-4">
-              <div className="flex items-center justify-between">
-                <div>
-                  <div className={`font-medium ${config.textClass}`}>
-                    {authStatus.authenticated ? t('agents.login.reAuthenticate') : t('agents.login.title')}
-                  </div>
-                  <div className={`text-sm ${config.subtextClass}`}>
-                    {authStatus.authenticated
-                      ? t('agents.login.reAuthDescription')
-                      : t('agents.login.description', { agent: config.name })}
+          {agent === 'pi' ? (
+            <>
+              {/*
+                Pi has no account to sign into: credentials are a local auth
+                store or an API key from the environment, so this panel walks
+                through install/configure instead of offering a login.
+              */}
+              {authStatus.authenticated && authStatus.method && (
+                <div className="border-t border-border/50 pt-4">
+                  <div className="flex items-center gap-2">
+                    <div className={`text-sm font-medium ${config.textClass}`}>
+                      {t('agents.pi.authMethod.label')}
+                    </div>
+                    <Badge variant="secondary" className="bg-muted">
+                      {authStatus.method === 'oauth'
+                        ? t('agents.pi.authMethod.oauth')
+                        : t('agents.pi.authMethod.env')}
+                    </Badge>
                   </div>
                 </div>
-                <Button
-                  onClick={onLogin}
-                  className={`${config.buttonClass} text-white`}
-                  size="sm"
-                >
-                  <LogIn className="mr-2 h-4 w-4" />
-                  {authStatus.authenticated ? t('agents.login.reLoginButton') : t('agents.login.button')}
-                </Button>
+              )}
+
+              <div className="border-t border-border/50 pt-4">
+                <div className="flex items-start justify-between gap-4">
+                  <div className="min-w-0">
+                    <div className={`font-medium ${config.textClass}`}>
+                      {authStatus.installed === false
+                        ? t('agents.pi.setup.installTitle')
+                        : t('agents.pi.setup.title')}
+                    </div>
+                    <div className={`text-sm ${config.subtextClass}`}>
+                      {t('agents.pi.setup.description')}
+                    </div>
+                  </div>
+                  <Button
+                    onClick={onLogin}
+                    className={`${config.buttonClass} text-white`}
+                    size="sm"
+                  >
+                    <Terminal className="mr-2 h-4 w-4" />
+                    {t('agents.pi.setup.button')}
+                  </Button>
+                </div>
+                {authStatus.installed === false && (
+                  <div className="mt-3 rounded-md border border-border/60 bg-muted/30 px-3 py-2">
+                    <code className="block whitespace-normal break-all text-xs text-foreground">
+                      {t('agents.pi.setup.installCommand')}
+                    </code>
+                  </div>
+                )}
+                <div className={`mt-3 text-sm ${config.subtextClass}`}>
+                  {t('agents.pi.setup.modelsHint')}
+                </div>
               </div>
-            </div>
+            </>
+          ) : (
+            authStatus.method !== 'api_key' && (
+              <div className="border-t border-border/50 pt-4">
+                <div className="flex items-center justify-between">
+                  <div>
+                    <div className={`font-medium ${config.textClass}`}>
+                      {authStatus.authenticated ? t('agents.login.reAuthenticate') : t('agents.login.title')}
+                    </div>
+                    <div className={`text-sm ${config.subtextClass}`}>
+                      {authStatus.authenticated
+                        ? t('agents.login.reAuthDescription')
+                        : t('agents.login.description', { agent: config.name })}
+                    </div>
+                  </div>
+                  <Button
+                    onClick={onLogin}
+                    className={`${config.buttonClass} text-white`}
+                    size="sm"
+                  >
+                    <LogIn className="mr-2 h-4 w-4" />
+                    {authStatus.authenticated ? t('agents.login.reLoginButton') : t('agents.login.button')}
+                  </Button>
+                </div>
+              </div>
+            )
           )}
 
           {authStatus.error && (

--- a/src/modules/settings/tests/accountContentPiSetup.test.tsx
+++ b/src/modules/settings/tests/accountContentPiSetup.test.tsx
@@ -1,0 +1,93 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+import { render } from '@testing-library/react';
+import React from 'react';
+import { test, vi } from 'vitest';
+
+import type { ProviderAuthStatus } from '@/shared/types';
+
+/**
+ * Pi has no login command, so its account panel must walk the user through
+ * install/configure (and show the credential source) instead of the generic
+ * sign-in block the other providers get.
+ */
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    // Keys are asserted verbatim so this test stays independent of locale files.
+    t: (key: string) => key,
+  }),
+}));
+
+const { default: AccountContent } = await import('@/modules/settings/tabs/agents-settings/sections/content/AccountContent');
+
+const makeStatus = (overrides: Partial<ProviderAuthStatus> = {}): ProviderAuthStatus => ({
+  authenticated: false,
+  email: null,
+  method: null,
+  error: null,
+  loading: false,
+  ...overrides,
+});
+
+const onLogin = vi.fn();
+
+test('an uninstalled pi shows the install command instead of a login prompt', () => {
+  const { container } = render(
+    <AccountContent
+      agent="pi"
+      authStatus={makeStatus({ installed: false })}
+      onLogin={onLogin}
+    />,
+  );
+
+  const text = container.textContent ?? '';
+  assert.equal(text.includes('agents.pi.setup.installTitle'), true);
+  assert.equal(text.includes('agents.pi.setup.installCommand'), true);
+  assert.equal(text.includes('agents.login.title'), false);
+});
+
+test('an authenticated pi reports its credential source', () => {
+  const { container } = render(
+    <AccountContent
+      agent="pi"
+      authStatus={makeStatus({ authenticated: true, method: 'env' })}
+      onLogin={onLogin}
+    />,
+  );
+
+  const text = container.textContent ?? '';
+  assert.equal(text.includes('agents.pi.authMethod.label'), true);
+  assert.equal(text.includes('agents.pi.authMethod.env'), true);
+  assert.equal(text.includes('agents.login.title'), false);
+});
+
+test('other providers keep the generic sign-in block', () => {
+  const { container } = render(
+    <AccountContent
+      agent="claude"
+      authStatus={makeStatus({ installed: false })}
+      onLogin={onLogin}
+    />,
+  );
+
+  const text = container.textContent ?? '';
+  assert.equal(text.includes('agents.login.title'), true);
+  assert.equal(text.includes('agents.pi.setup.'), false);
+});
+
+test('the en locale points the pi install guidance at the public package', () => {
+  const settings = JSON.parse(
+    readFileSync(
+      path.join(process.cwd(), 'src/modules/i18n/locales/en/settings.json'),
+      'utf8',
+    ),
+  ) as { agents: { pi: { setup: Record<string, string> } } };
+
+  assert.equal(
+    settings.agents.pi.setup.installCommand,
+    'npm install -g @earendil-works/pi-coding-agent',
+  );
+});

--- a/src/modules/sidebar/utils/sidebarProjectFormatting.ts
+++ b/src/modules/sidebar/utils/sidebarProjectFormatting.ts
@@ -214,4 +214,5 @@ export const PROVIDER_LABELS: Record<LLMProvider, string> = {
   codex: 'Codex',
   cursor: 'Cursor',
   opencode: 'OpenCode',
+  pi: 'Pi',
 };

--- a/src/modules/skills/ProviderSkills.tsx
+++ b/src/modules/skills/ProviderSkills.tsx
@@ -64,6 +64,21 @@ const PROVIDER_SKILL_PATHS: Record<Exclude<SkillsProvider, 'opencode'>, string> 
   pi: '~/.pi/agent/skills/<skill-name>/SKILL.md',
 };
 
+/**
+ * Whether the backend accepts managed skill installs for a provider.
+ *
+ * Pi only discovers skills from disk (its own folder, settings-configured
+ * folders and the workspace's `.pi/skills`), so its page stays read-only: the
+ * backend rejects writes until pi exposes a writable skill home.
+ */
+const PROVIDER_SUPPORTS_SKILL_WRITES: Record<SkillsProvider, boolean> = {
+  claude: true,
+  codex: true,
+  cursor: true,
+  opencode: false,
+  pi: false,
+};
+
 const SCOPE_BADGE_CLASSES: Record<SkillsScope, string> = {
   user: 'border-emerald-500/30 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300',
   plugin: 'border-sky-500/30 bg-sky-500/10 text-sky-700 dark:text-sky-300',
@@ -209,6 +224,7 @@ export default function ProviderSkills({ selectedProvider, currentProjects }: Pr
 
   const providerName = PROVIDER_NAMES[selectedProvider];
   const providerPath = selectedProvider === 'opencode' ? null : PROVIDER_SKILL_PATHS[selectedProvider];
+  const supportsSkillWrites = PROVIDER_SUPPORTS_SKILL_WRITES[selectedProvider];
 
   useEffect(() => {
     setQueuedFiles([]);
@@ -509,7 +525,9 @@ export default function ProviderSkills({ selectedProvider, currentProjects }: Pr
         <div className="min-w-0 space-y-1">
           <h3 className="text-lg font-medium text-foreground">{t('tabs.skills', { defaultValue: 'Skills' })}</h3>
           <p className="text-sm text-muted-foreground">
-            {t('skillsPage.description', { provider: providerName })}
+            {supportsSkillWrites
+              ? t('skillsPage.description', { provider: providerName })
+              : t('skillsPage.readOnlyDescription', { provider: providerName })}
           </p>
         </div>
       </div>
@@ -537,15 +555,17 @@ export default function ProviderSkills({ selectedProvider, currentProjects }: Pr
               </button>
             )}
           </div>
-          <Button
-            type="button"
-            size="sm"
-            className="w-full sm:w-auto"
-            onClick={() => handleAddDialogOpenChange(true)}
-          >
-            <Plus className="h-4 w-4" />
-            {t('skillsPage.addSkill')}
-          </Button>
+          {supportsSkillWrites && (
+            <Button
+              type="button"
+              size="sm"
+              className="w-full sm:w-auto"
+              onClick={() => handleAddDialogOpenChange(true)}
+            >
+              <Plus className="h-4 w-4" />
+              {t('skillsPage.addSkill')}
+            </Button>
+          )}
           <Button
             onClick={() => void refreshSkills({ force: true })}
             variant="outline"
@@ -672,8 +692,15 @@ export default function ProviderSkills({ selectedProvider, currentProjects }: Pr
             </div>
             <div className="mt-4 text-sm font-medium text-foreground">{t('skillsPage.emptyTitle')}</div>
             <div className="mt-1 text-sm text-muted-foreground">
-              {t('skillsPage.emptyDescription')}
+              {supportsSkillWrites
+                ? t('skillsPage.emptyDescription')
+                : t('skillsPage.emptyReadOnlyDescription', { provider: providerName })}
             </div>
+            {!supportsSkillWrites && providerPath && (
+              <code className="mx-auto mt-3 block max-w-md whitespace-normal break-all rounded-md border border-border/60 bg-muted/20 px-2 py-1 text-xs text-foreground">
+                {providerPath}
+              </code>
+            )}
           </div>
         )}
 

--- a/src/modules/skills/ProviderSkills.tsx
+++ b/src/modules/skills/ProviderSkills.tsx
@@ -54,12 +54,14 @@ const PROVIDER_NAMES: Record<SkillsProvider, string> = {
   codex: 'Codex',
   cursor: 'Cursor',
   opencode: 'OpenCode',
+  pi: 'Pi',
 };
 
 const PROVIDER_SKILL_PATHS: Record<Exclude<SkillsProvider, 'opencode'>, string> = {
   claude: '~/.claude/skills/<skill-name>/SKILL.md',
   codex: '~/.agents/skills/<skill-name>/SKILL.md',
   cursor: '~/.cursor/skills/<skill-name>/SKILL.md',
+  pi: '~/.pi/agent/skills/<skill-name>/SKILL.md',
 };
 
 const SCOPE_BADGE_CLASSES: Record<SkillsScope, string> = {

--- a/src/modules/skills/tests/providerSkillsReadOnly.test.tsx
+++ b/src/modules/skills/tests/providerSkillsReadOnly.test.tsx
@@ -1,0 +1,66 @@
+import assert from 'node:assert/strict';
+
+import { render } from '@testing-library/react';
+import React from 'react';
+import { beforeEach, test, vi } from 'vitest';
+
+import type { SkillsProject } from '@/shared/types';
+
+/**
+ * Pi discovers skills from disk but has no writable skill home, so the backend
+ * rejects every managed install. The skills page must therefore hide the write
+ * affordance for read-only providers instead of offering an install that can
+ * only fail, while write-capable providers keep it.
+ */
+
+const useProviderSkillsMock = vi.fn();
+
+vi.mock('@/modules/skills/hooks/useProviderSkills', () => ({
+  useProviderSkills: (args: unknown) => useProviderSkillsMock(args),
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    // Keys are asserted verbatim so this test stays independent of locale files.
+    t: (key: string) => key,
+  }),
+  Trans: () => null,
+}));
+
+const { default: ProviderSkills } = await import('@/modules/skills/ProviderSkills');
+
+const baseHookResult = {
+  skills: [],
+  isLoading: false,
+  isLoadingProjectScopes: false,
+  loadError: null,
+  saveStatus: null,
+  addSkills: vi.fn(),
+  refreshSkills: vi.fn(),
+};
+
+const currentProjects: SkillsProject[] = [];
+
+beforeEach(() => {
+  useProviderSkillsMock.mockReset().mockReturnValue({ ...baseHookResult });
+});
+
+test('pi renders a read-only skills page with no install affordance', () => {
+  const { container } = render(
+    <ProviderSkills selectedProvider="pi" currentProjects={currentProjects} />,
+  );
+
+  assert.equal(container.textContent?.includes('skillsPage.addSkill'), false);
+  assert.equal(container.textContent?.includes('skillsPage.readOnlyDescription'), true);
+  // The empty state points at a directory pi actually scans.
+  assert.equal(container.textContent?.includes('~/.pi/agent/skills/'), true);
+});
+
+test('write-capable providers keep the install affordance', () => {
+  const { container } = render(
+    <ProviderSkills selectedProvider="claude" currentProjects={currentProjects} />,
+  );
+
+  assert.equal(container.textContent?.includes('skillsPage.addSkill'), true);
+  assert.equal(container.textContent?.includes('skillsPage.readOnlyDescription'), false);
+});

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -120,6 +120,7 @@ export const MCP_PROVIDER_NAMES: Record<McpProvider, string> = {
   cursor: 'Cursor',
   codex: 'Codex',
   opencode: 'OpenCode',
+  pi: 'Pi',
 };
 
 /** Scopes each provider can install an MCP server into; drives the scope selector and validation. */
@@ -128,6 +129,9 @@ export const MCP_SUPPORTED_SCOPES: Record<McpProvider, McpScope[]> = {
   cursor: ['user', 'project'],
   codex: ['user', 'project'],
   opencode: ['user', 'project'],
+  // pi has no MCP integration yet; the empty lists keep the type total while
+  // gating every scope/transport option off in the form.
+  pi: [],
 };
 
 /** Transports each provider can talk to an MCP server over; drives the transport selector and validation. */
@@ -136,6 +140,7 @@ export const MCP_SUPPORTED_TRANSPORTS: Record<McpProvider, McpTransport[]> = {
   cursor: ['stdio', 'http'],
   codex: ['stdio', 'http'],
   opencode: ['stdio', 'http'],
+  pi: [],
 };
 
 /** Transports offered when configuring a global (provider-agnostic) MCP server. */
@@ -147,6 +152,7 @@ export const MCP_SUPPORTS_WORKING_DIRECTORY: Record<McpProvider, boolean> = {
   cursor: false,
   codex: true,
   opencode: false,
+  pi: false,
 };
 
 // ---------------------------
@@ -217,4 +223,5 @@ export const PROVIDER_PERMISSION_PREFERENCE_KEYS: Record<LLMProvider, UserPrefer
   cursor: 'cursorPermissions',
   codex: 'codexPermissions',
   opencode: 'opencodePermissions',
+  pi: 'piPermissions',
 };

--- a/src/shared/selectedProvider.ts
+++ b/src/shared/selectedProvider.ts
@@ -16,7 +16,7 @@ import { readUserPreference, writeUserPreference } from '@/shared/userSettings';
  * choice both reaches every reader at once and follows the user between devices.
  */
 
-const PROVIDERS: LLMProvider[] = ['claude', 'cursor', 'codex', 'opencode'];
+const PROVIDERS: LLMProvider[] = ['claude', 'cursor', 'codex', 'opencode', 'pi'];
 
 const DEFAULT_PROVIDER: LLMProvider = 'claude';
 

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -5,7 +5,7 @@ import type { NavigateFunction } from 'react-router-dom';
 //----------------- LLM PROVIDER MODEL CATALOG ------------
 
 /** Identifies which coding-agent CLI backs a session, project selection or model list. */
-export type LLMProvider = 'claude' | 'cursor' | 'codex' | 'opencode';
+export type LLMProvider = 'claude' | 'cursor' | 'codex' | 'opencode' | 'pi';
 
 /** One selectable model in a provider's model menu, including its optional reasoning-effort choices. */
 export type ProviderModelOption = {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1091,6 +1091,12 @@ export type ProviderAuthStatus = {
   method: string | null;
   error: string | null;
   loading: boolean;
+  /**
+   * Whether the provider's CLI answered on this machine, as reported by the
+   * backend status endpoint. Absent while the status is loading or the check
+   * failed, so consumers can tell "known to be missing" from "unknown".
+   */
+  installed?: boolean;
 };
 
 /** The authentication state of every CLI provider at once, keyed by LLMProvider, so onboarding and settings can render each provider's connected, loading and error state from one object returned by useProviderAuthStatus. */

--- a/src/shared/ui/LLMProviderLogo.tsx
+++ b/src/shared/ui/LLMProviderLogo.tsx
@@ -3,6 +3,7 @@ import ClaudeLogo from '@/shared/ui/ClaudeLogo';
 import CodexLogo from '@/shared/ui/CodexLogo';
 import CursorLogo from '@/shared/ui/CursorLogo';
 import OpenCodeLogo from '@/shared/ui/OpenCodeLogo';
+import PiLogo from '@/shared/ui/PiLogo';
 
 type LLMProviderLogoProps = {
   provider?: LLMProvider | string | null;
@@ -24,6 +25,10 @@ export function LLMProviderLogo({
 
   if (provider === 'opencode') {
     return <OpenCodeLogo className={className} />;
+  }
+
+  if (provider === 'pi') {
+    return <PiLogo className={className} />;
   }
 
   return <ClaudeLogo className={className} />;

--- a/src/shared/ui/PiLogo.tsx
+++ b/src/shared/ui/PiLogo.tsx
@@ -5,8 +5,10 @@ type PiLogoProps = {
 /**
  * Rendered by the shared LLMProviderLogo when the provider is Pi.
  *
- * Draws a terminal prompt (`>_`) on the same filled tile the other agent
- * logos use, so it reads as a CLI tool at 16-24px.
+ * Draws a terminal prompt (`>_`) on the same filled tile the other agent logos
+ * use. The glyph is sized so it carries the same visual weight as OpenCode's
+ * brackets inside the tile, and the stroke width and caps match the sibling
+ * logos so the five marks read as one family at 16-24px.
  */
 const PiLogo = ({ className = 'w-5 h-5' }: PiLogoProps) => (
   <svg
@@ -19,14 +21,14 @@ const PiLogo = ({ className = 'w-5 h-5' }: PiLogoProps) => (
   >
     <rect x="2.5" y="2.5" width="19" height="19" rx="4" className="fill-foreground" />
     <path
-      d="M6.6 8.4 10.3 12l-3.7 3.6"
+      d="M5.9 7.6 11.2 12 5.9 16.4"
       className="stroke-background"
       strokeWidth="1.9"
       strokeLinecap="round"
       strokeLinejoin="round"
     />
     <path
-      d="M13.2 15.6h4.2"
+      d="M13.5 16.4h4.6"
       className="stroke-background"
       strokeWidth="1.9"
       strokeLinecap="round"

--- a/src/shared/ui/PiLogo.tsx
+++ b/src/shared/ui/PiLogo.tsx
@@ -1,0 +1,37 @@
+type PiLogoProps = {
+  className?: string;
+};
+
+/**
+ * Rendered by the shared LLMProviderLogo when the provider is Pi.
+ *
+ * Draws a terminal prompt (`>_`) on the same filled tile the other agent
+ * logos use, so it reads as a CLI tool at 16-24px.
+ */
+const PiLogo = ({ className = 'w-5 h-5' }: PiLogoProps) => (
+  <svg
+    viewBox="0 0 24 24"
+    role="img"
+    aria-label="Pi"
+    className={className}
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <rect x="2.5" y="2.5" width="19" height="19" rx="4" className="fill-foreground" />
+    <path
+      d="M6.6 8.4 10.3 12l-3.7 3.6"
+      className="stroke-background"
+      strokeWidth="1.9"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M13.2 15.6h4.2"
+      className="stroke-background"
+      strokeWidth="1.9"
+      strokeLinecap="round"
+    />
+  </svg>
+);
+
+export default PiLogo;

--- a/src/shared/userSettings.ts
+++ b/src/shared/userSettings.ts
@@ -25,6 +25,7 @@ export type UserPreferences = {
   cursorPermissions: unknown;
   codexPermissions: unknown;
   opencodePermissions: unknown;
+  piPermissions: unknown;
   codeEditorSettings: unknown;
   uiPreferences: unknown;
   selectedProvider: string;
@@ -62,6 +63,7 @@ const LEGACY_STORAGE_KEYS: Record<UserPreferenceKey, string> = {
   cursorPermissions: 'cursor-tools-settings',
   codexPermissions: 'codex-settings',
   opencodePermissions: 'opencode-settings',
+  piPermissions: 'pi-settings',
   // Unused: the four code-editor settings never shared one key, so they are
   // read by readLegacyCodeEditorSettings instead.
   codeEditorSettings: '',


### PR DESCRIPTION
## Motivation

[pi](https://github.com/earendil-works/pi) is an open-source (MIT) minimal coding agent with a first-class headless integration surface (`pi -p --mode json` streams a documented JSONL event protocol). This PR adds **pi as the fifth agent provider**, so CloudCLI users can drive it from the same web/mobile UI as Claude Code, Codex, Cursor CLI and opencode.

## What this adds

Same architecture as the opencode provider — each message spawns `pi -p --mode json --session <id>` in the project cwd and maps its event stream to `NormalizedMessage`:

- **Runtime**: spawn/args builder, JSONL line parser (session header capture, cumulative usage → token budget), complete-once contract, SIGTERM abort, typed `PROVIDER_NOT_INSTALLED` on ENOENT. pi always exits 0 — model errors surface via `stopReason: "error"` events and are mapped to `kind: "error"` messages (single outlet, deduplicated across `message_start`/`message_end`/`turn_end`).
- **Sessions**: event → message mapping (stream deltas, thinking, tool_use/tool_result pairing by toolCallId, errors) and `fetchHistory` reading pi's on-disk session transcripts (`~/.pi/agent/sessions/<encoded-cwd>/*.jsonl`, tree format v3) with tail pagination.
- **Session synchronizer**: scans the pi session dir (mtime-based cursor — pi appends to the same file on resume, so birthtime would miss resumed sessions), upserts into the sidebar DB with pending-app-session binding.
- **Auth**: `pi --version` install probe; credential detection from `~/.pi/agent/auth.json` (oauth) or env keys, following pi's own [env-api-keys mapping](https://github.com/earendil-works/pi/blob/main/packages/ai/src/env-api-keys.ts) (`ANTHROPIC_API_KEY`, `ANTHROPIC_AUTH_TOKEN`, `OPENAI_API_KEY`, `GEMINI_API_KEY`, `ZAI_CODING_CN_API_KEY`).
- **Models**: static predefined catalog (`PI_PREDEFINED_MODELS`, default `anthropic/claude-sonnet-4`); custom models can be added per-user via the existing model library (DB CHECK constraint migration included, probe-gated rebuild so existing DBs upgrade in place).
- **Skills**: read-only discovery of `~/.pi/agent/skills`, `skills` array in `~/.pi/agent/settings.json`, and `<workspace>/.pi/skills` (agentskills.io layout).
- **Not implemented by design** — pi has no permission system, no session forking, and no MCP: capabilities disable those surfaces and the MCP facet returns `NOT_SUPPORTED` (`server/modules/providers/README.md` capability tables updated accordingly).
- Frontend: provider card, `PiLogo`, settings sections (setup guide incl. `npm install -g @earendil-works/pi-coding-agent`, credential-source badge), terminal wiring (`pi --session`), i18n (en; other locales fall back via `fallbackLng`).

Zero new npm dependencies — the provider uses `cross-spawn` and Node built-ins only.

## Testing

- 45 new server tests (node:test): runtime contract incl. abort/ENOENT/double-complete guards, event mapping table, fetchHistory pagination, synchronizer upserts/mtime filter, auth/models/skills/mcp facets, DB migration (old-DB rebuild + data preservation + idempotency), registry smoke.
- Opt-in e2e against a real `pi` binary and a real model (`PI_E2E=1 PI_E2E_MODEL=…`): run → stream → single `complete` → transcript on disk → resume → history read-back → tool_use/tool_result pairing → abort. Runs through the production stack (runtime service → run registry → gateway writer), asserting client-visible frames.
- Full suite green locally: `npm test` (452), `npm run test:client` (408), `npm run typecheck`, `npm run lint`.
- Dogfooded end-to-end on a live deployment (web + mobile), which surfaced and confirmed fixes for five real-world issues (see "Hardening" below).

## Hardening (found by dogfooding, each with tests)

- `pi` emits `thinking_delta` per token — the runtime now aggregates them server-side into one `thinking` message per reasoning block (`thinking_end` carries the full text), instead of flooding the transcript.
- Frontend: live-stream rows and persisted-transcript rows never share a message id, so **thinking** rows (unlike text rows) had no echo-dedup path — live + persisted duplicates stacked up after every refresh. Thinking now gets the same same-turn content-echo dedup text has (`fix(chat)`).
- Frontend: completion-time flash (server copy + live copy visible for one frame) — same-turn echo dedup no longer relies on row adjacency.
- Frontend: `JSON.stringify(undefined)` returns `undefined`, which crashed transcript rendering with `Cannot read properties of undefined (reading 'trim')` — now guarded; pi tool_result rows also carry a text `content` field like claude's, not just the structured `toolResult` object.

## Reviewer notes

- `GEMINI_API_KEY` (not `GOOGLE_GENERATIVE_AI_API_KEY`) matches pi's env mapping — see linked env-api-keys.ts above.
- `supportsTokenUsage: false` on the usage endpoint is intentional: live runs already emit cumulative usage via the event stream, and history usage is served by the sessions API.
- The model dropdown is a static catalog in this iteration; `pi --list-models`-based dynamic discovery would be a natural follow-up.
- i18n keys added for `en` only (matching how new-provider keys have landed before); happy to add the other locales.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Pi as an AI provider across chat, onboarding, settings, model selection, API documentation, and transcript exports.
  * Added Pi CLI authentication, streaming sessions, history synchronization, session resuming, abort support, skills discovery, setup guidance, branding, permissions, and localized labels.
  * Added migration support for existing provider-model data.

* **Limitations**
  * Pi’s MCP integration and managed skill installation are unavailable; skills are read-only.

* **Bug Fixes**
  * Improved message deduplication and safely handled non-serializable tool results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->